### PR TITLE
Fix live tracker repost

### DIFF
--- a/src/durable-objects/fakes/live-tracker-do.fake.mts
+++ b/src/durable-objects/fakes/live-tracker-do.fake.mts
@@ -56,11 +56,6 @@ export function aFakeLiveTrackerDOWith(opts: FakeLiveTrackerDOOpts = {}): FakeLi
         backoffMinutes: 3,
         lastSuccessTime: new Date().toISOString(),
       },
-      metrics: {
-        totalChecks: 1,
-        totalMatches: 0,
-        totalErrors: 0,
-      },
       lastMessageState: {
         matchCount: 0,
         substitutionCount: 0,

--- a/src/durable-objects/live-tracker-do.mts
+++ b/src/durable-objects/live-tracker-do.mts
@@ -948,8 +948,9 @@ export class LiveTrackerDO {
       await this.setState(trackerState);
 
       const { name } = channel;
-      const baseChannelName = name.replace(/ \([^)]+\)$/, "");
-      const newChannelName = `${baseChannelName} (${seriesScore})`;
+      const baseChannelName = name.replace(/(┊.+)$/, "");
+      // discord does not like spaces, and colons, so we replace them with special characters
+      const newChannelName = `${baseChannelName}┊${seriesScore.replace(":", "﹕")}`;
       if (name !== newChannelName) {
         await this.discordService.updateChannel(trackerState.channelId, {
           name: newChannelName,

--- a/src/durable-objects/live-tracker-do.mts
+++ b/src/durable-objects/live-tracker-do.mts
@@ -199,8 +199,6 @@ export class LiveTrackerDO {
       const currentTime = new Date();
       trackerState.lastUpdateTime = currentTime.toISOString();
 
-      await this.setState(trackerState);
-
       if (trackerState.liveMessageId != null && trackerState.liveMessageId !== "") {
         try {
           const nextAlarmInterval = this.getNextAlarmInterval(trackerState);
@@ -252,9 +250,10 @@ export class LiveTrackerDO {
             ]),
           );
           this.handleError(trackerState, `Discord update failed: ${String(error)}`);
-          await this.setState(trackerState);
         }
       }
+
+      await this.setState(trackerState);
 
       const nextAlarmInterval = this.getNextAlarmInterval(trackerState);
       await this.state.storage.setAlarm(Date.now() + nextAlarmInterval);
@@ -431,7 +430,6 @@ export class LiveTrackerDO {
       trackerState.checkCount += 1;
       const currentTime = new Date();
       trackerState.lastUpdateTime = currentTime.toISOString();
-      await this.setState(trackerState);
 
       if (trackerState.liveMessageId != null && trackerState.liveMessageId !== "") {
         const nextAlarmInterval = this.getNextAlarmInterval(trackerState);
@@ -460,6 +458,8 @@ export class LiveTrackerDO {
         await this.updateChannelName(trackerState, seriesScore, false);
         await this.updateLiveTrackerMessage(trackerState, liveTrackerEmbed);
       }
+
+      await this.setState(trackerState);
 
       return Response.json({ success: true, state: trackerState });
     } catch (error) {
@@ -944,8 +944,6 @@ export class LiveTrackerDO {
       if (!hasPermission) {
         return;
       }
-
-      await this.setState(trackerState);
 
       const { name } = channel;
       const baseChannelName = name.replace(/(┊.+)$/, "");

--- a/src/durable-objects/tests/live-tracker-do.test.mts
+++ b/src/durable-objects/tests/live-tracker-do.test.mts
@@ -1463,7 +1463,7 @@ describe("LiveTrackerDO", () => {
 
         expect(getChannelSpy).toHaveBeenCalledWith("test-channel-id");
         expect(updateChannelSpy).toHaveBeenCalledWith("test-channel-id", {
-          name: "my-queue-channel (1:0)",
+          name: "my-queue-channel┊1﹕0",
           reason: "Live Tracker: Updated series score to 1:0",
         });
       });
@@ -1492,7 +1492,7 @@ describe("LiveTrackerDO", () => {
 
         const mockChannel = {
           id: "test-channel-id",
-          name: "my-queue-channel (0:1)",
+          name: "my-queue-channel┊0﹕1",
           type: 0,
         };
         const getChannelSpy = vi.spyOn(services.discordService, "getChannel").mockResolvedValue(mockChannel);
@@ -1523,7 +1523,7 @@ describe("LiveTrackerDO", () => {
 
         expect(getChannelSpy).toHaveBeenCalledWith("test-channel-id");
         expect(updateChannelSpy).toHaveBeenCalledWith("test-channel-id", {
-          name: "my-queue-channel (1:0)",
+          name: "my-queue-channel┊1﹕0",
           reason: "Live Tracker: Updated series score to 1:0",
         });
       });


### PR DESCRIPTION
## Context

We aren't saving what the live tracker message ID is after it gets reposted, causing it to continuously post new messages.

Additionally, there is a misunderstanding as to how channel names work.

This PR fixes these issues.