### PR TITLE
feat(api): individual tracker profile CRUD (A2, individual-tracker port)

### DIFF
--- a/api/base/cors.ts
+++ b/api/base/cors.ts
@@ -18,7 +18,7 @@ const CORS_CONFIG: CorsConfig = {
     "https://guilty-spark.app", // Production
     "https://www.guilty-spark.app", // Production (www)
   ],
-  allowedMethods: "GET, POST, OPTIONS",
+  allowedMethods: "GET, POST, PATCH, OPTIONS",
   allowedHeaders: "Content-Type",
   maxAge: 86400, // 24 hours
 };

--- a/api/routes/individual-tracker/individual-tracker.ts
+++ b/api/routes/individual-tracker/individual-tracker.ts
@@ -1,0 +1,6 @@
+import type { RoutesRegisterHandler } from "../base/types";
+import { trackerProfileRoutesRegisterHandler } from "./profile";
+
+export const individualTrackerRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
+  trackerProfileRoutesRegisterHandler(router, installServices);
+};

--- a/api/routes/individual-tracker/mapper.ts
+++ b/api/routes/individual-tracker/mapper.ts
@@ -1,0 +1,10 @@
+import type { TrackerProfile } from "@guilty-spark/shared/contracts/individual-tracker/profile";
+import type { IndividualTrackerProfilesRow } from "../../services/database/types/individual_tracker_profiles";
+
+export function toTrackerProfile(row: IndividualTrackerProfilesRow): TrackerProfile {
+  return {
+    profileId: row.ProfileId,
+    activeIdentityId: row.ActiveIdentityId,
+    name: row.Name,
+  };
+}

--- a/api/routes/individual-tracker/profile.ts
+++ b/api/routes/individual-tracker/profile.ts
@@ -1,0 +1,101 @@
+import { errorContract } from "@guilty-spark/shared/contracts/error";
+import {
+  trackerProfileContract,
+  updateTrackerProfileRequestSchema,
+} from "@guilty-spark/shared/contracts/individual-tracker/profile";
+import { parseJsonBody } from "@guilty-spark/shared/base/request-parsing";
+import { addCorsHeaders } from "../../base/cors";
+import { IdentityNotOwnedError, ProfileNotFoundError } from "../../services/individual-tracker/errors";
+import type { UpdateProfileOptions } from "../../services/individual-tracker/types";
+import type { RoutesRegisterHandler } from "../base/types";
+import { requireSession } from "../base/require-session";
+import { toTrackerProfile } from "./mapper";
+
+export const trackerProfileRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
+  router.get("/api/individual-tracker/profile", async (request, env: Env) => {
+    const services = installServices({ env });
+    const { authService, individualTrackerService, logService } = services;
+
+    try {
+      const auth = await requireSession(request, authService);
+      if (!auth.ok) {
+        return auth.response;
+      }
+
+      const profile = await individualTrackerService.getOrCreateProfile(auth.session.userId);
+
+      return addCorsHeaders(
+        trackerProfileContract.toResponse({ profile: toTrackerProfile(profile) }, { noStore: true }),
+        request,
+        true,
+      );
+    } catch (error) {
+      logService.error(error as Error, new Map([["message", "Individual tracker profile get error"]]));
+      return addCorsHeaders(
+        errorContract.toResponse({ error: "Failed to fetch profile" }, { status: 500, noStore: true }),
+        request,
+        true,
+      );
+    }
+  });
+
+  router.patch("/api/individual-tracker/profile", async (request, env: Env) => {
+    const services = installServices({ env });
+    const { authService, individualTrackerService, logService } = services;
+
+    try {
+      const auth = await requireSession(request, authService);
+      if (!auth.ok) {
+        return auth.response;
+      }
+
+      const parsed = await parseJsonBody(request, updateTrackerProfileRequestSchema, "Invalid profile update request");
+      if (!parsed.success) {
+        return addCorsHeaders(parsed.response, request, true);
+      }
+
+      const options: UpdateProfileOptions = { userId: auth.session.userId, profileId: parsed.data.profileId };
+      if (parsed.data.name !== undefined) {
+        options.name = parsed.data.name;
+      }
+      if (parsed.data.activeIdentityId !== undefined) {
+        options.activeIdentityId = parsed.data.activeIdentityId;
+      }
+
+      try {
+        const profile = await individualTrackerService.updateProfile(options);
+        return addCorsHeaders(
+          trackerProfileContract.toResponse({ profile: toTrackerProfile(profile) }, { noStore: true }),
+          request,
+          true,
+        );
+      } catch (error) {
+        if (error instanceof ProfileNotFoundError) {
+          return addCorsHeaders(
+            errorContract.toResponse({ error: "Profile not found" }, { status: 404, noStore: true }),
+            request,
+            true,
+          );
+        }
+        if (error instanceof IdentityNotOwnedError) {
+          return addCorsHeaders(
+            errorContract.toResponse(
+              { error: "Active identity is not linked to this user" },
+              { status: 400, noStore: true },
+            ),
+            request,
+            true,
+          );
+        }
+        throw error;
+      }
+    } catch (error) {
+      logService.error(error as Error, new Map([["message", "Individual tracker profile update error"]]));
+      return addCorsHeaders(
+        errorContract.toResponse({ error: "Failed to update profile" }, { status: 500, noStore: true }),
+        request,
+        true,
+      );
+    }
+  });
+};

