### PR TITLE
Refactor/fix: rework server to send a response back and run rest of command work async

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,4 +17,7 @@ export default tseslint.config(
       },
     },
   },
+  {
+    ignores: [".wrangler/*", "dist/*", "patches/*"],
+  },
 );

--- a/src/commands/base/base.mts
+++ b/src/commands/base/base.mts
@@ -1,16 +1,9 @@
 import { Services } from "../../services/install.mjs";
-import {
-  APIApplicationCommandInteraction,
-  APIApplicationCommand,
-  RESTPostAPIWebhookWithTokenJSONBody,
-} from "discord-api-types/v10";
+import { APIApplicationCommandInteraction, APIApplicationCommand, APIInteractionResponse } from "discord-api-types/v10";
 
 export interface ExecuteResponse {
-  response: Omit<
-    RESTPostAPIWebhookWithTokenJSONBody,
-    "username" | "avatar_url" | "thread_name" | "tts" | "applied_tags"
-  >;
-  deferred: boolean;
+  response: APIInteractionResponse;
+  jobToComplete?: Promise<void>;
 }
 
 export abstract class BaseCommand {
@@ -18,5 +11,5 @@ export abstract class BaseCommand {
 
   abstract data: Omit<APIApplicationCommand, "id" | "application_id" | "default_member_permissions" | "version">;
 
-  abstract execute(interaction: APIApplicationCommandInteraction): Promise<ExecuteResponse>;
+  abstract execute(interaction: APIApplicationCommandInteraction): ExecuteResponse;
 }

--- a/src/server.mts
+++ b/src/server.mts
@@ -10,24 +10,9 @@ import { getCommands } from "./commands/commands.mjs";
 const router = AutoRouter();
 
 router.get("/", (_request, env: Env) => {
-  return new Response(`👋 ${env.DISCORD_APP_ID} 🚀`);
-});
-
-router.get("/test", async (_request, env: Env) => {
-  try {
-    console.log("test called, awaiting timeout...");
-    await new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(undefined);
-      }, 5000);
-    });
-    console.log("timeout completed, returning response");
-    return new Response(`👋 ${env.DISCORD_APP_ID}`);
-  } catch (error) {
-    console.error(error);
-
-    return new Response("Internal error", { status: 500 });
-  }
+  return new Response(
+    `👋 G'day from Guilty Spark (env.DISCORD_APP_ID: ${env.DISCORD_APP_ID})... Interested? https://discord.com/oauth2/authorize?client_id=1290269474536034357 🚀`,
+  );
 });
 
 router.post("/interactions", async (request, env: Env, ctx: EventContext<Env, "", unknown>) => {

--- a/src/server.mts
+++ b/src/server.mts
@@ -30,7 +30,7 @@ router.get("/test", async (_request, env: Env) => {
   }
 });
 
-router.post("/interactions", async (request, env: Env) => {
+router.post("/interactions", async (request, env: Env, ctx: EventContext<Env, "", unknown>) => {
   try {
     const services = installServices({ env });
     const { discordService } = services;
@@ -42,7 +42,11 @@ router.post("/interactions", async (request, env: Env) => {
       return new Response("Bad request signature.", { status: 401 });
     }
 
-    const response = await discordService.handleInteraction(interaction);
+    const { response, jobToComplete } = discordService.handleInteraction(interaction);
+
+    if (jobToComplete) {
+      ctx.waitUntil(jobToComplete);
+    }
 
     return response;
   } catch (error) {


### PR DESCRIPTION
## Context

In testing the previous implementation built for Cloudflare, requests from Discord were being cancelled.

After some digging around, I found that there is a worker context `waitFor` which allows for workers to continue working even after responding.

Using this knowledge which is what I would have loved to have known before, I have reworked the approach so that the Discord request receives an immediate response (i.e. acknowledgement) and then subsequently updating the message.