### PR TITLE
fix discord rate limit

### DIFF
--- a/src/services/discord/discord.mts
+++ b/src/services/discord/discord.mts
@@ -702,9 +702,12 @@ export class DiscordService {
 
     if (rateLimit != null && rateLimit.remaining === 0 && rateLimit.reset != null) {
       const now = Date.now();
-      if (now < rateLimit.reset) {
-        const timeUntilReset = rateLimit.reset - now;
-        await new Promise((resolve) => setTimeout(resolve, timeUntilReset));
+      const resetTimeMs = rateLimit.reset * 1000;
+      if (now < resetTimeMs) {
+        const timeUntilReset = resetTimeMs - now;
+        const maxWaitTime = 90 * 1000;
+        const waitTime = Math.min(timeUntilReset, maxWaitTime);
+        await new Promise((resolve) => setTimeout(resolve, waitTime));
       }
     }
 


### PR DESCRIPTION
This pull request improves how Discord rate limit reset times are handled in both the service logic and its tests. The main change is to ensure that reset times from Discord, which are provided in seconds, are properly converted to milliseconds before being used for delays. Additionally, a maximum wait time of 90 seconds is enforced to prevent excessive delays in worker environments. The test suite has also been updated to reflect these changes and to add new test coverage for these scenarios.

**Rate limit handling improvements:**

* Updated `DiscordService` to convert Discord's rate limit reset time from seconds to milliseconds before calculating the wait duration, and introduced a 90-second maximum wait time to prevent long delays.

**Test suite updates:**

* Refactored all relevant tests in `discord.test.mts` to use reset times in seconds (matching Discord's API), and ensured assertions and mocks reflect the new conversion logic. [[1]](diffhunk://#diff-a32ea95f2442b6fa26126972c99d6ae2156b29d30d700e6790574e73ed190e09L804-R810) [[2]](diffhunk://#diff-a32ea95f2442b6fa26126972c99d6ae2156b29d30d700e6790574e73ed190e09L821-R840) [[3]](diffhunk://#diff-a32ea95f2442b6fa26126972c99d6ae2156b29d30d700e6790574e73ed190e09L848-R855) [[4]](diffhunk://#diff-a32ea95f2442b6fa26126972c99d6ae2156b29d30d700e6790574e73ed190e09L872-R880) [[5]](diffhunk://#diff-a32ea95f2442b6fa26126972c99d6ae2156b29d30d700e6790574e73ed190e09L896-R903) [[6]](diffhunk://#diff-a32ea95f2442b6fa26126972c99d6ae2156b29d30d700e6790574e73ed190e09L913-R928) [[7]](diffhunk://#diff-a32ea95f2442b6fa26126972c99d6ae2156b29d30d700e6790574e73ed190e09L938-R985)
* Added new tests verifying that the rate limit reset time is properly converted from seconds to milliseconds, and that the 90-second maximum wait time is respected.