### PR TITLE
DiscordService: adjust /users/* calls to be sequential and better rate limit handling

### DIFF
--- a/src/services/discord/discord.mts
+++ b/src/services/discord/discord.mts
@@ -430,6 +430,8 @@ export class DiscordService {
         url.searchParams.set(key, value.toString());
       }
     }
+    this.logService.debug("Discord API request", new Map([["url", url.toString()]]));
+    this.logService.debug("Rate limit", new Map([["rateLimit", rateLimit ? { ...rateLimit } : null]]));
 
     const headers = new Headers(options.headers);
     headers.set("Authorization", `Bot ${this.env.DISCORD_TOKEN}`);
@@ -446,6 +448,7 @@ export class DiscordService {
     const boundFetch = this.globalFetch.bind(null);
     const response = await boundFetch(url.toString(), fetchOptions);
     if (!response.ok) {
+      this.logService.warn(`Discord API request failed: ${response.status.toString()} ${response.statusText}`);
       if (response.status === 429 && !retry) {
         const rateLimitFromResponse = this.getRateLimitFromResponse(response);
 

--- a/src/services/discord/tests/discord.test.mts
+++ b/src/services/discord/tests/discord.test.mts
@@ -757,6 +757,16 @@ describe("DiscordService", () => {
       expect(appConfigGetSpy).toHaveBeenCalledWith("rateLimit./channels/fake-channel/messages", { type: "json" });
     });
 
+    describe("path grouping", () => {
+      it("groups /users/* calls under the same rate limit path", async () => {
+        await discordService.getUsers(["fake-id-01", "fake-id-02"]);
+
+        expect(appConfigGetSpy).toHaveBeenCalledTimes(2);
+        expect(appConfigGetSpy).toHaveBeenNthCalledWith(1, "rateLimit./users/*", { type: "json" });
+        expect(appConfigGetSpy).toHaveBeenNthCalledWith(2, "rateLimit./users/*", { type: "json" });
+      });
+    });
+
     it("puts rate limit in app config when headers are present", async () => {
       const reset = now + 100;
       const response = new Response(null, {


### PR DESCRIPTION
## Context

With the recent adjustments in https://github.com/davidhouweling/guilty-spark/pull/88 and https://github.com/davidhouweling/guilty-spark/pull/89, we're now seeing `Response closed due to connection limit` in Sentry and the NeatQueue integration still not working.

Changing the approach for to sequential for better rate limit handling.