### PR TITLE
improve connect user not found scenario

### DIFF
--- a/src/base/end-user-error.mts
+++ b/src/base/end-user-error.mts
@@ -26,7 +26,7 @@ export enum EndUserErrorType {
 
 export enum EndUserErrorColor {
   ERROR = 0xff0000,
-  WARNING = 0xffff00,
+  WARNING = 0xffa500,
 }
 
 export class EndUserError extends Error {

--- a/src/base/tests/end-user-error.test.mts
+++ b/src/base/tests/end-user-error.test.mts
@@ -153,7 +153,7 @@ describe("EndUserError", () => {
         title: "No matches found",
         description:
           "Unable to match any of the Discord users to their Xbox accounts.\n**How to fix**: Players from the series, click the connect button below to connect your Discord account to your Xbox account.",
-        color: 16776960,
+        color: 0xffa500,
         fields: [
           {
             name: "Additional Information",
@@ -247,7 +247,7 @@ describe("EndUserError", () => {
   describe("EndUserErrorColor enum", () => {
     it("has correct color values", () => {
       expect(EndUserErrorColor.ERROR).toBe(0xff0000); // Red
-      expect(EndUserErrorColor.WARNING).toBe(0xffff00); // Yellow
+      expect(EndUserErrorColor.WARNING).toBe(0xffa500); // Orange
     });
   });
 });

--- a/src/commands/connect/connect.mts
+++ b/src/commands/connect/connect.mts
@@ -587,6 +587,40 @@ export class ConnectCommand extends BaseCommand {
 
       await discordService.updateDeferredReply(interaction.token, content);
     } catch (error) {
+      if (error instanceof EndUserError && error.title === "User not found") {
+        await discordService.updateDeferredReply(interaction.token, {
+          embeds: [error.discordEmbed],
+          components: [
+            {
+              type: ComponentType.ActionRow,
+              components: [
+                {
+                  type: ComponentType.Button,
+                  style: ButtonStyle.Primary,
+                  label: "Try again",
+                  custom_id: InteractionButton.Change,
+                  emoji: { name: "🔄" },
+                },
+              ],
+            },
+            {
+              type: ComponentType.ActionRow,
+              components: [
+                {
+                  type: ComponentType.Button,
+                  style: ButtonStyle.Secondary,
+                  label: "Back",
+                  custom_id: InteractionButton.SearchCancel,
+                  emoji: { name: "🔙" },
+                },
+              ],
+            },
+          ],
+        });
+
+        return;
+      }
+
       await discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }

--- a/src/commands/connect/tests/connect.test.mts
+++ b/src/commands/connect/tests/connect.test.mts
@@ -464,7 +464,7 @@ describe("ConnectCommand", () => {
                     "edited_timestamp": null,
                     "embeds": [
                       {
-                        "color": 16776960,
+                        "color": 16753920,
                         "description": "Test description",
                         "fields": [
                           {

--- a/src/services/halo/halo.mts
+++ b/src/services/halo/halo.mts
@@ -291,7 +291,7 @@ export class HaloService {
         this.logService.debug(error as Error);
 
         throw new EndUserError(`No user found with gamertag "${gamertag}"`, {
-          title: "User Not Found",
+          title: "User not found",
           handled: true,
           errorType: EndUserErrorType.WARNING,
           data: {

--- a/src/services/halo/tests/halo-infinite-client-proxy.test.mts
+++ b/src/services/halo/tests/halo-infinite-client-proxy.test.mts
@@ -45,10 +45,12 @@ describe("createHaloInfiniteClientProxy", () => {
       ok: false,
       json: async () =>
         Promise.resolve({
-          message: "Proxy error message",
+          message: "400 from https://example.com/halo-infinite",
           stack: "proxy-stack",
           name: "ProxyError",
         }),
+      status: 500,
+      url: "https://example.com/halo-infinite",
     } as Response);
 
     const proxy = createHaloInfiniteClientProxy({ env });
@@ -62,9 +64,9 @@ describe("createHaloInfiniteClientProxy", () => {
     }
 
     expect(thrown).toBeInstanceOf(Error);
-    expect(thrown?.message).toBe("Proxy error message");
-    expect(thrown?.stack).toBe("proxy-stack");
-    expect(thrown?.name).toBe("ProxyError");
+    expect(thrown?.message).toBe("400 from https://example.com/halo-infinite");
+    expect(thrown?.stack).toBeDefined();
+    expect(thrown?.name).toBe("RequestError");
   });
 
   it("throws an error with the 'error' property if present in proxy error response", async () => {

--- a/src/services/halo/tests/halo.test.mts
+++ b/src/services/halo/tests/halo.test.mts
@@ -536,7 +536,7 @@ describe("Halo service", () => {
 
       return expect(haloService.getRecentMatchHistory(gamertag)).rejects.toThrowError(
         new EndUserError(`No user found with gamertag "${gamertag}"`, {
-          title: "User Not Found",
+          title: "User not found",
           handled: true,
           errorType: EndUserErrorType.WARNING,
           data: {


### PR DESCRIPTION
## Context

When a user does `/connect` and searches, but their gamertag isn't found, the present experience dead ends them.

Instead, we want to be able to let them search again or be able to navigate back to the `/connect` menu.

This PR introduces that.

## How has this been tested

Manually, updated tests