### PR TITLE
Stats: include player names and start + end times

### DIFF
--- a/src/commands/stats/embeds/base-match-embed.mts
+++ b/src/commands/stats/embeds/base-match-embed.mts
@@ -94,7 +94,7 @@ export abstract class BaseMatchEmbed<TCategory extends GameVariantCategory> {
     const embed: APIEmbed = {
       title: gameTypeAndMap,
       url: `https://halodatahive.com/Infinite/Match/${match.MatchId}`,
-      description: "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+      description: "-# Legend: **Best in team** | __**Best overall**__",
       fields: [],
     };
 

--- a/src/commands/stats/embeds/series-matches-embed.mts
+++ b/src/commands/stats/embeds/series-matches-embed.mts
@@ -18,7 +18,7 @@ export class SeriesMatchesEmbed extends BaseMatchEmbed<GameVariantCategory.Multi
     const firstMatch = Preconditions.checkExists(matches[0], "No matches found");
     const embed: APIEmbed = {
       title: "Accumulated Series Stats",
-      description: "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+      description: "-# Legend: **Best in team** | __**Best overall**__",
       fields: [],
     };
 

--- a/src/commands/stats/embeds/tests/__snapshots__/ctf-match-embed.test.mts.snap
+++ b/src/commands/stats/embeds/tests/__snapshots__/ctf-match-embed.test.mts.snap
@@ -2,7 +2,7 @@
 
 exports[`CtfMatchEmbed > getEmbed > returns the expected embed 1`] = `
 {
-  "description": "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+  "description": "-# Legend: **Best in team** | __**Best overall**__",
   "fields": [
     {
       "inline": false,

--- a/src/commands/stats/embeds/tests/__snapshots__/koth-match-embed.test.mts.snap
+++ b/src/commands/stats/embeds/tests/__snapshots__/koth-match-embed.test.mts.snap
@@ -2,7 +2,7 @@
 
 exports[`KOTHMatchEmbed > getEmbed > returns the expected embed 1`] = `
 {
-  "description": "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+  "description": "-# Legend: **Best in team** | __**Best overall**__",
   "fields": [
     {
       "inline": false,

--- a/src/commands/stats/embeds/tests/__snapshots__/land-grab-match-embed.test.mts.snap
+++ b/src/commands/stats/embeds/tests/__snapshots__/land-grab-match-embed.test.mts.snap
@@ -2,7 +2,7 @@
 
 exports[`LandGrabMatchEmbed > getEmbed > returns the expected embed 1`] = `
 {
-  "description": "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+  "description": "-# Legend: **Best in team** | __**Best overall**__",
   "fields": [
     {
       "inline": false,

--- a/src/commands/stats/embeds/tests/__snapshots__/oddball-match-embed.test.mts.snap
+++ b/src/commands/stats/embeds/tests/__snapshots__/oddball-match-embed.test.mts.snap
@@ -2,7 +2,7 @@
 
 exports[`OddballMatchEmbed > getEmbed > returns the expected embed 1`] = `
 {
-  "description": "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+  "description": "-# Legend: **Best in team** | __**Best overall**__",
   "fields": [
     {
       "inline": false,

--- a/src/commands/stats/embeds/tests/__snapshots__/slayer-match-embed.test.mts.snap
+++ b/src/commands/stats/embeds/tests/__snapshots__/slayer-match-embed.test.mts.snap
@@ -2,7 +2,7 @@
 
 exports[`SlayerMatchEmbed > getEmbed > returns the expected embed 1`] = `
 {
-  "description": "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+  "description": "-# Legend: **Best in team** | __**Best overall**__",
   "fields": [
     {
       "inline": false,

--- a/src/commands/stats/embeds/tests/__snapshots__/strongholds-match-embed.test.mts.snap
+++ b/src/commands/stats/embeds/tests/__snapshots__/strongholds-match-embed.test.mts.snap
@@ -2,7 +2,7 @@
 
 exports[`StrongholdsMatchEmbed > getEmbed > returns the expected embed 1`] = `
 {
-  "description": "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+  "description": "-# Legend: **Best in team** | __**Best overall**__",
   "fields": [
     {
       "inline": false,

--- a/src/commands/stats/embeds/tests/__snapshots__/total-control-match-embed.test.mts.snap
+++ b/src/commands/stats/embeds/tests/__snapshots__/total-control-match-embed.test.mts.snap
@@ -2,7 +2,7 @@
 
 exports[`TotalControlMatchEmbed > getEmbed > returns the expected embed 1`] = `
 {
-  "description": "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+  "description": "-# Legend: **Best in team** | __**Best overall**__",
   "fields": [
     {
       "inline": false,

--- a/src/commands/stats/embeds/tests/__snapshots__/vip-match-embed.test.mts.snap
+++ b/src/commands/stats/embeds/tests/__snapshots__/vip-match-embed.test.mts.snap
@@ -2,7 +2,7 @@
 
 exports[`VIPMatchEmbed > getEmbed > returns the expected embed 1`] = `
 {
-  "description": "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+  "description": "-# Legend: **Best in team** | __**Best overall**__",
   "fields": [
     {
       "inline": false,

--- a/src/commands/stats/stats.mts
+++ b/src/commands/stats/stats.mts
@@ -284,7 +284,7 @@ export class StatsCommand extends BaseCommand {
     series: MatchStats[];
   }): Promise<APIEmbed> {
     const { haloService } = this.services;
-    const titles = ["Game", "Duration", "Score"];
+    const titles = ["Game", "Duration", `Score${queueData.teams.length === 2 ? " (🦅:🐍)" : ""}`];
     const tableData = [titles];
     for (const seriesMatch of series) {
       const gameTypeAndMap = await haloService.getGameTypeAndMap(seriesMatch);
@@ -295,8 +295,12 @@ export class StatsCommand extends BaseCommand {
     }
 
     const messageId = Preconditions.checkExists(queueData.message.id);
+    const teams = queueData.teams
+      .map((team) => `**${team.name}:** ${team.players.map((player) => `<@${player.id}>`).join(" ")}`)
+      .join("\n");
     const embed: APIEmbed = {
       title: `Series stats for queue #${queue.toLocaleString(locale)}`,
+      description: teams,
       url: `https://discord.com/channels/${guildId}/${channel}/${messageId}`,
       color: 3447003,
     };

--- a/src/commands/stats/stats.mts
+++ b/src/commands/stats/stats.mts
@@ -298,9 +298,15 @@ export class StatsCommand extends BaseCommand {
     const teams = queueData.teams
       .map((team) => `**${team.name}:** ${team.players.map((player) => `<@${player.id}>`).join(" ")}`)
       .join("\n");
+    const startUnixTime = Math.floor(
+      new Date(Preconditions.checkExists(series[0]?.MatchInfo.StartTime)).getTime() / 1000,
+    );
+    const endUnixTime = Math.floor(
+      new Date(Preconditions.checkExists(series[series.length - 1]?.MatchInfo.EndTime)).getTime() / 1000,
+    );
     const embed: APIEmbed = {
       title: `Series stats for queue #${queue.toLocaleString(locale)}`,
-      description: teams,
+      description: `${teams}\n\n-# Start time: <t:${startUnixTime.toString()}:f> | End time: <t:${endUnixTime.toString()}:f>`,
       url: `https://discord.com/channels/${guildId}/${channel}/${messageId}`,
       color: 3447003,
     };

--- a/src/commands/stats/tests/__snapshots__/stats.test.mts.snap
+++ b/src/commands/stats/tests/__snapshots__/stats.test.mts.snap
@@ -6,7 +6,7 @@ exports[`StatsCommand > execute() > match > jobToComplete > calls discordService
   {
     "embeds": [
       {
-        "description": "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+        "description": "-# Legend: **Best in team** | __**Best overall**__",
         "fields": [
           {
             "inline": false,
@@ -230,7 +230,7 @@ exports[`StatsCommand > execute() > neatqueue > jobToComplete > adds each game a
     {
       "embeds": [
         {
-          "description": "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+          "description": "-# Legend: **Best in team** | __**Best overall**__",
           "fields": [
             {
               "inline": false,
@@ -401,7 +401,7 @@ Av damage/life: 218.49
     {
       "embeds": [
         {
-          "description": "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+          "description": "-# Legend: **Best in team** | __**Best overall**__",
           "fields": [
             {
               "inline": false,
@@ -621,7 +621,7 @@ Carriers killed: __**1**__
     {
       "embeds": [
         {
-          "description": "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+          "description": "-# Legend: **Best in team** | __**Best overall**__",
           "fields": [
             {
               "inline": false,
@@ -833,7 +833,7 @@ Defensive kills: __**4**__
     {
       "embeds": [
         {
-          "description": "Legend: **BOLD = Best in team** | __UNDERLINE = Best overall__",
+          "description": "-# Legend: **Best in team** | __**Best overall**__",
           "fields": [
             {
               "inline": false,
@@ -1153,7 +1153,9 @@ exports[`StatsCommand > execute() > neatqueue > jobToComplete > calls discordSer
       {
         "color": 3447003,
         "description": "**Eagle:** <@000000000000000001> <@000000000000000002> <@000000000000000003> <@000000000000000004>
-**Cobra:** <@000000000000000005> <@000000000000000006> <@000000000000000007> <@000000000000000008>",
+**Cobra:** <@000000000000000005> <@000000000000000006> <@000000000000000007> <@000000000000000008>
+
+-# Start time: <t:1732617393:f> | End time: <t:1732508761:f>",
         "fields": [
           {
             "inline": true,

--- a/src/commands/stats/tests/__snapshots__/stats.test.mts.snap
+++ b/src/commands/stats/tests/__snapshots__/stats.test.mts.snap
@@ -1152,6 +1152,8 @@ exports[`StatsCommand > execute() > neatqueue > jobToComplete > calls discordSer
     "embeds": [
       {
         "color": 3447003,
+        "description": "**Eagle:** <@000000000000000001> <@000000000000000002> <@000000000000000003> <@000000000000000004>
+**Cobra:** <@000000000000000005> <@000000000000000006> <@000000000000000007> <@000000000000000008>",
         "fields": [
           {
             "inline": true,
@@ -1169,7 +1171,7 @@ Land Grab: Fake name for asset a778ae21-a8ae-4569-acb5-898efbd4b3f3",
           },
           {
             "inline": true,
-            "name": "Score",
+            "name": "Score (🦅:🐍)",
             "value": "3:0
 3:2
 11:8",


### PR DESCRIPTION
## Context

To make it easier to understand who is in the series stats and when it started and completed, without needing to click through to the stats message, this PR includes the discord users in the stats message along with the time stamps for start and end time, so that its clear as to who was involved in the series.