### PR TITLE
feat(api): IndividualTrackers registry table + DB methods (B1)

### DIFF
--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -10,6 +10,7 @@ import type { LinkedIdentitiesRow, IdentityProvider } from "./types/linked_ident
 import type { IndividualTrackerProfilesRow } from "./types/individual_tracker_profiles";
 import type { IndividualTrackerGamesRow } from "./types/individual_tracker_games";
 import type { StreamerViewSettingsRow } from "./types/streamer_view_settings";
+import type { IndividualTrackersRow } from "./types/individual_trackers";
 
 export interface DatabaseServiceOpts {
   env: Env;
@@ -413,5 +414,69 @@ export class DatabaseService {
       settings.UpdatedAt,
     );
     await stmt.run();
+  }
+
+  async findIndividualTrackersByUserId(userId: string): Promise<IndividualTrackersRow[]> {
+    const query = "SELECT * FROM IndividualTrackers WHERE UserId = ? ORDER BY CreatedAt ASC";
+    const stmt = this.DB.prepare(query).bind(userId);
+    const response = await stmt.all<IndividualTrackersRow>();
+    return response.results;
+  }
+
+  async getIndividualTracker(trackerId: string): Promise<IndividualTrackersRow | null> {
+    const query = "SELECT * FROM IndividualTrackers WHERE TrackerId = ?";
+    const stmt = this.DB.prepare(query).bind(trackerId);
+    return await stmt.first<IndividualTrackersRow>();
+  }
+
+  async findIndividualTrackersByXuids(xuids: string[]): Promise<IndividualTrackersRow[]> {
+    if (xuids.length === 0) {
+      return [];
+    }
+    const placeholders = xuids.map(() => "?").join(",");
+    const query = `SELECT * FROM IndividualTrackers WHERE Xuid IN (${placeholders})`;
+    const stmt = this.DB.prepare(query).bind(...xuids);
+    const response = await stmt.all<IndividualTrackersRow>();
+    return response.results;
+  }
+
+  async findLiveIndividualTrackerByUserId(userId: string): Promise<IndividualTrackersRow | null> {
+    const query = "SELECT * FROM IndividualTrackers WHERE UserId = ? AND IsLive = 1";
+    const stmt = this.DB.prepare(query).bind(userId);
+    return await stmt.first<IndividualTrackersRow>();
+  }
+
+  async upsertIndividualTracker(tracker: IndividualTrackersRow): Promise<void> {
+    const query = `
+      INSERT INTO IndividualTrackers (TrackerId, UserId, Gamertag, Xuid, Status, IsLive, CreatedAt, UpdatedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(TrackerId) DO UPDATE SET Gamertag=excluded.Gamertag, Xuid=excluded.Xuid, Status=excluded.Status, IsLive=excluded.IsLive, UpdatedAt=excluded.UpdatedAt
+    `;
+    const stmt = this.DB.prepare(query).bind(
+      tracker.TrackerId,
+      tracker.UserId,
+      tracker.Gamertag,
+      tracker.Xuid,
+      tracker.Status,
+      tracker.IsLive,
+      tracker.CreatedAt,
+      tracker.UpdatedAt,
+    );
+    await stmt.run();
+  }
+
+  async deleteIndividualTracker(trackerId: string): Promise<void> {
+    const stmt = this.DB.prepare("DELETE FROM IndividualTrackers WHERE TrackerId = ?").bind(trackerId);
+    await stmt.run();
+  }
+
+  async setLiveIndividualTracker(userId: string, trackerId: string): Promise<void> {
+    const nowEpoch = Math.floor(Date.now() / 1000);
+    const clearStmt = this.DB.prepare(
+      "UPDATE IndividualTrackers SET IsLive = 0, UpdatedAt = ? WHERE UserId = ? AND IsLive = 1 AND TrackerId != ?",
+    ).bind(nowEpoch, userId, trackerId);
+    const setStmt = this.DB.prepare(
+      "UPDATE IndividualTrackers SET IsLive = 1, UpdatedAt = ? WHERE TrackerId = ? AND UserId = ?",
+    ).bind(nowEpoch, trackerId, userId);
+    await this.DB.batch([clearStmt, setStmt]);
   }
 }

