### PR TITLE
feat(api): individual tracker pause/resume/select-active (B5b)

### DIFF
--- a/api/routes/individual-tracker/manage.ts
+++ b/api/routes/individual-tracker/manage.ts
@@ -1,6 +1,7 @@
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { errorContract } from "@guilty-spark/shared/contracts/error";
 import {
+  selectActiveTrackerRequestSchema,
   startTrackerRequestSchema,
   stopTrackerContract,
   trackerContract,
@@ -8,6 +9,8 @@ import {
 } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import { parseJsonBody } from "@guilty-spark/shared/base/request-parsing";
 import type {
+  IndividualTrackerPauseResponse,
+  IndividualTrackerResumeResponse,
   IndividualTrackerStartRequest,
   IndividualTrackerStartResponse,
   IndividualTrackerState,
@@ -36,6 +39,20 @@ async function startTrackerDo(env: Env, startRequest: IndividualTrackerStartRequ
     body: JSON.stringify(startRequest),
   });
   const result = await response.json<IndividualTrackerStartResponse>();
+  return result.state;
+}
+
+async function pauseTrackerDo(env: Env, userId: string, trackerId: string): Promise<IndividualTrackerState> {
+  const stub = trackerDoStub(env, userId, trackerId);
+  const response = await stub.fetch("http://do/pause", { method: "POST" });
+  const result = await response.json<IndividualTrackerPauseResponse>();
+  return result.state;
+}
+
+async function resumeTrackerDo(env: Env, userId: string, trackerId: string): Promise<IndividualTrackerState> {
+  const stub = trackerDoStub(env, userId, trackerId);
+  const response = await stub.fetch("http://do/resume", { method: "POST" });
+  const result = await response.json<IndividualTrackerResumeResponse>();
   return result.state;
 }
 
@@ -130,12 +147,114 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
       }
 
       await stopTrackerDo(env, auth.session.userId, tracker.TrackerId);
-      await individualTrackerService.markTrackerStopped(tracker);
+      await individualTrackerService.markTrackerStatus(tracker, "stopped");
 
       return stopTrackerContract.toResponse({ success: true }, { noStore: true });
     } catch (error) {
       logService.error(error as Error, new Map([["message", "Individual tracker stop error"]]));
       return errorContract.toResponse({ error: "Failed to stop tracker" }, { status: 500, noStore: true });
+    }
+  });
+
+  router.post("/api/individual-tracker/:trackerId/pause", async (request, env: Env) => {
+    const services = installServices({ env });
+    const { authService, individualTrackerService, logService } = services;
+
+    try {
+      const auth = await requireSession(request, authService);
+      if (!auth.ok) {
+        return auth.response;
+      }
+
+      const trackerId = Preconditions.checkExists(request.params["trackerId"], "Missing trackerId");
+
+      let tracker: IndividualTrackersRow;
+      try {
+        tracker = await individualTrackerService.getOwnedTracker(auth.session.userId, trackerId);
+      } catch (error) {
+        if (error instanceof TrackerNotFoundError) {
+          return errorContract.toResponse({ error: "Tracker not found" }, { status: 404, noStore: true });
+        }
+        throw error;
+      }
+
+      const state = await pauseTrackerDo(env, auth.session.userId, tracker.TrackerId);
+      const paused = await individualTrackerService.markTrackerStatus(tracker, "paused");
+
+      return trackerContract.toResponse({ tracker: toTracker(paused, state) }, { noStore: true });
+    } catch (error) {
+      logService.error(error as Error, new Map([["message", "Individual tracker pause error"]]));
+      return errorContract.toResponse({ error: "Failed to pause tracker" }, { status: 500, noStore: true });
+    }
+  });
+
+  router.post("/api/individual-tracker/:trackerId/resume", async (request, env: Env) => {
+    const services = installServices({ env });
+    const { authService, individualTrackerService, logService } = services;
+
+    try {
+      const auth = await requireSession(request, authService);
+      if (!auth.ok) {
+        return auth.response;
+      }
+
+      const trackerId = Preconditions.checkExists(request.params["trackerId"], "Missing trackerId");
+
+      let tracker: IndividualTrackersRow;
+      try {
+        tracker = await individualTrackerService.getOwnedTracker(auth.session.userId, trackerId);
+      } catch (error) {
+        if (error instanceof TrackerNotFoundError) {
+          return errorContract.toResponse({ error: "Tracker not found" }, { status: 404, noStore: true });
+        }
+        throw error;
+      }
+
+      const state = await resumeTrackerDo(env, auth.session.userId, tracker.TrackerId);
+      const resumed = await individualTrackerService.markTrackerStatus(tracker, "active");
+
+      return trackerContract.toResponse({ tracker: toTracker(resumed, state) }, { noStore: true });
+    } catch (error) {
+      logService.error(error as Error, new Map([["message", "Individual tracker resume error"]]));
+      return errorContract.toResponse({ error: "Failed to resume tracker" }, { status: 500, noStore: true });
+    }
+  });
+
+  router.post("/api/individual-tracker/manage/select-active", async (request, env: Env) => {
+    const services = installServices({ env });
+    const { authService, individualTrackerService, logService } = services;
+
+    try {
+      const auth = await requireSession(request, authService);
+      if (!auth.ok) {
+        return auth.response;
+      }
+
+      const parsed = await parseJsonBody(
+        request,
+        selectActiveTrackerRequestSchema,
+        "Invalid select active tracker request",
+      );
+      if (!parsed.success) {
+        return parsed.response;
+      }
+
+      let tracker: IndividualTrackersRow;
+      try {
+        tracker = await individualTrackerService.setLiveTracker(auth.session.userId, parsed.data.trackerId);
+      } catch (error) {
+        if (error instanceof TrackerNotFoundError) {
+          return errorContract.toResponse({ error: "Tracker not found" }, { status: 404, noStore: true });
+        }
+        throw error;
+      }
+
+      const state = await statusTrackerDo(env, auth.session.userId, tracker.TrackerId);
+
+      return trackerContract.toResponse({ tracker: toTracker(tracker, state) }, { noStore: true });
+    } catch (error) {
+      logService.error(error as Error, new Map([["message", "Individual tracker select active error"]]));
+      return errorContract.toResponse({ error: "Failed to select active tracker" }, { status: 500, noStore: true });
     }
   });
 

