### PR TITLE
NeatQueue: fix timeline expiration value

### DIFF
--- a/src/services/neatqueue/neatqueue.mts
+++ b/src/services/neatqueue/neatqueue.mts
@@ -315,7 +315,7 @@ export class NeatQueueService {
     timeline.push({ timestamp: new Date().toISOString(), event: request });
 
     await this.env.APP_DATA.put(this.getTimelineKey(request, neatQueueConfig), JSON.stringify(timeline), {
-      metadata: { expirationTtl: 60 * 60 * 24 }, // 1 day
+      expirationTtl: 60 * 60 * 24, // 1 day
     });
   }
 


### PR DESCRIPTION
## Context

Noticed that certain timelines weren't being deleted automatically from the KV store.

This is because the expiration had accidently been put into the metadata rather than directly on the options.