### PR TITLE
HaloService: global name search to case insensitive

### DIFF
--- a/src/services/halo/halo.mts
+++ b/src/services/halo/halo.mts
@@ -354,8 +354,8 @@ export class HaloService {
         (cachedUser.GamesRetrievable !== GamesRetrievable.YES &&
           user.globalName != null &&
           user.globalName !== "" &&
-          user.username !== user.globalName &&
-          user.globalName !== cachedUser.DiscordDisplayNameSearched)
+          user.username.toLowerCase() !== user.globalName.toLowerCase() &&
+          user.globalName.toLowerCase() !== cachedUser.DiscordDisplayNameSearched?.toLowerCase())
       );
     });
     const unresolvedUsersByDiscordGlobalNameResult = await Promise.allSettled(


### PR DESCRIPTION
## Context

Halo (and Xbox) doesn't care that the username is case sensitive or not. To optimise, we should not search for the same string if it's only different by casing.