### PR TITLE
Shorten routes

### DIFF
--- a/src/commands/setup/setup.mts
+++ b/src/commands/setup/setup.mts
@@ -476,7 +476,7 @@ export class SetupCommand extends BaseCommand {
   ];
 
   readonly webhookSecretInstructions = [
-    `1. Copy this URL: \n\`${this.env.HOST_URL}/api/neatqueue\``,
+    `1. Copy this URL: \n\`${this.env.HOST_URL}/neatqueue\``,
     "2. Switch to the queue channel if you are not already there",
     "3. Use NeatQueue's `/webhook add` command and paste in the url",
     "4. NeatQueue will reply with a webhook secret, copy it",

--- a/src/server.mts
+++ b/src/server.mts
@@ -1,4 +1,4 @@
-import { withSentry } from "@sentry/cloudflare";
+import * as Sentry from "@sentry/cloudflare";
 import { AutoRouter } from "itty-router";
 import { installServices } from "./services/install.mjs";
 import { getCommands } from "./commands/commands.mjs";
@@ -70,7 +70,7 @@ const server: ExportedHandler = {
   fetch: router.fetch,
 };
 
-export default withSentry(
+export default Sentry.withSentry(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   (_env) => ({
     dsn: "https://76d3531a8ad7eb47ae6e8574e5fd9f9d@o4509134330462208.ingest.us.sentry.io/4509134352285696",
@@ -78,6 +78,20 @@ export default withSentry(
     // Learn more at
     // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
     tracesSampleRate: 1.0,
+    beforeSend: (
+      event: Sentry.ErrorEvent,
+      hint: Sentry.EventHint,
+    ): PromiseLike<Sentry.ErrorEvent | null> | Sentry.ErrorEvent | null => {
+      console.debug("Sentry event:", event);
+      const response = hint.originalException as Response | undefined;
+      if (response?.status === 404) {
+        // Filter out 404 responses
+
+        console.debug("Filtered out 404 response");
+        return null;
+      }
+      return event;
+    },
   }),
   server satisfies ExportedHandler<Env>,
 );

--- a/src/server.mts
+++ b/src/server.mts
@@ -11,7 +11,7 @@ router.get("/", (_request, env: Env) => {
   );
 });
 
-router.post("/api/interactions", async (request, env: Env, ctx: EventContext<Env, "", unknown>) => {
+router.post("/interactions", async (request, env: Env, ctx: EventContext<Env, "", unknown>) => {
   try {
     const services = await installServices({ env });
     const { discordService } = services;
@@ -38,7 +38,7 @@ router.post("/api/interactions", async (request, env: Env, ctx: EventContext<Env
   }
 });
 
-router.post("/api/neatqueue", async (request, env: Env, ctx: EventContext<Env, "", unknown>) => {
+router.post("/neatqueue", async (request, env: Env, ctx: EventContext<Env, "", unknown>) => {
   try {
     const services = await installServices({ env });
     const { neatQueueService } = services;


### PR DESCRIPTION
## Context

Given the domain is now `https://api.guilty-spark.app`, we no longer need `/api/` at the start of each route, so shortening it.

Also adding some adjustments to the server to hopefully filter out http 404 responses.