### PR TITLE
Fix connect username not found

### DIFF
--- a/scripts/infinite-client.mts
+++ b/scripts/infinite-client.mts
@@ -22,8 +22,49 @@ const user = await client.getUser("soundmanD");
 await writeFile(path.join(__dirname, "user.json"), JSON.stringify(user, null, 2));
 
 /*
+const serviceRecord = await client.getUserServiceRecord(`xuid(${user.xuid})`);
+await writeFile(path.join(__dirname, "service-record.json"), JSON.stringify(serviceRecord, null, 2));
+*/
+
+/*
 const playerMatches = await client.getPlayerMatches(user.xuid, MatchType.Custom);
 await writeFile(path.join(__dirname, "player-matches.json"), JSON.stringify(playerMatches, null, 2));
+*/
+
+/*
+for (const playlistAssetId of serviceRecord.Subqueries.PlaylistAssetIds) {
+  try {
+    const playlist = await client.getPlaylist(playlistAssetId);
+    await writeFile(path.join(__dirname, `playlist-${playlistAssetId}.json`), JSON.stringify(playlist, null, 2));
+  } catch (error) {
+    console.error(`Failed to fetch playlist asset ID ${playlistAssetId}:`, error);
+  }
+}
+*/
+
+/*
+for (const seasonId of serviceRecord.Subqueries.SeasonIds) {
+  const match = /^Csr\/Seasons\/(.+)\.json$/.exec(seasonId);
+  if (!match) {
+    continue;
+  }
+  const [, season] = match;
+  if (season == null || season === "") {
+    continue;
+  }
+
+  try {
+    const playlistCsr = await client.getPlaylistCsr("edfef3ac-9cbe-4fa2-b949-8f29deafd483", [user.xuid], season);
+    await writeFile(path.join(__dirname, `playlist-csr-${season}.json`), JSON.stringify(playlistCsr, null, 2));
+  } catch (error) {
+    console.error(`Failed to fetch playlist CSR for season ${season}:`, error);
+  }
+}
+*/
+
+/*
+const playlistCsr = await client.getPlaylistCsr("edfef3ac-9cbe-4fa2-b949-8f29deafd483", [user.xuid], "CsrSeason9-1");
+await writeFile(path.join(__dirname, "playlist-csr-season9-1.json"), JSON.stringify(playlistCsr, null, 2));
 */
 
 /*

--- a/src/services/halo/halo.mts
+++ b/src/services/halo/halo.mts
@@ -290,7 +290,14 @@ export class HaloService {
       if (error instanceof RequestError && error.response.status === 400) {
         this.logService.debug(error as Error);
 
-        throw new EndUserError(`No user found with gamertag "${gamertag}"`);
+        throw new EndUserError(`No user found with gamertag "${gamertag}"`, {
+          title: "User Not Found",
+          handled: true,
+          errorType: EndUserErrorType.WARNING,
+          data: {
+            gamertag,
+          },
+        });
       }
 
       throw error;

--- a/src/services/halo/tests/halo.test.mts
+++ b/src/services/halo/tests/halo.test.mts
@@ -12,6 +12,7 @@ import { Preconditions } from "../../../base/preconditions.mjs";
 import { aFakeHaloInfiniteClient } from "../fakes/infinite-client.fake.mjs";
 import type { LogService } from "../../log/types.mjs";
 import { aFakeLogServiceWith } from "../../log/fakes/log.fake.mjs";
+import { EndUserError, EndUserErrorType } from "../../../base/end-user-error.mjs";
 
 describe("Halo service", () => {
   let logService: LogService;
@@ -533,8 +534,15 @@ describe("Halo service", () => {
 
       infiniteClient.getUser.mockRejectedValue(new RequestError(new URL("https://example.com"), response));
 
-      return expect(haloService.getRecentMatchHistory(gamertag)).rejects.toThrow(
-        `No user found with gamertag "${gamertag}"`,
+      return expect(haloService.getRecentMatchHistory(gamertag)).rejects.toThrowError(
+        new EndUserError(`No user found with gamertag "${gamertag}"`, {
+          title: "User Not Found",
+          handled: true,
+          errorType: EndUserErrorType.WARNING,
+          data: {
+            gamertag,
+          },
+        }),
       );
     });
 


### PR DESCRIPTION
## Context

When people attempt to "search" for their username when they are running `/connect` command, if the username was incorrectly inputted it presently throws and logs into sentry.

However, this should be considered a handled error. As a result, this PR is to update the `EndUserError` with `handled: true`.

## How has this been tested

Updated unit tests