### PR TITLE
Improve NeatQueue errors

### DIFF
--- a/src/base/end-user-error.mts
+++ b/src/base/end-user-error.mts
@@ -1,0 +1,95 @@
+import type { APIEmbed } from "discord-api-types/v10";
+
+interface EndUserErrorOptions {
+  title?: string;
+  errorType?: EndUserErrorType;
+  innerError?: Error;
+  handled?: boolean;
+  data?: Record<string, string>;
+}
+
+export enum EndUserErrorType {
+  ERROR = "error",
+  WARNING = "warning",
+}
+
+export enum EndUserErrorColor {
+  ERROR = 0xff0000,
+  WARNING = 0xffff00,
+}
+
+export class EndUserError extends Error {
+  readonly endUserMessage: string;
+  readonly title: string;
+  readonly errorType: EndUserErrorType;
+  readonly handled: boolean;
+  readonly data: Record<string, string>;
+
+  constructor(
+    endUserMessage: string,
+    {
+      title = "Something went wrong",
+      errorType = EndUserErrorType.ERROR,
+      innerError,
+      handled = false,
+      data = {},
+    }: EndUserErrorOptions = {},
+  ) {
+    super(innerError?.message ?? endUserMessage);
+    this.name = "EndUserError";
+    this.stack = innerError?.stack ?? "No stack trace available";
+    this.endUserMessage = endUserMessage;
+    this.title = title;
+    this.errorType = errorType;
+    this.handled = handled;
+    this.data = data;
+  }
+
+  get discordEmbed(): APIEmbed {
+    const data = Object.entries(this.data);
+
+    return {
+      title: this.title,
+      description: this.endUserMessage,
+      color: this.errorType === EndUserErrorType.ERROR ? EndUserErrorColor.ERROR : EndUserErrorColor.WARNING,
+      fields:
+        data.length > 0
+          ? [
+              {
+                name: "Additional Information",
+                value: data.map(([key, value]) => `**${key}**: ${value}`).join("\n"),
+              },
+            ]
+          : [],
+    };
+  }
+
+  static fromDiscordEmbed(embed: APIEmbed): EndUserError | undefined {
+    if (
+      (embed.color !== EndUserErrorColor.ERROR && embed.color !== EndUserErrorColor.WARNING) ||
+      embed.title === undefined ||
+      embed.description === undefined
+    ) {
+      return undefined;
+    }
+
+    const { title, description: endUserMessage } = embed;
+    const errorType = embed.color === EndUserErrorColor.ERROR ? EndUserErrorType.ERROR : EndUserErrorType.WARNING;
+    const data: Record<string, string> = {};
+    if (embed.fields?.[0]?.name === "Additional Information") {
+      const fields = embed.fields[0].value.split("\n");
+      for (const field of fields) {
+        const [key, value] = field.split(": ");
+        if (key != null && value != null) {
+          data[key.replace(/\*\*/g, "").trim()] = value.trim();
+        }
+      }
+    }
+
+    return new EndUserError(endUserMessage, {
+      title,
+      errorType,
+      data,
+    });
+  }
+}

