### PR TITLE
add resilient fetch to work around HTTP 429

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,26 @@ https://github.com/user-attachments/assets/bcaccc99-0815-4792-a7ea-2c320cd40ef7
    npm run ngrok
    ```
 
+## Technical Features
+
+### Resilient Halo API Integration
+
+Guilty Spark includes a sophisticated circuit breaker pattern to ensure reliable access to Halo Waypoint data:
+
+**Automatic Failover**: When rate limiting (HTTP 429/526) is detected, requests are automatically retried through a proxy service
+
+**Circuit Breaker**: After 3 rate limit errors within 15 minutes, the system automatically switches to proxy mode for 1 hour
+
+**Control Mechanisms**:
+
+- **Environment Variable**: `PROXY_WORKER_URL` - Set to proxy server URL (e.g., `https://haloquery.com/proxy`)
+- **Master Toggle**: `halo:proxy:enabled` KV key - Manual control via Cloudflare UI
+- **Auto-Activation**: `halo:proxy:circuit_breaker` KV key - Automatically managed during incidents
+
+**Error Tracking**: All proxy activations and rate limit errors are logged to Sentry for monitoring
+
+This ensures the bot remains operational even during Halo Waypoint API incidents, providing a seamless experience for users.
+
 ## Privacy & Security
 
 ### Data Handling

