### PR TITLE
DiscordService: fix no embed timestamp

### DIFF
--- a/src/services/discord/discord.mts
+++ b/src/services/discord/discord.mts
@@ -394,7 +394,7 @@ export class DiscordService {
 
     return {
       message,
-      timestamp: new Date(Preconditions.checkExists(embed.timestamp, "No timestamp found")),
+      timestamp: new Date(Preconditions.checkExists(embed.timestamp ?? message.timestamp, "No timestamp found")),
       queue: queueNumber,
       teams: fields.map((field) => ({
         name: cleanTeamNames ? field.name.replace(/__/g, "").trim() : field.name,


### PR DESCRIPTION
## Context

For some reason, embed timestamp doesn't appear on certain calls, so fallback to message timestamp if it isn't there.