### PR TITLE
feat(pages): individual tracker API client service (D3)

### DIFF
--- a/pages/src/services/fakes/install.fake.ts
+++ b/pages/src/services/fakes/install.fake.ts
@@ -1,22 +1,27 @@
 import type { AuthService } from "../auth/types";
+import type { IndividualTrackerService } from "../individual-tracker/types";
 import type { LiveTrackerService } from "../live-tracker/types";
 
 interface FakeServices {
   readonly authService: AuthService;
+  readonly individualTrackerService: IndividualTrackerService;
   readonly liveTrackerService: LiveTrackerService;
 }
 
 export async function installFakeServices(): Promise<FakeServices> {
-  const [{ FakeAuthService }, { FakeLiveTrackerService }, { createSampleScenario }] = await Promise.all([
-    import("../auth/fakes/auth.fake"),
-    import("../live-tracker/fakes/live-tracker.fake"),
-    import("../live-tracker/fakes/scenario"),
-  ]);
+  const [{ FakeAuthService }, { FakeIndividualTrackerService }, { FakeLiveTrackerService }, { createSampleScenario }] =
+    await Promise.all([
+      import("../auth/fakes/auth.fake"),
+      import("../individual-tracker/fakes/individual-tracker.fake"),
+      import("../live-tracker/fakes/live-tracker.fake"),
+      import("../live-tracker/fakes/scenario"),
+    ]);
 
   const scenario = createSampleScenario();
 
   return {
     authService: new FakeAuthService(),
+    individualTrackerService: new FakeIndividualTrackerService(),
     liveTrackerService: new FakeLiveTrackerService(scenario),
   };
 }

--- a/pages/src/services/individual-tracker/fakes/individual-tracker.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/individual-tracker.fake.ts
@@ -1,0 +1,147 @@
+import type {
+  TrackerProfile,
+  TrackerProfileResponse,
+  UpdateTrackerProfileRequest,
+} from "@guilty-spark/shared/contracts/individual-tracker/profile";
+import type {
+  StartTrackerRequest,
+  Tracker,
+  TrackerResponse,
+  TrackersResponse,
+} from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import type { IndividualTrackerService } from "../types";
+
+interface FakeTrackerOverrides {
+  readonly trackerId?: string;
+  readonly gamertag?: string;
+  readonly xuid?: string;
+  readonly status?: Tracker["status"];
+  readonly isLive?: boolean;
+  readonly state?: Tracker["state"];
+}
+
+export function aFakeTrackerWith(overrides: FakeTrackerOverrides = {}): Tracker {
+  const trackerId = overrides.trackerId ?? "fake-tracker-id";
+  const gamertag = overrides.gamertag ?? "Fake Spartan";
+  const xuid = overrides.xuid ?? "2533274800000001";
+  const status = overrides.status ?? "active";
+  return {
+    trackerId,
+    gamertag,
+    xuid,
+    status,
+    isLive: overrides.isLive ?? true,
+    state: overrides.state ?? {
+      userId: "fake-user-id",
+      trackerId,
+      xuid,
+      gamertag,
+      status,
+      isPaused: status === "paused",
+      startTime: "2100-01-01T00:00:00.000Z",
+      lastUpdateTime: "2100-01-01T00:00:00.000Z",
+      idleTimeoutHours: 6,
+    },
+  };
+}
+
+interface FakeProfileOverrides {
+  readonly profileId?: string;
+  readonly activeIdentityId?: string | null;
+  readonly name?: string;
+}
+
+export function aFakeTrackerProfileWith(overrides: FakeProfileOverrides = {}): TrackerProfile {
+  return {
+    profileId: overrides.profileId ?? "fake-profile-id",
+    activeIdentityId: overrides.activeIdentityId ?? null,
+    name: overrides.name ?? "Fake Profile",
+  };
+}
+
+interface FakeIndividualTrackerServiceOptions {
+  readonly profile: TrackerProfile;
+  readonly trackers: readonly Tracker[];
+}
+
+export interface FakeIndividualTrackerServiceFactoryOpts {
+  readonly profile?: TrackerProfile;
+  readonly trackers?: readonly Tracker[];
+}
+
+export class FakeIndividualTrackerService implements IndividualTrackerService {
+  private profile: TrackerProfile;
+  private trackers: Tracker[];
+
+  public constructor(options?: Partial<FakeIndividualTrackerServiceOptions>) {
+    this.profile = options?.profile ?? aFakeTrackerProfileWith();
+    this.trackers = [...(options?.trackers ?? [aFakeTrackerWith()])];
+  }
+
+  public async getProfile(): Promise<TrackerProfileResponse> {
+    await Promise.resolve();
+    return { profile: this.profile };
+  }
+
+  public async updateProfile(req: UpdateTrackerProfileRequest): Promise<TrackerProfileResponse> {
+    await Promise.resolve();
+    this.profile = {
+      ...this.profile,
+      ...(req.name !== undefined ? { name: req.name } : {}),
+      ...(req.activeIdentityId !== undefined ? { activeIdentityId: req.activeIdentityId } : {}),
+    };
+    return { profile: this.profile };
+  }
+
+  public async listTrackers(): Promise<TrackersResponse> {
+    await Promise.resolve();
+    return { trackers: [...this.trackers] };
+  }
+
+  public async startTracker(req: StartTrackerRequest): Promise<TrackerResponse> {
+    await Promise.resolve();
+    const tracker = aFakeTrackerWith({ gamertag: req.gamertag });
+    this.trackers = [...this.trackers, tracker];
+    return { tracker };
+  }
+
+  public async stopTracker(trackerId: string): Promise<void> {
+    await Promise.resolve();
+    this.trackers = this.trackers.filter((tracker) => tracker.trackerId !== trackerId);
+  }
+
+  public async pauseTracker(trackerId: string): Promise<TrackerResponse> {
+    await Promise.resolve();
+    return { tracker: this.findTracker(trackerId, "paused") };
+  }
+
+  public async resumeTracker(trackerId: string): Promise<TrackerResponse> {
+    await Promise.resolve();
+    return { tracker: this.findTracker(trackerId, "active") };
+  }
+
+  public async selectActive(trackerId: string): Promise<TrackerResponse> {
+    await Promise.resolve();
+    return { tracker: this.findTracker(trackerId) };
+  }
+
+  public async getTrackerStatus(trackerId: string): Promise<TrackerResponse> {
+    await Promise.resolve();
+    return { tracker: this.findTracker(trackerId) };
+  }
+
+  private findTracker(trackerId: string, status?: Tracker["status"]): Tracker {
+    const existing = this.trackers.find((tracker) => tracker.trackerId === trackerId);
+    const base = existing ?? aFakeTrackerWith({ trackerId });
+    return status !== undefined ? aFakeTrackerWith({ ...base, status }) : base;
+  }
+}
+
+export function aFakeIndividualTrackerServiceWith(
+  opts: FakeIndividualTrackerServiceFactoryOpts = {},
+): FakeIndividualTrackerService {
+  return new FakeIndividualTrackerService({
+    ...(opts.profile !== undefined ? { profile: opts.profile } : {}),
+    ...(opts.trackers !== undefined ? { trackers: opts.trackers } : {}),
+  });
+}

