### PR TITLE
Substitution: disregard if event is before TEAMS_CREATED

### DIFF
--- a/src/services/halo/halo.mts
+++ b/src/services/halo/halo.mts
@@ -52,11 +52,16 @@ export class HaloService {
   }
 
   async getSeriesFromDiscordQueue(queueData: SeriesData): Promise<MatchStats[]> {
-    const noMatchError = new Error(
+    const noMatchError = new EndUserError(
       [
         "Unable to match any of the Discord users to their Xbox accounts.",
         "**How to fix**: Players from the series, please run `/connect` to link your Xbox account, then try again.",
       ].join("\n"),
+      {
+        title: "No matches found",
+        errorType: EndUserErrorType.WARNING,
+        handled: true,
+      },
     );
 
     const users = queueData.teams.flat();

--- a/src/services/neatqueue/neatqueue.mts
+++ b/src/services/neatqueue/neatqueue.mts
@@ -379,11 +379,15 @@ export class NeatQueueService {
           break;
         }
         case "SUBSTITUTION": {
-          endDateTime = new Date(timestamp);
+          if (!startDateTime) {
+            this.logService.debug("Substitution event before teams created, skipping");
+            break;
+          }
+
           try {
             const series = await this.getSeriesData(
               Preconditions.checkExists(seriesTeams, "expected seriesTeams"),
-              startDateTime ?? sub(endDateTime, { hours: 6 }),
+              startDateTime,
               Preconditions.checkExists(endDateTime, "expected endDateTime"),
             );
 


### PR DESCRIPTION
## Context

In the event the that substitutions are happening before teams created, such as when a player never shows up, we can disregard this event.