### PR TITLE
Setup: improve NeatQueue configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,12 +12,17 @@ export default config(
   importPlugin.flatConfigs.typescript,
   {
     ignores: [
+      ".github/",
+      ".vscode/",
       ".wrangler/",
       "coverage/",
       "dist/",
+      "node_modules/",
       "patches/",
       "test-results/",
       "**/*.json",
+      "**/*.log",
+      "**/*.vars",
       "worker-configuration.d.ts",
     ],
   },

--- a/scripts/deploy-commands.mts
+++ b/scripts/deploy-commands.mts
@@ -21,7 +21,7 @@ const url = new URL(`/api/v${APIVersion}${Routes.applicationCommands(env.DISCORD
 console.log("URL:", url.toString());
 
 const commandsToDeployMap = new Map<string, ApplicationCommandData>(
-  [...commands.values()]
+  Array.from(commands.values())
     .flatMap(({ data }) => data)
     .map((data) => {
       if (data.type === ApplicationCommandType.ChatInput) {

--- a/src/commands/base/base.mts
+++ b/src/commands/base/base.mts
@@ -33,7 +33,7 @@ export abstract class BaseCommand {
     readonly env: Env,
   ) {}
 
-  abstract data: CommandData[];
+  abstract readonly data: CommandData[];
 
   abstract execute(interaction: BaseInteraction): ExecuteResponse;
 }

--- a/src/commands/connect/connect.mts
+++ b/src/commands/connect/connect.mts
@@ -33,7 +33,7 @@ export enum InteractionButton {
 export const GamertagSearchModal = "gamertag_search_modal";
 
 export class ConnectCommand extends BaseCommand {
-  data: CommandData[] = [
+  readonly data: CommandData[] = [
     {
       type: ApplicationCommandType.ChatInput,
       name: "connect",

--- a/src/commands/stats/stats.mts
+++ b/src/commands/stats/stats.mts
@@ -55,7 +55,7 @@ export enum InteractionButton {
 }
 
 export class StatsCommand extends BaseCommand {
-  data: CommandData[] = [
+  readonly data: CommandData[] = [
     {
       type: ApplicationCommandType.ChatInput,
       name: "stats",

--- a/src/services/database/database.mts
+++ b/src/services/database/database.mts
@@ -112,10 +112,14 @@ export class DatabaseService {
     await stmt.run();
   }
 
-  async getNeatQueueConfig(guildId: string): Promise<NeatQueueConfigRow | null> {
-    const query = "SELECT * FROM NeatQueueConfig WHERE GuildId = ?";
-    const stmt = this.DB.prepare(query).bind(guildId);
+  async getNeatQueueConfig(guildId: string, channelId: string): Promise<NeatQueueConfigRow> {
+    const query = "SELECT * FROM NeatQueueConfig WHERE GuildId = ? AND ChannelId = ?";
+    const stmt = this.DB.prepare(query).bind(guildId, channelId);
     const result = await stmt.first<NeatQueueConfigRow>();
+
+    if (!result) {
+      throw new Error(`No NeatQueueConfig found for GuildId: ${guildId} and ChannelId: ${channelId}`);
+    }
 
     return result;
   }
@@ -157,6 +161,12 @@ export class DatabaseService {
       config.PostSeriesChannelId,
     ];
     const stmt = this.DB.prepare(query).bind(...bindings);
+    await stmt.run();
+  }
+
+  async deleteNeatQueueConfig(guildId: string, channelId: string): Promise<void> {
+    const query = "DELETE FROM NeatQueueConfig WHERE GuildId = ? AND ChannelId = ?";
+    const stmt = this.DB.prepare(query).bind(guildId, channelId);
     await stmt.run();
   }
 }

--- a/src/services/discord/discord.mts
+++ b/src/services/discord/discord.mts
@@ -4,6 +4,7 @@ import type {
   APIApplicationCommandInteraction,
   APIApplicationCommandInteractionDataBasicOption,
   APIApplicationCommandSubcommandOption,
+  APIChannel,
   APIInteraction,
   APIInteractionResponseChannelMessageWithSource,
   APIMessage,
@@ -292,6 +293,13 @@ export class DiscordService {
       { method: "PATCH", body: JSON.stringify(data) },
     );
     return response;
+  }
+
+  async getGuildChannels(guildId: string): Promise<APIChannel[]> {
+    return this.fetch<APIChannel[]>(Routes.guildChannels(guildId), {
+      method: "GET",
+      queryParameters: { limit: 100 },
+    });
   }
 
   async getMessage(channel: string, messageId: string): Promise<APIMessage> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
+    "strictNullChecks": true,
     "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
## Context

The current `/setup` command was very much a barely functional approach so that NeatQueue could be configured.

This PR refines the NeatQueue setup:
- improves the add functionality
  - resolves step numbers correctly even when previous steps skipped over
  - fixes back step navigation
- adds edit functionality
  - ability to change individual options associated with an existing queue (webhook secret, display mode, results channel)
  - ability to delete an integration

## How has this been tested

In test server... unit tests to come later.