--- a/pages/src/services/individual-tracker/individual-tracker.ts
+++ b/pages/src/services/individual-tracker/individual-tracker.ts
@@ -1,0 +1,190 @@
+import { errorContract } from "@guilty-spark/shared/contracts/error";
+import type {
+  TrackerProfileResponse,
+  UpdateTrackerProfileRequest,
+} from "@guilty-spark/shared/contracts/individual-tracker/profile";
+import { trackerProfileContract } from "@guilty-spark/shared/contracts/individual-tracker/profile";
+import type {
+  StartTrackerRequest,
+  TrackerResponse,
+  TrackersResponse,
+} from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import {
+  stopTrackerContract,
+  trackerContract,
+  trackersContract,
+} from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import type { IndividualTrackerService } from "./types";
+
+interface IndividualTrackerServiceOpts {
+  readonly apiHost: string;
+}
+
+export class RealIndividualTrackerService implements IndividualTrackerService {
+  private readonly apiHost: string;
+
+  public constructor({ apiHost }: IndividualTrackerServiceOpts) {
+    this.apiHost = apiHost;
+  }
+
+  private buildUrl(path: string): string {
+    const baseUrl = this.apiHost.endsWith("/") ? this.apiHost.slice(0, -1) : this.apiHost;
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    return `${baseUrl}${normalizedPath}`;
+  }
+
+  private async readError(response: Response): Promise<Error> {
+    const body = await response.text();
+    if (body !== "") {
+      try {
+        const parsed = errorContract.safeParse(JSON.parse(body));
+        if (parsed.success && parsed.data.error !== "") {
+          return new Error(parsed.data.error);
+        }
+      } catch {
+        return new Error(body);
+      }
+      return new Error(body);
+    }
+
+    return new Error(`Request failed (${String(response.status)})`);
+  }
+
+  public async getProfile(): Promise<TrackerProfileResponse> {
+    const response = await fetch(this.buildUrl("/api/individual-tracker/profile"), {
+      credentials: "include",
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    return trackerProfileContract.fromResponse(response);
+  }
+
+  public async updateProfile(req: UpdateTrackerProfileRequest): Promise<TrackerProfileResponse> {
+    const response = await fetch(this.buildUrl("/api/individual-tracker/profile"), {
+      credentials: "include",
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(req),
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    return trackerProfileContract.fromResponse(response);
+  }
+
+  public async listTrackers(): Promise<TrackersResponse> {
+    const response = await fetch(this.buildUrl("/api/individual-tracker/manage/trackers"), {
+      credentials: "include",
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    return trackersContract.fromResponse(response);
+  }
+
+  public async startTracker(req: StartTrackerRequest): Promise<TrackerResponse> {
+    const response = await fetch(this.buildUrl("/api/individual-tracker/manage/start"), {
+      credentials: "include",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(req),
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    return trackerContract.fromResponse(response);
+  }
+
+  public async stopTracker(trackerId: string): Promise<void> {
+    const response = await fetch(this.buildUrl(`/api/individual-tracker/${encodeURIComponent(trackerId)}/stop`), {
+      credentials: "include",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    await stopTrackerContract.fromResponse(response);
+  }
+
+  public async pauseTracker(trackerId: string): Promise<TrackerResponse> {
+    const response = await fetch(this.buildUrl(`/api/individual-tracker/${encodeURIComponent(trackerId)}/pause`), {
+      credentials: "include",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    return trackerContract.fromResponse(response);
+  }
+
+  public async resumeTracker(trackerId: string): Promise<TrackerResponse> {
+    const response = await fetch(this.buildUrl(`/api/individual-tracker/${encodeURIComponent(trackerId)}/resume`), {
+      credentials: "include",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    return trackerContract.fromResponse(response);
+  }
+
+  public async selectActive(trackerId: string): Promise<TrackerResponse> {
+    const response = await fetch(this.buildUrl("/api/individual-tracker/manage/select-active"), {
+      credentials: "include",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ trackerId }),
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    return trackerContract.fromResponse(response);
+  }
+
+  public async getTrackerStatus(trackerId: string): Promise<TrackerResponse> {
+    const response = await fetch(this.buildUrl(`/api/individual-tracker/${encodeURIComponent(trackerId)}/status`), {
+      credentials: "include",
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    return trackerContract.fromResponse(response);
+  }
+}

--- a/pages/src/services/individual-tracker/install.ts
+++ b/pages/src/services/individual-tracker/install.ts
@@ -1,0 +1,13 @@
+import { getMode } from "../mode";
+import { RealIndividualTrackerService } from "./individual-tracker";
+import type { IndividualTrackerService } from "./types";
+
+export async function installIndividualTrackerService(apiHost: string): Promise<IndividualTrackerService> {
+  if (getMode() === "FAKE") {
+    const { installFakeServices } = await import("../fakes/install.fake");
+    const { individualTrackerService } = await installFakeServices();
+    return individualTrackerService;
+  }
+
+  return new RealIndividualTrackerService({ apiHost });
+}

--- a/pages/src/services/individual-tracker/tests/individual-tracker.test.ts
+++ b/pages/src/services/individual-tracker/tests/individual-tracker.test.ts
@@ -1,0 +1,166 @@
+import type { TrackerProfile } from "@guilty-spark/shared/contracts/individual-tracker/profile";
+import type { Tracker } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { RealIndividualTrackerService } from "../individual-tracker";
+
+function jsonResponse(payload: object, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const FAKE_PROFILE: TrackerProfile = {
+  profileId: "profile-1",
+  activeIdentityId: "identity-1",
+  name: "Spartan",
+};
+
+const FAKE_TRACKER: Tracker = {
+  trackerId: "tracker-1",
+  gamertag: "Master Chief",
+  xuid: "2533274800000001",
+  status: "active",
+  isLive: true,
+  state: null,
+};
+
+describe("RealIndividualTrackerService", () => {
+  let fetchSpy: MockInstance;
+  let service: RealIndividualTrackerService;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    service = new RealIndividualTrackerService({ apiHost: "https://api.example.com" });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("gets the profile with credentials", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ profile: FAKE_PROFILE }));
+
+    const result = await service.getProfile();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/individual-tracker/profile",
+      expect.objectContaining({ credentials: "include", method: "GET" }),
+    );
+    expect(result).toEqual({ profile: FAKE_PROFILE });
+  });
+
+  it("patches the profile with a JSON body", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ profile: FAKE_PROFILE }));
+
+    const result = await service.updateProfile({ profileId: "profile-1", name: "Spartan" });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/individual-tracker/profile",
+      expect.objectContaining({
+        credentials: "include",
+        method: "PATCH",
+        body: JSON.stringify({ profileId: "profile-1", name: "Spartan" }),
+      }),
+    );
+    expect(result).toEqual({ profile: FAKE_PROFILE });
+  });
+
+  it("lists trackers with credentials", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ trackers: [FAKE_TRACKER] }));
+
+    const result = await service.listTrackers();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/individual-tracker/manage/trackers",
+      expect.objectContaining({ credentials: "include", method: "GET" }),
+    );
+    expect(result).toEqual({ trackers: [FAKE_TRACKER] });
+  });
+
+  it("starts a tracker with a JSON body", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ tracker: FAKE_TRACKER }));
+
+    const result = await service.startTracker({ gamertag: "Master Chief" });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/individual-tracker/manage/start",
+      expect.objectContaining({
+        credentials: "include",
+        method: "POST",
+        body: JSON.stringify({ gamertag: "Master Chief" }),
+      }),
+    );
+    expect(result).toEqual({ tracker: FAKE_TRACKER });
+  });
+
+  it("stops a tracker and returns void", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ success: true }));
+
+    await expect(service.stopTracker("tracker 1")).resolves.toBeUndefined();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/individual-tracker/tracker%201/stop",
+      expect.objectContaining({ credentials: "include", method: "POST" }),
+    );
+  });
+
+  it("pauses a tracker with credentials", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ tracker: FAKE_TRACKER }));
+
+    const result = await service.pauseTracker("tracker-1");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/individual-tracker/tracker-1/pause",
+      expect.objectContaining({ credentials: "include", method: "POST" }),
+    );
+    expect(result).toEqual({ tracker: FAKE_TRACKER });
+  });
+
+  it("resumes a tracker with credentials", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ tracker: FAKE_TRACKER }));
+
+    const result = await service.resumeTracker("tracker-1");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/individual-tracker/tracker-1/resume",
+      expect.objectContaining({ credentials: "include", method: "POST" }),
+    );
+    expect(result).toEqual({ tracker: FAKE_TRACKER });
+  });
+
+  it("selects the active tracker with a JSON body", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ tracker: FAKE_TRACKER }));
+
+    const result = await service.selectActive("tracker-1");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/individual-tracker/manage/select-active",
+      expect.objectContaining({
+        credentials: "include",
+        method: "POST",
+        body: JSON.stringify({ trackerId: "tracker-1" }),
+      }),
+    );
+    expect(result).toEqual({ tracker: FAKE_TRACKER });
+  });
+
+  it("gets the tracker status with credentials", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ tracker: FAKE_TRACKER }));
+
+    const result = await service.getTrackerStatus("tracker-1");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/individual-tracker/tracker-1/status",
+      expect.objectContaining({ credentials: "include", method: "GET" }),
+    );
+    expect(result).toEqual({ tracker: FAKE_TRACKER });
+  });
+
+  it("throws the error envelope message when a request fails", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ error: "Failed to list trackers" }, 500));
+
+    await expect(service.listTrackers()).rejects.toThrow("Failed to list trackers");
+  });
+});

