### PR TITLE
Fix URL for connect

### DIFF
--- a/src/commands/connect/connect.mts
+++ b/src/commands/connect/connect.mts
@@ -218,7 +218,8 @@ export class ConnectCommand extends BaseCommand {
       if (usersByXuids[0] != null) {
         searchedGamertag = usersByXuids[0].gamertag;
 
-        const thirdPartySites = [`[Halo Data Hive](<https://halodatahive.com/Player/Infinite/${searchedGamertag}>)`];
+        const url = new URL(`https://halodatahive.com/Player/Infinite/${searchedGamertag}`);
+        const thirdPartySites = [`[Halo Data Hive](<${url.href}>)`];
 
         currentAssociation = [
           `**Halo account:** ${searchedGamertag}`,


### PR DESCRIPTION
## Context

When executing the `/connect` mode, it has a link to the person's Halo Data Hive account.

It was noticed though that spaces can exist in user names, which I didn't take into account prior.

This PR leverages the `URL` capability to auto encode the URL correctly.