### PR TITLE
Allow usage of GuildAnnouncement as well as GuildText

### DIFF
--- a/src/commands/setup/setup.mts
+++ b/src/commands/setup/setup.mts
@@ -146,7 +146,7 @@ const NeatQueueIntegrationWizardSteps: NeatQueueIntegrationWizardStep[] = [
     input: {
       type: ComponentType.ChannelSelect,
       custom_id: InteractionComponent.NeatQueueIntegrationAddWizardNext,
-      channel_types: [ChannelType.GuildText],
+      channel_types: [ChannelType.GuildText, ChannelType.GuildAnnouncement],
       min_values: 1,
       max_values: 1,
       placeholder: "Select the queue channel",
@@ -180,7 +180,7 @@ const NeatQueueIntegrationWizardSteps: NeatQueueIntegrationWizardStep[] = [
     input: {
       type: ComponentType.ChannelSelect,
       custom_id: InteractionComponent.NeatQueueIntegrationAddWizardNext,
-      channel_types: [ChannelType.GuildText],
+      channel_types: [ChannelType.GuildText, ChannelType.GuildAnnouncement],
       min_values: 1,
       max_values: 1,
       placeholder: "Select the results channel",
@@ -218,7 +218,7 @@ const NeatQueueIntegrationWizardSteps: NeatQueueIntegrationWizardStep[] = [
     input: {
       type: ComponentType.ChannelSelect,
       custom_id: InteractionComponent.NeatQueueIntegrationAddWizardNext,
-      channel_types: [ChannelType.GuildText],
+      channel_types: [ChannelType.GuildText, ChannelType.GuildAnnouncement],
       min_values: 1,
       max_values: 1,
       placeholder: "Select the results post channel",
@@ -1228,7 +1228,7 @@ export class SetupCommand extends BaseCommand {
         try {
           const channel = await discordService.getChannel(channelId);
 
-          if (channel.type !== ChannelType.GuildText) {
+          if (channel.type !== ChannelType.GuildText && channel.type !== ChannelType.GuildAnnouncement) {
             errors.set(channelId, `Channel <#${channelId}> is not a text channel, select a text channel.`);
             continue;
           }

--- a/src/services/discord/discord.mts
+++ b/src/services/discord/discord.mts
@@ -463,8 +463,8 @@ export class DiscordService {
     requiredPermissions: bigint[],
   ): { hasAll: boolean; missing: bigint[] } {
     try {
-      if (channel.type !== ChannelType.GuildText) {
-        throw new Error("Channel is not a text channel");
+      if (channel.type !== ChannelType.GuildText && channel.type !== ChannelType.GuildAnnouncement) {
+        throw new Error("Channel is not a text channel or announcement channel");
       }
 
       const effectivePermissions = this.calculateEffectivePermissions(guild, guildMember, channel);
@@ -547,7 +547,7 @@ export class DiscordService {
   private calculateEffectivePermissions(
     guild: APIGuild,
     member: APIGuildMember,
-    channel: APIGuildChannel<ChannelType.GuildText>,
+    channel: APIGuildChannel<ChannelType.GuildText | ChannelType.GuildAnnouncement>,
   ): bigint {
     console.log("\n=== Permission Calculation ===");
     const everyoneRole = guild.roles.find((role) => role.id === guild.id);


### PR DESCRIPTION
## Context

When helping Clutch Acadamy, they are using `GuildAnnouncement` channel instead of `GuildText`. We should be able to support both.