### PR TITLE
Connect button

### DIFF
--- a/src/base/end-user-error.mts
+++ b/src/base/end-user-error.mts
@@ -35,7 +35,7 @@ export class EndUserError extends Error {
   readonly errorType: EndUserErrorType;
   readonly handled: boolean;
   readonly actions: EndUserErrorAction[] | undefined;
-  readonly callbackType: "stats" | undefined;
+  callbackType: "stats" | undefined;
   readonly data: Record<string, string>;
 
   constructor(
@@ -98,7 +98,7 @@ export class EndUserError extends Error {
               style: ButtonStyle.Primary,
               custom_id: "btn_connect_initiate", // TODO: work out how to share with connect command that doesn't create circular dependency
               emoji: {
-                name: "🔌",
+                name: "🔗",
               },
             });
             break;
@@ -131,10 +131,11 @@ export class EndUserError extends Error {
       for (const field of fields) {
         const [key, value] = field.split(": ");
         if (key != null && value != null) {
-          if (key === "Callback") {
+          const formattedKey = key.replace(/\*\*/g, "").trim();
+          if (formattedKey === "Callback") {
             callbackType = value.trim() as "stats";
           } else {
-            data[key.replace(/\*\*/g, "").trim()] = value.trim();
+            data[formattedKey] = value.trim();
           }
         }
       }

--- a/src/base/tests/end-user-error.test.mts
+++ b/src/base/tests/end-user-error.test.mts
@@ -1,0 +1,253 @@
+import type { APIEmbed } from "discord-api-types/v10";
+import { ButtonStyle, ComponentType, EmbedType } from "discord-api-types/v10";
+import { describe, it, expect } from "vitest";
+import { EndUserError, EndUserErrorType, EndUserErrorColor } from "../end-user-error.mjs";
+
+describe("EndUserError", () => {
+  describe("constructor", () => {
+    it("creates an error with default options", () => {
+      const error = new EndUserError("Something went wrong");
+
+      expect(error.endUserMessage).toBe("Something went wrong");
+      expect(error.title).toBe("Something went wrong");
+      expect(error.errorType).toBe(EndUserErrorType.ERROR);
+      expect(error.handled).toBe(false);
+      expect(error.actions).toBeUndefined();
+      expect(error.callbackType).toBeUndefined();
+      expect(error.data).toEqual({});
+    });
+
+    it("creates an error with custom options", () => {
+      const error = new EndUserError("Custom error message", {
+        title: "Custom Title",
+        errorType: EndUserErrorType.WARNING,
+        handled: true,
+        actions: ["connect"],
+        callbackType: "stats",
+        data: { key: "value" },
+      });
+
+      expect(error.endUserMessage).toBe("Custom error message");
+      expect(error.title).toBe("Custom Title");
+      expect(error.errorType).toBe(EndUserErrorType.WARNING);
+      expect(error.handled).toBe(true);
+      expect(error.actions).toEqual(["connect"]);
+      expect(error.callbackType).toBe("stats");
+      expect(error.data).toEqual({ key: "value" });
+    });
+
+    it("inherits from Error and preserves stack trace", () => {
+      const error = new EndUserError("Test error");
+
+      expect(error instanceof Error).toBe(true);
+      expect(error instanceof EndUserError).toBe(true);
+      expect(error.name).toBe("EndUserError");
+      expect(error.message).toBe("Test error");
+      expect(error.stack).toBeDefined();
+    });
+
+    it("handles inner error properly", () => {
+      const innerError = new Error("Inner error message");
+      const error = new EndUserError("Outer error", { innerError });
+
+      expect(error.endUserMessage).toBe("Outer error");
+      expect(error.message).toBe("Inner error message");
+      expect(error.stack).toContain("Inner error message");
+    });
+  });
+
+  describe("discordEmbed getter", () => {
+    it("creates an error embed with default settings", () => {
+      const error = new EndUserError("Something went wrong");
+      const embed = error.discordEmbed;
+
+      expect(embed.title).toBe("Something went wrong");
+      expect(embed.description).toBe("Something went wrong");
+      expect(embed.color).toBe(EndUserErrorColor.ERROR);
+      expect(embed.fields).toEqual([]);
+    });
+
+    it("creates a warning embed", () => {
+      const error = new EndUserError("Warning message", {
+        errorType: EndUserErrorType.WARNING,
+      });
+      const embed = error.discordEmbed;
+
+      expect(embed.title).toBe("Something went wrong");
+      expect(embed.description).toBe("Warning message");
+      expect(embed.color).toBe(EndUserErrorColor.WARNING);
+    });
+
+    it("creates an embed with custom title", () => {
+      const error = new EndUserError("Error message", {
+        title: "Custom Error Title",
+      });
+      const embed = error.discordEmbed;
+
+      expect(embed.title).toBe("Custom Error Title");
+      expect(embed.description).toBe("Error message");
+    });
+
+    it("includes additional data in fields", () => {
+      const error = new EndUserError("Error with data", {
+        data: { user: "123", action: "test" },
+      });
+      const embed = error.discordEmbed;
+
+      expect(embed.fields).toHaveLength(1);
+      expect(embed.fields?.[0]?.name).toBe("Additional Information");
+      expect(embed.fields?.[0]?.value).toContain("**user**: 123");
+      expect(embed.fields?.[0]?.value).toContain("**action**: test");
+    });
+
+    it("includes callback type in fields", () => {
+      const error = new EndUserError("Error with callback", {
+        callbackType: "stats",
+      });
+      const embed = error.discordEmbed;
+
+      expect(embed.fields).toHaveLength(1);
+      expect(embed.fields?.[0]?.value).toContain("**Callback**: stats");
+    });
+  });
+
+  describe("discordActions getter", () => {
+    it("returns empty array when no actions are specified", () => {
+      const error = new EndUserError("Test error");
+
+      expect(error.discordActions).toEqual([]);
+    });
+
+    it("returns empty array when actions array is empty", () => {
+      const error = new EndUserError("Test error", { actions: [] });
+
+      expect(error.discordActions).toEqual([]);
+    });
+
+    it("returns connect button when connect action is specified", () => {
+      const error = new EndUserError("Test error", { actions: ["connect"] });
+      const actions = error.discordActions;
+
+      expect(actions).toHaveLength(1);
+      expect(actions[0]).toEqual({
+        type: ComponentType.ActionRow,
+        components: [
+          {
+            type: ComponentType.Button,
+            style: ButtonStyle.Primary,
+            label: "Connect",
+            custom_id: "btn_connect_initiate",
+            emoji: {
+              name: "🔌",
+            },
+          },
+        ],
+      });
+    });
+  });
+
+  describe("fromDiscordEmbed static method", () => {
+    it("creates EndUserError from valid embed", () => {
+      const embed: APIEmbed = {
+        type: EmbedType.Rich,
+        title: "No matches found",
+        description:
+          "Unable to match any of the Discord users to their Xbox accounts.\n**How to fix**: Players from the series, click the connect button below to connect your Discord account to your Xbox account.",
+        color: 16776960,
+        fields: [
+          {
+            name: "Additional Information",
+            value:
+              "**Callback**: stats\n**Channel**: <#1000000000000000000>\n**Queue**: 2\n**Completed**: <t:1742634297:f>",
+            inline: false,
+          },
+        ],
+      };
+
+      const error = EndUserError.fromDiscordEmbed(embed);
+
+      expect(error).toBeInstanceOf(EndUserError);
+      expect(error?.endUserMessage).toBe(embed.description);
+      expect(error?.title).toBe(embed.title);
+      expect(error?.errorType).toBe(EndUserErrorType.WARNING);
+      expect(error?.handled).toBe(false);
+      expect(error?.callbackType).toBe("stats");
+      expect(error?.data).toEqual({
+        Channel: "<#1000000000000000000>",
+        Completed: "<t:1742634297:f>",
+        Queue: "2",
+      });
+    });
+
+    it("returns undefined for invalid embed", () => {
+      const embed = {
+        title: "Test",
+        description: "Test",
+        color: 0x123456, // Invalid color
+      };
+
+      const error = EndUserError.fromDiscordEmbed(embed);
+
+      expect(error).toBeUndefined();
+    });
+
+    it("handles callback type from embed", () => {
+      const embed = {
+        title: "Test Error",
+        description: "Test description",
+        color: EndUserErrorColor.WARNING,
+        fields: [
+          {
+            name: "Additional Information",
+            value: "Callback: stats\n**key**: value", // Note: Callback without markdown bold for the current parser
+          },
+        ],
+      };
+
+      const error = EndUserError.fromDiscordEmbed(embed);
+
+      expect(error?.callbackType).toBe("stats");
+      expect(error?.data).toEqual({ key: "value" });
+    });
+  });
+
+  describe("appendData method", () => {
+    it("appends new data to existing data", () => {
+      const error = new EndUserError("Test error", {
+        data: { existing: "value" },
+      });
+
+      error.appendData({ new: "data", another: "item" });
+
+      expect(error.data).toEqual({
+        existing: "value",
+        new: "data",
+        another: "item",
+      });
+    });
+
+    it("overwrites existing keys", () => {
+      const error = new EndUserError("Test error", {
+        data: { key: "old_value" },
+      });
+
+      error.appendData({ key: "new_value" });
+
+      expect(error.data).toEqual({ key: "new_value" });
+    });
+  });
+
+  describe("EndUserErrorType enum", () => {
+    it("has correct values", () => {
+      expect(EndUserErrorType.ERROR).toBe("error");
+      expect(EndUserErrorType.WARNING).toBe("warning");
+    });
+  });
+
+  describe("EndUserErrorColor enum", () => {
+    it("has correct color values", () => {
+      expect(EndUserErrorColor.ERROR).toBe(0xff0000); // Red
+      expect(EndUserErrorColor.WARNING).toBe(0xffff00); // Yellow
+    });
+  });
+});

--- a/src/commands/connect/tests/__snapshots__/connect.test.mts.snap
+++ b/src/commands/connect/tests/__snapshots__/connect.test.mts.snap
@@ -13,7 +13,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -25,14 +25,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -59,7 +52,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -71,14 +64,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -126,14 +112,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -215,14 +194,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -237,7 +209,11 @@ View profile on: [Halo Data Hive](<https://halodatahive.com/Player/Infinite/game
           },
           {
             "name": "No custom game matches found",
-            "value": "Go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+            "value": "To resolve, either:
+In game: open Settings, navigate to Accessibility tab, scroll down to Match History Privacy, set the "Matchmade Games" option to "Share", and set the "Non-Matchmade Games" option to "Share".
+Go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy): set '**Show ...**' for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.
+
+Once you have done this, try again.",
           },
         ],
         "title": "Connect Discord to Halo",
@@ -260,7 +236,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -272,14 +248,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -306,7 +275,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -318,14 +287,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -382,14 +344,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -471,14 +426,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -493,7 +441,11 @@ View profile on: [Halo Data Hive](<https://halodatahive.com/Player/Infinite/game
           },
           {
             "name": "No custom game matches found",
-            "value": "Go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+            "value": "To resolve, either:
+In game: open Settings, navigate to Accessibility tab, scroll down to Match History Privacy, set the "Matchmade Games" option to "Share", and set the "Non-Matchmade Games" option to "Share".
+Go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy): set '**Show ...**' for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.
+
+Once you have done this, try again.",
           },
         ],
         "title": "Connect Discord to Halo",