--- a/src/commands/connect/connect.mts
+++ b/src/commands/connect/connect.mts
@@ -186,15 +186,7 @@ export class ConnectCommand extends BaseCommand {
 
       await discordService.updateDeferredReply(interaction.token, content);
     } catch (error) {
-      this.services.logService.error(error as Error);
-
-      if (error instanceof Error && error.message === "Too many subrequests.") {
-        return;
-      }
-
-      await discordService.updateDeferredReply(interaction.token, {
-        content: `Failed to connect: ${error instanceof Error ? error.message : "unknown"}`,
-      });
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
 
@@ -418,15 +410,7 @@ export class ConnectCommand extends BaseCommand {
 
       await discordService.updateDeferredReply(interaction.token, content);
     } catch (error) {
-      this.services.logService.error(error as Error);
-
-      if (error instanceof Error && error.message === "Too many subrequests.") {
-        return;
-      }
-
-      await discordService.updateDeferredReply(interaction.token, {
-        content: `Failed to update: ${error instanceof Error ? error.message : "unknown"}`,
-      });
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
 
@@ -475,15 +459,7 @@ export class ConnectCommand extends BaseCommand {
 
       await discordService.updateDeferredReply(interaction.token, content);
     } catch (error) {
-      this.services.logService.error(error as Error);
-
-      if (error instanceof Error && error.message === "Too many subrequests.") {
-        return;
-      }
-
-      await discordService.updateDeferredReply(interaction.token, {
-        content: `Failed to remove: ${error instanceof Error ? error.message : "unknown"}`,
-      });
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
 
@@ -559,15 +535,7 @@ export class ConnectCommand extends BaseCommand {
 
       await discordService.updateDeferredReply(interaction.token, content);
     } catch (error) {
-      this.services.logService.error(error as Error);
-
-      if (error instanceof Error && error.message === "Too many subrequests.") {
-        return;
-      }
-
-      await discordService.updateDeferredReply(interaction.token, {
-        content: `Failed to fetch data: ${error instanceof Error ? error.message : "unknown"}`,
-      });
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
 
@@ -607,15 +575,7 @@ export class ConnectCommand extends BaseCommand {
 
       await discordService.updateDeferredReply(interaction.token, content);
     } catch (error) {
-      this.services.logService.error(error as Error);
-
-      if (error instanceof Error && error.message === "Too many subrequests.") {
-        return;
-      }
-
-      await discordService.updateDeferredReply(interaction.token, {
-        content: `Failed to update: ${error instanceof Error ? error.message : "unknown"}`,
-      });
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
 

--- a/src/commands/setup/setup.mts
+++ b/src/commands/setup/setup.mts
@@ -864,15 +864,7 @@ export class SetupCommand extends BaseCommand {
 
       await discordService.updateDeferredReply(interaction.token, content);
     } catch (error) {
-      this.services.logService.error(error as Error);
-
-      if (error instanceof Error && error.message === "Too many subrequests.") {
-        return;
-      }
-
-      await discordService.updateDeferredReply(interaction.token, {
-        content: `Failed to select stats display mode: ${error instanceof Error ? error.message : "unknown"}`,
-      });
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
 
@@ -891,15 +883,7 @@ export class SetupCommand extends BaseCommand {
 
       await databaseService.updateGuildConfig(guildId, config);
     } catch (error) {
-      this.services.logService.error(error as Error);
-
-      if (error instanceof Error && error.message === "Too many subrequests.") {
-        return;
-      }
-
-      await discordService.updateDeferredReply(interaction.token, {
-        content: `Failed to update stats display mode: ${error instanceof Error ? error.message : "unknown"}`,
-      });
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
 
@@ -1236,15 +1220,7 @@ export class SetupCommand extends BaseCommand {
 
       await this.setupSelectNeatQueueIntegrationJob(interaction);
     } catch (error) {
-      this.services.logService.error(error as Error);
-
-      if (error instanceof Error && error.message === "Too many subrequests.") {
-        return;
-      }
-
-      await discordService.updateDeferredReply(interaction.token, {
-        content: `Failed to save NeatQueue integration: ${error instanceof Error ? error.message : "unknown"}`,
-      });
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
 
@@ -1411,15 +1387,7 @@ export class SetupCommand extends BaseCommand {
         ],
       });
     } catch (error) {
-      this.services.logService.error(error as Error);
-
-      if (error instanceof Error && error.message === "Too many subrequests.") {
-        return;
-      }
-
-      await discordService.updateDeferredReply(interactionToken, {
-        content: `Failed to edit NeatQueue integration: ${error instanceof Error ? error.message : "unknown"}`,
-      });
+      await discordService.updateDeferredReplyWithError(interactionToken, error);
     }
   }
 
@@ -1521,7 +1489,7 @@ export class SetupCommand extends BaseCommand {
   private async setupNeatQueueIntegrationEditChannelWebhookSecretJob(
     interaction: APIModalSubmitInteraction,
   ): Promise<void> {
-    const { discordService, databaseService, logService, neatQueueService } = this.services;
+    const { discordService, databaseService, neatQueueService } = this.services;
 
     try {
       const guildId = Preconditions.checkExists(interaction.guild_id);
@@ -1545,15 +1513,7 @@ export class SetupCommand extends BaseCommand {
         "Webhook secret updated",
       );
     } catch (error) {
-      logService.error(error as Error);
-
-      if (error instanceof Error && error.message === "Too many subrequests.") {
-        return;
-      }
-
-      await discordService.updateDeferredReply(interaction.token, {
-        content: `Failed to edit NeatQueue integration: ${error instanceof Error ? error.message : "unknown"}`,
-      });
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
 
@@ -1562,7 +1522,7 @@ export class SetupCommand extends BaseCommand {
     updateConfigCallback: (config: NeatQueueConfigRow, selectedValue: string) => void,
     successMessage: string,
   ): Promise<void> {
-    const { discordService, databaseService, logService } = this.services;
+    const { discordService, databaseService } = this.services;
 
     try {
       const guildId = Preconditions.checkExists(interaction.guild_id);
@@ -1577,15 +1537,7 @@ export class SetupCommand extends BaseCommand {
       await databaseService.upsertNeatQueueConfig(neatQueueConfig);
       await this.setupNeatQueueIntegrationEditChannelJob(guildId, channelId, interaction.token, successMessage);
     } catch (error) {
-      logService.error(error as Error);
-
-      if (error instanceof Error && error.message === "Too many subrequests.") {
-        return;
-      }
-
-      await discordService.updateDeferredReply(interaction.token, {
-        content: `Failed to edit NeatQueue integration: ${error instanceof Error ? error.message : "unknown"}`,
-      });
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
 
@@ -1651,15 +1603,7 @@ export class SetupCommand extends BaseCommand {
       await databaseService.deleteNeatQueueConfig(guildId, channelId);
       await this.setupNeatQueueIntegrationEditJob(interaction, "NeatQueue integration deleted");
     } catch (error) {
-      this.services.logService.error(error as Error);
-
-      if (error instanceof Error && error.message === "Too many subrequests.") {
-        return;
-      }
-
-      await discordService.updateDeferredReply(interaction.token, {
-        content: `Failed to delete NeatQueue integration: ${error instanceof Error ? error.message : "unknown"}`,
-      });
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
 }

--- a/src/commands/stats/stats.mts
+++ b/src/commands/stats/stats.mts
@@ -80,12 +80,6 @@ export class StatsCommand extends BaseCommand {
               description: "The Queue number for the series",
               required: true,
             },
-            {
-              name: "private",
-              description: "Only provide the response to you instead of the channel",
-              required: false,
-              type: ApplicationCommandOptionType.Boolean,
-            },
           ],
         },
         {
@@ -184,16 +178,10 @@ export class StatsCommand extends BaseCommand {
   ): ExecuteResponse {
     const channel = Preconditions.checkExists(options.get("channel") as string, "Missing channel");
     const queue = Preconditions.checkExists(options.get("queue") as number, "Missing queue");
-    const ephemeral = (options.get("private") as boolean | undefined) ?? false;
-    const data: APIInteractionResponseDeferredChannelMessageWithSource["data"] = {};
-    if (ephemeral) {
-      data.flags = MessageFlags.Ephemeral;
-    }
 
     return {
       response: {
         type: InteractionResponseType.DeferredChannelMessageWithSource,
-        data,
       },
       jobToComplete: async () => this.neatQueueSubCommandJob(interaction, channel, queue),
     };

--- a/src/commands/stats/stats.mts
+++ b/src/commands/stats/stats.mts
@@ -214,7 +214,7 @@ export class StatsCommand extends BaseCommand {
       ]);
       if (!queueData) {
         throw new Error(
-          `No queue found within the last 100 messages of <#${channel}>, with queue number ${queue.toLocaleString(locale)}`,
+          `No queue found within the last 100 messages of <#${channel}>, with queue number ${queue.toString()}`,
         );
       }
 
@@ -307,7 +307,7 @@ export class StatsCommand extends BaseCommand {
       }
 
       await discordService.updateDeferredReply(interaction.token, {
-        content: `Failed to fetch (Channel: <#${channel}>, queue: ${queue.toLocaleString(locale)}): ${error instanceof Error ? error.message : "unknown"}`,
+        content: `Failed to fetch (Channel: <#${channel}>, queue: ${queue.toString()}): ${error instanceof Error ? error.message : "unknown"}`,
       });
     }
   }

--- a/src/commands/stats/tests/stats.test.mts
+++ b/src/commands/stats/tests/stats.test.mts
@@ -131,7 +131,6 @@ describe("StatsCommand", () => {
       const { response, jobToComplete } = statsCommand.execute(applicationCommandInteractionStatsNeatQueue);
 
       expect(response).toEqual<APIInteractionResponse>({
-        data: {},
         type: InteractionResponseType.DeferredChannelMessageWithSource,
       });
       expect(jobToComplete).toBeInstanceOf(Function);

--- a/src/services/halo/halo.mts
+++ b/src/services/halo/halo.mts
@@ -8,6 +8,7 @@ import { AssociationReason, GamesRetrievable } from "../database/types/discord_a
 import type { DatabaseService } from "../database/database.mjs";
 import { UnreachableError } from "../../base/unreachable-error.mjs";
 import type { LogService } from "../log/types.mjs";
+import { EndUserError, EndUserErrorType } from "../../base/end-user-error.mjs";
 
 export interface MatchPlayer {
   id: string;
@@ -272,7 +273,7 @@ export class HaloService {
       if (error instanceof RequestError && error.response.status === 400) {
         this.logService.debug(error as Error);
 
-        throw new Error(`No user found with gamertag "${gamertag}"`);
+        throw new EndUserError(`No user found with gamertag "${gamertag}"`);
       }
 
       throw error;
@@ -283,7 +284,7 @@ export class HaloService {
     } catch (error) {
       this.logService.error(error as Error);
 
-      throw new Error("Unable to retrieve match history");
+      throw new EndUserError("Unable to retrieve match history");
     }
   }
 
@@ -413,8 +414,13 @@ export class HaloService {
     }
 
     if (!userMatches.size) {
-      throw new Error(
+      throw new EndUserError(
         "No matches found either because discord users could not be resolved to xbox users or no matches visible in Halo Waypoint",
+        {
+          handled: true,
+          title: "No matches found",
+          errorType: EndUserErrorType.WARNING,
+        },
       );
     }
 


### PR DESCRIPTION
## Context

Presently, if someone subs in for another individual, and no games have been played, the stats don't get posted because the logic throws an exception when no matches are found.

This PR handles scenario where an error may be thrown from sub taking place (just log it and keep going).

Additionally, reworked errors:
1. introduce `EndUserError` which allows for us to create errors with a discord embed output
2. update `DiscordService` with consolidation of error output logic back to the user
3. migrate appropriate usages where we know it's an appropriate issue for the user to these `EndUserError`s
4. be more generic in scenarios where the end user shouldn't know about issues due to underlying reasons

This also sets the groundwork for some additional capabilities in the future around the error state.