--- a/pages/src/services/individual-tracker/types.ts
+++ b/pages/src/services/individual-tracker/types.ts
@@ -1,0 +1,21 @@
+import type {
+  TrackerProfileResponse,
+  UpdateTrackerProfileRequest,
+} from "@guilty-spark/shared/contracts/individual-tracker/profile";
+import type {
+  StartTrackerRequest,
+  TrackerResponse,
+  TrackersResponse,
+} from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+
+export interface IndividualTrackerService {
+  getProfile(): Promise<TrackerProfileResponse>;
+  updateProfile(req: UpdateTrackerProfileRequest): Promise<TrackerProfileResponse>;
+  listTrackers(): Promise<TrackersResponse>;
+  startTracker(req: StartTrackerRequest): Promise<TrackerResponse>;
+  stopTracker(trackerId: string): Promise<void>;
+  pauseTracker(trackerId: string): Promise<TrackerResponse>;
+  resumeTracker(trackerId: string): Promise<TrackerResponse>;
+  selectActive(trackerId: string): Promise<TrackerResponse>;
+  getTrackerStatus(trackerId: string): Promise<TrackerResponse>;
+}


### PR DESCRIPTION
## Milestone D · PR (D3) — pages IndividualTrackerService

Stacked on **#461 (B5b)**. Browser-side client for the individual-tracker API, mirroring `pages/src/services/auth/` exactly. Additive; no backend changes.

- `RealIndividualTrackerService`: `getProfile`/`updateProfile` + `listTrackers`/`startTracker`/`stopTracker`/`pauseTracker`/`resumeTracker`/`selectActive`/`getTrackerStatus` — credentialed `fetch`, contract-validated responses (`trackerProfileContract`/`trackerContract`/`trackersContract`/`stopTrackerContract`), `readError` envelope, `encodeURIComponent` path params.
- `FakeIndividualTrackerService` + `installIndividualTrackerService(apiHost)` (FAKE/REAL via `getMode`); aggregated into `install.fake.ts`.
- 10 tests (URL/method/credentials/body/parse + error envelope). typecheck:pages + full suite green; lint clean.

Reviewed clean (independent). Minor non-blocking note: the fake’s `selectActive` doesn’t persist the live selection yet — to enhance when the manager UI consumes it. Not yet wired into an app `services.ts` (the manager-UI PR does that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)