@@ -516,7 +468,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -528,14 +480,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -562,7 +507,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -574,14 +519,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -638,14 +576,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -727,14 +658,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -749,7 +673,11 @@ View profile on: [Halo Data Hive](<https://halodatahive.com/Player/Infinite/game
           },
           {
             "name": "No custom game matches found",
-            "value": "Go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+            "value": "To resolve, either:
+In game: open Settings, navigate to Accessibility tab, scroll down to Match History Privacy, set the "Matchmade Games" option to "Share", and set the "Non-Matchmade Games" option to "Share".
+Go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy): set '**Show ...**' for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.
+
+Once you have done this, try again.",
           },
         ],
         "title": "Connect Discord to Halo",
@@ -772,7 +700,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -784,14 +712,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -818,7 +739,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -830,14 +751,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -885,14 +799,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -974,14 +881,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -996,7 +896,11 @@ View profile on: [Halo Data Hive](<https://halodatahive.com/Player/Infinite/game
           },
           {
             "name": "No custom game matches found",
-            "value": "Go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+            "value": "To resolve, either:
+In game: open Settings, navigate to Accessibility tab, scroll down to Match History Privacy, set the "Matchmade Games" option to "Share", and set the "Non-Matchmade Games" option to "Share".
+Go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy): set '**Show ...**' for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.
+
+Once you have done this, try again.",
           },
         ],
         "title": "Connect Discord to Halo",
@@ -1019,7 +923,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -1031,14 +935,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -1065,7 +962,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -1077,14 +974,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -1111,7 +1001,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -1123,14 +1013,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -1157,7 +1040,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -1169,14 +1052,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -1233,14 +1109,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -1322,14 +1191,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > AssociationReaso
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -1344,7 +1206,11 @@ View profile on: [Halo Data Hive](<https://halodatahive.com/Player/Infinite/game
           },
           {
             "name": "No custom game matches found",
-            "value": "Go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+            "value": "To resolve, either:
+In game: open Settings, navigate to Accessibility tab, scroll down to Match History Privacy, set the "Matchmade Games" option to "Share", and set the "Non-Matchmade Games" option to "Share".
+Go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy): set '**Show ...**' for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.
+
+Once you have done this, try again.",
           },
         ],
         "title": "Connect Discord to Halo",
@@ -1367,7 +1233,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > No Association >
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -1379,14 +1245,7 @@ exports[`ConnectCommand > execute(): /command > jobToComplete > No Association >
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -1461,14 +1320,7 @@ exports[`ConnectCommand > execute(): InteractionButton.Confirm > jobToComplete >
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -1516,6 +1368,45 @@ Loss - 1:2 (198:256)",
 ]
 `;
 
+exports[`ConnectCommand > execute(): InteractionButton.Initiate > jobToComplete > calls updateDeferredReply with the expected opts 1`] = `
+[
+  "fake-token",
+  {
+    "components": [
+      {
+        "components": [
+          {
+            "custom_id": "btn_connect_change",
+            "emoji": {
+              "name": "🔗",
+            },
+            "label": "Connect new account",
+            "style": 1,
+            "type": 2,
+          },
+        ],
+        "type": 1,
+      },
+    ],
+    "content": "",
+    "embeds": [
+      {
+        "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
+
+Click the button below to search for your gamertag and recent game history.",
+        "fields": [
+          {
+            "name": "What Guilty Spark knows",
+            "value": "**Halo account:** *No account connected*",
+          },
+        ],
+        "title": "Connect Discord to Halo",
+      },
+    ],
+  },
+]
+`;
+
 exports[`ConnectCommand > execute(): InteractionButton.Remove > jobToComplete > calls updateDeferredReply with the expected opts 1`] = `
 [
   "fake-token",
@@ -1529,7 +1420,7 @@ exports[`ConnectCommand > execute(): InteractionButton.Remove > jobToComplete > 
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -1541,14 +1432,7 @@ exports[`ConnectCommand > execute(): InteractionButton.Remove > jobToComplete > 
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -1605,14 +1489,7 @@ exports[`ConnectCommand > execute(): InteractionButton.SearchCancel > jobToCompl
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -1673,7 +1550,7 @@ exports[`ConnectCommand > execute(): InteractionButton.SearchCancel > jobToCompl
               "name": "🔗",
             },
             "label": "Connect new account",
-            "style": 2,
+            "style": 1,
             "type": 2,
           },
         ],