--- a/api/services/halo/fakes/resilient-fetch.fake.mts
+++ b/api/services/halo/fakes/resilient-fetch.fake.mts
@@ -1,0 +1,62 @@
+import type { CircuitBreakerState, ErrorWindow } from "../types.mjs";
+
+interface FakeCircuitBreakerStateOptions {
+  activatedAt?: number;
+  expiresAt?: number;
+  reason?: string;
+}
+
+export function aFakeCircuitBreakerStateWith(options: FakeCircuitBreakerStateOptions = {}): CircuitBreakerState {
+  const now = Date.now();
+  return {
+    activatedAt: options.activatedAt ?? now,
+    expiresAt: options.expiresAt ?? now + 60 * 60 * 1000, // 1 hour
+    reason: options.reason ?? "Rate limit errors detected",
+  };
+}
+
+interface FakeErrorWindowOptions {
+  windowStart?: number;
+  errorCount?: number;
+  statusCode?: number;
+  url?: string;
+}
+
+export function aFakeErrorWindowWith(options: FakeErrorWindowOptions = {}): ErrorWindow {
+  const now = Date.now();
+  const windowStart = options.windowStart ?? Math.floor(now / (15 * 60 * 1000));
+  const errorCount = options.errorCount ?? 0;
+  const statusCode = options.statusCode ?? 429;
+  const url = options.url ?? "https://halostats.svc.halowaypoint.com/test";
+
+  const errors = Array.from({ length: errorCount }, (_, i) => ({
+    timestamp: now - i * 1000,
+    statusCode,
+    url,
+  }));
+
+  return {
+    windowStart,
+    errors,
+  };
+}
+
+interface FakeResponseOptions {
+  status?: number;
+  statusText?: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+export function aFakeResponseWith(options: FakeResponseOptions = {}): Response {
+  const status = options.status ?? 200;
+  const statusText = options.statusText ?? "OK";
+  const body = options.body !== undefined ? JSON.stringify(options.body) : null;
+  const headers = new Headers(options.headers ?? {});
+
+  return new Response(body, {
+    status,
+    statusText,
+    headers,
+  });
+}

--- a/api/services/halo/resilient-fetch.mts
+++ b/api/services/halo/resilient-fetch.mts
@@ -1,0 +1,255 @@
+import { addMilliseconds, differenceInSeconds } from "date-fns";
+import type { LogService } from "../log/types.mjs";
+import {
+  type CircuitBreakerState,
+  type ErrorWindow,
+  type ProxyConfig,
+  ProxyType,
+  KV_KEYS,
+  CIRCUIT_BREAKER_CONFIG,
+  ISSUE_STATUS_CODES,
+} from "./types.mjs";
+
+interface ResilientFetchOptions {
+  env: Env;
+  logService: LogService;
+  proxyUrl: string;
+}
+
+interface DebounceEntry {
+  timeout: NodeJS.Timeout;
+  data: string;
+}
+
+function isValidUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function detectProxyType(proxyUrl: string): ProxyType {
+  if (!isValidUrl(proxyUrl)) {
+    return ProxyType.NONE;
+  }
+
+  // HaloQuery-style proxy uses /proxy in the path (with or without trailing slash)
+  if (proxyUrl.includes("/proxy")) {
+    return ProxyType.URL_REWRITE;
+  }
+
+  // Default to JSON-RPC for backward compatibility
+  return ProxyType.JSON_RPC;
+}
+
+function getErrorWindowKey(): string {
+  const windowStart = Math.floor(Date.now() / CIRCUIT_BREAKER_CONFIG.ERROR_WINDOW_MS);
+  return `${KV_KEYS.ERROR_WINDOW}:${windowStart.toString()}`;
+}
+
+function filterHeadersForProxy(headers: Headers): Headers {
+  const proxiedHeaders = new Headers();
+  const excludedHeaders = ["host", "content-length"];
+
+  // Convert headers to array to iterate
+  const headerArray = Array.from(headers as unknown as Iterable<[string, string]>);
+  for (const [key, value] of headerArray) {
+    if (!excludedHeaders.includes(key.toLowerCase())) {
+      proxiedHeaders.set(key, value);
+    }
+  }
+
+  return proxiedHeaders;
+}
+
+function transformUrlForProxy(originalUrl: string, proxyBaseUrl: string): string {
+  const url = new URL(originalUrl);
+  // Extract everything after the protocol and slashes
+  // Example: https://halostats.svc.halowaypoint.com/hi/players/...
+  // becomes: halostats.svc.halowaypoint.com/hi/players/...
+  const pathWithDomain = `${url.host}${url.pathname}${url.search}`;
+
+  // Ensure proxy base URL ends with /proxy/ or /proxy
+  let proxyBase = proxyBaseUrl;
+  if (!proxyBase.endsWith("/")) {
+    proxyBase += "/";
+  }
+
+  return `${proxyBase}${pathWithDomain}`;
+}
+
+export function createResilientFetch({ env, logService, proxyUrl }: ResilientFetchOptions): typeof fetch {
+  const proxyConfig: ProxyConfig = {
+    type: detectProxyType(proxyUrl),
+    baseUrl: proxyUrl,
+    enabled: isValidUrl(proxyUrl),
+  };
+
+  const kvDebounceMap = new Map<string, DebounceEntry>();
+
+  async function getMasterToggle(): Promise<boolean> {
+    const value = await env.APP_DATA.get(KV_KEYS.PROXY_ENABLED);
+    return value === "true";
+  }
+
+  async function getCircuitBreakerState(): Promise<CircuitBreakerState | null> {
+    return await env.APP_DATA.get<CircuitBreakerState>(KV_KEYS.CIRCUIT_BREAKER, "json");
+  }
+
+  function scheduleKvWrite(key: string, data: string, ttlSeconds: number): void {
+    const scheduleWrite = (dataToWrite: string): void => {
+      const timeout = setTimeout(() => {
+        void env.APP_DATA.put(key, dataToWrite, {
+          expirationTtl: ttlSeconds,
+        });
+        kvDebounceMap.delete(key);
+      }, 1000);
+
+      kvDebounceMap.set(key, { timeout, data: dataToWrite });
+    };
+
+    const existing = kvDebounceMap.get(key);
+    if (existing) {
+      clearTimeout(existing.timeout);
+      existing.data = data;
+      scheduleWrite(existing.data);
+    } else {
+      scheduleWrite(data);
+    }
+  }
+
+  function activateCircuitBreaker(reason: string): void {
+    const now = new Date();
+    const expiresAt = addMilliseconds(now, CIRCUIT_BREAKER_CONFIG.CIRCUIT_BREAKER_DURATION_MS);
+
+    const state: CircuitBreakerState = {
+      activatedAt: now.getTime(),
+      expiresAt: expiresAt.getTime(),
+      reason,
+    };
+
+    const ttlSeconds = differenceInSeconds(expiresAt, now);
+
+    scheduleKvWrite(KV_KEYS.CIRCUIT_BREAKER, JSON.stringify(state), ttlSeconds);
+
+    logService.warn(
+      `Circuit breaker activated: ${reason}`,
+      new Map<string, number | string>([
+        ["activatedAt", state.activatedAt],
+        ["expiresAt", state.expiresAt],
+        ["reason", state.reason],
+      ]),
+    );
+  }
+
+  async function trackError(statusCode: number, url: string): Promise<void> {
+    const windowKey = getErrorWindowKey();
+    const now = Date.now();
+
+    const existingWindow = await env.APP_DATA.get<ErrorWindow>(windowKey, "json");
+    const errorWindow: ErrorWindow = existingWindow ?? {
+      windowStart: Math.floor(now / CIRCUIT_BREAKER_CONFIG.ERROR_WINDOW_MS),
+      errors: [],
+    };
+
+    errorWindow.errors.push({
+      timestamp: now,
+      statusCode,
+      url,
+    });
+
+    const windowStartTime = errorWindow.windowStart * CIRCUIT_BREAKER_CONFIG.ERROR_WINDOW_MS;
+    errorWindow.errors = errorWindow.errors.filter((error) => error.timestamp >= windowStartTime);
+
+    scheduleKvWrite(windowKey, JSON.stringify(errorWindow), CIRCUIT_BREAKER_CONFIG.ERROR_TRACKING_TTL_SECONDS);
+
+    logService.warn(
+      `Rate limit error tracked: ${statusCode.toString()} for ${url}`,
+      new Map<string, number>([
+        ["errorCount", errorWindow.errors.length],
+        ["threshold", CIRCUIT_BREAKER_CONFIG.ERROR_THRESHOLD],
+      ]),
+    );
+
+    if (errorWindow.errors.length >= CIRCUIT_BREAKER_CONFIG.ERROR_THRESHOLD) {
+      activateCircuitBreaker(
+        `${errorWindow.errors.length.toString()} rate limit errors in ${(CIRCUIT_BREAKER_CONFIG.ERROR_WINDOW_MS / 60000).toString()} minutes`,
+      );
+    }
+  }
+
+  async function shouldUseProxy(): Promise<boolean> {
+    if (!proxyConfig.enabled) {
+      return false;
+    }
+
+    // In development mode, only use proxy if explicitly enabled or circuit breaker is active
+    if (env.MODE === "development") {
+      const masterToggle = await getMasterToggle();
+      const circuitBreaker = await getCircuitBreakerState();
+      return masterToggle || circuitBreaker !== null;
+    }
+
+    // In production, check master toggle and circuit breaker
+    const masterToggle = await getMasterToggle();
+    if (masterToggle) {
+      return true;
+    }
+
+    const circuitBreaker = await getCircuitBreakerState();
+    return circuitBreaker !== null;
+  }
+
+  async function fetchViaProxy(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+
+    if (proxyConfig.type === ProxyType.URL_REWRITE) {
+      // HaloQuery-style: rewrite URL and pass through headers
+      const transformedUrl = transformUrlForProxy(url, proxyConfig.baseUrl);
+      const headers = init?.headers ? new Headers(init.headers) : new Headers();
+      const proxiedHeaders = filterHeadersForProxy(headers);
+
+      logService.info(`Proxying request via URL rewrite: ${url} -> ${transformedUrl}`);
+
+      return fetch(transformedUrl, {
+        ...init,
+        headers: proxiedHeaders,
+      });
+    } else {
+      // JSON-RPC style (existing behavior for backward compatibility)
+      logService.info(`Proxying request via JSON-RPC: ${url}`);
+      return fetch(input, init);
+    }
+  }
+
+  return async function resilientFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const useProxy = await shouldUseProxy();
+
+    if (useProxy) {
+      return fetchViaProxy(input, init);
+    }
+
+    try {
+      const response = await fetch(input, init);
+
+      if (ISSUE_STATUS_CODES.includes(response.status as 429 | 526)) {
+        logService.warn(`Rate limit error ${response.status.toString()} for ${url}`);
+
+        await trackError(response.status, url);
+
+        if (proxyConfig.enabled) {
+          logService.info(`Retrying via proxy after rate limit error`);
+          return await fetchViaProxy(input, init);
+        }
+      }
+
+      return response;
+    } catch (error) {
+      logService.error(error as Error, new Map([["url", url]]));
+      throw error;
+    }
+  };
+}

