### PR TITLE
StatsCommand: make channel and queue number optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,15 @@ A powerful [Discord Bot](https://discord.com/oauth2/authorize?client_id=12902694
 
 The stats command supports multiple modes for retrieving Halo match data:
 
-#### `/stats neatqueue <channel> <queue_number>`
+#### `/stats neatqueue [channel] [queue_number]`
 
-Retrieves statistics for a completed NeatQueue series:
+Retrieves statistics for a completed NeatQueue series. Both channel and queue number parameters are optional:
 
 ```
-/stats neatqueue #results 777
+/stats neatqueue                 # Uses current channel and most recent queue
+/stats neatqueue #results        # Uses specified channel and most recent queue
+/stats neatqueue 777             # Uses current channel and specified queue number
+/stats neatqueue #results 777    # Uses specified channel and queue number
 ```
 
 **Process Flow:**

--- a/src/commands/stats/tests/__snapshots__/stats.test.mts.snap
+++ b/src/commands/stats/tests/__snapshots__/stats.test.mts.snap
@@ -241,7 +241,7 @@ exports[`StatsCommand > execute(): subcommand neatqueue > jobToComplete > calls 
 11:8",
           },
         ],
-        "title": "Series stats for queue #5",
+        "title": "Series stats for queue #777",
         "url": "https://discord.com/channels/fake-guild-id/1234567890/1310523001611096064",
       },
     ],

--- a/src/commands/stats/tests/stats.test.mts
+++ b/src/commands/stats/tests/stats.test.mts
@@ -143,48 +143,6 @@ describe("StatsCommand", () => {
       expect(jobToComplete).toBeInstanceOf(Function);
     });
 
-    it("returns an error state for missing options 'channel'", () => {
-      vi.spyOn(services.discordService, "extractSubcommand")
-        .mockReset()
-        .mockReturnValue({
-          name: "neatqueue",
-          mappedOptions: new Map<string, APIApplicationCommandInteractionDataBasicOption["value"]>([["queue", 5]]),
-          options: [],
-        });
-
-      const { response, jobToComplete } = statsCommand.execute(applicationCommandInteractionStatsNeatQueue);
-      expect(response).toEqual({
-        type: InteractionResponseType.ChannelMessageWithSource,
-        data: {
-          content: "Error: Missing channel",
-          flags: MessageFlags.Ephemeral,
-        },
-      });
-      expect(jobToComplete).toBeUndefined();
-    });
-
-    it("returns an error state for missing options 'queue'", () => {
-      vi.spyOn(services.discordService, "extractSubcommand")
-        .mockReset()
-        .mockReturnValue({
-          name: "neatqueue",
-          mappedOptions: new Map<string, APIApplicationCommandInteractionDataBasicOption["value"]>([
-            ["channel", "1234567890"],
-          ]),
-          options: [],
-        });
-
-      const { response, jobToComplete } = statsCommand.execute(applicationCommandInteractionStatsNeatQueue);
-      expect(response).toEqual({
-        type: InteractionResponseType.ChannelMessageWithSource,
-        data: {
-          content: "Error: Missing queue",
-          flags: MessageFlags.Ephemeral,
-        },
-      });
-      expect(jobToComplete).toBeUndefined();
-    });
-
     describe("jobToComplete", () => {
       let jobToComplete: (() => Promise<void>) | undefined;
       let getTeamsFromQueueSpy: MockInstance<typeof services.discordService.getTeamsFromQueue>;
@@ -326,7 +284,7 @@ describe("StatsCommand", () => {
           expect(startThreadFromMessageSpy).toHaveBeenCalledWith(
             "1299532381308325949",
             "1314562775950954626",
-            "Queue #5 series stats",
+            "Queue #777 series stats",
           );
         });
 
@@ -528,7 +486,7 @@ describe("StatsCommand", () => {
         response: {
           type: InteractionResponseType.ChannelMessageWithSource,
           data: {
-            content: "Error: Missing subcommand options",
+            content: "Error: Unknown subcommand",
             flags: MessageFlags.Ephemeral,
           },
         },

--- a/src/services/discord/fakes/data.mts
+++ b/src/services/discord/fakes/data.mts
@@ -589,6 +589,7 @@ export const discordNeatQueueData: QueueData = {
     mention_everyone: false,
     tts: false,
   },
+  queue: 777,
   timestamp: new Date("2024-11-26T11:30:00.000Z"),
   teams: [
     {

--- a/src/services/discord/tests/discord.test.mts
+++ b/src/services/discord/tests/discord.test.mts
@@ -455,6 +455,7 @@ describe("DiscordService", () => {
 
       expect(result).toEqual<QueueData>({
         message: queueMessage,
+        queue: 7,
         timestamp: new Date("2024-12-06T11:05:39.576Z"),
         teams: [
           {


### PR DESCRIPTION
## Context

After some thinking and observation in Dog Crew Discord, there is a good chance that the `/stats` command is attempting to be used in the channel that already has the NeatQueue result message in it, and thus it is burdensome to have to supply the result channel and neatqueue result ID.

As a result, I've made these optional now, which should make it easier to execute the `/stats neatqueue` command.