--- a/api/services/database/fakes/database.fake.ts
+++ b/api/services/database/fakes/database.fake.ts
@@ -12,6 +12,7 @@ import type { LinkedIdentitiesRow } from "../types/linked_identities";
 import type { IndividualTrackerProfilesRow } from "../types/individual_tracker_profiles";
 import type { IndividualTrackerGamesRow } from "../types/individual_tracker_games";
 import type { StreamerViewSettingsRow } from "../types/streamer_view_settings";
+import type { IndividualTrackersRow } from "../types/individual_trackers";
 
 export function aFakeDiscordAssociationsRow(opts: Partial<DiscordAssociationsRow> = {}): DiscordAssociationsRow {
   const defaultOpts: DiscordAssociationsRow = {
@@ -155,6 +156,25 @@ export function aFakeStreamerViewSettingsRow(opts: Partial<StreamerViewSettingsR
     VisibleSectionsJson: "[]",
     StyleFlagsJson: "{}",
     UpdatedAt: Math.floor(Date.now() / 1000),
+  };
+
+  return {
+    ...defaultOpts,
+    ...opts,
+  };
+}
+
+export function aFakeIndividualTrackersRow(opts: Partial<IndividualTrackersRow> = {}): IndividualTrackersRow {
+  const nowEpoch = Math.floor(Date.now() / 1000);
+  const defaultOpts: IndividualTrackersRow = {
+    TrackerId: "tracker-1",
+    UserId: "user-1",
+    Gamertag: "Gamertag01",
+    Xuid: "2533274000000001",
+    Status: "stopped",
+    IsLive: 0,
+    CreatedAt: nowEpoch,
+    UpdatedAt: nowEpoch,
   };
 
   return {

--- a/api/services/database/schema.sql
+++ b/api/services/database/schema.sql
@@ -97,3 +97,18 @@ CREATE TABLE IF NOT EXISTS StreamerViewSettings (
     UpdatedAt INTEGER NOT NULL DEFAULT (unixepoch()),
     FOREIGN KEY (ProfileId) REFERENCES IndividualTrackerProfiles(ProfileId) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS IndividualTrackers (
+    TrackerId TEXT PRIMARY KEY NOT NULL,
+    UserId TEXT NOT NULL,
+    Gamertag TEXT NOT NULL,
+    Xuid TEXT NOT NULL,
+    Status TEXT NOT NULL DEFAULT 'stopped' CHECK (Status IN ('active', 'paused', 'stopped')),
+    IsLive INTEGER NOT NULL DEFAULT 0 CHECK (IsLive IN (0, 1)),
+    CreatedAt INTEGER NOT NULL DEFAULT (unixepoch()),
+    UpdatedAt INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS IdxIndividualTrackersUserId ON IndividualTrackers (UserId);
+CREATE INDEX IF NOT EXISTS IdxIndividualTrackersXuid ON IndividualTrackers (Xuid);
+CREATE UNIQUE INDEX IF NOT EXISTS UqIndividualTrackersLivePerUser ON IndividualTrackers (UserId) WHERE IsLive = 1;

--- a/api/services/database/tests/database.test.ts
+++ b/api/services/database/tests/database.test.ts
@@ -9,6 +9,7 @@ import {
   aFakeIndividualTrackerProfilesRow,
   aFakeIndividualTrackerGamesRow,
   aFakeStreamerViewSettingsRow,
+  aFakeIndividualTrackersRow,
 } from "../fakes/database.fake";
 import type { GuildConfigRow } from "../types/guild_config";
 import { StatsReturnType, MapsPostType, MapsPlaylistType, MapsFormatType } from "../types/guild_config";
@@ -784,6 +785,137 @@ describe("Database Service", () => {
         settings.UpdatedAt,
       );
       expect(runSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("IndividualTrackers", () => {
+    it("finds individual trackers by user id", async () => {
+      const tracker = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1" });
+      const fakePreparedStatement = new FakePreparedStatement();
+      const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      const bindSpy = vi.spyOn(fakePreparedStatement, "bind");
+      vi.spyOn(fakePreparedStatement, "all").mockResolvedValue({ ...fakeD1Response, results: [tracker] });
+
+      const result = await databaseService.findIndividualTrackersByUserId("user-1");
+
+      expect(prepareSpy).toHaveBeenCalledWith(
+        "SELECT * FROM IndividualTrackers WHERE UserId = ? ORDER BY CreatedAt ASC",
+      );
+      expect(bindSpy).toHaveBeenCalledWith("user-1");
+      expect(result).toEqual([tracker]);
+    });
+
+    it("gets an individual tracker by id", async () => {
+      const tracker = aFakeIndividualTrackersRow({ TrackerId: "t1" });
+      const fakePreparedStatement = new FakePreparedStatement();
+      const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      const bindSpy = vi.spyOn(fakePreparedStatement, "bind");
+      vi.spyOn(fakePreparedStatement, "first").mockResolvedValue(tracker);
+
+      const result = await databaseService.getIndividualTracker("t1");
+
+      expect(prepareSpy).toHaveBeenCalledWith("SELECT * FROM IndividualTrackers WHERE TrackerId = ?");
+      expect(bindSpy).toHaveBeenCalledWith("t1");
+      expect(result).toEqual(tracker);
+    });
+
+    it("finds individual trackers by xuids", async () => {
+      const tracker = aFakeIndividualTrackersRow({ Xuid: "111" });
+      const fakePreparedStatement = new FakePreparedStatement();
+      const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      const bindSpy = vi.spyOn(fakePreparedStatement, "bind");
+      vi.spyOn(fakePreparedStatement, "all").mockResolvedValue({ ...fakeD1Response, results: [tracker] });
+
+      const result = await databaseService.findIndividualTrackersByXuids(["111", "222"]);
+
+      expect(prepareSpy).toHaveBeenCalledWith("SELECT * FROM IndividualTrackers WHERE Xuid IN (?,?)");
+      expect(bindSpy).toHaveBeenCalledWith("111", "222");
+      expect(result).toEqual([tracker]);
+    });
+
+    it("returns an empty array without querying when no xuids are given", async () => {
+      const prepareSpy = vi.spyOn(env.DB, "prepare");
+
+      const result = await databaseService.findIndividualTrackersByXuids([]);
+
+      expect(prepareSpy).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it("finds the live individual tracker for a user", async () => {
+      const tracker = aFakeIndividualTrackersRow({ UserId: "user-1", IsLive: 1 });
+      const fakePreparedStatement = new FakePreparedStatement();
+      const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      const bindSpy = vi.spyOn(fakePreparedStatement, "bind");
+      vi.spyOn(fakePreparedStatement, "first").mockResolvedValue(tracker);
+
+      const result = await databaseService.findLiveIndividualTrackerByUserId("user-1");
+
+      expect(prepareSpy).toHaveBeenCalledWith("SELECT * FROM IndividualTrackers WHERE UserId = ? AND IsLive = 1");
+      expect(bindSpy).toHaveBeenCalledWith("user-1");
+      expect(result).toEqual(tracker);
+    });
+
+    it("upserts an individual tracker", async () => {
+      const tracker = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1", Gamertag: "GT", Xuid: "111" });
+      const fakePreparedStatement = new FakePreparedStatement();
+      const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      const bindSpy = vi.spyOn(fakePreparedStatement, "bind");
+      const runSpy = vi.spyOn(fakePreparedStatement, "run");
+
+      await databaseService.upsertIndividualTracker(tracker);
+
+      expect(prepareSpy).toHaveBeenCalledWith(expect.stringContaining("INSERT INTO IndividualTrackers"));
+      expect(bindSpy).toHaveBeenCalledWith(
+        tracker.TrackerId,
+        tracker.UserId,
+        tracker.Gamertag,
+        tracker.Xuid,
+        tracker.Status,
+        tracker.IsLive,
+        tracker.CreatedAt,
+        tracker.UpdatedAt,
+      );
+      expect(runSpy).toHaveBeenCalled();
+    });
+
+    it("deletes an individual tracker", async () => {
+      const fakePreparedStatement = new FakePreparedStatement();
+      const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      const bindSpy = vi.spyOn(fakePreparedStatement, "bind");
+      const runSpy = vi.spyOn(fakePreparedStatement, "run");
+
+      await databaseService.deleteIndividualTracker("t1");
+
+      expect(prepareSpy).toHaveBeenCalledWith("DELETE FROM IndividualTrackers WHERE TrackerId = ?");
+      expect(bindSpy).toHaveBeenCalledWith("t1");
+      expect(runSpy).toHaveBeenCalled();
+    });
+
+    it("sets one tracker live and clears the others in a batch", async () => {
+      const clearStatement = new FakePreparedStatement();
+      const setStatement = new FakePreparedStatement();
+      const prepareSpy = vi
+        .spyOn(env.DB, "prepare")
+        .mockReturnValueOnce(clearStatement)
+        .mockReturnValueOnce(setStatement);
+      const clearBindSpy = vi.spyOn(clearStatement, "bind");
+      const setBindSpy = vi.spyOn(setStatement, "bind");
+      const batchSpy = vi.spyOn(env.DB, "batch").mockResolvedValue([{ ...fakeD1Response, results: [] }]);
+
+      await databaseService.setLiveIndividualTracker("user-1", "t1");
+
+      expect(prepareSpy).toHaveBeenNthCalledWith(
+        1,
+        "UPDATE IndividualTrackers SET IsLive = 0, UpdatedAt = ? WHERE UserId = ? AND IsLive = 1 AND TrackerId != ?",
+      );
+      expect(prepareSpy).toHaveBeenNthCalledWith(
+        2,
+        "UPDATE IndividualTrackers SET IsLive = 1, UpdatedAt = ? WHERE TrackerId = ? AND UserId = ?",
+      );
+      expect(clearBindSpy).toHaveBeenCalledWith(expect.any(Number), "user-1", "t1");
+      expect(setBindSpy).toHaveBeenCalledWith(expect.any(Number), "t1", "user-1");
+      expect(batchSpy).toHaveBeenCalledWith([clearStatement, setStatement]);
     });
   });
 });

--- a/api/services/database/types/individual_trackers.ts
+++ b/api/services/database/types/individual_trackers.ts
@@ -1,0 +1,12 @@
+export type IndividualTrackerStatus = "active" | "paused" | "stopped";
+
+export interface IndividualTrackersRow {
+  TrackerId: string;
+  UserId: string;
+  Gamertag: string;
+  Xuid: string;
+  Status: IndividualTrackerStatus;
+  IsLive: 0 | 1;
+  CreatedAt: number;
+  UpdatedAt: number;
+}


### PR DESCRIPTION
## Milestone B · PR 1 — `IndividualTrackers` registry

First PR of the individual-tracker runtime. Adds the persisted **per-gamertag tracker registry** the Durable Object + control routes will build on.

**Model (confirmed):** one settings "profile" per user already exists in `main`. Separately, a user tracks their own gamertag + up to 4 others (**5 total**), with one marked **"live"** (for casters switching between players). Runtime match/series/token state lives in the DO; this table is the persisted index.

### Schema — new `IndividualTrackers`
`TrackerId` (PK), `UserId`, `Gamertag`, `Xuid`, `Status` (active|paused|stopped), `IsLive` (0|1), timestamps. Indexes on `UserId` and `Xuid` (the latter for NeatQueue fanout + public `/u/<gamertag>` resolution), plus a **partial unique index** `UqIndividualTrackersLivePerUser ON (UserId) WHERE IsLive = 1` enforcing at most one live tracker per user (mirrors the existing `UqLinkedIdentitiesActiveXboxPerUser`).

### DatabaseService methods
`findIndividualTrackersByUserId`, `getIndividualTracker`, `findIndividualTrackersByXuids` (empty-safe), `findLiveIndividualTrackerByUserId`, `upsertIndividualTracker`, `deleteIndividualTracker`, `setLiveIndividualTracker` (atomic clear-others-then-set via `DB.batch`, ordered to never violate the partial index).

> Contract for later PRs: `IsLive = 1` writes go through `setLiveIndividualTracker`; the upsert path trusts the caller (same precedent as `upsertLinkedIdentity`).

### Tests
8 new DB-method tests (asserting SQL + binds + batch). `npm run typecheck` clean; database suite green (45); lint/format clean.

### ⚠️ D1 migration required (manual — repo convention has no migrations dir)
`schema.sql` is applied by hand. Apply the new table to each D1 environment. Easiest is to re-run the whole file (every statement is `CREATE … IF NOT EXISTS`, so it's idempotent):
```
cd api && npx wrangler d1 execute <your-d1-db> --remote --file=services/database/schema.sql
```
The exact DDL (table + 3 indexes) is in `api/services/database/schema.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
