### PR TITLE
Refactor: halo service to try and reduce calls and use D1

### DIFF
--- a/src/commands/stats/stats.mts
+++ b/src/commands/stats/stats.mts
@@ -164,9 +164,9 @@ export class StatsCommand extends BaseCommand {
 
       const message = await discordService.getMessageFromInteractionToken(interaction.token);
       const thread = await discordService.startThreadFromMessage(
-        channel,
+        message.channel_id,
         message.id,
-        `In depth match stats for queue #${queue.toString()}`,
+        `Queue #${queue.toString()} series stats`,
       );
       for (const match of series) {
         const players = await this.services.haloService.getPlayerXuidsToGametags(match);

--- a/src/commands/stats/stats.mts
+++ b/src/commands/stats/stats.mts
@@ -139,7 +139,7 @@ export class StatsCommand extends BaseCommand {
     channel: string,
     queue: number,
   ): Promise<void> {
-    const { discordService } = this.services;
+    const { discordService, haloService } = this.services;
 
     try {
       const queueData = await discordService.getTeamsFromQueue(channel, queue);
@@ -149,7 +149,7 @@ export class StatsCommand extends BaseCommand {
         );
       }
 
-      const series = await this.services.haloService.getSeriesFromDiscordQueue(queueData);
+      const series = await haloService.getSeriesFromDiscordQueue(queueData);
       const seriesEmbed = await this.createSeriesEmbed(
         Preconditions.checkExists(interaction.guild_id, "No guild id"),
         channel,
@@ -169,12 +169,14 @@ export class StatsCommand extends BaseCommand {
         `Queue #${queue.toString()} series stats`,
       );
       for (const match of series) {
-        const players = await this.services.haloService.getPlayerXuidsToGametags(match);
+        const players = await haloService.getPlayerXuidsToGametags(match);
         const matchEmbed = this.getMatchEmbed(match);
         const embed = await matchEmbed.getEmbed(match, players);
 
         await discordService.createMessage(thread.id, { embeds: [embed] });
       }
+
+      await haloService.updateDiscordAssociations();
     } catch (error) {
       console.error(error);
 

--- a/src/services/database/database.mts
+++ b/src/services/database/database.mts
@@ -14,8 +14,7 @@ export class DatabaseService {
   async getDiscordAssociations(discordIds: string[]): Promise<DiscordAssociationsRow[]> {
     const placeholders = discordIds.map(() => "?").join(",");
     const query = `SELECT * FROM DiscordAssociations WHERE DiscordId IN (${placeholders})`;
-    const stmt = this.env.DB.prepare(query);
-    discordIds.forEach((discordId, index) => stmt.bind(index + 1, discordId));
+    const stmt = this.env.DB.prepare(query).bind(...discordIds);
     const response = await stmt.all<DiscordAssociationsRow>();
     return response.results;
   }

--- a/src/services/database/database.mts
+++ b/src/services/database/database.mts
@@ -1,0 +1,37 @@
+import { DiscordAssociationsRow } from "./types/discord_associations.mjs";
+
+interface DatabaseServiceOpts {
+  env: Env;
+}
+
+export class DatabaseService {
+  private readonly env: Env;
+
+  constructor({ env }: DatabaseServiceOpts) {
+    this.env = env;
+  }
+
+  async getDiscordAssociations(discordIds: string[]): Promise<DiscordAssociationsRow[]> {
+    const placeholders = discordIds.map(() => "?").join(",");
+    const query = `SELECT * FROM DiscordAssociations WHERE DiscordId IN (${placeholders})`;
+    const stmt = this.env.DB.prepare(query);
+    discordIds.forEach((discordId, index) => stmt.bind(index + 1, discordId));
+    const response = await stmt.all<DiscordAssociationsRow>();
+    return response.results;
+  }
+
+  async addDiscordAssociation(associations: DiscordAssociationsRow[]): Promise<void> {
+    const placeholders = associations.map(() => "(?, ?, ?, ?, ?)").join(",");
+    const query = `INSERT INTO DiscordAssociations (DiscordId, XboxId, AssociationReason, AssociationDate, GamesRetrievable) VALUES ${placeholders}`;
+    const stmt = this.env.DB.prepare(query);
+    const bindings = associations.flatMap((association) => [
+      association.DiscordId,
+      association.XboxId,
+      association.AssociationReason,
+      association.AssociationDate,
+      association.GamesRetrievable,
+    ]);
+    stmt.bind(...bindings);
+    await stmt.run();
+  }
+}

--- a/src/services/database/schema.sql
+++ b/src/services/database/schema.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS DiscordAssociations;
+CREATE TABLE IF NOT EXISTS DiscordAssociations (
+  DiscordId TEXT PRIMARY KEY NOT NULL,
+  XboxId TEXT NOT NULL,
+  AssociationReason CHAR(1) CHECK(AssociationReason IN ('C', 'M', 'U', 'D', 'G', '?')) NOT NULL DEFAULT '?',
+  AssociationDate TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  GamesRetrievable CHAR(1) CHECK(AssociationReason IN ('Y', 'N', '?')) NOT NULL DEFAULT '?'
+);

--- a/src/services/database/schema.sql
+++ b/src/services/database/schema.sql
@@ -3,6 +3,6 @@ CREATE TABLE IF NOT EXISTS DiscordAssociations (
   DiscordId TEXT PRIMARY KEY NOT NULL,
   XboxId TEXT NOT NULL,
   AssociationReason CHAR(1) CHECK(AssociationReason IN ('C', 'M', 'U', 'D', 'G', '?')) NOT NULL DEFAULT '?',
-  AssociationDate TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  GamesRetrievable CHAR(1) CHECK(AssociationReason IN ('Y', 'N', '?')) NOT NULL DEFAULT '?'
+  AssociationDate INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  GamesRetrievable CHAR(1) CHECK(GamesRetrievable IN ('Y', 'N', '?')) NOT NULL DEFAULT '?'
 );

--- a/src/services/database/types/discord_associations.mts
+++ b/src/services/database/types/discord_associations.mts
@@ -17,6 +17,6 @@ export interface DiscordAssociationsRow {
   DiscordId: string;
   XboxId: string;
   AssociationReason: AssociationReason;
-  AssociationDate: string;
+  AssociationDate: number;
   GamesRetrievable: GamesRetrievable;
 }

--- a/src/services/database/types/discord_associations.mts
+++ b/src/services/database/types/discord_associations.mts
@@ -1,0 +1,22 @@
+export enum AssociationReason {
+  CONNECTED = "C",
+  MANUAL = "M",
+  USERNAME_SEARCH = "U",
+  DISPLAY_NAME_SEARCH = "D",
+  GAME_SIMILARITY = "G",
+  UNKNOWN = "?",
+}
+
+export enum GamesRetrievable {
+  YES = "Y",
+  NO = "N",
+  UNKNOWN = "?",
+}
+
+export interface DiscordAssociationsRow {
+  DiscordId: string;
+  XboxId: string;
+  AssociationReason: AssociationReason;
+  AssociationDate: string;
+  GamesRetrievable: GamesRetrievable;
+}

--- a/src/services/discord/discord.mts
+++ b/src/services/discord/discord.mts
@@ -17,6 +17,7 @@ import {
   RESTPatchAPIChannelMessageResult,
   RESTPostAPIChannelMessageJSONBody,
   RESTPostAPIChannelMessageResult,
+  RESTPostAPIChannelMessagesThreadsJSONBody,
   RESTPostAPIChannelThreadsResult,
   RESTPostAPIWebhookWithTokenJSONBody,
   Routes,
@@ -212,10 +213,24 @@ export class DiscordService {
     });
   }
 
-  startThreadFromMessage(channel: string, message: string, name: string, autoArchiveDuration = 60) {
+  startThreadFromMessage(
+    channel: string,
+    message: string,
+    name: string,
+    autoArchiveDuration: 60 | 1440 | 4320 | 10080 = 60,
+  ) {
+    if (name.length > 100) {
+      throw new Error("Thread name must be 100 characters or fewer");
+    }
+
+    const data: RESTPostAPIChannelMessagesThreadsJSONBody = {
+      name,
+      auto_archive_duration: autoArchiveDuration,
+    };
+
     return this.fetch<RESTPostAPIChannelThreadsResult>(Routes.threads(channel, message), {
       method: "POST",
-      body: JSON.stringify({ name, auto_archive_duration: autoArchiveDuration }),
+      body: JSON.stringify(data),
     });
   }
 

--- a/src/services/halo/halo.mts
+++ b/src/services/halo/halo.mts
@@ -160,7 +160,7 @@ export class HaloService {
           DiscordId: discordId,
           XboxId: result.value.xuid,
           AssociationReason: AssociationReason.USERNAME_SEARCH,
-          AssociationDate: new Date().toISOString(),
+          AssociationDate: new Date().getTime(),
           GamesRetrievable: GamesRetrievable.UNKNOWN,
         });
       }
@@ -180,7 +180,7 @@ export class HaloService {
         DiscordId: discordId,
         XboxId: resolved ? result.value.xuid : "",
         AssociationReason: resolved ? AssociationReason.DISPLAY_NAME_SEARCH : AssociationReason.UNKNOWN,
-        AssociationDate: new Date().toISOString(),
+        AssociationDate: new Date().getTime(),
         GamesRetrievable: GamesRetrievable.UNKNOWN,
       });
     }
@@ -207,7 +207,7 @@ export class HaloService {
       if (!playerMatches.length) {
         this.userCache.set(user.DiscordId, {
           ...user,
-          AssociationDate: new Date().toISOString(),
+          AssociationDate: new Date().getTime(),
           GamesRetrievable: GamesRetrievable.NO,
         });
         continue;
@@ -225,13 +225,13 @@ export class HaloService {
           for (const [discordId] of otherUsersWithSameLastMatch) {
             this.userCache.set(discordId, {
               ...Preconditions.checkExists(this.userCache.get(discordId)),
-              AssociationDate: new Date().toISOString(),
+              AssociationDate: new Date().getTime(),
               GamesRetrievable: GamesRetrievable.YES,
             });
           }
           this.userCache.set(user.DiscordId, {
             ...user,
-            AssociationDate: new Date().toISOString(),
+            AssociationDate: new Date().getTime(),
             GamesRetrievable: GamesRetrievable.YES,
           });
           matches.push(...playerMatches);
@@ -246,7 +246,7 @@ export class HaloService {
       const [discordId, playerMatches] = Preconditions.checkExists(userMatches.entries().next().value);
       this.userCache.set(discordId, {
         ...Preconditions.checkExists(this.userCache.get(discordId)),
-        AssociationDate: new Date().toISOString(),
+        AssociationDate: new Date().getTime(),
         GamesRetrievable: GamesRetrievable.YES,
       });
       matches.push(...playerMatches);

--- a/src/services/halo/halo.mts
+++ b/src/services/halo/halo.mts
@@ -160,16 +160,16 @@ export class HaloService {
       ),
     );
     for (const [index, result] of xboxUsersByDiscordDisplayNameResult.entries()) {
-      if (result.status === "fulfilled") {
-        const discordId = Preconditions.checkExists(unresolvedUsers[index]).id;
-        this.userCache.set(discordId, {
-          DiscordId: discordId,
-          XboxId: result.value.xuid,
-          AssociationReason: AssociationReason.DISPLAY_NAME_SEARCH,
-          AssociationDate: new Date().toISOString(),
-          GamesRetrievable: GamesRetrievable.UNKNOWN,
-        });
-      }
+      const discordId = Preconditions.checkExists(unresolvedUsers[index]).id;
+      const resolved = result.status === "fulfilled";
+
+      this.userCache.set(discordId, {
+        DiscordId: discordId,
+        XboxId: resolved ? result.value.xuid : "",
+        AssociationReason: resolved ? AssociationReason.DISPLAY_NAME_SEARCH : AssociationReason.UNKNOWN,
+        AssociationDate: new Date().toISOString(),
+        GamesRetrievable: GamesRetrievable.UNKNOWN,
+      });
     }
   }
 

--- a/src/services/install.mts
+++ b/src/services/install.mts
@@ -1,8 +1,10 @@
+import { DatabaseService } from "./database/database.mjs";
 import { DiscordService } from "./discord/discord.mjs";
 import { HaloService } from "./halo/halo.mjs";
 import { XboxService } from "./xbox/xbox.mjs";
 
 export interface Services {
+  databaseService: DatabaseService;
   discordService: DiscordService;
   xboxService: XboxService;
   haloService: HaloService;
@@ -13,13 +15,15 @@ interface InstallServicesOpts {
 }
 
 export async function installServices({ env }: InstallServicesOpts): Promise<Services> {
+  const databaseService = new DatabaseService({ env });
   const discordService = new DiscordService({ env });
   const xboxService = new XboxService({ env });
-  const haloService = new HaloService({ xboxService });
+  const haloService = new HaloService({ databaseService, xboxService });
 
   await xboxService.loadCredentials();
 
   return {
+    databaseService,
     discordService,
     xboxService,
     haloService,

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -7,4 +7,5 @@ interface Env {
 	DISCORD_PUBLIC_KEY: string;
 	XBOX_USERNAME: string;
 	XBOX_PASSWORD: string;
+	DB: D1Database;
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,6 +6,10 @@ upload_source_maps = true
 kv_namespaces = [
   { binding = "SERVICE_API_TOKENS", id = "374fa9b9bed741fe9b5cb2d777206413" }
 ]
+d1_databases = [
+  { binding = "DB", database_name = "staging-db-guilty-spark", database_id = "f36b6b07-dc66-43d8-8653-571b473c6cd5" }
+]
+
 
 [observability]
 enabled = true
@@ -17,10 +21,16 @@ name = "guilty-spark-staging"
 kv_namespaces = [
   { binding = "SERVICE_API_TOKENS", id = "15f902ee57834484a4809a839a5c0a71" }
 ]
+d1_databases = [
+  { binding = "DB", database_name = "staging-db-guilty-spark", database_id = "f36b6b07-dc66-43d8-8653-571b473c6cd5" }
+]
 
 
 [env.production]
 name = "guilty-spark"
 kv_namespaces = [
   { binding = "SERVICE_API_TOKENS", id = "2b593da40c7e4762be0c2095afdad49f" }
+]
+d1_databases = [
+  { binding = "DB", database_name = "prod-db-guilty-spark", database_id = "fa6747b9-e9e0-47ca-891b-d4608ade66a3" }
 ]


### PR DESCRIPTION
## Context

When attempting to use the current implementation, we seem to be hitting the Cloudflare Worker request limits.

This PR:
- Sets up D1 database so that we can start to track discord IDs to xbox user ids
- Reduces down the way in which games are found by sequentially searching players until it finds 2 players with the same last game... rather than fetching them all eagerly
- ...
