### PR TITLE
Improve message for no users matching

### DIFF
--- a/src/commands/stats/stats.mts
+++ b/src/commands/stats/stats.mts
@@ -104,7 +104,7 @@ export class StatsCommand extends BaseCommand {
           throw new Error("Unknown subcommand");
       }
     } catch (error) {
-      console.error(error);
+      console.trace(error);
 
       return {
         response: {
@@ -178,7 +178,7 @@ export class StatsCommand extends BaseCommand {
 
       await haloService.updateDiscordAssociations();
     } catch (error) {
-      console.error(error);
+      console.trace(error);
 
       if (error instanceof Error && error.message === "Too many subrequests.") {
         return;
@@ -223,7 +223,7 @@ export class StatsCommand extends BaseCommand {
 
       await discordService.updateDeferredReply(interaction.token, { embeds: [embed] });
     } catch (error) {
-      console.error(error);
+      console.trace(error);
 
       if (error instanceof Error && error.message === "Too many subrequests.") {
         return;

--- a/src/server.mts
+++ b/src/server.mts
@@ -35,7 +35,7 @@ router.post("/interactions", async (request, env: Env, ctx: EventContext<Env, ""
 
     return response;
   } catch (error) {
-    console.error(error);
+    console.trace(error);
 
     return new Response("Internal error", { status: 500 });
   }

--- a/src/services/discord/discord.mts
+++ b/src/services/discord/discord.mts
@@ -77,7 +77,7 @@ export class DiscordService {
       const parsedInteraction = JSON.parse(body) as APIInteraction;
       return { interaction: parsedInteraction, isValid: true };
     } catch (error) {
-      console.error(error);
+      console.trace(error);
 
       return { isValid: false, error: "Invalid JSON" };
     }
@@ -97,7 +97,7 @@ export class DiscordService {
       }
       case InteractionType.ApplicationCommand: {
         if (!this.commands) {
-          console.error("No commands found");
+          console.trace("No commands found");
           return {
             response: new JsonResponse({ error: "No commands found" }, { status: 500 }),
           };

--- a/src/services/halo/halo.mts
+++ b/src/services/halo/halo.mts
@@ -50,6 +50,12 @@ export class HaloService {
     // whilst we only need to find the first one matchable, allow us to go through the list and update cache if not matching
     const usersToSearch = [...usersWithGamesRetrieved, ...usersWithGamesUnknown];
 
+    if (!usersToSearch.length) {
+      await this.updateDiscordAssociations();
+
+      throw new Error("Unable to match any of the Discord users to their Xbox accounts");
+    }
+
     const matchesForUsers = await this.getMatchesForUsers(usersToSearch, queueData.timestamp);
     const matchDetails = await this.getMatchDetails(matchesForUsers, (match) => {
       const parsedDuration = tinyduration.parse(match.MatchInfo.Duration);

--- a/src/services/xbox/xbox.mts
+++ b/src/services/xbox/xbox.mts
@@ -22,8 +22,9 @@ export class XboxService {
     if (tokenInfo) {
       try {
         this.tokenInfoMap = new Map(JSON.parse(tokenInfo) as [TokenInfoKey, string][]);
-      } catch (e) {
-        console.error(e);
+      } catch (error) {
+        console.trace(error);
+        console.log("Continuing without cached Xbox credentials");
       }
     }
   }


### PR DESCRIPTION
## Context

When there are no users matching, currently it shows the following to the channel

> Failed to fetch (Channel: ⁠📝results, queue: 1112): 400 from https://halostats.svc.halowaypoint.com/hi/players/xuid()/matches?type=2&count=25&start=0

This PR:
- Provides a better end user message of `Unable to match any of the Discord users to their Xbox accounts`
- Saves the user cache to the database so that we don't try and resolve for the same users again
- Improves the server logs to include tracing by swapping to `console.trace()`