@@ -1685,14 +1562,7 @@ exports[`ConnectCommand > execute(): InteractionButton.SearchCancel > jobToCompl
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -1740,14 +1610,7 @@ exports[`ConnectCommand > execute(): InteractionButton.SearchConfirm > jobToComp
       {
         "description": "Connecting your Discord account to Halo account, within Guilty Spark, allows Guilty Spark to find your matches and correctly track and report on series you have played.
 
-To make sure this all works, open up Halo Infinite and follow these steps:
-1. Open Settings
-2. Navigate to Accessibility tab
-3. Scroll down to Match History Privacy
-4. Set the Matchmade Games option to Share
-5. Set the Non-Matchmade Games option to Share
-
-Or you can go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+Click the button below to search for your gamertag and recent game history.",
         "fields": [
           {
             "name": "What Guilty Spark knows",
@@ -1836,7 +1699,7 @@ exports[`ConnectCommand > execute(): InteractionType.ModalSubmit GamertagSearchM
     "content": "",
     "embeds": [
       {
-        "description": "Please confirm the recent game history for yourself below:",
+        "description": "Please confirm the recent custom game history for yourself below:",
         "fields": [
           {
             "inline": true,
@@ -1905,11 +1768,15 @@ exports[`ConnectCommand > execute(): InteractionType.ModalSubmit GamertagSearchM
     "content": "",
     "embeds": [
       {
-        "description": "Please confirm the recent game history for yourself below:",
+        "description": "Please confirm the recent custom game history for yourself below:",
         "fields": [
           {
             "name": "No custom game matches found",
-            "value": "Go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy) and ensure '**Show ...**' is set for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.",
+            "value": "To resolve, either:
+In game: open Settings, navigate to Accessibility tab, scroll down to Match History Privacy, set the "Matchmade Games" option to "Share", and set the "Non-Matchmade Games" option to "Share".
+Go to [**Halo Waypoint Privacy settings**](https://www.halowaypoint.com/settings/privacy): set '**Show ...**' for both 'Halo Infinite matchmade games' and 'Halo Infinite Non-Matchmade Games'.
+
+Once you have done this, try again.",
           },
         ],
         "title": "Gamertag search for "gamertag0000000000001"",

--- a/src/commands/stats/stats.mts
+++ b/src/commands/stats/stats.mts
@@ -178,7 +178,7 @@ export class StatsCommand extends BaseCommand {
       ]);
       if (!queueData) {
         throw new EndUserError(
-          `No queue found within the last 100 messages of <#${channel}>${queue != null ? `, with queue number ${queue.toString()}` : ""}`,
+          `No queue found within the last 100 messages of <#${channel}>${queue != null ? `, with queue number ${queue.toString()}` : ""}. If the results are in a different channel to this one, please specify the channel with the \`/stats neatqueue channel:\` option.`,
           {
             errorType: EndUserErrorType.WARNING,
             handled: true,

--- a/src/commands/stats/stats.mts
+++ b/src/commands/stats/stats.mts
@@ -170,6 +170,8 @@ export class StatsCommand extends BaseCommand {
   ): Promise<void> {
     const { databaseService, discordService, haloService } = this.services;
     const locale = interaction.guild_locale ?? interaction.locale;
+    let computedQueue = queue;
+    let endDateTime: Date | undefined;
 
     try {
       const [guildConfig, queueData] = await Promise.all([
@@ -187,8 +189,9 @@ export class StatsCommand extends BaseCommand {
       }
       this.services.logService.debug("Found queue data", new Map([["queueData", JSON.stringify(queueData)]]));
 
+      computedQueue = queueData.queue;
       const startDateTime = subHours(queueData.timestamp, 6);
-      const endDateTime = queueData.timestamp;
+      endDateTime = queueData.timestamp;
       const series = await haloService.getSeriesFromDiscordQueue({
         teams: queueData.teams.map((team) =>
           team.players.map((player) => ({
@@ -275,6 +278,14 @@ export class StatsCommand extends BaseCommand {
 
       await haloService.updateDiscordAssociations();
     } catch (error) {
+      if (error instanceof EndUserError && computedQueue != null && endDateTime != null) {
+        error.callbackType = "stats";
+        error.appendData({
+          Channel: `<#${channel}>`,
+          Queue: computedQueue.toString(),
+          Completed: discordService.getTimestamp(endDateTime.toISOString()),
+        });
+      }
       await discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }

--- a/src/commands/stats/tests/stats.test.mts
+++ b/src/commands/stats/tests/stats.test.mts
@@ -188,12 +188,12 @@ describe("StatsCommand", () => {
         await jobToComplete?.();
 
         expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledOnce();
-        expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
-          "fake-token",
-          expect.objectContaining({
-            endUserMessage: "No queue found within the last 100 messages of <#1234567890>, with queue number 5",
-          }),
-        );
+        expect(updateDeferredReplyWithErrorSpy.mock.lastCall).toMatchInlineSnapshot(`
+          [
+            "fake-token",
+            [EndUserError: No queue found within the last 100 messages of <#1234567890>, with queue number 5. If the results are in a different channel to this one, please specify the channel with the \`/stats neatqueue channel:\` option.],
+          ]
+        `);
       });
 
       it('fetches series data from haloService using "getSeriesFromDiscordQueue" with expected data', async () => {

--- a/src/embeds/series-overview-embed.mts
+++ b/src/embeds/series-overview-embed.mts
@@ -9,6 +9,18 @@ interface SeriesOverviewEmbedOpts {
   haloService: HaloService;
 }
 
+export interface SeriesOverviewEmbedFinalTeams {
+  name: string;
+  playerIds: string[];
+}
+
+export interface SeriesOverviewEmbedSubstitution {
+  date: Date;
+  playerOut: string;
+  playerIn: string;
+  team: string;
+}
+
 export class SeriesOverviewEmbed {
   private readonly discordService: DiscordService;
   private readonly haloService: HaloService;
@@ -35,16 +47,8 @@ export class SeriesOverviewEmbed {
     locale: string;
     queue: number;
     series: MatchStats[];
-    finalTeams: {
-      name: string;
-      playerIds: string[];
-    }[];
-    substitutions: {
-      date: Date;
-      playerOut: string;
-      playerIn: string;
-      team: string;
-    }[];
+    finalTeams: SeriesOverviewEmbedFinalTeams[];
+    substitutions: SeriesOverviewEmbedSubstitution[];
     hideTeamsDescription: boolean;
   }): Promise<APIEmbed> {
     const titles = ["Game", "Duration", `Score${finalTeams.length === 2 ? " (🦅:🐍)" : ""}`];

--- a/src/embeds/tests/series-overview-embed.test.mts
+++ b/src/embeds/tests/series-overview-embed.test.mts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { MatchStats } from "halo-infinite-api";
+import { SeriesOverviewEmbed } from "../series-overview-embed.mjs";
+import type { SeriesOverviewEmbedFinalTeams, SeriesOverviewEmbedSubstitution } from "../series-overview-embed.mjs";
+import type { DiscordService } from "../../services/discord/discord.mjs";
+import type { HaloService } from "../../services/halo/halo.mjs";
+import { aFakeDiscordServiceWith } from "../../services/discord/fakes/discord.fake.mjs";
+import { aFakeHaloServiceWith } from "../../services/halo/fakes/halo.fake.mjs";
+import { matchStats } from "../../services/halo/fakes/data.mjs";
+
+describe("SeriesOverviewEmbed", () => {
+  let discordService: DiscordService;
+  let haloService: HaloService;
+  let seriesOverviewEmbed: SeriesOverviewEmbed;
+  let sampleMatchStats: MatchStats;
+
+  beforeEach(() => {
+    discordService = aFakeDiscordServiceWith();
+    haloService = aFakeHaloServiceWith();
+    seriesOverviewEmbed = new SeriesOverviewEmbed({ discordService, haloService });
+
+    // Get a sample match from the fake data
+    const matchStatsArray = Array.from(matchStats.values());
+    const [firstMatch] = matchStatsArray;
+    if (!firstMatch) {
+      throw new Error("No match stats available for testing");
+    }
+    sampleMatchStats = firstMatch;
+
+    vi.spyOn(haloService, "getGameTypeAndMap").mockResolvedValue("CTF on Bazaar");
+    vi.spyOn(haloService, "getReadableDuration").mockReturnValue("10m 30s");
+    vi.spyOn(haloService, "getMatchScore").mockReturnValue("3-1");
+    vi.spyOn(discordService, "getTimestamp").mockReturnValue("<t:1700000000:f>");
+  });
+
+  describe("getEmbed", () => {
+    it("creates an embed with final teams data", async () => {
+      const finalTeams: SeriesOverviewEmbedFinalTeams[] = [
+        {
+          name: "Team Alpha",
+          playerIds: ["user1", "user2"],
+        },
+        {
+          name: "Team Beta",
+          playerIds: ["user3", "user4"],
+        },
+      ];
+
+      const embed = await seriesOverviewEmbed.getEmbed({
+        guildId: "guild123",
+        channel: "channel123",
+        messageId: "message123",
+        locale: "en-US",
+        queue: 1,
+        series: [sampleMatchStats],
+        finalTeams,
+        substitutions: [],
+        hideTeamsDescription: false,
+      });
+
+      expect(embed).toBeDefined();
+      expect(embed.title).toContain("Series stats for queue #1");
+      expect(embed.fields).toBeDefined();
+      expect(embed.description).toContain("Team Alpha");
+      expect(embed.description).toContain("Team Beta");
+    });
+
+    it("creates an embed with substitutions", async () => {
+      const finalTeams: SeriesOverviewEmbedFinalTeams[] = [
+        {
+          name: "Team Alpha",
+          playerIds: ["user1", "user5"], // user5 substituted for user2
+        },
+        {
+          name: "Team Beta",
+          playerIds: ["user3", "user4"],
+        },
+      ];
+
+      const substitutions: SeriesOverviewEmbedSubstitution[] = [
+        {
+          playerIn: "user5",
+          playerOut: "user2",
+          date: new Date("2024-01-01T10:05:00Z"), // Before match start
+          team: "Team Alpha",
+        },
+      ];
+
+      const embed = await seriesOverviewEmbed.getEmbed({
+        guildId: "guild123",
+        channel: "channel123",
+        messageId: "message123",
+        locale: "en-US",
+        queue: 1,
+        series: [sampleMatchStats],
+        finalTeams,
+        substitutions,
+        hideTeamsDescription: false,
+      });
+
+      expect(embed).toBeDefined();
+      expect(embed.title).toContain("Series stats for queue #1");
+      // The substitution should appear in the embed since it happened before the match
+    });
+
+    it("handles hidden teams description", async () => {
+      const finalTeams: SeriesOverviewEmbedFinalTeams[] = [
+        {
+          name: "Team Alpha",
+          playerIds: ["user1", "user2"],
+        },
+        {
+          name: "Team Beta",
+          playerIds: ["user3", "user4"],
+        },
+      ];
+
+      const embed = await seriesOverviewEmbed.getEmbed({
+        guildId: "guild123",
+        channel: "channel123",
+        messageId: "message123",
+        locale: "en-US",
+        queue: 1,
+        series: [sampleMatchStats],
+        finalTeams,
+        substitutions: [],
+        hideTeamsDescription: true,
+      });
+
+      expect(embed).toBeDefined();
+      expect(embed.description).not.toContain("Team Alpha");
+      expect(embed.description).not.toContain("Team Beta");
+      expect(embed.description).toContain("Start time:");
+    });
+
+    it("handles empty substitutions array", async () => {
+      const finalTeams: SeriesOverviewEmbedFinalTeams[] = [
+        {
+          name: "Team Alpha",
+          playerIds: ["user1", "user2"],
+        },
+        {
+          name: "Team Beta",
+          playerIds: ["user3", "user4"],
+        },
+      ];
+
+      const embed = await seriesOverviewEmbed.getEmbed({
+        guildId: "guild123",
+        channel: "channel123",
+        messageId: "message123",
+        locale: "en-US",
+        queue: 1,
+        series: [sampleMatchStats],
+        finalTeams,
+        substitutions: [],
+        hideTeamsDescription: false,
+      });
+
+      expect(embed).toBeDefined();
+      expect(embed.fields).toBeDefined();
+      expect(embed.fields?.length).toBeGreaterThan(0);
+    });
+
+    it("includes correct game information in fields", async () => {
+      const finalTeams: SeriesOverviewEmbedFinalTeams[] = [
+        {
+          name: "Team Alpha",
+          playerIds: ["user1", "user2"],
+        },
+        {
+          name: "Team Beta",
+          playerIds: ["user3", "user4"],
+        },
+      ];
+
+      const getGameTypeAndMapSpy = vi.spyOn(haloService, "getGameTypeAndMap");
+      const getReadableDurationSpy = vi.spyOn(haloService, "getReadableDuration");
+      const getMatchScoreSpy = vi.spyOn(haloService, "getMatchScore");
+
+      const embed = await seriesOverviewEmbed.getEmbed({
+        guildId: "guild123",
+        channel: "channel123",
+        messageId: "message123",
+        locale: "en-US",
+        queue: 1,
+        series: [sampleMatchStats],
+        finalTeams,
+        substitutions: [],
+        hideTeamsDescription: false,
+      });
+
+      expect(getGameTypeAndMapSpy).toHaveBeenCalledWith(sampleMatchStats.MatchInfo);
+      expect(getReadableDurationSpy).toHaveBeenCalledWith(sampleMatchStats.MatchInfo.Duration, "en-US");
+      expect(getMatchScoreSpy).toHaveBeenCalledWith(sampleMatchStats, "en-US");
+
+      expect(embed.fields).toBeDefined();
+      expect(embed.fields?.some((field) => field.name === "Game")).toBe(true);
+      expect(embed.fields?.some((field) => field.name === "Duration")).toBe(true);
+      expect(embed.fields?.some((field) => field.name === "Score (🦅:🐍)")).toBe(true);
+    });
+  });
+});

--- a/src/services/discord/discord.mts
+++ b/src/services/discord/discord.mts
@@ -436,6 +436,17 @@ export class DiscordService {
     });
   }
 
+  async editMessage(
+    channelId: string,
+    messageId: string,
+    data: RESTPostAPIChannelMessageJSONBody,
+  ): Promise<RESTPatchAPIChannelMessageResult> {
+    return this.fetch<RESTPatchAPIChannelMessageResult>(Routes.channelMessage(channelId, messageId), {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    });
+  }
+
   async deleteMessage(channelId: string, messageId: string, reason: string): Promise<void> {
     await this.fetch(Routes.channelMessage(channelId, messageId), {
       method: "DELETE",
@@ -620,6 +631,16 @@ export class DiscordService {
     const unixTime = Math.floor(new Date(isoDate).getTime() / 1000);
 
     return `<t:${unixTime.toString()}:${format}>`;
+  }
+
+  getDateFromTimestamp(timestamp: string): Date {
+    const match = /<t:(\d+):[FfDdTtR]>/.exec(timestamp);
+    if (!match) {
+      throw new Error(`Invalid timestamp format: ${timestamp}`);
+    }
+
+    const unixTime = Number(match[1]);
+    return new Date(unixTime * 1000);
   }
 
   getReadableAssociationReason(association: DiscordAssociationsRow): string {

--- a/src/services/discord/discord.mts
+++ b/src/services/discord/discord.mts
@@ -344,8 +344,10 @@ export class DiscordService {
   async updateDeferredReplyWithError(interactionToken: string, error: unknown): Promise<APIMessage | undefined> {
     try {
       const endUserError = this.handleError(error as Error, this.logService);
+
       return await this.updateDeferredReply(interactionToken, {
         embeds: [endUserError.discordEmbed],
+        components: endUserError.discordActions,
       });
     } catch {
       return undefined;

--- a/src/services/discord/tests/discord.test.mts
+++ b/src/services/discord/tests/discord.test.mts
@@ -947,4 +947,51 @@ describe("DiscordService", () => {
       );
     });
   });
+
+  describe("editMessage()", () => {
+    it("edits a message", async () => {
+      const data = { content: "edited content" };
+      const mockResponse = { id: "message-id", content: "edited content" };
+      mockFetch.mockResolvedValue(new Response(JSON.stringify(mockResponse)));
+
+      const result = await discordService.editMessage("channel-id", "message-id", data);
+
+      expect(mockFetch).toHaveBeenCalledWith("https://discord.com/api/v10/channels/channel-id/messages/message-id", {
+        method: "PATCH",
+        body: JSON.stringify(data),
+        headers: new Headers({
+          Authorization: "Bot DISCORD_TOKEN",
+          "content-type": "application/json;charset=UTF-8",
+        }),
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe("getDateFromTimestamp()", () => {
+    it("converts a Discord timestamp to a Date", () => {
+      const timestamp = "<t:1733483139:f>";
+      const result = discordService.getDateFromTimestamp(timestamp);
+
+      expect(result).toEqual(new Date(1733483139 * 1000));
+    });
+
+    it("handles different timestamp formats", () => {
+      const formats = ["f", "F", "d", "D", "t", "T", "R"];
+
+      formats.forEach((format) => {
+        const timestamp = `<t:1733483139:${format}>`;
+        const result = discordService.getDateFromTimestamp(timestamp);
+        expect(result).toEqual(new Date(1733483139 * 1000));
+      });
+    });
+
+    it("throws an error for invalid timestamp format", () => {
+      expect(() => discordService.getDateFromTimestamp("invalid")).toThrow("Invalid timestamp format: invalid");
+    });
+
+    it("throws an error for malformed Discord timestamp", () => {
+      expect(() => discordService.getDateFromTimestamp("<t:abc:f>")).toThrow("Invalid timestamp format: <t:abc:f>");
+    });
+  });
 });

--- a/src/services/halo/halo.mts
+++ b/src/services/halo/halo.mts
@@ -55,12 +55,13 @@ export class HaloService {
     const noMatchError = new EndUserError(
       [
         "Unable to match any of the Discord users to their Xbox accounts.",
-        "**How to fix**: Players from the series, please run `/connect` to link your Xbox account, then try again.",
+        "**How to fix**: Players from the series, click the connect button below to connect your Discord account to your Xbox account.",
       ].join("\n"),
       {
         title: "No matches found",
         errorType: EndUserErrorType.WARNING,
         handled: true,
+        actions: ["connect"],
       },
     );
 

--- a/src/services/halo/halo.mts
+++ b/src/services/halo/halo.mts
@@ -35,6 +35,19 @@ export interface HaloServiceOpts {
   infiniteClient: HaloInfiniteClient;
 }
 
+const noMatchError = new EndUserError(
+  [
+    "Unable to match any of the Discord users to their Xbox accounts.",
+    "**How to fix**: Players from the series, click the connect button below to connect your Discord account to your Xbox account.",
+  ].join("\n"),
+  {
+    title: "No matches found",
+    errorType: EndUserErrorType.WARNING,
+    handled: true,
+    actions: ["connect"],
+  },
+);
+
 export class HaloService {
   private readonly logService: LogService;
   private readonly databaseService: DatabaseService;
@@ -52,19 +65,6 @@ export class HaloService {
   }
 
   async getSeriesFromDiscordQueue(queueData: SeriesData): Promise<MatchStats[]> {
-    const noMatchError = new EndUserError(
-      [
-        "Unable to match any of the Discord users to their Xbox accounts.",
-        "**How to fix**: Players from the series, click the connect button below to connect your Discord account to your Xbox account.",
-      ].join("\n"),
-      {
-        title: "No matches found",
-        errorType: EndUserErrorType.WARNING,
-        handled: true,
-        actions: ["connect"],
-      },
-    );
-
     const users = queueData.teams.flat();
     await this.populateUserCache(users, queueData.startDateTime, queueData.endDateTime);
 
@@ -379,9 +379,22 @@ export class HaloService {
   }
 
   private async getPlayerMatches(xboxUserId: string, startDate: Date, endDate: Date): Promise<PlayerMatchHistory[]> {
-    if (!this.playerMatchesCache.has(xboxUserId)) {
-      const playerMatches = await this.infiniteClient.getPlayerMatches(xboxUserId, MatchType.Custom, 40, 0);
-      this.playerMatchesCache.set(xboxUserId, playerMatches);
+    const history = this.playerMatchesCache.get(xboxUserId) ?? [];
+
+    if (!this.playerMatchesCache.has(xboxUserId) || history.length > 0) {
+      while (
+        history.length == 0 ||
+        isAfter(new Date(Preconditions.checkExists(history[history.length - 1]).MatchInfo.StartTime), startDate)
+      ) {
+        const matches = await this.infiniteClient.getPlayerMatches(xboxUserId, MatchType.Custom, 25, history.length);
+        history.push(...matches);
+
+        if (matches.length === 0) {
+          break;
+        }
+      }
+
+      this.playerMatchesCache.set(xboxUserId, history);
     }
 
     const playerMatches = Preconditions.checkExists(this.playerMatchesCache.get(xboxUserId));
@@ -420,14 +433,15 @@ export class HaloService {
     );
 
     if (!userMatches.size) {
-      throw new EndUserError(
-        "No matches found either because discord users could not be resolved to xbox users or no matches visible in Halo Waypoint",
-        {
-          handled: true,
+      if (this.playerMatchesCache.values().some((matches) => matches.length > 0)) {
+        throw new EndUserError("No matches found for the series", {
           title: "No matches found",
           errorType: EndUserErrorType.WARNING,
-        },
-      );
+          handled: true,
+        });
+      } else {
+        throw noMatchError;
+      }
     }
 
     // Get first player's matches as initial set

--- a/src/services/halo/tests/halo.test.mts
+++ b/src/services/halo/tests/halo.test.mts
@@ -147,7 +147,7 @@ describe("Halo service", () => {
       );
 
       return expect(haloService.getSeriesFromDiscordQueue(neatQueueSeriesData)).rejects.toThrow(
-        "Unable to match any of the Discord users to their Xbox accounts.\n**How to fix**: Players from the series, please run `/connect` to link your Xbox account, then try again.",
+        "Unable to match any of the Discord users to their Xbox accounts.\n**How to fix**: Players from the series, click the connect button below to connect your Discord account to your Xbox account.",
       );
     });
 
@@ -156,7 +156,7 @@ describe("Halo service", () => {
       infiniteClient.getUser.mockRejectedValue(new Error("User not found"));
 
       return expect(haloService.getSeriesFromDiscordQueue(neatQueueSeriesData)).rejects.toThrow(
-        "Unable to match any of the Discord users to their Xbox accounts.\n**How to fix**: Players from the series, please run `/connect` to link your Xbox account, then try again.",
+        "Unable to match any of the Discord users to their Xbox accounts.\n**How to fix**: Players from the series, click the connect button below to connect your Discord account to your Xbox account.",
       );
     });
 
@@ -165,7 +165,7 @@ describe("Halo service", () => {
       infiniteClient.getPlayerMatches.mockResolvedValue([]);
 
       return expect(haloService.getSeriesFromDiscordQueue(neatQueueSeriesData)).rejects.toThrow(
-        "Unable to match any of the Discord users to their Xbox accounts.\n**How to fix**: Players from the series, please run `/connect` to link your Xbox account, then try again.",
+        "Unable to match any of the Discord users to their Xbox accounts.\n**How to fix**: Players from the series, click the connect button below to connect your Discord account to your Xbox account.",
       );
     });
   });

--- a/src/services/neatqueue/neatqueue.mts
+++ b/src/services/neatqueue/neatqueue.mts
@@ -1,15 +1,19 @@
 import { createHmac } from "crypto";
 import { inspect } from "util";
 import type { MatchStats, GameVariantCategory } from "halo-infinite-api";
-import type { RESTPostAPIChannelThreadsResult, APIEmbed } from "discord-api-types/v10";
-import { ComponentType } from "discord-api-types/v10";
+import type { RESTPostAPIChannelThreadsResult, APIEmbed, APIMessage } from "discord-api-types/v10";
+import { ChannelType, ComponentType } from "discord-api-types/v10";
 import { sub, isAfter } from "date-fns";
 import type { DatabaseService } from "../database/database.mjs";
 import type { NeatQueueConfigRow } from "../database/types/neat_queue_config.mjs";
 import { NeatQueuePostSeriesDisplayMode } from "../database/types/neat_queue_config.mjs";
 import type { DiscordService } from "../discord/discord.mjs";
-import type { HaloService } from "../halo/halo.mjs";
+import type { HaloService, MatchPlayer } from "../halo/halo.mjs";
 import { Preconditions } from "../../base/preconditions.mjs";
+import type {
+  SeriesOverviewEmbedFinalTeams,
+  SeriesOverviewEmbedSubstitution,
+} from "../../embeds/series-overview-embed.mjs";
 import { SeriesOverviewEmbed } from "../../embeds/series-overview-embed.mjs";
 import { SeriesTeamsEmbed } from "../../embeds/series-teams-embed.mjs";
 import { SeriesPlayersEmbed } from "../../embeds/series-players-embed.mjs";
@@ -118,6 +122,174 @@ export class NeatQueueService {
     }
   }
 
+  async handleRetry({
+    errorEmbed,
+    guildId,
+    message,
+  }: {
+    errorEmbed: EndUserError;
+    guildId: string;
+    message: APIMessage;
+  }): Promise<void> {
+    const { discordService, haloService, logService } = this;
+
+    try {
+      const channel = await discordService.getChannel(message.channel_id);
+
+      if (channel.type != ChannelType.GuildText && channel.type != ChannelType.PublicThread) {
+        logService.warn("Expected channel for retry", new Map([["channel", channel.id]]));
+        return;
+      }
+
+      const queueChannel = Preconditions.checkExists(errorEmbed.data["Channel"], "expected queue channel").substring(
+        2,
+        -1,
+      );
+      const queue = parseInt(Preconditions.checkExists(errorEmbed.data["Queue"], "expected queue number"), 10);
+      const startedTimestamp = discordService.getDateFromTimestamp(
+        Preconditions.checkExists(errorEmbed.data["Started"], "expected Started timestamp"),
+      );
+      const completedTimestamp = discordService.getDateFromTimestamp(
+        Preconditions.checkExists(errorEmbed.data["Completed"], "expected Completed timestamp"),
+      );
+      const substitutions = (errorEmbed.data["Substitutions"] ?? "")
+        .split(", ")
+        .map((substitution) => {
+          const match = /<@(\d+)> subbed in for <@(\d+)> on (.+)/.exec(substitution);
+          if (match == null) {
+            logService.warn("Failed to parse substitution", new Map([["substitution", substitution]]));
+            return null;
+          }
+          const [, playerInId, playerOutId, date] = match;
+          return {
+            playerInId: Preconditions.checkExists(playerInId, "expected playerInId for substitution"),
+            playerOutId: Preconditions.checkExists(playerOutId, "expected playerOutId for substitution"),
+            date: discordService.getDateFromTimestamp(
+              Preconditions.checkExists(date, "expected date for substitution"),
+            ),
+          };
+        })
+        .filter((substitution) => substitution !== null)
+        .reverse();
+
+      const queueMessage = await discordService.getTeamsFromQueue(queueChannel, queue);
+      if (queueMessage == null) {
+        logService.warn(
+          "Failed to find queue message for retry",
+          new Map([
+            ["messageId", message.id],
+            ["messageChannel", message.channel_id],
+          ]),
+        );
+
+        return;
+      }
+
+      const series: MatchStats[] = [];
+      const teams: MatchPlayer[][] = queueMessage.teams.map((team) =>
+        team.players.map((player) => ({
+          id: player.id,
+          username: player.username,
+          globalName: player.global_name,
+        })),
+      );
+      let endDateTime = completedTimestamp;
+      const substitutionsEmbed: SeriesOverviewEmbedSubstitution[] = [];
+      for (const substitution of substitutions) {
+        const { playerInId, playerOutId, date: startDateTime } = substitution;
+        const data = await haloService.getSeriesFromDiscordQueue({
+          teams,
+          startDateTime,
+          endDateTime,
+        });
+        series.unshift(...data);
+        endDateTime = startDateTime;
+
+        for (const team of teams) {
+          const playerIndex = team.findIndex((player) => player.id === playerOutId);
+          const users = await discordService.getUsers([playerInId]);
+          const user = Preconditions.checkExists(users[0], "expected user for substitution");
+
+          if (playerIndex !== -1) {
+            team[playerIndex] = { id: playerInId, username: user.username, globalName: user.global_name };
+            const teamIndex = queueMessage.teams.findIndex((t) => t.players.some((p) => p.id === playerOutId));
+            substitutionsEmbed.push({
+              playerIn: playerInId,
+              playerOut: playerOutId,
+              team: queueMessage.teams[teamIndex]?.name ?? `Team ${(teamIndex + 1).toLocaleString()}`,
+              date: startDateTime,
+            });
+            break;
+          }
+        }
+      }
+
+      const startData = await haloService.getSeriesFromDiscordQueue({
+        teams,
+        startDateTime: startedTimestamp,
+        endDateTime,
+      });
+      series.unshift(...startData);
+
+      const seriesOverviewEmbed = await this.getSeriesOverviewEmbed({
+        guildId,
+        channelId: queueMessage.message.channel_id,
+        messageId: queueMessage.message.id,
+        queue,
+        series,
+        finalTeams: queueMessage.teams.map((team) => ({
+          name: team.name,
+          playerIds: team.players.map((player) => player.id),
+        })),
+        substitutions: substitutionsEmbed,
+      });
+      await discordService.editMessage(message.channel_id, message.id, {
+        content: "",
+        embeds: [seriesOverviewEmbed],
+        components: [],
+      });
+
+      let threadId = message.channel_id;
+      if (channel.type !== ChannelType.PublicThread) {
+        const thread = await discordService.startThreadFromMessage(
+          queueMessage.message.channel_id,
+          queueMessage.message.id,
+          `Queue #${queue.toString()} series stats`,
+        );
+        threadId = thread.id;
+      }
+
+      await this.postSeriesDetailsToChannel(threadId, guildId, series);
+    } catch (error) {
+      if (error instanceof EndUserError) {
+        if (error.handled) {
+          this.logService.info("Handled end user error during retry", new Map([["error", error.message]]));
+        } else {
+          this.logService.error(error, new Map([["reason", "Unhandled end user error during retry"]]));
+        }
+
+        error.appendData({
+          ...errorEmbed.data,
+        });
+        await discordService.editMessage(message.channel_id, message.id, {
+          embeds: [error.discordEmbed],
+        });
+
+        return;
+      }
+
+      this.logService.error(error as Error, new Map([["reason", "Unhandled error during retry"]]));
+      const endUserError = new EndUserError("An unexpected error occurred while retrying the neat queue job");
+      endUserError.appendData({
+        ...errorEmbed.data,
+      });
+
+      await discordService.editMessage(message.channel_id, message.id, {
+        embeds: [endUserError.discordEmbed],
+      });
+    }
+  }
+
   private async findNeatQueueConfig(
     body: NeatQueueRequest,
     authorization: string,
@@ -138,11 +310,11 @@ export class NeatQueueService {
     const timeline = await this.getTimeline(request, neatQueueConfig);
     timeline.push({ timestamp: new Date().toISOString(), event: request });
 
-    let seriesData: MatchStats[] = [];
+    let series: MatchStats[] = [];
     let errorOccurred = false;
 
     try {
-      seriesData = await this.getSeriesDataFromTimeline(timeline, neatQueueConfig);
+      series = await this.getSeriesDataFromTimeline(timeline, neatQueueConfig);
     } catch (error) {
       this.logService.info(error as Error, new Map([["reason", "Failed to get series data from timeline"]]));
       errorOccurred = true;
@@ -151,8 +323,8 @@ export class NeatQueueService {
       await this.handlePostSeriesError(neatQueueConfig.PostSeriesMode, opts);
     }
 
-    if (!errorOccurred && seriesData.length > 0) {
-      const opts = { request, neatQueueConfig, seriesData, timeline };
+    if (!errorOccurred && series.length > 0) {
+      const opts = { request, neatQueueConfig, series, timeline };
       await this.handlePostSeriesData(neatQueueConfig.PostSeriesMode, opts);
     }
 
@@ -186,7 +358,7 @@ export class NeatQueueService {
     opts: {
       request: NeatQueueMatchCompletedRequest;
       neatQueueConfig: NeatQueueConfigRow;
-      seriesData: MatchStats[];
+      series: MatchStats[];
       timeline: NeatQueueTimelineEvent[];
     },
   ): Promise<void> {
@@ -240,7 +412,7 @@ export class NeatQueueService {
     timeline: NeatQueueTimelineEvent[],
     neatQueueConfig: NeatQueueConfigRow,
   ): Promise<MatchStats[]> {
-    const seriesData: MatchStats[] = [];
+    const series: MatchStats[] = [];
     let seriesTeams: NeatQueuePlayer[][] = [];
     let startDateTime: Date | null = null;
     let endDateTime: Date | null = null;
@@ -270,13 +442,10 @@ export class NeatQueueService {
           endDateTime = new Date(timestamp);
 
           try {
-            const series = await this.getSeriesData(
-              Preconditions.checkExists(seriesTeams, "expected seriesTeams"),
-              startDateTime,
-              endDateTime,
-            );
+            const mappedTeams: MatchPlayer[][] = await this.mapNeatQueueTeamsToMatchPlayers(seriesTeams);
+            const subSeries = await this.getSeriesData(mappedTeams, startDateTime, endDateTime);
 
-            seriesData.push(...series);
+            series.push(...subSeries);
           } catch (error) {
             // don't fail if its just a substitution
             this.logService.info(error as Error, new Map([["reason", "No series data from substitution"]]));
@@ -308,12 +477,13 @@ export class NeatQueueService {
             seriesTeams = event.teams;
           }
 
-          const series = await this.getSeriesData(
-            seriesTeams,
+          const mappedTeams: MatchPlayer[][] = await this.mapNeatQueueTeamsToMatchPlayers(seriesTeams);
+          const subSeries = await this.getSeriesData(
+            mappedTeams,
             startDateTime ?? sub(endDateTime, { hours: 6 }),
             endDateTime,
           );
-          seriesData.push(...series);
+          series.push(...subSeries);
           break;
         }
         default: {
@@ -322,14 +492,28 @@ export class NeatQueueService {
       }
     }
 
-    return seriesData;
+    return series;
   }
 
-  private async getSeriesData(
-    teams: NeatQueuePlayer[][],
-    startDateTime: Date,
-    endDateTime: Date,
-  ): Promise<MatchStats[]> {
+  private async mapNeatQueueTeamsToMatchPlayers(seriesTeams: NeatQueuePlayer[][]): Promise<MatchPlayer[][]> {
+    const mappedTeams: MatchPlayer[][] = [];
+    for (const team of seriesTeams) {
+      const mappedTeam: MatchPlayer[] = [];
+      for (const player of team) {
+        const users = await this.discordService.getUsers([player.id]);
+        const user = Preconditions.checkExists(users[0], "expected user for match completed");
+        mappedTeam.push({
+          id: player.id,
+          username: user.username,
+          globalName: user.global_name,
+        });
+      }
+      mappedTeams.push(mappedTeam);
+    }
+    return mappedTeams;
+  }
+
+  private async getSeriesData(teams: MatchPlayer[][], startDateTime: Date, endDateTime: Date): Promise<MatchStats[]> {
     const { haloService, discordService } = this;
     const users = await discordService.getUsers(teams.flatMap((team) => team.map((player) => player.id)));
 
@@ -353,12 +537,12 @@ export class NeatQueueService {
   private async postSeriesDataByThread({
     request,
     neatQueueConfig,
-    seriesData,
+    series,
     timeline,
   }: {
     request: NeatQueueMatchCompletedRequest;
     neatQueueConfig: NeatQueueConfigRow;
-    seriesData: MatchStats[];
+    series: MatchStats[];
     timeline: NeatQueueTimelineEvent[];
   }): Promise<void> {
     const { discordService } = this;
@@ -383,25 +567,29 @@ export class NeatQueueService {
       );
       useFallback = false;
 
+      const finalTeams = this.getTeams(request);
+      const substitutions = this.getSubstitutionsFromTimeline(timeline, finalTeams);
       const seriesOverviewEmbed = await this.getSeriesOverviewEmbed({
-        request,
+        guildId: request.guild,
         channelId,
         messageId,
-        seriesData,
-        timeline,
+        queue: request.match_number,
+        series,
+        finalTeams,
+        substitutions,
       });
       await discordService.createMessage(thread.id, {
         embeds: [seriesOverviewEmbed],
       });
 
-      await this.postSeriesDetailsToChannel(thread.id, request.guild, seriesData);
+      await this.postSeriesDetailsToChannel(thread.id, request.guild, series);
     } catch (error) {
       this.logService.warn(error as Error, new Map([["reason", "Failed to post series data to thread"]]));
 
       if (useFallback) {
         this.logService.info("Attempting to post direct to channel");
 
-        await this.postSeriesDataByChannel({ request, neatQueueConfig, seriesData, timeline });
+        await this.postSeriesDataByChannel({ request, neatQueueConfig, series, timeline });
       } else if (thread != null) {
         this.logService.info("Attempting to post error to thread");
 
@@ -462,12 +650,12 @@ export class NeatQueueService {
   private async postSeriesDataByChannel({
     request,
     neatQueueConfig,
-    seriesData,
+    series,
     timeline,
   }: {
     request: NeatQueueMatchCompletedRequest;
     neatQueueConfig: NeatQueueConfigRow;
-    seriesData: MatchStats[];
+    series: MatchStats[];
     timeline: NeatQueueTimelineEvent[];
   }): Promise<void> {
     const { discordService } = this;
@@ -482,12 +670,16 @@ export class NeatQueueService {
         throw new EndUserError("Failed to find the results message");
       }
 
+      const finalTeams = this.getTeams(request);
+      const substitutions = this.getSubstitutionsFromTimeline(timeline, finalTeams);
       const seriesOverviewEmbed = await this.getSeriesOverviewEmbed({
-        request,
+        guildId: request.guild,
         channelId: resultsMessage.message.channel_id,
         messageId: resultsMessage.message.id,
-        seriesData,
-        timeline,
+        queue: request.match_number,
+        series: series,
+        finalTeams,
+        substitutions,
       });
 
       const createdMessage = await discordService.createMessage(channelId, {
@@ -501,7 +693,7 @@ export class NeatQueueService {
       );
 
       channelId = thread.id;
-      await this.postSeriesDetailsToChannel(channelId, request.guild, seriesData);
+      await this.postSeriesDetailsToChannel(channelId, request.guild, series);
     } catch (error) {
       this.logService.error(error as Error, new Map([["reason", "Failed to post series data direct to channel"]]));
 
@@ -510,6 +702,33 @@ export class NeatQueueService {
         embeds: [endUserError.discordEmbed],
       });
     }
+  }
+
+  private getTeams(request: NeatQueueMatchCompletedRequest): SeriesOverviewEmbedFinalTeams[] {
+    return request.teams.map((team, teamIndex) => ({
+      name: team[0]?.team_name ?? `Team ${(teamIndex + 1).toLocaleString()}`,
+      playerIds: team.map((player) => player.id),
+    }));
+  }
+
+  private getSubstitutionsFromTimeline(
+    timeline: NeatQueueTimelineEvent[],
+    finalTeams: SeriesOverviewEmbedFinalTeams[],
+  ): SeriesOverviewEmbedSubstitution[] {
+    return timeline
+      .filter((event) => event.event.action === "SUBSTITUTION")
+      .map((event) => {
+        const { player_subbed_out, player_subbed_in } = event.event as NeatQueueSubstitutionRequest;
+        return {
+          date: new Date(event.timestamp),
+          playerOut: player_subbed_out.id,
+          playerIn: player_subbed_in.id,
+          team:
+            player_subbed_out.team_name ??
+            finalTeams[player_subbed_out.team_num - 1]?.name ??
+            `Team ${player_subbed_out.team_num.toLocaleString()}`,
+        };
+      });
   }
 
   private async postErrorByChannel({
@@ -536,29 +755,25 @@ export class NeatQueueService {
     }
   }
 
-  private async postSeriesDetailsToChannel(
-    channelId: string,
-    guildId: string,
-    seriesData: MatchStats[],
-  ): Promise<void> {
+  private async postSeriesDetailsToChannel(channelId: string, guildId: string, series: MatchStats[]): Promise<void> {
     const { databaseService, discordService, haloService } = this;
 
     const guildConfig = await databaseService.getGuildConfig(guildId);
 
     const seriesTeamsEmbed = new SeriesTeamsEmbed({ discordService, haloService, guildConfig, locale: this.locale });
-    const seriesTeamsEmbedOutput = await seriesTeamsEmbed.getSeriesEmbed(seriesData);
+    const seriesTeamsEmbedOutput = await seriesTeamsEmbed.getSeriesEmbed(series);
     await discordService.createMessage(channelId, {
       embeds: [seriesTeamsEmbedOutput],
     });
 
-    const seriesPlayers = await haloService.getPlayerXuidsToGametags(seriesData);
+    const seriesPlayers = await haloService.getPlayerXuidsToGametags(series);
     const seriesPlayersEmbed = new SeriesPlayersEmbed({
       discordService,
       haloService,
       guildConfig,
       locale: this.locale,
     });
-    const seriesPlayersEmbedsOutput = await seriesPlayersEmbed.getSeriesEmbed(seriesData, seriesPlayers, this.locale);
+    const seriesPlayersEmbedsOutput = await seriesPlayersEmbed.getSeriesEmbed(series, seriesPlayers, this.locale);
     for (const seriesPlayersEmbedOutput of seriesPlayersEmbedsOutput) {
       await discordService.createMessage(channelId, {
         embeds: [seriesPlayersEmbedOutput],
@@ -585,7 +800,7 @@ export class NeatQueueService {
         ],
       });
     } else {
-      for (const match of seriesData) {
+      for (const match of series) {
         const players = await haloService.getPlayerXuidsToGametags(match);
         const matchEmbed = this.getMatchEmbed(guildConfig, match, this.locale);
         const embed = await matchEmbed.getEmbed(match, players);
@@ -596,50 +811,32 @@ export class NeatQueueService {
   }
 
   private async getSeriesOverviewEmbed({
-    request,
+    guildId,
     channelId,
     messageId,
-    seriesData,
-    timeline,
+    queue,
+    series,
+    finalTeams,
+    substitutions,
   }: {
-    request: NeatQueueMatchCompletedRequest;
+    guildId: string;
     channelId: string;
     messageId: string;
-    seriesData: MatchStats[];
-    timeline: NeatQueueTimelineEvent[];
+    queue: number;
+    series: MatchStats[];
+    finalTeams: SeriesOverviewEmbedFinalTeams[];
+    substitutions: SeriesOverviewEmbedSubstitution[];
   }): Promise<APIEmbed> {
     const { discordService, haloService } = this;
     const seriesOverviewEmbed = new SeriesOverviewEmbed({ discordService, haloService });
-    const finalTeams = request.teams.map((team, teamIndex) => ({
-      name: team[0]?.team_name ?? `Team ${(teamIndex + 1).toLocaleString()}`,
-      playerIds: team.map((player) => player.id),
-    }));
-    const substitutions = timeline
-      .filter((event) => event.event.action === "SUBSTITUTION")
-      .map((event) => {
-        const { player_subbed_out, player_subbed_in } = event.event as NeatQueueSubstitutionRequest;
-        return {
-          date: new Date(event.timestamp),
-          playerOut: player_subbed_out.id,
-          playerIn: player_subbed_in.id,
-          team:
-            player_subbed_out.team_name ??
-            finalTeams[player_subbed_out.team_num - 1]?.name ??
-            `Team ${player_subbed_out.team_num.toLocaleString()}`,
-        };
-      });
-
     return await seriesOverviewEmbed.getEmbed({
-      guildId: request.guild,
+      guildId,
       channel: channelId,
       messageId,
       locale: this.locale,
-      queue: request.match_number,
-      series: seriesData,
-      finalTeams: request.teams.map((team, teamIndex) => ({
-        name: team[0]?.team_name ?? `Team ${(teamIndex + 1).toLocaleString()}`,
-        playerIds: team.map((player) => player.id),
-      })),
+      queue,
+      series,
+      finalTeams,
       substitutions,
       hideTeamsDescription: true,
     });


### PR DESCRIPTION
## Context

Presently, when stats are attempted to compute, if it cannot resolve, it simply tells folks to run the `/connect` command and go again. However, this isn't very intuitive.

A better approach would be to introduce a button with the stats output that would allow folks to click a "Connect" button, and once they do connect their halo gamertag, it should then go back and update the stats accordingly.

This PR does that.

## How has this been tested

Manually in test server, added tests.