--- a/api/routes/individual-tracker/tests/profile.test.ts
+++ b/api/routes/individual-tracker/tests/profile.test.ts
@@ -1,0 +1,128 @@
+import type { AutoRouterType } from "itty-router";
+import { AutoRouter } from "itty-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TrackerProfileResponse } from "@guilty-spark/shared/contracts/individual-tracker/profile";
+import { aFakeEnvWith } from "../../../base/fakes/env.fake";
+import { aFakeIndividualTrackerProfilesRow } from "../../../services/database/fakes/database.fake";
+import { installFakeServicesWith } from "../../../services/fakes/services";
+import { IdentityNotOwnedError, ProfileNotFoundError } from "../../../services/individual-tracker/errors";
+import { individualTrackerRoutesRegisterHandler } from "../individual-tracker";
+import { aFakeAuthSessionWith } from "../../../services/auth/fakes/data";
+
+function jsonRequest(method: string, body: unknown): Request {
+  return new Request("http://localhost/api/individual-tracker/profile", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/individual-tracker/profile", () => {
+  let env: Env;
+  let router: AutoRouterType;
+
+  beforeEach(() => {
+    env = aFakeEnvWith();
+    router = AutoRouter();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(null);
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const req = new Request("http://localhost/api/individual-tracker/profile", { method: "GET" });
+    const res = (await router.fetch(req, env)) as Response;
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the (get-or-created) profile mapped to the contract shape", async () => {
+    const row = aFakeIndividualTrackerProfilesRow({ ProfileId: "p1", ActiveIdentityId: "id-1", Name: "default" });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith());
+      vi.spyOn(services.individualTrackerService, "getOrCreateProfile").mockResolvedValue(row);
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const req = new Request("http://localhost/api/individual-tracker/profile", {
+      method: "GET",
+      headers: { Origin: env.PAGES_URL },
+    });
+    const res = (await router.fetch(req, env)) as Response;
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    const body = await res.json<TrackerProfileResponse>();
+    expect(body).toEqual({ profile: { profileId: "p1", activeIdentityId: "id-1", name: "default" } });
+  });
+
+  it("updates a profile and returns 200", async () => {
+    const row = aFakeIndividualTrackerProfilesRow({ ProfileId: "p1", ActiveIdentityId: "id-2", Name: "New" });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith());
+      vi.spyOn(services.individualTrackerService, "updateProfile").mockResolvedValue(row);
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(
+      jsonRequest("PATCH", { profileId: "p1", name: "New", activeIdentityId: "id-2" }),
+      env,
+    )) as Response;
+
+    expect(res.status).toBe(200);
+    const body = await res.json<TrackerProfileResponse>();
+    expect(body).toEqual({ profile: { profileId: "p1", activeIdentityId: "id-2", name: "New" } });
+  });
+
+  it("returns 404 when updating a profile that is not found or not owned", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith());
+      vi.spyOn(services.individualTrackerService, "updateProfile").mockRejectedValue(new ProfileNotFoundError());
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(jsonRequest("PATCH", { profileId: "p1" }), env)) as Response;
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 on update when the active identity is not owned", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith());
+      vi.spyOn(services.individualTrackerService, "updateProfile").mockRejectedValue(new IdentityNotOwnedError());
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(
+      jsonRequest("PATCH", { profileId: "p1", activeIdentityId: "not-mine" }),
+      env,
+    )) as Response;
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when the update body is missing the profileId", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith());
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(jsonRequest("PATCH", {}), env)) as Response;
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/api/server.ts
+++ b/api/server.ts
@@ -5,6 +5,7 @@ import type { SessionTokenPayload } from "./services/auth/types";
 import { addCorsHeaders, handleCorsPreflightRequest } from "./base/cors";
 import { authRoutesRegisterHandler } from "./routes/auth/auth";
 import { discordInteractionsRoute } from "./routes/discord/interactions";
