### PR TITLE
DiscordService: better global 429 retry

### DIFF
--- a/src/services/discord/discord.mts
+++ b/src/services/discord/discord.mts
@@ -888,6 +888,18 @@ export class DiscordService {
       }
       this.logService.warn(error);
 
+      if (error instanceof DiscordError && error.httpStatus === 429 && error.restError.code === 1015 && !retry) {
+        this.setRateLimitInAppConfig(path, {
+          limit: 0,
+          remaining: 0,
+          reset: Date.now() / 1000 + 10,
+          resetAfter: 10,
+          bucket: undefined,
+        });
+
+        return this.fetch<T>(path, options, true);
+      }
+
       throw error;
     }
 


### PR DESCRIPTION
## Context

When receiving HTTP 429 with error code i was expecting there to be rate limit headers, but it doesn't appear to be the case.

I'm not sure if 10 seconds is sufficient for a retry but let's give it a go...