### PR TITLE
Fix and improve caching of user info

### DIFF
--- a/api/services/halo/types.mts
+++ b/api/services/halo/types.mts
@@ -2,6 +2,7 @@ import type { UserInfo as HaloUserInfo } from "halo-infinite-api";
 import { EndUserError, EndUserErrorType } from "../../base/end-user-error.mjs";
 
 export type UserInfo = Pick<HaloUserInfo, "xuid" | "gamertag">;
+export type CachedUserInfo = UserInfo & { fetchedAt: number };
 
 export interface MatchPlayer {
   id: string;


### PR DESCRIPTION
## Context

I derped in a last go of improving the user info cache, where if there was no missing entries it attempted to fetch with no xuids.

This fixes that, but it also creates a longer term cache for user info. I'm doing this because we have seen it frequently enough that the server returns 500 for getting user info...

We will cache for 30 days, but try again after 1 day... if it fails it will reuse the stale cache... which is better than nothing.