### PR TITLE
Fix live tracker match filtering after player substitutions

### DIFF
--- a/src/durable-objects/live-tracker-do.mts
+++ b/src/durable-objects/live-tracker-do.mts
@@ -889,7 +889,7 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   }
 
   private async enrichAndMergeMatches(trackerState: LiveTrackerState, matches: MatchStats[]): Promise<void> {
-    const trackingPlayers = Object.keys(trackerState.players);
+    const trackingPlayers = trackerState.teams.flatMap((team) => team.playerIds);
 
     for (const match of matches) {
       if (trackerState.discoveredMatches[match.MatchId] != null) {


### PR DESCRIPTION
Problem: After player substitutions in live tracking, the system was using `trackerState.players` to determine which players to track for matches. This included all historical players (including those who were substituted out), causing match filtering to be based on an incorrect player count.

Solution: Changed the filtering logic to use `trackerState.teams.flatMap((team) => team.playerIds)` which only includes currently active players in the teams.

Impact:

Live match discovery now correctly filters based on current roster only
Prevents matches from being incorrectly excluded when player substitutions occur
Ensures accurate match tracking throughout the duration of a queue
