### PR TITLE
feat(api): IndividualTrackerDO skeleton (B2)

### DIFF
--- a/api/durable-objects/individual-tracker/fakes/individual-tracker-do.fake.ts
+++ b/api/durable-objects/individual-tracker/fakes/individual-tracker-do.fake.ts
@@ -1,0 +1,130 @@
+import type {
+  IndividualTrackerPauseResponse,
+  IndividualTrackerResumeResponse,
+  IndividualTrackerStartResponse,
+  IndividualTrackerState,
+  IndividualTrackerStateSanitized,
+  IndividualTrackerStatusResponse,
+  IndividualTrackerStopResponse,
+} from "../types";
+import type { IndividualTrackerDO } from "../individual-tracker-do";
+import { aFakeDurableObjectId } from "../../../base/fakes/do.fake";
+
+export interface FakeIndividualTrackerDOOpts {
+  startResponse?: IndividualTrackerStartResponse;
+  pauseResponse?: IndividualTrackerPauseResponse;
+  resumeResponse?: IndividualTrackerResumeResponse;
+  stopResponse?: IndividualTrackerStopResponse;
+  statusResponse?: IndividualTrackerStatusResponse;
+  shouldThrowError?: boolean;
+  errorMessage?: string;
+}
+
+export type FakeIndividualTrackerDO = DurableObjectStub<IndividualTrackerDO> & Rpc.DurableObjectBranded;
+
+export function aFakeIndividualTrackerStateWith(opts: Partial<IndividualTrackerState> = {}): IndividualTrackerState {
+  return {
+    userId: "fake-user-id",
+    trackerId: "fake-tracker-id",
+    xuid: "fake-xuid",
+    gamertag: "FakeGamertag",
+    status: "active",
+    isPaused: false,
+    startTime: new Date().toISOString(),
+    lastUpdateTime: new Date().toISOString(),
+    searchStartTime: new Date().toISOString(),
+    lastMatchDiscoveredAt: undefined,
+    checkCount: 0,
+    idleTimeoutHours: 6,
+    errorState: {
+      consecutiveErrors: 0,
+      backoffMinutes: 3,
+      lastSuccessTime: new Date().toISOString(),
+    },
+    ...opts,
+  };
+}
+
+export function aFakeIndividualTrackerStateSanitizedWith(
+  opts: Partial<IndividualTrackerStateSanitized> = {},
+): IndividualTrackerStateSanitized {
+  return {
+    userId: "fake-user-id",
+    trackerId: "fake-tracker-id",
+    xuid: "fake-xuid",
+    gamertag: "FakeGamertag",
+    status: "active",
+    isPaused: false,
+    startTime: new Date().toISOString(),
+    lastUpdateTime: new Date().toISOString(),
+    idleTimeoutHours: 6,
+    ...opts,
+  };
+}
+
+export function aFakeIndividualTrackerDOWith(opts: FakeIndividualTrackerDOOpts = {}): FakeIndividualTrackerDO {
+  const defaultState = aFakeIndividualTrackerStateSanitizedWith();
+
+  const startResponse: IndividualTrackerStartResponse = opts.startResponse ?? { success: true, state: defaultState };
+  const pauseResponse: IndividualTrackerPauseResponse = opts.pauseResponse ?? { success: true, state: defaultState };
+  const resumeResponse: IndividualTrackerResumeResponse = opts.resumeResponse ?? { success: true, state: defaultState };
+  const stopResponse: IndividualTrackerStopResponse = opts.stopResponse ?? { success: true };
+  const statusResponse: IndividualTrackerStatusResponse = opts.statusResponse ?? { state: defaultState };
+  const { shouldThrowError = false, errorMessage = "Fake DO error" } = opts;
+
+  const fetchMock: FakeIndividualTrackerDO["fetch"] = async (input) => {
+    if (shouldThrowError) {
+      throw new Error(errorMessage);
+    }
+
+    let urlString: string;
+    if (typeof input === "string") {
+      urlString = input;
+    } else if (input instanceof URL) {
+      urlString = input.href;
+    } else {
+      urlString = input.url;
+    }
+
+    const urlObj = new URL(urlString);
+    const path = urlObj.pathname;
+
+    let responseBody: string;
+    switch (path) {
+      case "/start":
+        responseBody = JSON.stringify(startResponse);
+        break;
+      case "/pause":
+        responseBody = JSON.stringify(pauseResponse);
+        break;
+      case "/resume":
+        responseBody = JSON.stringify(resumeResponse);
+        break;
+      case "/stop":
+        responseBody = JSON.stringify(stopResponse);
+        break;
+      case "/status":
+        responseBody = JSON.stringify(statusResponse);
+        break;
+      default:
+        responseBody = JSON.stringify({ success: false, error: `Unknown endpoint: ${path}` });
+        break;
+    }
+
+    return Promise.resolve(
+      new Response(responseBody, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  };
+
+  return {
+    ["__DURABLE_OBJECT_BRAND"]: undefined as never,
+    fetch: fetchMock,
+    connect: (): Socket => {
+      throw new Error("Socket connections not supported in fake");
+    },
+    id: aFakeDurableObjectId(),
+  };
+}

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1,0 +1,200 @@
+import * as Sentry from "@sentry/cloudflare";
+import { addMilliseconds } from "date-fns";
+import type { LogService } from "../../services/log/types";
+import { installServices as installServicesImpl } from "../../services/install";
+import type {
+  IndividualTrackerStartRequest,
+  IndividualTrackerState,
+  IndividualTrackerStateSanitized,
+  IndividualTrackerStartResponse,
+  IndividualTrackerPauseResponse,
+  IndividualTrackerResumeResponse,
+  IndividualTrackerStopResponse,
+  IndividualTrackerStatusResponse,
+} from "./types";
+
+const DISPLAY_INTERVAL_MS = 3 * 60 * 1000;
+const EXECUTION_BUFFER_MS = 8 * 1000;
+const ALARM_INTERVAL_MS = DISPLAY_INTERVAL_MS - EXECUTION_BUFFER_MS;
+
+const NORMAL_INTERVAL_MINUTES = 3;
+
+const STATE_STORAGE_KEY = "individualTrackerState";
+
+export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
+  __DURABLE_OBJECT_BRAND = undefined as never;
+  private readonly state: DurableObjectState;
+  private readonly logService: LogService;
+
+  constructor(state: DurableObjectState, env: Env, installServices = installServicesImpl) {
+    this.state = state;
+
+    const services = installServices({ env });
+    this.logService = services.logService;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    return await Sentry.withScope(async () => {
+      const url = new URL(request.url);
+      const action = url.pathname.split("/").pop();
+
+      Sentry.setTag("durableObject", "IndividualTrackerDO");
+      Sentry.setTag("action", action ?? "unknown");
+      Sentry.setContext("request", {
+        url: request.url,
+        method: request.method,
+      });
+
+      try {
+        switch (action) {
+          case "start": {
+            return await this.handleStart(request);
+          }
+          case "pause": {
+            return await this.handlePause();
+          }
+          case "resume": {
+            return await this.handleResume();
+          }
+          case "stop": {
+            return await this.handleStop();
+          }
+          case "status": {
+            return await this.handleStatus();
+          }
+          case undefined: {
+            return new Response("Bad Request", { status: 400 });
+          }
+          default: {
+            return new Response("Not Found", { status: 404 });
+          }
+        }
+      } catch (error) {
+        this.logService.error("IndividualTrackerDO fetch error:", new Map([["error", String(error)]]));
+        Sentry.captureException(error);
+        return new Response("Internal Server Error", { status: 500 });
+      }
+    });
+  }
+
+  async alarm(): Promise<void> {
+    await Sentry.withScope(async () => {
+      Sentry.setTag("durableObject", "IndividualTrackerDO");
+      Sentry.setTag("method", "alarm");
+
+      const trackerState = await this.getState();
+      if (trackerState == null || trackerState.isPaused || trackerState.status !== "active") {
+        return;
+      }
+
+      trackerState.lastUpdateTime = new Date().toISOString();
+      trackerState.checkCount += 1;
+      await this.setState(trackerState);
+
+      await this.state.storage.setAlarm(addMilliseconds(new Date(), ALARM_INTERVAL_MS).getTime());
+    });
+  }
+
+  private async handleStart(request: Request): Promise<Response> {
+    const body = await request.json<IndividualTrackerStartRequest>();
+    const now = new Date().toISOString();
+
+    const trackerState: IndividualTrackerState = {
+      userId: body.userId,
+      trackerId: body.trackerId,
+      xuid: body.xuid,
+      gamertag: body.gamertag,
+      status: "active",
+      isPaused: false,
+      startTime: now,
+      lastUpdateTime: now,
+      searchStartTime: body.searchStartTime,
+      lastMatchDiscoveredAt: undefined,
+      checkCount: 0,
+      idleTimeoutHours: body.idleTimeoutHours,
+      errorState: {
+        consecutiveErrors: 0,
+        backoffMinutes: NORMAL_INTERVAL_MINUTES,
+        lastSuccessTime: now,
+        lastErrorMessage: undefined,
+      },
+    };
+
+    await this.setState(trackerState);
+    await this.state.storage.setAlarm(addMilliseconds(new Date(), ALARM_INTERVAL_MS).getTime());
+
+    const response: IndividualTrackerStartResponse = { success: true, state: this.sanitizeState(trackerState) };
+    return Response.json(response);
+  }
+
+  private async handlePause(): Promise<Response> {
+    const trackerState = await this.getState();
+    if (!trackerState) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    trackerState.isPaused = true;
+    trackerState.status = "paused";
+    trackerState.lastUpdateTime = new Date().toISOString();
+    await this.state.storage.deleteAlarm();
+    await this.setState(trackerState);
+
+    const response: IndividualTrackerPauseResponse = { success: true, state: this.sanitizeState(trackerState) };
+    return Response.json(response);
+  }
+
+  private async handleResume(): Promise<Response> {
+    const trackerState = await this.getState();
+    if (!trackerState) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    trackerState.isPaused = false;
+    trackerState.status = "active";
+    trackerState.lastUpdateTime = new Date().toISOString();
+    await this.setState(trackerState);
+    await this.state.storage.setAlarm(addMilliseconds(new Date(), ALARM_INTERVAL_MS).getTime());
+
+    const response: IndividualTrackerResumeResponse = { success: true, state: this.sanitizeState(trackerState) };
+    return Response.json(response);
+  }
+
+  private async handleStop(): Promise<Response> {
+    await this.state.storage.deleteAlarm();
+    await this.state.storage.delete(STATE_STORAGE_KEY);
+
+    const response: IndividualTrackerStopResponse = { success: true };
+    return Response.json(response);
+  }
+
+  private async handleStatus(): Promise<Response> {
+    const trackerState = await this.getState();
+    const response: IndividualTrackerStatusResponse = {
+      state: trackerState == null ? null : this.sanitizeState(trackerState),
+    };
+    return Response.json(response);
+  }
+
+  private async getState(): Promise<IndividualTrackerState | null> {
+    const state = await this.state.storage.get<IndividualTrackerState>(STATE_STORAGE_KEY);
+    return state ?? null;
+  }
+
+  private async setState(state: IndividualTrackerState): Promise<void> {
+    await this.state.storage.put(STATE_STORAGE_KEY, state);
+  }
+
+  private sanitizeState(state: IndividualTrackerState): IndividualTrackerStateSanitized {
+    return {
+      userId: state.userId,
+      trackerId: state.trackerId,
+      xuid: state.xuid,
+      gamertag: state.gamertag,
+      status: state.status,
+      isPaused: state.isPaused,
+      startTime: state.startTime,
+      lastUpdateTime: state.lastUpdateTime,
+      idleTimeoutHours: state.idleTimeoutHours,
+    };
+  }
+}

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1,0 +1,297 @@
+import { describe, beforeEach, it, expect, vi, afterEach } from "vitest";
+import type { MockInstance } from "vitest";
+import { IndividualTrackerDO } from "../individual-tracker-do";
+import { installFakeServicesWith } from "../../../services/fakes/services";
+import { aFakeEnvWith } from "../../../base/fakes/env.fake";
+import type { Services } from "../../../services/install";
+import { aFakeDurableObjectStateWith } from "../../../base/fakes/do.fake";
+import type {
+  IndividualTrackerStartRequest,
+  IndividualTrackerState,
+  IndividualTrackerStartResponse,
+  IndividualTrackerPauseResponse,
+  IndividualTrackerResumeResponse,
+  IndividualTrackerStatusResponse,
+} from "../types";
+import { aFakeIndividualTrackerStateWith } from "../fakes/individual-tracker-do.fake";
+
+const createMockStartRequest = (
+  overrides: Partial<IndividualTrackerStartRequest> = {},
+): IndividualTrackerStartRequest => ({
+  userId: "test-user-id",
+  trackerId: "test-tracker-id",
+  xuid: "test-xuid",
+  gamertag: "TestGamertag",
+  searchStartTime: new Date().toISOString(),
+  idleTimeoutHours: 6,
+  ...overrides,
+});
+
+describe("IndividualTrackerDO", () => {
+  let individualTrackerDO: IndividualTrackerDO;
+  let mockState: DurableObjectState;
+  let mockStorage: DurableObjectStorage;
+  let services: Services;
+  let env: Env;
+  let storageGetSpy: MockInstance<(key: string) => Promise<IndividualTrackerState | null>>;
+  let storagePutSpy: MockInstance<(key: string, value: IndividualTrackerState) => Promise<void>>;
+  let storageDeleteSpy: MockInstance<typeof mockStorage.delete>;
+  let storageSetAlarmSpy: MockInstance<typeof mockStorage.setAlarm>;
+  let storageDeleteAlarmSpy: MockInstance<typeof mockStorage.deleteAlarm>;
+
+  beforeEach(() => {
+    vi.useFakeTimers({
+      now: new Date("2024-11-26T12:00:00.000Z"),
+    });
+
+    mockState = aFakeDurableObjectStateWith();
+    mockStorage = mockState.storage;
+    services = installFakeServicesWith();
+    env = aFakeEnvWith();
+
+    storageGetSpy = vi.spyOn(mockStorage, "get");
+    storagePutSpy = vi.spyOn(mockStorage, "put");
+    storageDeleteSpy = vi.spyOn(mockStorage, "delete");
+    storageSetAlarmSpy = vi.spyOn(mockStorage, "setAlarm");
+    storageDeleteAlarmSpy = vi.spyOn(mockStorage, "deleteAlarm");
+
+    individualTrackerDO = new IndividualTrackerDO(mockState, env, () => services);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("constructor", () => {
+    it("initializes services correctly", () => {
+      expect(individualTrackerDO).toBeInstanceOf(IndividualTrackerDO);
+    });
+  });
+
+  describe("fetch()", () => {
+    it("returns 404 for unknown endpoints", async () => {
+      const response = await individualTrackerDO.fetch(new Request("http://do/unknown", { method: "GET" }));
+
+      expect(response.status).toBe(404);
+      const text = await response.text();
+      expect(text).toBe("Not Found");
+    });
+
+    it("returns 500 when storage throws", async () => {
+      storageGetSpy.mockRejectedValue(new Error("Storage error"));
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/status", { method: "GET" }));
+
+      expect(response.status).toBe(500);
+      const text = await response.text();
+      expect(text).toBe("Internal Server Error");
+    });
+  });
+
+  describe("handleStart()", () => {
+    it("initializes state to active and returns sanitized state", async () => {
+      const request = new Request("http://do/start", {
+        method: "POST",
+        body: JSON.stringify(createMockStartRequest()),
+      });
+
+      const response = await individualTrackerDO.fetch(request);
+
+      expect(response.status).toBe(200);
+      const body: IndividualTrackerStartResponse = await response.json();
+      expect(body.success).toBe(true);
+      expect(body.state.status).toBe("active");
+      expect(body.state.isPaused).toBe(false);
+      expect(body.state.gamertag).toBe("TestGamertag");
+      expect(body.state.idleTimeoutHours).toBe(6);
+    });
+
+    it("persists initial state with active status and zero check count", async () => {
+      const request = new Request("http://do/start", {
+        method: "POST",
+        body: JSON.stringify(createMockStartRequest()),
+      });
+
+      await individualTrackerDO.fetch(request);
+
+      expect(storagePutSpy).toHaveBeenCalledWith(
+        "individualTrackerState",
+        expect.objectContaining({ status: "active", isPaused: false, checkCount: 0 }),
+      );
+    });
+
+    it("schedules an alarm", async () => {
+      const request = new Request("http://do/start", {
+        method: "POST",
+        body: JSON.stringify(createMockStartRequest()),
+      });
+
+      await individualTrackerDO.fetch(request);
+
+      expect(storageSetAlarmSpy).toHaveBeenCalled();
+    });
+
+    it("does not include internal-only fields in the returned state", async () => {
+      const request = new Request("http://do/start", {
+        method: "POST",
+        body: JSON.stringify(createMockStartRequest()),
+      });
+
+      const response = await individualTrackerDO.fetch(request);
+      const body: IndividualTrackerStartResponse = await response.json();
+
+      expect(Object.keys(body.state).sort()).toEqual(
+        [
+          "gamertag",
+          "idleTimeoutHours",
+          "isPaused",
+          "lastUpdateTime",
+          "startTime",
+          "status",
+          "trackerId",
+          "userId",
+          "xuid",
+        ].sort(),
+      );
+    });
+  });
+
+  describe("handlePause()", () => {
+    it("sets state to paused and persists", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerStateWith());
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/pause", { method: "POST" }));
+
+      expect(response.status).toBe(200);
+      const body: IndividualTrackerPauseResponse = await response.json();
+      expect(body.state.status).toBe("paused");
+      expect(body.state.isPaused).toBe(true);
+      expect(storagePutSpy).toHaveBeenCalledWith(
+        "individualTrackerState",
+        expect.objectContaining({ status: "paused", isPaused: true }),
+      );
+    });
+
+    it("clears the alarm", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerStateWith());
+
+      await individualTrackerDO.fetch(new Request("http://do/pause", { method: "POST" }));
+
+      expect(storageDeleteAlarmSpy).toHaveBeenCalled();
+    });
+
+    it("returns 404 when no state exists", async () => {
+      storageGetSpy.mockResolvedValue(null);
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/pause", { method: "POST" }));
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("handleResume()", () => {
+    it("sets state to active and persists", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerStateWith({ status: "paused", isPaused: true }));
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/resume", { method: "POST" }));
+
+      expect(response.status).toBe(200);
+      const body: IndividualTrackerResumeResponse = await response.json();
+      expect(body.state.status).toBe("active");
+      expect(body.state.isPaused).toBe(false);
+    });
+
+    it("schedules an alarm", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerStateWith({ status: "paused", isPaused: true }));
+
+      await individualTrackerDO.fetch(new Request("http://do/resume", { method: "POST" }));
+
+      expect(storageSetAlarmSpy).toHaveBeenCalled();
+    });
+
+    it("returns 404 when no state exists", async () => {
+      storageGetSpy.mockResolvedValue(null);
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/resume", { method: "POST" }));
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("handleStop()", () => {
+    it("deletes the persisted state and clears the alarm", async () => {
+      const response = await individualTrackerDO.fetch(new Request("http://do/stop", { method: "POST" }));
+
+      expect(response.status).toBe(200);
+      expect(storageDeleteSpy).toHaveBeenCalledWith("individualTrackerState");
+      expect(storageDeleteAlarmSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("handleStatus()", () => {
+    it("returns sanitized state when present", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerStateWith());
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/status", { method: "GET" }));
+
+      expect(response.status).toBe(200);
+      const body: IndividualTrackerStatusResponse = await response.json();
+      expect(body.state?.gamertag).toBe("FakeGamertag");
+    });
+
+    it("returns null state when absent", async () => {
+      storageGetSpy.mockResolvedValue(null);
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/status", { method: "GET" }));
+
+      expect(response.status).toBe(200);
+      const body: IndividualTrackerStatusResponse = await response.json();
+      expect(body.state).toBeNull();
+    });
+
+    it("excludes internal-only fields from the returned state", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerStateWith());
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/status", { method: "GET" }));
+      const body: IndividualTrackerStatusResponse = await response.json();
+
+      expect.assertions(5);
+      if (body.state != null) {
+        expect(body.state).not.toHaveProperty("errorState");
+        expect(body.state).not.toHaveProperty("searchStartTime");
+        expect(body.state).not.toHaveProperty("checkCount");
+        expect(body.state).not.toHaveProperty("lastMatchDiscoveredAt");
+        expect(Object.keys(body.state)).toHaveLength(9);
+      }
+    });
+  });
+
+  describe("alarm()", () => {
+    it("bumps check count and reschedules when active", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerStateWith({ checkCount: 2 }));
+
+      await individualTrackerDO.alarm();
+
+      expect(storagePutSpy).toHaveBeenCalledWith("individualTrackerState", expect.objectContaining({ checkCount: 3 }));
+      expect(storageSetAlarmSpy).toHaveBeenCalled();
+    });
+
+    it("does nothing when state is absent", async () => {
+      storageGetSpy.mockResolvedValue(null);
+
+      await individualTrackerDO.alarm();
+
+      expect(storagePutSpy).not.toHaveBeenCalled();
+      expect(storageSetAlarmSpy).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when paused", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerStateWith({ isPaused: true, status: "paused" }));
+
+      await individualTrackerDO.alarm();
+
+      expect(storagePutSpy).not.toHaveBeenCalled();
+      expect(storageSetAlarmSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -1,0 +1,95 @@
+import type { IndividualTrackerStatus } from "../../services/database/types/individual_trackers";
+
+export interface IndividualTrackerStartRequest {
+  userId: string;
+  trackerId: string;
+  xuid: string;
+  gamertag: string;
+  searchStartTime: string;
+  idleTimeoutHours: number;
+}
+
+export interface IndividualTrackerState {
+  userId: string;
+  trackerId: string;
+  xuid: string;
+  gamertag: string;
+  status: IndividualTrackerStatus;
+  isPaused: boolean;
+  startTime: string;
+  lastUpdateTime: string;
+  searchStartTime: string;
+  lastMatchDiscoveredAt: string | undefined;
+  checkCount: number;
+  idleTimeoutHours: number;
+  errorState: {
+    consecutiveErrors: number;
+    backoffMinutes: number;
+    lastSuccessTime: string;
+    lastErrorMessage?: string | undefined;
+  };
+}
+
+export interface IndividualTrackerStateSanitized {
+  userId: string;
+  trackerId: string;
+  xuid: string;
+  gamertag: string;
+  status: IndividualTrackerStatus;
+  isPaused: boolean;
+  startTime: string;
+  lastUpdateTime: string;
+  idleTimeoutHours: number;
+}
+
+export interface IndividualTrackerStartResponse {
+  success: true;
+  state: IndividualTrackerStateSanitized;
+}
+
+export interface IndividualTrackerPauseResponse {
+  success: true;
+  state: IndividualTrackerStateSanitized;
+}
+
+export interface IndividualTrackerResumeResponse {
+  success: true;
+  state: IndividualTrackerStateSanitized;
+}
+
+export interface IndividualTrackerStopResponse {
+  success: true;
+}
+
+export interface IndividualTrackerStatusResponse {
+  state: IndividualTrackerStateSanitized | null;
+}
+
+export type IndividualTrackerAction = "start" | "pause" | "resume" | "stop" | "status";
+
+export interface IndividualTrackerApiMap {
+  start: {
+    request: IndividualTrackerStartRequest;
+    response: IndividualTrackerStartResponse;
+  };
+  pause: {
+    request: never;
+    response: IndividualTrackerPauseResponse;
+  };
+  resume: {
+    request: never;
+    response: IndividualTrackerResumeResponse;
+  };
+  stop: {
+    request: never;
+    response: IndividualTrackerStopResponse;
+  };
+  status: {
+    request: never;
+    response: IndividualTrackerStatusResponse;
+  };
+}
+
+export type IndividualTrackerRequestFor<T extends IndividualTrackerAction> = IndividualTrackerApiMap[T]["request"];
+
+export type IndividualTrackerResponseFor<T extends IndividualTrackerAction> = IndividualTrackerApiMap[T]["response"];

--- a/api/worker.ts
+++ b/api/worker.ts
@@ -5,6 +5,7 @@ import { Server } from "./server";
 
 // Export Durable Object classes
 export { LiveTrackerDO } from "./durable-objects/live-tracker/live-tracker-do";
+export { IndividualTrackerDO } from "./durable-objects/individual-tracker/individual-tracker-do";
 
 const server = new Server({
   router: createApiRouter(),

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -30,6 +30,10 @@
         "name": "LIVE_TRACKER_DO",
         "class_name": "LiveTrackerDO",
       },
+      {
+        "name": "INDIVIDUAL_TRACKER_DO",
+        "class_name": "IndividualTrackerDO",
+      },
     ],
   },
 
@@ -46,6 +50,10 @@
     {
       "tag": "v3",
       "deleted_classes": ["LiveTrackerIndividualDO"],
+    },
+    {
+      "tag": "v4",
+      "new_classes": ["IndividualTrackerDO"],
     },
   ],
 
@@ -98,6 +106,10 @@
             "name": "LIVE_TRACKER_DO",
             "class_name": "LiveTrackerDO",
           },
+          {
+            "name": "INDIVIDUAL_TRACKER_DO",
+            "class_name": "IndividualTrackerDO",
+          },
         ],
       },
       "vars": {
@@ -140,6 +152,10 @@
           {
             "name": "LIVE_TRACKER_DO",
             "class_name": "LiveTrackerDO",
+          },
+          {
+            "name": "INDIVIDUAL_TRACKER_DO",
+            "class_name": "IndividualTrackerDO",
           },
         ],
       },


### PR DESCRIPTION
## Milestone B · PR 2 — `IndividualTrackerDO` skeleton

The Durable Object that owns the **active runtime state** for one individual tracker (one per `userId:trackerId`). **Skeleton scope** — lifecycle + alarm scaffold only. Deliberately excluded (later PRs): Halo polling/match-discovery (B4), user OAuth tokens + the proxy `UserTokenProvider` (B3), the D1 registry writes (B5 control routes), and viewer WebSocket broadcast (Milestone C).

### What's here
- **`IndividualTrackerDO`** mirroring `LiveTrackerDO`: `fetch()` routes on the trailing path segment to `start` / `pause` / `resume` / `stop` / `status`; `getState`/`setState` over DO storage; `alarm()` is a scaffold that only bumps `lastUpdateTime`/`checkCount` and reschedules while active (no polling, no Halo calls).
- **Token-leak boundary established up front:** `status` returns `sanitizeState()` — an explicit 9-field allowlist (not a spread), and `IndividualTrackerStateSanitized` is a separate hand-written type. So when B3 adds `userMicrosoftTokens` to the internal state, it cannot leak through `status` without being added by name in two places. A test locks the sanitized shape to exactly those 9 keys.
- **Wiring:** `INDIVIDUAL_TRACKER_DO` binding added to all three wrangler environments (dev/staging/production) + migration `{ tag: "v4", new_classes: ["IndividualTrackerDO"] }` (fresh class name — not the deleted `LiveTrackerIndividualDO`); `worker.ts` export.
- Fakes + 20 black-box DO tests (lifecycle transitions, alarm scaffold, sanitized-shape lock).

### Process
Implemented by a subagent under orchestration; I independently re-ran verification + read the code + ran an independent correctness/AGENTS.md review (came back clean for scope).

### Notes
- **No D1 migration**; the `v4` DO migration registers the new DO class on the next **deploy** (no manual step).
- `api/worker-configuration.d.ts` (generated) is intentionally **not** regenerated here — nothing references the binding yet; B5 (first consumer of `env.INDIVIDUAL_TRACKER_DO`) will refresh it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
