### PR TITLE
Add NeatQueue Informer to the setup command

### DIFF
--- a/src/commands/stats/tests/stats.test.mts
+++ b/src/commands/stats/tests/stats.test.mts
@@ -30,6 +30,7 @@ import { matchStats, playerXuidsToGametags } from "../../../services/halo/fakes/
 import { Preconditions } from "../../../base/preconditions.mjs";
 import { StatsReturnType } from "../../../services/database/types/guild_config.mjs";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake.mjs";
+import { aFakeGuildConfigRow } from "../../../services/database/fakes/database.fake.mjs";
 
 const applicationCommandInteractionStatsNeatQueue: APIApplicationCommandInteraction = {
   ...fakeBaseAPIApplicationCommandInteraction,
@@ -289,11 +290,11 @@ describe("StatsCommand", () => {
         });
 
         it("adds series summary and game stats to the thread when guildConfig StatsReturn is SERIES_AND_GAMES", async () => {
-          const getGuildConfigSpy = vi.spyOn(services.databaseService, "getGuildConfig").mockResolvedValue({
-            GuildId: "fake-guild-id",
-            Medals: "Y",
-            StatsReturn: StatsReturnType.SERIES_AND_GAMES,
-          });
+          const getGuildConfigSpy = vi.spyOn(services.databaseService, "getGuildConfig").mockResolvedValue(
+            aFakeGuildConfigRow({
+              StatsReturn: StatsReturnType.SERIES_AND_GAMES,
+            }),
+          );
 
           await jobToComplete?.();
 
@@ -303,11 +304,11 @@ describe("StatsCommand", () => {
         });
 
         it("does not add games to the thread when guildConfig StatsReturn is SERIES_ONLY", async () => {
-          const getGuildConfigSpy = vi.spyOn(services.databaseService, "getGuildConfig").mockResolvedValue({
-            GuildId: "fake-guild-id",
-            Medals: "Y",
-            StatsReturn: StatsReturnType.SERIES_ONLY,
-          });
+          const getGuildConfigSpy = vi.spyOn(services.databaseService, "getGuildConfig").mockResolvedValue(
+            aFakeGuildConfigRow({
+              StatsReturn: StatsReturnType.SERIES_ONLY,
+            }),
+          );
 
           await jobToComplete?.();
 

--- a/src/services/database/database.mts
+++ b/src/services/database/database.mts
@@ -73,12 +73,13 @@ export class DatabaseService {
       GuildId: guildId,
       StatsReturn: StatsReturnType.SERIES_ONLY,
       Medals: "Y",
+      PlayerConnections: "Y",
     };
 
     if (autoCreate) {
       const insertStmt = this.DB.prepare(
-        "INSERT INTO GuildConfig (GuildId, StatsReturn, Medals) VALUES (?, ?, ?)",
-      ).bind(defaultConfig.GuildId, defaultConfig.StatsReturn, defaultConfig.Medals);
+        "INSERT INTO GuildConfig (GuildId, StatsReturn, Medals, PlayerConnections) VALUES (?, ?, ?, ?)",
+      ).bind(defaultConfig.GuildId, defaultConfig.StatsReturn, defaultConfig.Medals, defaultConfig.PlayerConnections);
 
       await insertStmt.run();
     }
@@ -99,6 +100,11 @@ export class DatabaseService {
     if (updates.Medals !== undefined) {
       setStatements.push("Medals = ?");
       values.push(updates.Medals);
+    }
+
+    if (updates.PlayerConnections !== undefined) {
+      setStatements.push("PlayerConnections = ?");
+      values.push(updates.PlayerConnections);
     }
 
     if (setStatements.length === 0) {

--- a/src/services/database/fakes/database.fake.mts
+++ b/src/services/database/fakes/database.fake.mts
@@ -29,6 +29,7 @@ export function aFakeGuildConfigRow(opts: Partial<GuildConfigRow> = {}): GuildCo
     GuildId: "discord_guild_01",
     Medals: "Y",
     StatsReturn: StatsReturnType.SERIES_ONLY,
+    PlayerConnections: "Y",
   };
 
   return {

--- a/src/services/database/schema.sql
+++ b/src/services/database/schema.sql
@@ -10,7 +10,8 @@ CREATE TABLE IF NOT EXISTS DiscordAssociations (
 CREATE TABLE IF NOT EXISTS GuildConfig (
     GuildId TEXT PRIMARY KEY,
     StatsReturn CHAR(1) CHECK(StatsReturn IN ('S', 'A')) NOT NULL DEFAULT 'S',
-    Medals CHAR(1) CHECK(Medals IN ('Y', 'N')) NOT NULL DEFAULT 'Y'
+    Medals CHAR(1) CHECK(Medals IN ('Y', 'N')) NOT NULL DEFAULT 'Y',
+    PlayerConnections CHAR(1) CHECK(PlayerConnections IN ('Y', 'N')) NOT NULL DEFAULT 'Y'
 );
 
 CREATE TABLE IF NOT EXISTS NeatQueueConfig (

--- a/src/services/database/types/guild_config.mts
+++ b/src/services/database/types/guild_config.mts
@@ -7,4 +7,5 @@ export interface GuildConfigRow {
   GuildId: string;
   StatsReturn: StatsReturnType;
   Medals: "Y" | "N";
+  PlayerConnections: "Y" | "N";
 }


### PR DESCRIPTION
## Context

To allow for other servers to leverage the newly introduced NeatQueue Informer, this PR adds the option to see it in the `/setup` command, which provides them the necessary instructions to make it work.

## How has this been tested

Manually, added tests.