### PR TITLE
neatqueue maps: fix scenario for player connections = N and maps = button

### DIFF
--- a/src/services/neatqueue/neatqueue.mts
+++ b/src/services/neatqueue/neatqueue.mts
@@ -428,13 +428,36 @@ export class NeatQueueService {
           },
         );
         await discordService.createMessage(request.channel, embed.toMessageData());
+      } else if (
+        guildConfig.NeatQueueInformerMapsPost === MapsPostType.BUTTON &&
+        guildConfig.NeatQueueInformerPlayerConnections !== "Y"
+      ) {
+        await discordService.createMessage(request.channel, {
+          components: [
+            {
+              type: ComponentType.ActionRow,
+              components: [
+                {
+                  type: ComponentType.Button,
+                  style: ButtonStyle.Secondary,
+                  label: "Generate maps",
+                  custom_id: "btn_maps_initiate", // TODO: work out how to share with connect command that doesn't create circular dependency
+                  emoji: {
+                    name: "🗺️",
+                  },
+                },
+              ],
+            },
+          ],
+        });
       }
     } catch (error) {
-      logService.warn(error as Error, new Map([["reason", "Failed to post players message"]]));
+      logService.warn(error as Error, new Map([["reason", "Failed to post players message or maps button"]]));
 
       if ((error instanceof DiscordError && error.restError.code === 50001) || error === insufficientPermissionsError) {
         await databaseService.updateGuildConfig(request.guild, {
           NeatQueueInformerPlayerConnections: "N",
+          NeatQueueInformerMapsPost: MapsPostType.OFF,
         });
       }
     }

--- a/src/services/neatqueue/tests/neatqueue.test.mts
+++ b/src/services/neatqueue/tests/neatqueue.test.mts
@@ -322,9 +322,12 @@ describe("NeatQueueService", () => {
       });
 
       it("skips message creation when NeatQueueInformerPlayerConnections is disabled", async () => {
-        getGuildConfigSpy
-          .mockReset()
-          .mockResolvedValue(aFakeGuildConfigRow({ NeatQueueInformerPlayerConnections: "N" }));
+        getGuildConfigSpy.mockReset().mockResolvedValue(
+          aFakeGuildConfigRow({
+            NeatQueueInformerPlayerConnections: "N",
+            NeatQueueInformerMapsPost: MapsPostType.OFF,
+          }),
+        );
 
         await jobToComplete();
 
@@ -344,7 +347,10 @@ describe("NeatQueueService", () => {
 
         expect(updateGuildConfigSpy).toHaveBeenCalledWith(
           "guild-id",
-          expect.objectContaining({ NeatQueueInformerPlayerConnections: "N" }),
+          expect.objectContaining({
+            NeatQueueInformerPlayerConnections: "N",
+            NeatQueueInformerMapsPost: MapsPostType.OFF,
+          }),
         );
         expect(warnSpy).toHaveBeenCalledWith(expect.any(Error), expect.any(Map));
         expect(createMessageSpy).not.toHaveBeenCalled();
@@ -357,7 +363,10 @@ describe("NeatQueueService", () => {
 
         expect(updateGuildConfigSpy).toHaveBeenCalledWith(
           "guild-id",
-          expect.objectContaining({ NeatQueueInformerPlayerConnections: "N" }),
+          expect.objectContaining({
+            NeatQueueInformerPlayerConnections: "N",
+            NeatQueueInformerMapsPost: MapsPostType.OFF,
+          }),
         );
         expect(warnSpy).toHaveBeenCalledWith(expect.any(Error), expect.any(Map));
         expect(createMessageSpy).not.toHaveBeenCalled();
@@ -498,6 +507,24 @@ describe("NeatQueueService", () => {
         const messageString = JSON.stringify(messageData);
         expect(messageString).toContain("btn_connect_initiate");
         expect(messageString).not.toContain("btn_maps_initiate");
+      });
+
+      it("posts maps button when maps are set to BUTTON and player connections are disabled", async () => {
+        getGuildConfigSpy.mockReset().mockResolvedValue(
+          aFakeGuildConfigRow({
+            NeatQueueInformerPlayerConnections: "N",
+            NeatQueueInformerMapsPost: MapsPostType.BUTTON,
+          }),
+        );
+
+        await jobToComplete();
+
+        expect(createMessageSpy).toHaveBeenCalledTimes(1);
+        const [, messageData] = createMessageSpy.mock.calls[0] as [string, { components: unknown[] }];
+        const messageString = JSON.stringify(messageData);
+        expect(messageString).toContain("btn_maps_initiate");
+        expect(messageString).not.toContain("btn_connect_initiate");
+        expect(messageString).not.toContain("Players in queue");
       });
     });
 


### PR DESCRIPTION
This pull request enhances the behavior of the `NeatQueueService` to support posting a "Generate maps" button when player connections are disabled and the maps post type is set to BUTTON. It also updates error handling and ensures that both the implementation and tests consistently update and check the relevant guild configuration flags.

**Feature enhancements:**

* Added logic to `NeatQueueService` to post a "Generate maps" button (`btn_maps_initiate`) when `NeatQueueInformerPlayerConnections` is disabled and `NeatQueueInformerMapsPost` is set to BUTTON, improving the user experience for guilds with these settings.

**Error handling improvements:**

* Updated error logging and guild config update logic to set both `NeatQueueInformerPlayerConnections` and `NeatQueueInformerMapsPost` to "N" and "OFF" respectively when message posting fails due to insufficient permissions.

**Test coverage updates:**

* Updated tests to mock both `NeatQueueInformerPlayerConnections` and `NeatQueueInformerMapsPost` flags, ensuring correct behavior when player connections are disabled and maps posting is off. [[1]](diffhunk://#diff-5a85c6d5ff0df3520fb6c31c25d1d8a1aa6038b307998b1d769301a35a448970L325-R330) [[2]](diffhunk://#diff-5a85c6d5ff0df3520fb6c31c25d1d8a1aa6038b307998b1d769301a35a448970L347-R353) [[3]](diffhunk://#diff-5a85c6d5ff0df3520fb6c31c25d1d8a1aa6038b307998b1d769301a35a448970L360-R369)
* Added a new test verifying that the "Generate maps" button is posted when maps are set to BUTTON and player connections are disabled, and that other buttons or player messages are not shown in this scenario.