### PR TITLE
NeatQueue: timeline key swap from queue number to queue channel id

### DIFF
--- a/src/services/neatqueue/neatqueue.mts
+++ b/src/services/neatqueue/neatqueue.mts
@@ -287,7 +287,7 @@ export class NeatQueueService {
   }
 
   private getTimelineKey(request: NeatQueueTimelineRequest, neatQueueConfig: NeatQueueConfigRow): string {
-    return `neatqueue:${neatQueueConfig.GuildId}:${neatQueueConfig.ChannelId}:${request.action === "MATCH_STARTED" ? request.match_num.toString() : request.match_number.toString()}`;
+    return `neatqueue:${neatQueueConfig.GuildId}:${neatQueueConfig.ChannelId}:${request.channel}`;
   }
 
   private async getTimeline(

--- a/src/services/neatqueue/neatqueue.mts
+++ b/src/services/neatqueue/neatqueue.mts
@@ -97,7 +97,7 @@ export interface NeatQueueTeamsCreatedRequest extends NeatQueueBaseRequest {
 
 export interface NeatQueueSubstitutionRequest extends NeatQueueBaseRequest {
   action: "SUBSTITUTION";
-  match_number: number;
+  match_number?: number;
   player_subbed_out: NeatQueuePlayer;
   player_subbed_in: NeatQueuePlayer;
 }


### PR DESCRIPTION
## Context

For NeatQueue, if someone gets subbed in/out before a `TEAMS_CREATED` (or `MATCH_STARTED`?), the `SUBSTITUTION` doesn't contain a `match_number`.

What is consistent though is the `channel` property. This `channel` property is the temporary channel that was created for the queue.

Swapping the timeline key to use the temporary channel id in the key instead to resolve instances where it failed to handle pushing the `SUBSTITUTION` to the right timeline KV.