### PR TITLE
Remove tail_consumers configuration for Sentry

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -109,11 +109,6 @@
           "database_id": "fa6747b9-e9e0-47ca-891b-d4608ade66a3",
         },
       ],
-      "tail_consumers": [
-        {
-          "service": "guilty-spark-tail",
-        },
-      ],
       "durable_objects": {
         "bindings": [
           {


### PR DESCRIPTION
- Removed tail_consumers config from production environment in wrangler.jsonc
- This eliminates the old log tail approach for Sentry integration
- The application now uses only the official @sentry/cloudflare integration
- Next step: manually delete the guilty-spark-tail worker from Cloudflare Dashboard