### PR TITLE
fix vitest in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,5 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.formatOnPaste": true,
-  "vitest.shellType": "terminal",
   "cSpell.words": ["gamertag", "Gametags", "Xuid", "Xuids"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,5 +5,6 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true
-  }
+  },
+  "exclude": ["vitest.config.mts", "scripts", "**/fakes/**", "**/tests/**"]
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -2,9 +2,6 @@ import { coverageConfigDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    typecheck: {
-      tsconfig: "tsconfig.test.json",
-    },
     restoreMocks: true,
     reporters: ["junit", "default"],
     outputFile: {
@@ -15,5 +12,6 @@ export default defineConfig({
       reportOnFailure: true,
       exclude: [...coverageConfigDefaults.exclude, "scripts/**/*", "**/fakes/**", "**/install.mts"],
     },
+    exclude: [...coverageConfigDefaults.exclude, "scripts/**/*", "test-results/**/*", ".wrangler/**/*"],
   },
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -12,6 +12,5 @@ export default defineConfig({
       reportOnFailure: true,
       exclude: [...coverageConfigDefaults.exclude, "scripts/**/*", "**/fakes/**", "**/install.mts"],
     },
-    exclude: [...coverageConfigDefaults.exclude, "scripts/**/*", "test-results/**/*", ".wrangler/**/*"],
   },
 });


### PR DESCRIPTION
## Context

In VSCode, Vitest extension was having an issue starting up.

This was down to the aspect that the `tsconfig.build.json` was too inclusive and adding in a bunch of things it shouldn't, such as test files and the vitest config file.

This PR resolves that issue.