+import { individualTrackerRoutesRegisterHandler } from "./routes/individual-tracker/individual-tracker";
 
 interface ServerOpts {
   router: AutoRouterType;
@@ -41,6 +42,8 @@ export class Server {
     });
 
     authRoutesRegisterHandler(this.router, this.installServices);
+
+    individualTrackerRoutesRegisterHandler(this.router, this.installServices);
 
     discordInteractionsRoute(this.router, this.installServices);
 

--- a/api/services/fakes/services.ts
+++ b/api/services/fakes/services.ts
@@ -9,6 +9,7 @@ import { aFakeNeatQueueServiceWith } from "../neatqueue/fakes/neatqueue.fake";
 import { aFakeAuthServiceWith } from "../auth/fakes/auth.fake";
 import { aFakeXboxServiceWith } from "../xbox/fakes/xbox.fake";
 import { aFakeLiveTrackerServiceWith } from "../live-tracker/fakes/live-tracker.fake";
+import { aFakeIndividualTrackerServiceWith } from "../individual-tracker/fakes/individual-tracker.fake";
 
 export function installFakeServicesWith(opts: Partial<Services & { env: Env }> = {}): Services {
   const env = opts.env ?? aFakeEnvWith();
@@ -24,6 +25,8 @@ export function installFakeServicesWith(opts: Partial<Services & { env: Env }> =
   const neatQueueService =
     opts.neatQueueService ??
     aFakeNeatQueueServiceWith({ env, databaseService, discordService, haloService, liveTrackerService });
+  const individualTrackerService =
+    opts.individualTrackerService ?? aFakeIndividualTrackerServiceWith({ databaseService });
 
   return {
     logService,
@@ -35,5 +38,6 @@ export function installFakeServicesWith(opts: Partial<Services & { env: Env }> =
     haloInfiniteClient,
     liveTrackerService,
     neatQueueService,
+    individualTrackerService,
   };
 }

--- a/api/services/individual-tracker/errors.ts
+++ b/api/services/individual-tracker/errors.ts
@@ -1,0 +1,13 @@
+export class ProfileNotFoundError extends Error {
+  constructor(message = "Profile not found") {
+    super(message);
+    this.name = "ProfileNotFoundError";
+  }
+}
+
+export class IdentityNotOwnedError extends Error {
+  constructor(message = "Active identity is not linked to this user") {
+    super(message);
+    this.name = "IdentityNotOwnedError";
+  }
+}

--- a/api/services/individual-tracker/fakes/individual-tracker.fake.ts
+++ b/api/services/individual-tracker/fakes/individual-tracker.fake.ts
@@ -1,0 +1,9 @@
+import type { DatabaseService } from "../../database/database";
+import { aFakeDatabaseServiceWith } from "../../database/fakes/database.fake";
+import { IndividualTrackerService } from "../individual-tracker";
+
+export function aFakeIndividualTrackerServiceWith(
+  opts: { databaseService?: DatabaseService } = {},
+): IndividualTrackerService {
+  return new IndividualTrackerService({ databaseService: opts.databaseService ?? aFakeDatabaseServiceWith() });
+}

--- a/api/services/individual-tracker/individual-tracker.ts
+++ b/api/services/individual-tracker/individual-tracker.ts
@@ -1,0 +1,72 @@
+import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import type { DatabaseService } from "../database/database";
+import type { IndividualTrackerProfilesRow } from "../database/types/individual_tracker_profiles";
+import { IdentityNotOwnedError, ProfileNotFoundError } from "./errors";
+import type { UpdateProfileOptions } from "./types";
+
+export interface IndividualTrackerServiceOpts {
+  databaseService: DatabaseService;
+}
+
+export class IndividualTrackerService {
+  private readonly databaseService: DatabaseService;
+
+  constructor({ databaseService }: IndividualTrackerServiceOpts) {
+    this.databaseService = databaseService;
+  }
+
+  async getOrCreateProfile(userId: string): Promise<IndividualTrackerProfilesRow> {
+    const profiles = await this.databaseService.findIndividualTrackerProfilesByUserId(userId);
+    const [existing] = profiles;
+    if (existing != null) {
+      return existing;
+    }
+
+    const identities = await this.databaseService.findLinkedIdentitiesByUserId(userId);
+    const activeXboxIdentity = identities.find((identity) => identity.Provider === "xbox" && identity.IsActive === 1);
+    const nowEpoch = Math.floor(Date.now() / 1000);
+    const profile: IndividualTrackerProfilesRow = {
+      ProfileId: crypto.randomUUID(),
+      UserId: userId,
+      ActiveIdentityId: activeXboxIdentity?.IdentityId ?? null,
+      Name: "default",
+      CreatedAt: nowEpoch,
+      UpdatedAt: nowEpoch,
+    };
+    await this.databaseService.createIndividualTrackerProfile(profile);
+    return profile;
+  }
+
+  async updateProfile(options: UpdateProfileOptions): Promise<IndividualTrackerProfilesRow> {
+    const existing = await this.databaseService.getIndividualTrackerProfile(options.profileId);
+    if (existing?.UserId !== options.userId) {
+      throw new ProfileNotFoundError();
+    }
+
+    await this.assertIdentityOwned(options.userId, options.activeIdentityId);
+
+    const updates: Partial<Pick<IndividualTrackerProfilesRow, "ActiveIdentityId" | "Name" | "UpdatedAt">> = {
+      UpdatedAt: Math.floor(Date.now() / 1000),
+    };
+    if (options.name !== undefined && options.name.trim() !== "") {
+      updates.Name = options.name;
+    }
+    if (options.activeIdentityId !== undefined) {
+      updates.ActiveIdentityId = options.activeIdentityId;
+    }
+
+    await this.databaseService.updateIndividualTrackerProfile(options.profileId, updates);
+    const updated = await this.databaseService.getIndividualTrackerProfile(options.profileId);
+    return Preconditions.checkExists(updated, "Profile disappeared after update");
+  }
+
+  private async assertIdentityOwned(userId: string, activeIdentityId: string | null | undefined): Promise<void> {
+    if (activeIdentityId == null) {
+      return;
+    }
+    const identities = await this.databaseService.findLinkedIdentitiesByUserId(userId);
+    if (!identities.some((identity) => identity.IdentityId === activeIdentityId)) {
+      throw new IdentityNotOwnedError();
+    }
+  }
+}

--- a/api/services/individual-tracker/tests/individual-tracker.test.ts
+++ b/api/services/individual-tracker/tests/individual-tracker.test.ts
@@ -1,0 +1,136 @@
+import type { MockInstance } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  aFakeDatabaseServiceWith,
+  aFakeIndividualTrackerProfilesRow,
+  aFakeLinkedIdentitiesRow,
+} from "../../database/fakes/database.fake";
+import type { DatabaseService } from "../../database/database";
+import { IndividualTrackerService } from "../individual-tracker";
+import { IdentityNotOwnedError, ProfileNotFoundError } from "../errors";
+
+describe("IndividualTrackerService", () => {
+  let databaseService: DatabaseService;
+  let service: IndividualTrackerService;
+
+  beforeEach(() => {
+    databaseService = aFakeDatabaseServiceWith();
+    service = new IndividualTrackerService({ databaseService });
+  });
+
+  describe("getOrCreateProfile", () => {
+    it("returns the existing profile when one exists", async () => {
+      const profile = aFakeIndividualTrackerProfilesRow({ ProfileId: "p1", UserId: "user-1" });
+      vi.spyOn(databaseService, "findIndividualTrackerProfilesByUserId").mockResolvedValue([profile]);
+      const createSpy: MockInstance<DatabaseService["createIndividualTrackerProfile"]> = vi.spyOn(
+        databaseService,
+        "createIndividualTrackerProfile",
+      );
+
+      expect(await service.getOrCreateProfile("user-1")).toEqual(profile);
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it("creates a default profile keyed to the user's active xbox identity when none exists", async () => {
+      vi.spyOn(databaseService, "findIndividualTrackerProfilesByUserId").mockResolvedValue([]);
+      vi.spyOn(databaseService, "findLinkedIdentitiesByUserId").mockResolvedValue([
+        aFakeLinkedIdentitiesRow({ IdentityId: "xbox-id", UserId: "user-1", Provider: "xbox", IsActive: 1 }),
+      ]);
+      const createSpy: MockInstance<DatabaseService["createIndividualTrackerProfile"]> = vi
+        .spyOn(databaseService, "createIndividualTrackerProfile")
+        .mockResolvedValue();
+
+      const profile = await service.getOrCreateProfile("user-1");
+
+      expect(profile.UserId).toBe("user-1");
+      expect(profile.Name).toBe("default");
+      expect(profile.ActiveIdentityId).toBe("xbox-id");
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ UserId: "user-1", Name: "default", ActiveIdentityId: "xbox-id" }),
+      );
+    });
+
+    it("creates a default profile with no active identity when there is no active xbox identity", async () => {
+      vi.spyOn(databaseService, "findIndividualTrackerProfilesByUserId").mockResolvedValue([]);
+      vi.spyOn(databaseService, "findLinkedIdentitiesByUserId").mockResolvedValue([]);
+      vi.spyOn(databaseService, "createIndividualTrackerProfile").mockResolvedValue();
+
+      const profile = await service.getOrCreateProfile("user-1");
+
+      expect(profile.ActiveIdentityId).toBeNull();
+    });
+  });
+
+  describe("updateProfile", () => {
+    it("throws ProfileNotFoundError when the profile does not exist", async () => {
+      vi.spyOn(databaseService, "getIndividualTrackerProfile").mockResolvedValue(null);
+
+      await expect(service.updateProfile({ userId: "user-1", profileId: "p1" })).rejects.toThrow(ProfileNotFoundError);
+    });
+
+    it("throws ProfileNotFoundError when the profile belongs to another user", async () => {
+      vi.spyOn(databaseService, "getIndividualTrackerProfile").mockResolvedValue(
+        aFakeIndividualTrackerProfilesRow({ ProfileId: "p1", UserId: "other-user" }),
+      );
+
+      await expect(service.updateProfile({ userId: "user-1", profileId: "p1" })).rejects.toThrow(ProfileNotFoundError);
+    });
+
+    it("updates the name and active identity and returns the refreshed profile", async () => {
+      const existing = aFakeIndividualTrackerProfilesRow({ ProfileId: "p1", UserId: "user-1", Name: "Old" });
+      const updated = aFakeIndividualTrackerProfilesRow({
+        ProfileId: "p1",
+        UserId: "user-1",
+        Name: "New",
+        ActiveIdentityId: "id-2",
+      });
+      vi.spyOn(databaseService, "getIndividualTrackerProfile")
+        .mockResolvedValueOnce(existing)
+        .mockResolvedValueOnce(updated);
+      vi.spyOn(databaseService, "findLinkedIdentitiesByUserId").mockResolvedValue([
+        aFakeLinkedIdentitiesRow({ IdentityId: "id-2", UserId: "user-1" }),
+      ]);
+      const updateSpy: MockInstance<DatabaseService["updateIndividualTrackerProfile"]> = vi
+        .spyOn(databaseService, "updateIndividualTrackerProfile")
+        .mockResolvedValue();
+
+      const result = await service.updateProfile({
+        userId: "user-1",
+        profileId: "p1",
+        name: "New",
+        activeIdentityId: "id-2",
+      });
+
+      expect(result).toEqual(updated);
+      expect(updateSpy).toHaveBeenCalledWith("p1", expect.objectContaining({ Name: "New", ActiveIdentityId: "id-2" }));
+    });
+
+    it("ignores a blank name", async () => {
+      const existing = aFakeIndividualTrackerProfilesRow({ ProfileId: "p1", UserId: "user-1", Name: "Old" });
+      vi.spyOn(databaseService, "getIndividualTrackerProfile").mockResolvedValue(existing);
+      const updateSpy: MockInstance<DatabaseService["updateIndividualTrackerProfile"]> = vi
+        .spyOn(databaseService, "updateIndividualTrackerProfile")
+        .mockResolvedValue();
+
+      await service.updateProfile({ userId: "user-1", profileId: "p1", name: "   " });
+
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      expect(updateSpy.mock.calls[0]?.[1]).not.toHaveProperty("Name");
+    });
+
+    it("throws IdentityNotOwnedError when the active identity is not linked to the user", async () => {
+      vi.spyOn(databaseService, "getIndividualTrackerProfile").mockResolvedValue(
+        aFakeIndividualTrackerProfilesRow({ ProfileId: "p1", UserId: "user-1" }),
+      );
+      vi.spyOn(databaseService, "findLinkedIdentitiesByUserId").mockResolvedValue([]);
+      const updateSpy: MockInstance<DatabaseService["updateIndividualTrackerProfile"]> = vi
+        .spyOn(databaseService, "updateIndividualTrackerProfile")
+        .mockResolvedValue();
+
+      await expect(
+        service.updateProfile({ userId: "user-1", profileId: "p1", activeIdentityId: "not-mine" }),
+      ).rejects.toThrow(IdentityNotOwnedError);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/services/individual-tracker/types.ts
+++ b/api/services/individual-tracker/types.ts
@@ -1,0 +1,6 @@
+export interface UpdateProfileOptions {
+  userId: string;
+  profileId: string;
+  name?: string;
+  activeIdentityId?: string | null;
+}

--- a/api/services/install.ts
+++ b/api/services/install.ts
@@ -9,6 +9,7 @@ import { CustomSpartanTokenProvider } from "./halo/custom-spartan-token-provider
 import { NeatQueueService } from "./neatqueue/neatqueue";
 import { LiveTrackerService } from "./live-tracker/live-tracker";
 import { AuthService } from "./auth/auth";
+import { IndividualTrackerService } from "./individual-tracker/individual-tracker";
 import type { LogService } from "./log/types";
 import { AggregatorClient } from "./log/aggregator-client";
 import { ConsoleLogClient } from "./log/console-log-client";
@@ -27,6 +28,7 @@ export interface Services {
   haloInfiniteClient: HaloInfiniteClient;
   liveTrackerService: LiveTrackerService;
   neatQueueService: NeatQueueService;
+  individualTrackerService: IndividualTrackerService;
 }
 
 interface InstallServicesOpts {
@@ -82,6 +84,7 @@ export function installServices({ env }: InstallServicesOpts): Services {
     playerMatchesRateLimiter: new PlayerMatchesRateLimiter({ logService, maxCallsPerSecond: 2 }),
   });
   const liveTrackerService = new LiveTrackerService({ env, logService, discordService });
+  const individualTrackerService = new IndividualTrackerService({ databaseService });
   const neatQueueService = new NeatQueueService({
     env,
     logService,
@@ -101,5 +104,6 @@ export function installServices({ env }: InstallServicesOpts): Services {
     haloInfiniteClient,
     liveTrackerService,
     neatQueueService,
+    individualTrackerService,
   };
 }

--- a/shared/src/contracts/individual-tracker/profile.ts
+++ b/shared/src/contracts/individual-tracker/profile.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { defineContract } from "../base";
+
+export const trackerProfileSchema = z.object({
+  profileId: z.string(),
+  activeIdentityId: z.string().nullable(),
+  name: z.string(),
+});
+export type TrackerProfile = z.infer<typeof trackerProfileSchema>;
+
+export const trackerProfileContract = defineContract(z.object({ profile: trackerProfileSchema }));
+export type TrackerProfileResponse = z.infer<typeof trackerProfileContract.schema>;
+
+export const updateTrackerProfileRequestSchema = z.object({
+  profileId: z.string().min(1),
+  name: z.string().optional(),
+  activeIdentityId: z.string().nullable().optional(),
+});
+export type UpdateTrackerProfileRequest = z.infer<typeof updateTrackerProfileRequestSchema>;


### PR DESCRIPTION
## Individual tracker profile (Milestone A of the individual-tracker port)

Now rebased onto `main` (the #454 commits it was stacked on are merged). Adds `IndividualTrackerService` + `/api/individual-tracker/profile` over the existing `IndividualTrackerProfiles` D1 table.

- **GET** is **get-or-create**: always returns the user's single profile, creating a default keyed to their active xbox identity if none exists — consumers never handle a null profile.
- **PATCH** updates `name` / `activeIdentityId`; **404** when not found/owned, **400** when the active identity isn't the user's.
- Profile contract is **non-nullable**; there is **no POST** (the profile is auto-ensured on GET). PATCH added to the CORS allowed methods.

### Tests
get-or-create (returns existing / creates default with active xbox identity / no-identity → null), update happy path, 404 not-owned, 400 active-identity-not-owned, 400 missing profileId. `npm run typecheck` clean; full suite green; lint/format clean. **No D1 migration** (`IndividualTrackerProfiles` already exists in main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
