### PR TITLE
Improve user lookup

### DIFF
--- a/api/commands/connect/connect.mts
+++ b/api/commands/connect/connect.mts
@@ -537,7 +537,7 @@ export class ConnectCommand extends BaseCommand {
       if (gamerTagFromTitle == null) {
         throw new Error("Gamertag not found in embed title");
       }
-      const user = await haloService.getUserByGamertagOrXuid(gamerTagFromTitle);
+      const user = await haloService.getUserByGamertag(gamerTagFromTitle);
 
       await databaseService.upsertDiscordAssociations([
         {

--- a/api/services/database/database.mts
+++ b/api/services/database/database.mts
@@ -25,6 +25,14 @@ export class DatabaseService {
     return response.results;
   }
 
+  async getDiscordAssociationsByXboxId(xboxIds: string[]): Promise<DiscordAssociationsRow[]> {
+    const placeholders = xboxIds.map(() => "?").join(",");
+    const query = `SELECT * FROM DiscordAssociations WHERE XboxId IN (${placeholders})`;
+    const stmt = this.DB.prepare(query).bind(...xboxIds);
+    const response = await stmt.all<DiscordAssociationsRow>();
+    return response.results;
+  }
+
   async upsertDiscordAssociations(associations: DiscordAssociationsRow[]): Promise<void> {
     if (associations.length === 0) {
       return;

--- a/api/services/neatqueue/tests/neatqueue.test.mts
+++ b/api/services/neatqueue/tests/neatqueue.test.mts
@@ -1321,7 +1321,7 @@ describe("NeatQueueService", () => {
         list_complete: true,
         cacheStatus: null,
       });
-      const appDataGetSpy = vi.spyOn(env.APP_DATA, "get") as MockInstance;
+      const appDataGetSpy: MockInstance = vi.spyOn(env.APP_DATA, "get");
       appDataGetSpy.mockResolvedValue(timeline);
       const editMessageSpy = vi.spyOn(discordService, "editMessage").mockResolvedValue(apiMessage);
 
@@ -1450,7 +1450,7 @@ describe("NeatQueueService", () => {
         list_complete: true,
         cacheStatus: null,
       });
-      const appDataGetSpy = vi.spyOn(env.APP_DATA, "get") as MockInstance;
+      const appDataGetSpy: MockInstance = vi.spyOn(env.APP_DATA, "get");
       appDataGetSpy.mockResolvedValue(timeline);
       vi.spyOn(discordService, "editMessage").mockResolvedValue(apiMessage);
 
@@ -1474,8 +1474,8 @@ describe("NeatQueueService", () => {
       createMessageSpy = vi.spyOn(discordService, "createMessage").mockResolvedValue(apiMessage);
       deleteMessageSpy = vi.spyOn(discordService, "deleteMessage").mockResolvedValue();
       getGuildConfigSpy = vi.spyOn(databaseService, "getGuildConfig");
-      appDataGetSpy = vi.spyOn(env.APP_DATA, "get") as MockInstance;
-      appDataPutSpy = vi.spyOn(env.APP_DATA, "put") as MockInstance;
+      appDataGetSpy = vi.spyOn(env.APP_DATA, "get");
+      appDataPutSpy = vi.spyOn(env.APP_DATA, "put");
     });
 
     it("updates players embed when substitution occurs and player connections are enabled", async () => {


### PR DESCRIPTION
## Context

Seeing a fair bit of HTTP 429s still when talking with Halo waypoint server...

As a starting point, given people's Xbox accounts don't change that frequently, going to start caching this more aggressively.

The standard cloudflare caching doesn't work as well in this scenario and thus we need to use KV for caching instead.