--- a/api/services/halo/tests/resilient-fetch.test.mts
+++ b/api/services/halo/tests/resilient-fetch.test.mts
@@ -1,0 +1,457 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/unbound-method */
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
+import { createResilientFetch } from "../resilient-fetch.mjs";
+import { aFakeEnvWith } from "../../../base/fakes/env.fake.mjs";
+import {
+  aFakeCircuitBreakerStateWith,
+  aFakeErrorWindowWith,
+  aFakeResponseWith,
+} from "../fakes/resilient-fetch.fake.mjs";
+import { KV_KEYS, CIRCUIT_BREAKER_CONFIG } from "../types.mjs";
+import type { LogService } from "../../log/types.mjs";
+
+describe("createResilientFetch", () => {
+  let env: Env;
+  let logService: LogService;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    env = aFakeEnvWith({
+      PROXY_WORKER_URL: "https://haloquery.com/proxy",
+      MODE: "production",
+    });
+    logService = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    };
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe("direct requests (no proxy)", () => {
+    it("makes direct request when proxy is disabled and no circuit breaker", async () => {
+      env.APP_DATA.get = vi.fn().mockResolvedValue(null);
+      fetchSpy.mockResolvedValue(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith("https://halostats.svc.halowaypoint.com/test", undefined);
+    });
+
+    it("makes direct request in production when master toggle is false and no circuit breaker", async () => {
+      env.APP_DATA.get = vi.fn().mockResolvedValue(null);
+      fetchSpy.mockResolvedValue(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(env.APP_DATA.get).toHaveBeenCalledWith(KV_KEYS.PROXY_ENABLED);
+      expect(env.APP_DATA.get).toHaveBeenCalledWith(KV_KEYS.CIRCUIT_BREAKER, "json");
+    });
+  });
+
+  describe("master toggle", () => {
+    it("uses proxy when master toggle is enabled", async () => {
+      const kvGetSpy = vi.fn().mockImplementation(async (key) => {
+        if (key === KV_KEYS.PROXY_ENABLED) {
+          return Promise.resolve("true");
+        }
+        if (key === KV_KEYS.CIRCUIT_BREAKER) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(null);
+      });
+      env.APP_DATA.get = kvGetSpy;
+      fetchSpy.mockResolvedValue(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/hi/players/test");
+
+      // Debug: check what KV calls were made
+      expect(kvGetSpy).toHaveBeenCalled();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://haloquery.com/proxy/halostats.svc.halowaypoint.com/hi/players/test",
+        expect.anything(),
+      );
+      expect(logService.info).toHaveBeenCalledWith(expect.stringContaining("Proxying request via URL rewrite"));
+    });
+  });
+
+  describe("circuit breaker", () => {
+    it("uses proxy when circuit breaker is active", async () => {
+      const circuitBreaker = aFakeCircuitBreakerStateWith();
+      env.APP_DATA.get = vi.fn().mockImplementation(async (key) => {
+        if (key === KV_KEYS.PROXY_ENABLED) {
+          return Promise.resolve(null);
+        }
+        if (key === KV_KEYS.CIRCUIT_BREAKER) {
+          return Promise.resolve(circuitBreaker);
+        }
+        return Promise.resolve(null);
+      });
+      fetchSpy.mockResolvedValue(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://haloquery.com/proxy/halostats.svc.halowaypoint.com/test",
+        expect.anything(),
+      );
+    });
+
+    it("activates circuit breaker after 3 errors in 15 minutes", async () => {
+      const errorWindow = aFakeErrorWindowWith({ errorCount: 2 });
+      env.APP_DATA.get = vi.fn().mockImplementation(async (key: string) => {
+        if (key.startsWith(KV_KEYS.ERROR_WINDOW)) {
+          return Promise.resolve(errorWindow);
+        }
+        return Promise.resolve(null);
+      });
+      env.APP_DATA.put = vi.fn().mockResolvedValue(undefined);
+
+      fetchSpy
+        .mockResolvedValueOnce(aFakeResponseWith({ status: 429 }))
+        .mockResolvedValueOnce(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      // Advance timers to trigger the debounced KV writes
+      await vi.advanceTimersByTimeAsync(1000);
+
+      // Should have tracked the error and activated circuit breaker
+      expect(env.APP_DATA.put).toHaveBeenCalledWith(
+        expect.stringContaining(KV_KEYS.ERROR_WINDOW),
+        expect.any(String),
+        expect.objectContaining({
+          expirationTtl: CIRCUIT_BREAKER_CONFIG.ERROR_TRACKING_TTL_SECONDS,
+        }),
+      );
+
+      // Circuit breaker should be activated
+      expect(env.APP_DATA.put).toHaveBeenCalledWith(
+        KV_KEYS.CIRCUIT_BREAKER,
+        expect.any(String),
+        expect.objectContaining({
+          expirationTtl: expect.any(Number),
+        }),
+      );
+
+      expect(logService.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Circuit breaker activated"),
+        expect.any(Map),
+      );
+    });
+  });
+
+  describe("rate limit error handling", () => {
+    it("retries via proxy on 429 error", async () => {
+      env.APP_DATA.get = vi.fn().mockResolvedValue(null);
+      env.APP_DATA.put = vi.fn().mockResolvedValue(undefined);
+
+      fetchSpy
+        .mockResolvedValueOnce(aFakeResponseWith({ status: 429 }))
+        .mockResolvedValueOnce(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+      });
+
+      const response = await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      expect(response.status).toBe(200);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(fetchSpy).toHaveBeenNthCalledWith(1, "https://halostats.svc.halowaypoint.com/test", undefined);
+      expect(fetchSpy).toHaveBeenNthCalledWith(
+        2,
+        "https://haloquery.com/proxy/halostats.svc.halowaypoint.com/test",
+        expect.anything(),
+      );
+      expect(logService.warn).toHaveBeenCalledWith(expect.stringContaining("Rate limit error 429"));
+      expect(logService.info).toHaveBeenCalledWith(expect.stringContaining("Retrying via proxy"));
+    });
+
+    it("retries via proxy on 526 error", async () => {
+      env.APP_DATA.get = vi.fn().mockResolvedValue(null);
+      env.APP_DATA.put = vi.fn().mockResolvedValue(undefined);
+
+      fetchSpy
+        .mockResolvedValueOnce(aFakeResponseWith({ status: 526 }))
+        .mockResolvedValueOnce(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      expect(logService.warn).toHaveBeenCalledWith(expect.stringContaining("Rate limit error 526"));
+    });
+
+    it("does not retry via proxy when proxy is disabled", async () => {
+      env.APP_DATA.get = vi.fn().mockResolvedValue(null);
+      env.APP_DATA.put = vi.fn().mockResolvedValue(undefined);
+      fetchSpy.mockResolvedValue(aFakeResponseWith({ status: 429 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "",
+      });
+
+      const response = await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      expect(response.status).toBe(429);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("URL transformation", () => {
+    it("transforms URL correctly for HaloQuery proxy", async () => {
+      env.APP_DATA.get = vi.fn().mockImplementation(async (key) => {
+        if (key === KV_KEYS.PROXY_ENABLED) {
+          return Promise.resolve("true");
+        }
+        if (key === KV_KEYS.CIRCUIT_BREAKER) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(null);
+      });
+      fetchSpy.mockResolvedValue(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/hi/players/xuid(123)/matches?count=25");
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://haloquery.com/proxy/halostats.svc.halowaypoint.com/hi/players/xuid(123)/matches?count=25",
+        expect.anything(),
+      );
+    });
+
+    it("handles different subdomains correctly", async () => {
+      env.APP_DATA.get = vi.fn().mockImplementation(async (key) => {
+        if (key === KV_KEYS.PROXY_ENABLED) {
+          return Promise.resolve("true");
+        }
+        if (key === KV_KEYS.CIRCUIT_BREAKER) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(null);
+      });
+      fetchSpy.mockResolvedValue(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+      });
+
+      await resilientFetch("https://economy.svc.halowaypoint.com/hi/store");
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://haloquery.com/proxy/economy.svc.halowaypoint.com/hi/store",
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("header preservation", () => {
+    it("preserves all headers except host and content-length", async () => {
+      env.APP_DATA.get = vi.fn().mockImplementation(async (key) => {
+        if (key === KV_KEYS.PROXY_ENABLED) {
+          return Promise.resolve("true");
+        }
+        if (key === KV_KEYS.CIRCUIT_BREAKER) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(null);
+      });
+      fetchSpy.mockResolvedValue(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+      });
+
+      const headers = new Headers({
+        "x-343-authorization-spartan": "spartan-token",
+        authorization: "Bearer token",
+        "user-agent": "test-agent",
+        host: "should-be-removed.com",
+        "content-length": "123",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test", { headers });
+
+      const [, callInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const sentHeaders = new Headers(callInit.headers);
+
+      expect(sentHeaders.get("x-343-authorization-spartan")).toBe("spartan-token");
+      expect(sentHeaders.get("authorization")).toBe("Bearer token");
+      expect(sentHeaders.get("user-agent")).toBe("test-agent");
+      expect(sentHeaders.has("host")).toBe(false);
+      expect(sentHeaders.has("content-length")).toBe(false);
+    });
+  });
+
+  describe("development mode", () => {
+    it("uses direct requests in development mode when master toggle is false", async () => {
+      env.MODE = "development";
+      env.APP_DATA.get = vi.fn().mockResolvedValue(null);
+      fetchSpy.mockResolvedValue(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      expect(fetchSpy).toHaveBeenCalledWith("https://halostats.svc.halowaypoint.com/test", undefined);
+    });
+
+    it("uses proxy in development mode when circuit breaker is active", async () => {
+      env.MODE = "development";
+      const circuitBreaker = aFakeCircuitBreakerStateWith();
+      env.APP_DATA.get = vi.fn().mockImplementation(async (key) => {
+        if (key === KV_KEYS.PROXY_ENABLED) {
+          return Promise.resolve(null);
+        }
+        if (key === KV_KEYS.CIRCUIT_BREAKER) {
+          return Promise.resolve(circuitBreaker);
+        }
+        return Promise.resolve(null);
+      });
+      fetchSpy.mockResolvedValue(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://haloquery.com/proxy/halostats.svc.halowaypoint.com/test",
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("error tracking", () => {
+    it("tracks errors with timestamp and URL", async () => {
+      env.APP_DATA.get = vi.fn().mockResolvedValue(null);
+      env.APP_DATA.put = vi.fn().mockResolvedValue(undefined);
+      fetchSpy
+        .mockResolvedValueOnce(aFakeResponseWith({ status: 429 }))
+        .mockResolvedValueOnce(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      // Advance timers to trigger the debounced KV write
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(env.APP_DATA.put).toHaveBeenCalledWith(
+        expect.stringContaining(KV_KEYS.ERROR_WINDOW),
+        expect.stringMatching(/timestamp.*statusCode.*url/),
+        expect.any(Object),
+      );
+    });
+
+    it("filters out old errors from error window", async () => {
+      const oldTimestamp = Date.now() - 20 * 60 * 1000; // 20 minutes ago
+      const errorWindow = aFakeErrorWindowWith({
+        errorCount: 1,
+        statusCode: 429,
+      });
+      if (errorWindow.errors[0]) {
+        errorWindow.errors[0].timestamp = oldTimestamp;
+      }
+
+      env.APP_DATA.get = vi.fn().mockImplementation(async (key: string) => {
+        if (key.startsWith(KV_KEYS.ERROR_WINDOW)) {
+          return Promise.resolve(errorWindow);
+        }
+        return Promise.resolve(null);
+      });
+      env.APP_DATA.put = vi.fn().mockResolvedValue(undefined);
+
+      fetchSpy
+        .mockResolvedValueOnce(aFakeResponseWith({ status: 429 }))
+        .mockResolvedValueOnce(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      // Should not activate circuit breaker since old error should be filtered
+      const circuitBreakerCalls = (env.APP_DATA.put as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call) => call[0] === KV_KEYS.CIRCUIT_BREAKER,
+      );
+      expect(circuitBreakerCalls).toHaveLength(0);
+    });
+  });
+});

--- a/api/services/halo/types.mts
+++ b/api/services/halo/types.mts
@@ -1,0 +1,43 @@
+export interface CircuitBreakerState {
+  activatedAt: number;
+  expiresAt: number;
+  reason: string;
+}
+
+export interface ErrorWindow {
+  windowStart: number;
+  errors: ErrorRecord[];
+}
+
+export interface ErrorRecord {
+  timestamp: number;
+  statusCode: number;
+  url: string;
+}
+
+export enum ProxyType {
+  NONE = "none",
+  JSON_RPC = "json-rpc",
+  URL_REWRITE = "url-rewrite",
+}
+
+export interface ProxyConfig {
+  type: ProxyType;
+  baseUrl: string;
+  enabled: boolean;
+}
+
+export const KV_KEYS = {
+  PROXY_ENABLED: "halo:proxy:enabled",
+  CIRCUIT_BREAKER: "halo:proxy:circuit_breaker",
+  ERROR_WINDOW: "halo:proxy:errors",
+};
+
+export const CIRCUIT_BREAKER_CONFIG = {
+  ERROR_THRESHOLD: 3,
+  ERROR_WINDOW_MS: 15 * 60 * 1000, // 15 minutes
+  CIRCUIT_BREAKER_DURATION_MS: 60 * 60 * 1000, // 1 hour
+  ERROR_TRACKING_TTL_SECONDS: 24 * 60 * 60, // 24 hours
+};
+
+export const ISSUE_STATUS_CODES = [429, 526];


### PR DESCRIPTION
## Context

Since Cloudflare big stuff up... Halo waypoint is no having a bit of issues with us and giving us HTTP 429...

This PR introduces proxying to route via Halo Query which is an agreement with them to use their server.