### PR TITLE
fix(pages): bind existing SESSION KV namespace by id (stop deploy re-provisioning)

### DIFF
--- a/pages/wrangler.jsonc
+++ b/pages/wrangler.jsonc
@@ -8,6 +8,14 @@
     "directory": "./dist",
     "binding": "ASSETS",
   },
+  // The @astrojs/cloudflare adapter enables Astro KV sessions and binds them to "SESSION".
+  // Declaring the existing namespace by id stops Wrangler from re-provisioning it on every deploy.
+  "kv_namespaces": [
+    {
+      "binding": "SESSION",
+      "id": "42913da988334480aa9273db24556291",
+    },
+  ],
   "observability": {
     "enabled": true,
   },


### PR DESCRIPTION
## Fix the repeated `SESSION` KV provisioning failure on pages deploys

### Symptom
```
Provisioning SESSION (KV Namespace)...
  🌀 Creating new KV Namespace "guilty-spark-web-session"...
  ✘ a namespace with this account ID and title already exists [code: 10014]
```

### Cause
The `@astrojs/cloudflare` adapter auto-enables Astro KV sessions. When `pages/wrangler.jsonc` declares **no** `SESSION` KV binding, the adapter injects an **id-less** one (`@astrojs/cloudflare/dist/wrangler.js`: it only injects when `hasSessionBinding` is false). Wrangler 4 then tries to **provision** (create) `guilty-spark-web-session` on every deploy, which collides with the namespace that already exists.

> Note: the app doesn't actually use Astro sessions — all "session" code is the app's own API-cookie auth — but the adapter enables KV sessions by default regardless.

### Fix
Declare the existing namespace by `id` (mirrors how `api/wrangler.jsonc` declares its KV namespaces). The adapter then detects the binding and skips auto-injection; Wrangler binds to the existing namespace instead of creating it. Validated with `wrangler types` (config accepted, `SESSION: KVNamespace` recognized). Generated `worker-configuration.d.ts` churn intentionally not committed.