--- a/api/routes/individual-tracker/tests/manage.test.ts
+++ b/api/routes/individual-tracker/tests/manage.test.ts
@@ -1,6 +1,7 @@
 import type { AutoRouterType } from "itty-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MockInstance } from "vitest";
+import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import type {
   StopTrackerResponse,
   TrackerResponse,
@@ -178,13 +179,13 @@ describe("/api/individual-tracker manage routes", () => {
     const localEnv = envWithTrackerDo(doStub);
 
     const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "active" });
-    let markStoppedSpy: MockInstance<IndividualTrackerService["markTrackerStopped"]> | null = null;
+    let markStatusSpy: MockInstance<IndividualTrackerService["markTrackerStatus"]> | null = null;
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env: localEnv });
       vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-123" }));
       vi.spyOn(services.individualTrackerService, "getOwnedTracker").mockResolvedValue(row);
-      markStoppedSpy = vi
-        .spyOn(services.individualTrackerService, "markTrackerStopped")
+      markStatusSpy = vi
+        .spyOn(services.individualTrackerService, "markTrackerStatus")
         .mockResolvedValue({ ...row, Status: "stopped" });
       return services;
     });
@@ -196,7 +197,157 @@ describe("/api/individual-tracker manage routes", () => {
     const body = await res.json<StopTrackerResponse>();
     expect(body.success).toBe(true);
     expect(stopSpy).toHaveBeenCalledWith("http://do/stop", expect.objectContaining({ method: "POST" }));
-    expect(markStoppedSpy).not.toBeNull();
+    expect(Preconditions.checkExists(markStatusSpy, "markStatus spy")).toHaveBeenCalledWith(row, "stopped");
+  });
+
+  it("returns 404 on pause when the tracker is not owned", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith());
+      vi.spyOn(services.individualTrackerService, "getOwnedTracker").mockRejectedValue(new TrackerNotFoundError());
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(postRequest("/api/individual-tracker/not-mine/pause", {}), env)) as Response;
+
+    expect(res.status).toBe(404);
+  });
+
+  it("pauses a tracker: calls the DO pause, marks the registry row paused, returns the tracker", async () => {
+    const doStub = aFakeIndividualTrackerDOWith({
+      pauseResponse: {
+        success: true,
+        state: aFakeIndividualTrackerStateWith({ trackerId: "t1", status: "paused", isPaused: true }),
+      },
+    });
+    const pauseSpy: MockInstance<FakeIndividualTrackerDO["fetch"]> = vi.spyOn(doStub, "fetch");
+    const localEnv = envWithTrackerDo(doStub);
+
+    const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "active" });
+    let markStatusSpy: MockInstance<IndividualTrackerService["markTrackerStatus"]> | null = null;
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env: localEnv });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-123" }));
+      vi.spyOn(services.individualTrackerService, "getOwnedTracker").mockResolvedValue(row);
+      markStatusSpy = vi
+        .spyOn(services.individualTrackerService, "markTrackerStatus")
+        .mockResolvedValue({ ...row, Status: "paused" });
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(postRequest("/api/individual-tracker/t1/pause", {}), localEnv)) as Response;
+
+    expect(res.status).toBe(200);
+    const body = await res.json<TrackerResponse>();
+    expect(body.tracker.status).toBe("paused");
+    expect(pauseSpy).toHaveBeenCalledWith("http://do/pause", expect.objectContaining({ method: "POST" }));
+    expect(Preconditions.checkExists(markStatusSpy, "markStatus spy")).toHaveBeenCalledWith(row, "paused");
+  });
+
+  it("returns 404 on resume when the tracker is not owned", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith());
+      vi.spyOn(services.individualTrackerService, "getOwnedTracker").mockRejectedValue(new TrackerNotFoundError());
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(postRequest("/api/individual-tracker/not-mine/resume", {}), env)) as Response;
+
+    expect(res.status).toBe(404);
+  });
+
+  it("resumes a tracker: calls the DO resume, marks the registry row active, returns the tracker", async () => {
+    const doStub = aFakeIndividualTrackerDOWith({
+      resumeResponse: {
+        success: true,
+        state: aFakeIndividualTrackerStateWith({ trackerId: "t1", status: "active", isPaused: false }),
+      },
+    });
+    const resumeSpy: MockInstance<FakeIndividualTrackerDO["fetch"]> = vi.spyOn(doStub, "fetch");
+    const localEnv = envWithTrackerDo(doStub);
+
+    const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "paused" });
+    let markStatusSpy: MockInstance<IndividualTrackerService["markTrackerStatus"]> | null = null;
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env: localEnv });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-123" }));
+      vi.spyOn(services.individualTrackerService, "getOwnedTracker").mockResolvedValue(row);
+      markStatusSpy = vi
+        .spyOn(services.individualTrackerService, "markTrackerStatus")
+        .mockResolvedValue({ ...row, Status: "active" });
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(postRequest("/api/individual-tracker/t1/resume", {}), localEnv)) as Response;
+
+    expect(res.status).toBe(200);
+    const body = await res.json<TrackerResponse>();
+    expect(body.tracker.status).toBe("active");
+    expect(resumeSpy).toHaveBeenCalledWith("http://do/resume", expect.objectContaining({ method: "POST" }));
+    expect(Preconditions.checkExists(markStatusSpy, "markStatus spy")).toHaveBeenCalledWith(row, "active");
+  });
+
+  it("returns 404 on select-active when the tracker is not owned", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith());
+      vi.spyOn(services.individualTrackerService, "setLiveTracker").mockRejectedValue(new TrackerNotFoundError());
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(
+      postRequest("/api/individual-tracker/manage/select-active", { trackerId: "not-mine" }),
+      env,
+    )) as Response;
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 on select-active when the trackerId is missing", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith());
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(postRequest("/api/individual-tracker/manage/select-active", {}), env)) as Response;
+
+    expect(res.status).toBe(400);
+  });
+
+  it("selects the active tracker: calls setLiveIndividualTracker via the service and returns the now-live tracker", async () => {
+    const doStub = aFakeIndividualTrackerDOWith({
+      statusResponse: { state: aFakeIndividualTrackerStateWith({ trackerId: "t1", status: "active" }) },
+    });
+    const localEnv = envWithTrackerDo(doStub);
+
+    const liveRow = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "active", IsLive: 1 });
+    let setLiveSpy: MockInstance<IndividualTrackerService["setLiveTracker"]> | null = null;
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env: localEnv });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-123" }));
+      setLiveSpy = vi.spyOn(services.individualTrackerService, "setLiveTracker").mockResolvedValue(liveRow);
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(
+      postRequest("/api/individual-tracker/manage/select-active", { trackerId: "t1" }),
+      localEnv,
+    )) as Response;
+
+    expect(res.status).toBe(200);
+    const body = await res.json<TrackerResponse>();
+    expect(body.tracker.trackerId).toBe("t1");
+    expect(body.tracker.isLive).toBe(true);
+    expect(Preconditions.checkExists(setLiveSpy, "setLive spy")).toHaveBeenCalledWith("user-123", "t1");
   });
 
   it("lists the user's trackers hydrated with DO status", async () => {

--- a/api/services/individual-tracker/individual-tracker.ts
+++ b/api/services/individual-tracker/individual-tracker.ts
@@ -1,7 +1,7 @@
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import type { DatabaseService } from "../database/database";
 import type { IndividualTrackerProfilesRow } from "../database/types/individual_tracker_profiles";
-import type { IndividualTrackersRow } from "../database/types/individual_trackers";
+import type { IndividualTrackerStatus, IndividualTrackersRow } from "../database/types/individual_trackers";
 import { IdentityNotOwnedError, ProfileNotFoundError, TrackerLimitReachedError, TrackerNotFoundError } from "./errors";
 import type { CreateTrackerOptions, UpdateProfileOptions } from "./types";
 
@@ -99,15 +99,25 @@ export class IndividualTrackerService {
     return tracker;
   }
 
-  async markTrackerStopped(tracker: IndividualTrackersRow): Promise<IndividualTrackersRow> {
-    const stopped: IndividualTrackersRow = {
+  async markTrackerStatus(
+    tracker: IndividualTrackersRow,
+    status: IndividualTrackerStatus,
+  ): Promise<IndividualTrackersRow> {
+    const updated: IndividualTrackersRow = {
       ...tracker,
-      Status: "stopped",
-      IsLive: 0,
+      Status: status,
+      IsLive: status === "stopped" ? 0 : tracker.IsLive,
       UpdatedAt: Math.floor(Date.now() / 1000),
     };
-    await this.databaseService.upsertIndividualTracker(stopped);
-    return stopped;
+    await this.databaseService.upsertIndividualTracker(updated);
+    return updated;
+  }
+
+  async setLiveTracker(userId: string, trackerId: string): Promise<IndividualTrackersRow> {
+    await this.getOwnedTracker(userId, trackerId);
+    await this.databaseService.setLiveIndividualTracker(userId, trackerId);
+    const refreshed = await this.databaseService.getIndividualTracker(trackerId);
+    return Preconditions.checkExists(refreshed, "Tracker disappeared after setting live");
   }
 
   private async assertIdentityOwned(userId: string, activeIdentityId: string | null | undefined): Promise<void> {

--- a/api/services/individual-tracker/tests/individual-tracker.test.ts
+++ b/api/services/individual-tracker/tests/individual-tracker.test.ts
@@ -219,20 +219,71 @@ describe("IndividualTrackerService", () => {
     });
   });
 
-  describe("markTrackerStopped", () => {
+  describe("markTrackerStatus", () => {
     it("upserts the tracker row with stopped status and not live", async () => {
       const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1", Status: "active", IsLive: 1 });
       const upsertSpy: MockInstance<DatabaseService["upsertIndividualTracker"]> = vi
         .spyOn(databaseService, "upsertIndividualTracker")
         .mockResolvedValue();
 
-      const stopped = await service.markTrackerStopped(row);
+      const stopped = await service.markTrackerStatus(row, "stopped");
 
       expect(stopped.Status).toBe("stopped");
       expect(stopped.IsLive).toBe(0);
       expect(upsertSpy).toHaveBeenCalledWith(
         expect.objectContaining({ TrackerId: "t1", Status: "stopped", IsLive: 0 }),
       );
+    });
+
+    it("upserts the tracker row with paused status while preserving live", async () => {
+      const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1", Status: "active", IsLive: 1 });
+      const upsertSpy: MockInstance<DatabaseService["upsertIndividualTracker"]> = vi
+        .spyOn(databaseService, "upsertIndividualTracker")
+        .mockResolvedValue();
+
+      const paused = await service.markTrackerStatus(row, "paused");
+
+      expect(paused.Status).toBe("paused");
+      expect(paused.IsLive).toBe(1);
+      expect(upsertSpy).toHaveBeenCalledWith(expect.objectContaining({ TrackerId: "t1", Status: "paused", IsLive: 1 }));
+    });
+
+    it("upserts the tracker row with active status when resuming", async () => {
+      const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1", Status: "paused", IsLive: 0 });
+      const upsertSpy: MockInstance<DatabaseService["upsertIndividualTracker"]> = vi
+        .spyOn(databaseService, "upsertIndividualTracker")
+        .mockResolvedValue();
+
+      const resumed = await service.markTrackerStatus(row, "active");
+
+      expect(resumed.Status).toBe("active");
+      expect(upsertSpy).toHaveBeenCalledWith(expect.objectContaining({ TrackerId: "t1", Status: "active" }));
+    });
+  });
+
+  describe("setLiveTracker", () => {
+    it("throws TrackerNotFoundError when the tracker is not owned", async () => {
+      vi.spyOn(databaseService, "getIndividualTracker").mockResolvedValue(null);
+      const setLiveSpy: MockInstance<DatabaseService["setLiveIndividualTracker"]> = vi
+        .spyOn(databaseService, "setLiveIndividualTracker")
+        .mockResolvedValue();
+
+      await expect(service.setLiveTracker("user-1", "t1")).rejects.toThrow(TrackerNotFoundError);
+      expect(setLiveSpy).not.toHaveBeenCalled();
+    });
+
+    it("sets the tracker live and returns the refreshed row", async () => {
+      const owned = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1", IsLive: 0 });
+      const refreshed = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1", IsLive: 1 });
+      vi.spyOn(databaseService, "getIndividualTracker").mockResolvedValueOnce(owned).mockResolvedValueOnce(refreshed);
+      const setLiveSpy: MockInstance<DatabaseService["setLiveIndividualTracker"]> = vi
+        .spyOn(databaseService, "setLiveIndividualTracker")
+        .mockResolvedValue();
+
+      const result = await service.setLiveTracker("user-1", "t1");
+
+      expect(result.IsLive).toBe(1);
+      expect(setLiveSpy).toHaveBeenCalledWith("user-1", "t1");
     });
   });
 });

--- a/shared/src/contracts/individual-tracker/tracker.ts
+++ b/shared/src/contracts/individual-tracker/tracker.ts
@@ -34,6 +34,11 @@ export const startTrackerRequestSchema = z.object({
 });
 export type StartTrackerRequest = z.infer<typeof startTrackerRequestSchema>;
 
+export const selectActiveTrackerRequestSchema = z.object({
+  trackerId: z.string().min(1),
+});
+export type SelectActiveTrackerRequest = z.infer<typeof selectActiveTrackerRequestSchema>;
+
 export const trackerContract = defineContract(z.object({ tracker: trackerSchema }));
 export type TrackerResponse = z.infer<typeof trackerContract.schema>;
 


### PR DESCRIPTION
## Milestone B · PR (B5b) — pause / resume / select-active

Stacked on **#460 (B5)**. Completes the individual-tracker control plane. `select-active` marks which of a user's trackers is the **"live"** one (central to casters switching between players).

> Base branch is `it/b5-tracker-control` (#460).

- **POST `/api/individual-tracker/:trackerId/pause`** — ownership-checked (404), DO `pause`, registry `Status: paused` (keeps `IsLive`).
- **POST `/api/individual-tracker/:trackerId/resume`** — ownership-checked, DO `resume`, registry `Status: active`.
- **POST `/api/individual-tracker/manage/select-active`** `{ trackerId }` — ownership-checked, then `setLiveIndividualTracker` (registry-only, atomic clear-others-then-set; the partial unique index guarantees one live tracker per user). No DO call (IsLive is a registry pointer, decoupled from DO runtime state).
- Generalized `markTrackerStopped` → `markTrackerStatus(tracker, status)` — clears `IsLive` only on `stopped`, preserves it otherwise (so pausing a live tracker keeps it live). B5's stop callsite updated; behaviour identical.

### Process / tests
Subagent-built under orchestration; independent correctness/security/AGENTS.md review came back clean (ownership enforced before the live mutation + user-scoped SQL defense-in-depth; no regression to stop; no token leak; no route collisions). 43 tracker tests + full suite green; typecheck (api+shared+pages) + lint clean. No D1 migration.

**Product note (non-blocking):** `select-active` currently allows marking a `stopped`/`paused` tracker as live — `IsLive` is just a per-user pointer with no live⇒running invariant, so nothing breaks. If you want "live ⇒ active" enforced, that's a one-line status guard in `setLiveTracker` — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
