### PR TITLE
NeatQueue: adjust timeline key

### DIFF
--- a/src/services/neatqueue/neatqueue.mts
+++ b/src/services/neatqueue/neatqueue.mts
@@ -144,6 +144,12 @@ interface NeatQueueTimelineEvent {
   event: NeatQueueRequest;
 }
 
+type NeatQueueTimelineRequest =
+  | NeatQueueMatchStartedRequest
+  | NeatQueueTeamsCreatedRequest
+  | NeatQueueSubstitutionRequest
+  | NeatQueueMatchCompletedRequest;
+
 export interface NeatQueueServiceOpts {
   env: Env;
   logService: LogService;
@@ -280,12 +286,12 @@ export class NeatQueueService {
     await Promise.all([this.clearTimeline(request, neatQueueConfig), this.haloService.updateDiscordAssociations()]);
   }
 
-  private getTimelineKey(request: NeatQueueRequest, neatQueueConfig: NeatQueueConfigRow): string {
-    return `neatqueue:${neatQueueConfig.GuildId}:${neatQueueConfig.ChannelId}:${request.queue}`;
+  private getTimelineKey(request: NeatQueueTimelineRequest, neatQueueConfig: NeatQueueConfigRow): string {
+    return `neatqueue:${neatQueueConfig.GuildId}:${neatQueueConfig.ChannelId}:${request.action === "MATCH_STARTED" ? request.match_num.toString() : request.match_number.toString()}`;
   }
 
   private async getTimeline(
-    request: NeatQueueRequest,
+    request: NeatQueueTimelineRequest,
     neatQueueConfig: NeatQueueConfigRow,
   ): Promise<NeatQueueTimelineEvent[]> {
     try {
@@ -304,7 +310,7 @@ export class NeatQueueService {
     }
   }
 
-  private async extendTimeline(request: NeatQueueRequest, neatQueueConfig: NeatQueueConfigRow): Promise<void> {
+  private async extendTimeline(request: NeatQueueTimelineRequest, neatQueueConfig: NeatQueueConfigRow): Promise<void> {
     const timeline = await this.getTimeline(request, neatQueueConfig);
     timeline.push({ timestamp: new Date().toISOString(), event: request });
 
@@ -619,7 +625,7 @@ export class NeatQueueService {
     });
   }
 
-  private async clearTimeline(request: NeatQueueRequest, neatQueueConfig: NeatQueueConfigRow): Promise<void> {
+  private async clearTimeline(request: NeatQueueTimelineRequest, neatQueueConfig: NeatQueueConfigRow): Promise<void> {
     await this.env.APP_DATA.delete(this.getTimelineKey(request, neatQueueConfig));
   }
 


### PR DESCRIPTION
## Context

https://github.com/davidhouweling/guilty-spark/pull/88 was a workaround where `MATCH_COMPLETED` event would leverage the existing teams in the NeatQueue request if the timeline didn't contain the `TEAMS_CREATED` event to pull the team from.

After some thought, i surmise that this is because the key we are using isn't actually unique per queue and that if a new queue starts whilst an existing queue is going, it mixes up the data into the one timeline, and thus when one of the queues finishes, it clears the whole timeline.

This fix changes the timeline key so that it is based on the `match_number`. As `match_number` isn't in all of the NeatQueue Request events, the fix also means that we reduce down the scope of events we handle for the timeline, which is fine as the code execution path aligns with it anyways.