### PR TITLE
feat(api): allowlisted Halo proxy + per-op cache headers, drop x-proxy-auth (B3a)

### DIFF
--- a/api/base/fakes/cache.fake.ts
+++ b/api/base/fakes/cache.fake.ts
@@ -1,0 +1,37 @@
+import { vi } from "vitest";
+
+function cacheKey(request: RequestInfo | URL): string {
+  if (typeof request === "string") {
+    return request;
+  }
+  if (request instanceof URL) {
+    return request.toString();
+  }
+  return request.url;
+}
+
+export function aFakeCache(): Cache {
+  const store = new Map<string, Response>();
+
+  const cache: Pick<Cache, "match" | "put" | "delete"> = {
+    match: vi.fn<Cache["match"]>(async (request) => {
+      const stored = store.get(cacheKey(request));
+      return Promise.resolve(stored ? stored.clone() : undefined);
+    }),
+    put: vi.fn<Cache["put"]>(async (request, response) => {
+      store.set(cacheKey(request), response.clone());
+      return Promise.resolve();
+    }),
+    delete: vi.fn<Cache["delete"]>(async (request) => Promise.resolve(store.delete(cacheKey(request)))),
+  };
+
+  return cache;
+}
+
+export function aFakeCacheStorage(): CacheStorage {
+  const storage: Pick<CacheStorage, "default"> = {
+    default: aFakeCache(),
+  };
+
+  return storage as CacheStorage;
+}

--- a/api/routes/halo-proxy/halo-proxy.ts
+++ b/api/routes/halo-proxy/halo-proxy.ts
@@ -2,7 +2,6 @@ import { HaloInfiniteClient, StaticXstsTicketTokenSpartanTokenProvider } from "h
 import {
   buildHaloProxyCacheControl,
   isHaloProxyOperationName,
-  parseHaloProxyArgsFromBody,
   parseHaloProxyArgsFromUrl,
   resolveHaloProxyOperation,
 } from "@guilty-spark/shared/halo/halo-infinite-proxy-operations";
@@ -57,26 +56,8 @@ async function resolveHaloProxyClient(request: Request, services: Services): Pro
   return { ok: true, resolved: { client: services.haloInfiniteClient } };
 }
 
-async function readHaloProxyArgs(
-  request: Request,
-  httpMethod: "GET" | "POST",
-): Promise<{ ok: true; args: unknown[] } | { ok: false; response: Response }> {
-  if (httpMethod === "GET") {
-    const parsed = parseHaloProxyArgsFromUrl(new URL(request.url));
-    if (!parsed.ok) {
-      return { ok: false, response: new Response(parsed.error, { status: 400 }) };
-    }
-    return { ok: true, args: parsed.args };
-  }
-
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return { ok: false, response: new Response("Invalid JSON body", { status: 400 }) };
-  }
-
-  const parsed = parseHaloProxyArgsFromBody(body);
+function readHaloProxyArgs(request: Request): { ok: true; args: unknown[] } | { ok: false; response: Response } {
+  const parsed = parseHaloProxyArgsFromUrl(new URL(request.url));
   if (!parsed.ok) {
     return { ok: false, response: new Response(parsed.error, { status: 400 }) };
   }
@@ -93,7 +74,7 @@ function callHaloProxyOperation(
 }
 
 export const haloProxyRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices: InstallServices) => {
-  router.all("/proxy/halo-infinite/:operation", async (request, env: Env) => {
+  router.all("/proxy/halo-infinite/:operation", async (request, env: Env, ctx: ExecutionContext) => {
     try {
       const { operation } = request.params;
       if (operation == null || !isHaloProxyOperationName(operation)) {
@@ -109,7 +90,13 @@ export const haloProxyRoutesRegisterHandler: RoutesRegisterHandler = (router, in
         return new Response("Method not allowed", { status: 405 });
       }
 
-      const argsResult = await readHaloProxyArgs(request, operationDefinition.httpMethod);
+      const cache = caches.default;
+      const cached = await cache.match(request);
+      if (cached) {
+        return cached;
+      }
+
+      const argsResult = readHaloProxyArgs(request);
       if (!argsResult.ok) {
         return argsResult.response;
       }
@@ -122,10 +109,14 @@ export const haloProxyRoutesRegisterHandler: RoutesRegisterHandler = (router, in
 
       const result = await callHaloProxyOperation(clientResult.resolved.client, operation, argsResult.args);
 
-      return Response.json(result, {
+      const response = Response.json(result, {
         status: 200,
         headers: { "Cache-Control": buildHaloProxyCacheControl(operationDefinition) },
       });
+
+      ctx.waitUntil(cache.put(request, response.clone()));
+
+      return response;
     } catch (error) {
       console.error("Halo proxy error:", error instanceof Error ? error.message : String(error));
       return Response.json({ error: "Proxy request failed" }, { status: 500 });

--- a/api/routes/halo-proxy/halo-proxy.ts
+++ b/api/routes/halo-proxy/halo-proxy.ts
@@ -1,0 +1,134 @@
+import { HaloInfiniteClient, StaticXstsTicketTokenSpartanTokenProvider } from "halo-infinite-api";
+import {
+  buildHaloProxyCacheControl,
+  isHaloProxyOperationName,
+  parseHaloProxyArgsFromBody,
+  parseHaloProxyArgsFromUrl,
+  resolveHaloProxyOperation,
+} from "@guilty-spark/shared/halo/halo-infinite-proxy-operations";
+import type { HaloProxyOperationName } from "@guilty-spark/shared/halo/halo-infinite-proxy-operations";
+import type { Services } from "../../services/install";
+import type { SessionTokenPayload } from "../../services/auth/types";
+import type { RoutesRegisterHandler } from "../base/types";
+
+type InstallServices = ({ env }: { env: Env }) => Services;
+
+interface ResolvedHaloProxyClient {
+  readonly client: HaloInfiniteClient;
+}
+
+type ResolveHaloProxyClientResult =
+  | { readonly ok: true; readonly resolved: ResolvedHaloProxyClient }
+  | { readonly ok: false; readonly response: Response };
+
+async function resolveHaloProxyClient(request: Request, services: Services): Promise<ResolveHaloProxyClientResult> {
+  const session = await services.authService.validateSession(request);
+
+  if (session !== null) {
+    let microsoftAccessToken = session.accessToken;
+
+    if (session.isExpired) {
+      let refreshedSessionPayload: SessionTokenPayload | null;
+      try {
+        refreshedSessionPayload = await services.authService.refreshSession(session);
+      } catch {
+        const response = new Response("Unauthorized", { status: 401 });
+        services.authService.clearSessionCookie(response);
+        return { ok: false, response };
+      }
+
+      if (refreshedSessionPayload === null) {
+        const response = new Response("Unauthorized", { status: 401 });
+        services.authService.clearSessionCookie(response);
+        return { ok: false, response };
+      }
+
+      microsoftAccessToken = refreshedSessionPayload.accessToken;
+    }
+
+    const xstsTokenInfo = await services.xboxService.exchangeMicrosoftAccessTokenForXstsToken(microsoftAccessToken);
+    const client = new HaloInfiniteClient(new StaticXstsTicketTokenSpartanTokenProvider(xstsTokenInfo.XSTSToken));
+    return { ok: true, resolved: { client } };
+  }
+
+  // Future PR (B3b): insert gamertag -> owner-token resolution here, between the
+  // authenticated-session branch above and the bot-account fallback below.
+
+  return { ok: true, resolved: { client: services.haloInfiniteClient } };
+}
+
+async function readHaloProxyArgs(
+  request: Request,
+  httpMethod: "GET" | "POST",
+): Promise<{ ok: true; args: unknown[] } | { ok: false; response: Response }> {
+  if (httpMethod === "GET") {
+    const parsed = parseHaloProxyArgsFromUrl(new URL(request.url));
+    if (!parsed.ok) {
+      return { ok: false, response: new Response(parsed.error, { status: 400 }) };
+    }
+    return { ok: true, args: parsed.args };
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return { ok: false, response: new Response("Invalid JSON body", { status: 400 }) };
+  }
+
+  const parsed = parseHaloProxyArgsFromBody(body);
+  if (!parsed.ok) {
+    return { ok: false, response: new Response(parsed.error, { status: 400 }) };
+  }
+  return { ok: true, args: parsed.args };
+}
+
+function callHaloProxyOperation(
+  client: HaloInfiniteClient,
+  operation: HaloProxyOperationName,
+  args: unknown[],
+): unknown {
+  const method: (...callArgs: never[]) => unknown = client[operation];
+  return Reflect.apply(method, client, args);
+}
+
+export const haloProxyRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices: InstallServices) => {
+  router.all("/proxy/halo-infinite/:operation", async (request, env: Env) => {
+    try {
+      const { operation } = request.params;
+      if (operation == null || !isHaloProxyOperationName(operation)) {
+        return new Response(`Operation not found: ${operation ?? ""}`, { status: 404 });
+      }
+
+      const operationDefinition = resolveHaloProxyOperation(operation);
+      if (operationDefinition === null) {
+        return new Response(`Operation not found: ${operation}`, { status: 404 });
+      }
+
+      if (request.method !== operationDefinition.httpMethod) {
+        return new Response("Method not allowed", { status: 405 });
+      }
+
+      const argsResult = await readHaloProxyArgs(request, operationDefinition.httpMethod);
+      if (!argsResult.ok) {
+        return argsResult.response;
+      }
+
+      const services = installServices({ env });
+      const clientResult = await resolveHaloProxyClient(request, services);
+      if (!clientResult.ok) {
+        return clientResult.response;
+      }
+
+      const result = await callHaloProxyOperation(clientResult.resolved.client, operation, argsResult.args);
+
+      return Response.json(result, {
+        status: 200,
+        headers: { "Cache-Control": buildHaloProxyCacheControl(operationDefinition) },
+      });
+    } catch (error) {
+      console.error("Halo proxy error:", error instanceof Error ? error.message : String(error));
+      return Response.json({ error: "Proxy request failed" }, { status: 500 });
+    }
+  });
+};

--- a/api/server.ts
+++ b/api/server.ts
@@ -1,10 +1,9 @@
 import type { AutoRouterType } from "itty-router";
-import { HaloInfiniteClient, StaticXstsTicketTokenSpartanTokenProvider } from "halo-infinite-api";
 import type { installServices } from "./services/install";
-import type { SessionTokenPayload } from "./services/auth/types";
 import { authRoutesRegisterHandler } from "./routes/auth/auth";
 import { discordInteractionsRoute } from "./routes/discord/interactions";
 import { individualTrackerRoutesRegisterHandler } from "./routes/individual-tracker/individual-tracker";
+import { haloProxyRoutesRegisterHandler } from "./routes/halo-proxy/halo-proxy";
 
 interface ServerOpts {
   router: AutoRouterType;
@@ -32,6 +31,8 @@ export class Server {
     authRoutesRegisterHandler(this.router, this.installServices);
 
     individualTrackerRoutesRegisterHandler(this.router, this.installServices);
+
+    haloProxyRoutesRegisterHandler(this.router, this.installServices);
 
     discordInteractionsRoute(this.router, this.installServices);
 
@@ -101,107 +102,6 @@ export class Server {
         console.trace();
 
         return new Response("Internal error", { status: 500 });
-      }
-    });
-
-    this.router.post("/proxy/halo-infinite", async (request, env: Env) => {
-      try {
-        const authHeader = request.headers.get("x-proxy-auth");
-        if (authHeader != null && authHeader !== env.PROXY_WORKER_TOKEN) {
-          return new Response("Unauthorized", { status: 401 });
-        }
-
-        const hasValidWorkerToken = authHeader === env.PROXY_WORKER_TOKEN;
-
-        let services: ReturnType<typeof this.installServices> | null = null;
-        let microsoftAccessToken: string | null = null;
-        let refreshedSessionPayload: SessionTokenPayload | null = null;
-
-        if (!hasValidWorkerToken) {
-          services = this.installServices({ env });
-          const session = await services.authService.validateSession(request);
-          if (session === null) {
-            return new Response("Unauthorized", { status: 401 });
-          }
-
-          if (session.isExpired) {
-            try {
-              refreshedSessionPayload = await services.authService.refreshSession(session);
-            } catch {
-              const response = new Response("Unauthorized", { status: 401 });
-              services.authService.clearSessionCookie(response);
-              return response;
-            }
-
-            if (refreshedSessionPayload === null) {
-              const response = new Response("Unauthorized", { status: 401 });
-              services.authService.clearSessionCookie(response);
-              return response;
-            }
-
-            microsoftAccessToken = refreshedSessionPayload.accessToken;
-          } else {
-            microsoftAccessToken = session.accessToken;
-          }
-        }
-
-        let body: unknown;
-        try {
-          body = await request.json();
-        } catch {
-          return new Response("Invalid JSON body", { status: 400 });
-        }
-
-        if (
-          typeof body !== "object" ||
-          body === null ||
-          typeof (body as { method?: unknown }).method !== "string" ||
-          !Array.isArray((body as { args?: unknown[] }).args)
-        ) {
-          return new Response("Invalid request format", { status: 400 });
-        }
-
-        const { method, args } = body as { method: string; args: unknown[] };
-
-        const activeServices = services ?? this.installServices({ env });
-        let haloInfiniteClient: HaloInfiniteClient;
-        if (microsoftAccessToken !== null) {
-          const xstsTokenInfo =
-            await activeServices.xboxService.exchangeMicrosoftAccessTokenForXstsToken(microsoftAccessToken);
-          haloInfiniteClient = new HaloInfiniteClient(
-            new StaticXstsTicketTokenSpartanTokenProvider(xstsTokenInfo.XSTSToken),
-          );
-        } else {
-          ({ haloInfiniteClient } = activeServices);
-        }
-
-        const isFunctionProperty = <T>(
-          obj: T,
-          key: string,
-        ): obj is T & Record<string, (...args: unknown[]) => unknown> => {
-          return (
-            Object.prototype.hasOwnProperty.call(obj, key) &&
-            typeof (obj as Record<string, unknown>)[key] === "function"
-          );
-        };
-        if (!isFunctionProperty(haloInfiniteClient, method)) {
-          return new Response(`Method not found: ${method}`, { status: 404 });
-        }
-
-        const targetMethod = haloInfiniteClient[method] as (...a: unknown[]) => unknown;
-
-        const result: unknown = await targetMethod.apply(haloInfiniteClient, args);
-
-        return new Response(JSON.stringify({ result }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        });
-      } catch (error) {
-        console.error("Halo proxy error:", error);
-        return new Response(JSON.stringify({ error: "Proxy request failed" }), {
-          status: 500,
-          headers: { "content-type": "application/json" },
-        });
       }
     });
 

--- a/api/services/halo/halo-infinite-client-proxy.ts
+++ b/api/services/halo/halo-infinite-client-proxy.ts
@@ -1,4 +1,8 @@
 import { RequestError, type HaloInfiniteClient } from "halo-infinite-api";
+import {
+  appendHaloProxyArgsToUrl,
+  resolveHaloProxyOperation,
+} from "@guilty-spark/shared/halo/halo-infinite-proxy-operations";
 
 function isProxyErrorResponse(
   data: unknown,
@@ -8,10 +12,6 @@ function isProxyErrorResponse(
     data !== null &&
     ("message" in data || "error" in data || "stack" in data || "name" in data)
   );
-}
-
-function isProxySuccessResponse(data: unknown): data is { result: unknown } {
-  return typeof data === "object" && data !== null && "result" in data;
 }
 
 async function handleProxyResponse(response: Response): Promise<unknown> {
@@ -37,10 +37,8 @@ async function handleProxyResponse(response: Response): Promise<unknown> {
 
     throw requestError;
   }
-  if (isProxySuccessResponse(data)) {
-    return data.result;
-  }
-  throw new Error("Malformed proxy response");
+
+  return data;
 }
 
 export function createHaloInfiniteClientProxy({ env }: { env: Env }): HaloInfiniteClient {
@@ -52,15 +50,29 @@ export function createHaloInfiniteClientProxy({ env }: { env: Env }): HaloInfini
         if (typeof prop !== "string") {
           return undefined;
         }
+
         return async (...args: unknown[]): Promise<unknown> => {
-          const response = await fetch(`${env.PROXY_WORKER_URL}/proxy/halo-infinite`, {
-            method: "POST",
-            headers: {
-              "content-type": "application/json",
-              "x-proxy-auth": env.PROXY_WORKER_TOKEN,
-            },
-            body: JSON.stringify({ method: prop, args }),
-          });
+          const operation = resolveHaloProxyOperation(prop);
+          if (operation === null) {
+            throw new Error(`Halo proxy operation not allowed: ${prop}`);
+          }
+
+          const url = new URL(`${env.PROXY_WORKER_URL}/proxy/halo-infinite/${prop}`);
+          const headers = new Headers();
+          const requestInit: RequestInit & { credentials: "include" } = {
+            method: operation.httpMethod,
+            headers,
+            credentials: "include",
+          };
+
+          if (operation.httpMethod === "GET") {
+            appendHaloProxyArgsToUrl(url, args);
+          } else {
+            headers.set("content-type", "application/json");
+            requestInit.body = JSON.stringify({ args });
+          }
+
+          const response = await fetch(url.toString(), requestInit);
           return handleProxyResponse(response);
         };
       },

--- a/api/services/halo/halo-infinite-client-proxy.ts
+++ b/api/services/halo/halo-infinite-client-proxy.ts
@@ -65,12 +65,7 @@ export function createHaloInfiniteClientProxy({ env }: { env: Env }): HaloInfini
             credentials: "include",
           };
 
-          if (operation.httpMethod === "GET") {
-            appendHaloProxyArgsToUrl(url, args);
-          } else {
-            headers.set("content-type", "application/json");
-            requestInit.body = JSON.stringify({ args });
-          }
+          appendHaloProxyArgsToUrl(url, args);
 
           const response = await fetch(url.toString(), requestInit);
           return handleProxyResponse(response);

--- a/api/services/halo/tests/halo-infinite-client-proxy.test.ts
+++ b/api/services/halo/tests/halo-infinite-client-proxy.test.ts
@@ -49,7 +49,7 @@ describe("createHaloInfiniteClientProxy", () => {
     expect(result).toEqual({ xuid: "123" });
   });
 
-  it("calls a POST operation with arguments encoded in the JSON body", async () => {
+  it("calls the multi-user operation as a GET with the array argument encoded in the query string", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(createMockResponse([{ xuid: "123" }]));
 
     const proxy = createHaloInfiniteClientProxy({ env });
@@ -59,10 +59,12 @@ describe("createHaloInfiniteClientProxy", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
 
     const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe(`${env.PROXY_WORKER_URL}/proxy/halo-infinite/getUsers`);
-    expect(options.method).toBe("POST");
+    const parsedUrl = new URL(url);
+    expect(parsedUrl.pathname).toBe("/proxy/halo-infinite/getUsers");
+    expect(parsedUrl.searchParams.getAll("arg")).toEqual([JSON.stringify(["xuid(123)"])]);
+    expect(options.method).toBe("GET");
     expect((options as RequestInit & { credentials?: string }).credentials).toBe("include");
-    expect(JSON.parse(options.body as string)).toEqual({ args: [["xuid(123)"]] });
+    expect(options.body).toBeUndefined();
 
     expect(result).toEqual([{ xuid: "123" }]);
   });

--- a/api/services/halo/tests/halo-infinite-client-proxy.test.ts
+++ b/api/services/halo/tests/halo-infinite-client-proxy.test.ts
@@ -29,8 +29,8 @@ describe("createHaloInfiniteClientProxy", () => {
     vi.restoreAllMocks();
   });
 
-  it("calls the proxy endpoint with the correct method and arguments", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(createMockResponse({ result: "proxy-result" }));
+  it("calls a GET operation with arguments encoded in the query string and credentials included", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(createMockResponse({ xuid: "123" }));
 
     const proxy = createHaloInfiniteClientProxy({ env });
 
@@ -39,18 +39,59 @@ describe("createHaloInfiniteClientProxy", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
 
     const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe(`${env.PROXY_WORKER_URL}/proxy/halo-infinite`);
-    expect(options.method).toBe("POST");
-    expect(options.headers).toMatchObject({
-      "content-type": "application/json",
-      "x-proxy-auth": env.PROXY_WORKER_TOKEN,
-    });
-    expect(JSON.parse(options.body as string)).toEqual({
-      method: "getUser",
-      args: ["foo"],
-    });
+    expect(url).toBe(`${env.PROXY_WORKER_URL}/proxy/halo-infinite/getUser?arg=%22foo%22`);
+    expect(options.method).toBe("GET");
+    expect((options as RequestInit & { credentials?: string }).credentials).toBe("include");
+    expect(options.body).toBeUndefined();
+    const sentHeaders = new Headers(options.headers);
+    expect(sentHeaders.get("x-proxy-auth")).toBeNull();
 
-    expect(result).toBe("proxy-result");
+    expect(result).toEqual({ xuid: "123" });
+  });
+
+  it("calls a POST operation with arguments encoded in the JSON body", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(createMockResponse([{ xuid: "123" }]));
+
+    const proxy = createHaloInfiniteClientProxy({ env });
+
+    const result = await proxy.getUsers(["xuid(123)"]);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${env.PROXY_WORKER_URL}/proxy/halo-infinite/getUsers`);
+    expect(options.method).toBe("POST");
+    expect((options as RequestInit & { credentials?: string }).credentials).toBe("include");
+    expect(JSON.parse(options.body as string)).toEqual({ args: [["xuid(123)"]] });
+
+    expect(result).toEqual([{ xuid: "123" }]);
+  });
+
+  it("returns raw json payloads without a result envelope", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(createMockResponse({ xuid: "123" }));
+
+    const proxy = createHaloInfiniteClientProxy({ env });
+
+    const result = await proxy.getUser("foo");
+
+    expect(result).toEqual({ xuid: "123" });
+  });
+
+  it("throws a clear error when calling an operation outside the allowlist", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const proxy = createHaloInfiniteClientProxy({ env });
+
+    let thrown: Error | undefined;
+    try {
+      await proxy.getCurrentUser();
+    } catch (e) {
+      thrown = e as Error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown?.message).toBe("Halo proxy operation not allowed: getCurrentUser");
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("throws an error with message, stack, and name from proxy error response", async () => {
@@ -99,22 +140,5 @@ describe("createHaloInfiniteClientProxy", () => {
     expect(thrown).toBeInstanceOf(Error);
     // The RequestError formats the message as "<status> from <url>" regardless of the original error message
     expect(thrown?.message).toBe("500 from https://example.com/halo-infinite");
-  });
-
-  it("throws a generic error if the proxy response is malformed", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(createMockResponse({}));
-
-    const proxy = createHaloInfiniteClientProxy({ env });
-
-    let thrown: Error | undefined;
-
-    try {
-      await proxy.getUser("foo");
-    } catch (e) {
-      thrown = e as Error;
-    }
-
-    expect(thrown).toBeInstanceOf(Error);
-    expect(thrown?.message).toBe("Malformed proxy response");
   });
 });

--- a/api/tests/server.test.ts
+++ b/api/tests/server.test.ts
@@ -1,11 +1,12 @@
 import type { MockInstance } from "vitest";
-import { describe, it, beforeEach, expect, vi } from "vitest";
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
 import type * as HaloInfiniteApi from "halo-infinite-api";
 import { HaloInfiniteClient, StaticXstsTicketTokenSpartanTokenProvider } from "halo-infinite-api";
 import { installFakeServicesWith } from "../services/fakes/services";
 import { createApiRouter } from "../base/router";
 import { Server } from "../server";
 import { aFakeEnvWith } from "../base/fakes/env.fake";
+import { aFakeCacheStorage } from "../base/fakes/cache.fake";
 import { aFakeHaloInfiniteClient } from "../services/halo/fakes/infinite-client.fake";
 import type { TokenInfo } from "../services/xbox/types";
 
@@ -71,6 +72,17 @@ describe("Server", () => {
   });
 
   describe("/proxy/halo-infinite/:operation", () => {
+    let ctx: EventContext<Env, "", unknown>;
+
+    beforeEach(() => {
+      vi.stubGlobal("caches", aFakeCacheStorage());
+      ctx = { waitUntil: vi.fn() } as unknown as EventContext<Env, "", unknown>;
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
     it("returns 404 when the operation is not in the allowlist", async () => {
       const req = new Request("http://localhost/proxy/halo-infinite/notARealMethod", { method: "GET" });
       const res = (await server.router.fetch(req, env)) as Response;
@@ -96,7 +108,7 @@ describe("Server", () => {
       const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22", {
         method: "GET",
       });
-      const res = (await server.router.fetch(req, env)) as Response;
+      const res = (await server.router.fetch(req, env, ctx)) as Response;
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body).toEqual({
@@ -117,19 +129,18 @@ describe("Server", () => {
       const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22", {
         method: "GET",
       });
-      const res = (await server.router.fetch(req, env)) as Response;
+      const res = (await server.router.fetch(req, env, ctx)) as Response;
       expect(res.status).toBe(200);
       expect(res.headers.get("Cache-Control")).toBe("public, max-age=86400, stale-while-revalidate=3600");
     });
 
-    it("returns 200 for a POST operation with arguments parsed from the JSON body", async () => {
+    it("returns 200 for the multi-user GET operation with the array argument round-tripped through the query", async () => {
       vi.mocked(StaticXstsTicketTokenSpartanTokenProvider).mockClear();
-      const req = new Request("http://localhost/proxy/halo-infinite/getUsers", {
-        method: "POST",
-        body: JSON.stringify({ args: [["xuid0000000000001"]] }),
-        headers: { "content-type": "application/json" },
+      const arg = encodeURIComponent(JSON.stringify(["xuid0000000000001"]));
+      const req = new Request(`http://localhost/proxy/halo-infinite/getUsers?arg=${arg}`, {
+        method: "GET",
       });
-      const res = (await server.router.fetch(req, env)) as Response;
+      const res = (await server.router.fetch(req, env, ctx)) as Response;
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body).toEqual([
@@ -145,30 +156,6 @@ describe("Server", () => {
         },
       ]);
       expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600, stale-while-revalidate=3600");
-    });
-
-    it("returns 400 for a POST operation with an invalid JSON body", async () => {
-      const req = new Request("http://localhost/proxy/halo-infinite/getUsers", {
-        method: "POST",
-        body: "{not-json}",
-        headers: { "content-type": "application/json" },
-      });
-      const res = (await server.router.fetch(req, env)) as Response;
-      expect(res.status).toBe(400);
-      const text = await res.text();
-      expect(text).toBe("Invalid JSON body");
-    });
-
-    it("returns 400 for a POST operation when the body args field is missing", async () => {
-      const req = new Request("http://localhost/proxy/halo-infinite/getUsers", {
-        method: "POST",
-        body: JSON.stringify({ foo: "bar" }),
-        headers: { "content-type": "application/json" },
-      });
-      const res = (await server.router.fetch(req, env)) as Response;
-      expect(res.status).toBe(400);
-      const text = await res.text();
-      expect(text).toBe("Invalid request format");
     });
 
     it("returns 400 for a GET operation with non-JSON query arguments", async () => {
@@ -216,7 +203,7 @@ describe("Server", () => {
         method: "GET",
         headers: { cookie: "auth-session=valid-token", Origin: env.PAGES_URL },
       });
-      const res = (await server.router.fetch(req, env)) as Response;
+      const res = (await server.router.fetch(req, env, ctx)) as Response;
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body).toEqual({
@@ -282,7 +269,7 @@ describe("Server", () => {
         method: "GET",
         headers: { cookie: "auth-session=expired-token" },
       });
-      const res = (await server.router.fetch(req, env)) as Response;
+      const res = (await server.router.fetch(req, env, ctx)) as Response;
       expect(res.status).toBe(200);
       expect(res.headers.get("Set-Cookie")).toBeNull();
 
@@ -336,10 +323,88 @@ describe("Server", () => {
       const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22", {
         method: "GET",
       });
-      const res = (await server.router.fetch(req, env)) as Response;
+      const res = (await server.router.fetch(req, env, ctx)) as Response;
       expect(res.status).toBe(500);
       const body = await res.json<{ error: string }>();
       expect(body).toEqual({ error: "Proxy request failed" });
+    });
+
+    it("stores a successful GET response into the edge cache on a miss", async () => {
+      const cache = caches.default;
+      const url = "http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22";
+
+      const firstReq = new Request(url, { method: "GET" });
+      const firstRes = (await server.router.fetch(firstReq, env, ctx)) as Response;
+      expect(firstRes.status).toBe(200);
+      expect(firstRes.headers.get("Cache-Control")).toBe("public, max-age=86400, stale-while-revalidate=3600");
+
+      const stored = await cache.match(new Request(url, { method: "GET" }));
+      expect(stored).toBeDefined();
+      expect(stored?.status).toBe(200);
+      expect(await stored?.json()).toEqual({
+        xuid: "0000000000001",
+        gamerpic: {
+          small: "small01.png",
+          medium: "medium01.png",
+          large: "large01.png",
+          xlarge: "xlarge01.png",
+        },
+        gamertag: "gamertag01",
+      });
+    });
+
+    it("serves a cache hit without invoking the Halo client a second time", async () => {
+      const localHaloInfiniteClient = aFakeHaloInfiniteClient();
+      const getUserSpy = vi.spyOn(localHaloInfiniteClient, "getUser");
+      const localInstallServices = vi.fn<typeof installServices>(() => ({
+        ...installFakeServicesWith({ env }),
+        haloInfiniteClient: localHaloInfiniteClient,
+      }));
+      server = new Server({
+        router: createApiRouter(),
+        installServices: localInstallServices,
+      });
+
+      const url = "http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22";
+
+      const firstRes = (await server.router.fetch(new Request(url, { method: "GET" }), env, ctx)) as Response;
+      expect(firstRes.status).toBe(200);
+      expect(getUserSpy).toHaveBeenCalledTimes(1);
+
+      const secondRes = (await server.router.fetch(new Request(url, { method: "GET" }), env, ctx)) as Response;
+      expect(secondRes.status).toBe(200);
+      expect(await secondRes.json()).toEqual({
+        xuid: "0000000000001",
+        gamerpic: {
+          small: "small01.png",
+          medium: "medium01.png",
+          large: "large01.png",
+          xlarge: "xlarge01.png",
+        },
+        gamertag: "gamertag01",
+      });
+      expect(getUserSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not cache a non-200 response", async () => {
+      const cache = caches.default;
+      const localHaloInfiniteClient = aFakeHaloInfiniteClient();
+      vi.spyOn(localHaloInfiniteClient, "getUser").mockRejectedValue(new Error("fail!"));
+      const localInstallServices = vi.fn<typeof installServices>(() => ({
+        ...installFakeServicesWith({ env }),
+        haloInfiniteClient: localHaloInfiniteClient,
+      }));
+      server = new Server({
+        router: createApiRouter(),
+        installServices: localInstallServices,
+      });
+
+      const url = "http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22";
+      const res = (await server.router.fetch(new Request(url, { method: "GET" }), env, ctx)) as Response;
+      expect(res.status).toBe(500);
+
+      const stored = await cache.match(new Request(url, { method: "GET" }));
+      expect(stored).toBeUndefined();
     });
   });
 

--- a/api/tests/server.test.ts
+++ b/api/tests/server.test.ts
@@ -70,80 +70,124 @@ describe("Server", () => {
     });
   });
 
-  describe("POST /proxy/halo-infinite", () => {
-    it("returns 401 if x-proxy-auth header is missing", async () => {
-      const req = new Request("http://localhost/proxy/halo-infinite", {
+  describe("/proxy/halo-infinite/:operation", () => {
+    it("returns 404 when the operation is not in the allowlist", async () => {
+      const req = new Request("http://localhost/proxy/halo-infinite/notARealMethod", { method: "GET" });
+      const res = (await server.router.fetch(req, env)) as Response;
+      expect(res.status).toBe(404);
+      const text = await res.text();
+      expect(text).toContain("Operation not found");
+    });
+
+    it("returns 405 when the HTTP method does not match the operation definition", async () => {
+      const req = new Request("http://localhost/proxy/halo-infinite/getUser", {
         method: "POST",
-        body: JSON.stringify({ method: "getUser", args: [] }),
+        body: JSON.stringify({ args: ["discord_user_01"] }),
         headers: { "content-type": "application/json" },
       });
       const res = (await server.router.fetch(req, env)) as Response;
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(405);
       const text = await res.text();
-      expect(text).toBe("Unauthorized");
+      expect(text).toBe("Method not allowed");
     });
 
-    it("returns 401 if x-proxy-auth header is invalid", async () => {
-      const req = new Request("http://localhost/proxy/halo-infinite", {
-        method: "POST",
-        body: JSON.stringify({ method: "getUser", args: [] }),
-        headers: {
-          "content-type": "application/json",
-          "x-proxy-auth": "wrong-token",
-        },
+    it("falls back to the bot account client when there is no session", async () => {
+      vi.mocked(StaticXstsTicketTokenSpartanTokenProvider).mockClear();
+      const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22", {
+        method: "GET",
       });
       const res = (await server.router.fetch(req, env)) as Response;
-      expect(res.status).toBe(401);
-      const text = await res.text();
-      expect(text).toBe("Unauthorized");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({
+        xuid: "0000000000001",
+        gamerpic: {
+          small: "small01.png",
+          medium: "medium01.png",
+          large: "large01.png",
+          xlarge: "xlarge01.png",
+        },
+        gamertag: "gamertag01",
+      });
+
+      expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).not.toHaveBeenCalled();
     });
 
-    it("returns 401 if x-proxy-auth header is invalid even with a valid session cookie", async () => {
-      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
-        const services = installFakeServicesWith({ env });
-        vi.spyOn(services.authService, "validateSession").mockResolvedValue({
-          sessionId: "session-123",
-          userId: "user-123",
-          accessToken: "access-token",
-          refreshToken: "refresh-token",
-          expiresAt: Date.now() + 3600000,
-          isExpired: false,
-        });
-        return services;
-      });
-      server = new Server({
-        router: createApiRouter(),
-        installServices: localInstallServices,
-      });
-
-      const req = new Request("http://localhost/proxy/halo-infinite", {
-        method: "POST",
-        body: JSON.stringify({ method: "getUser", args: [] }),
-        headers: {
-          "content-type": "application/json",
-          "x-proxy-auth": "wrong-token",
-          cookie: "auth-session=valid-token",
-        },
+    it("sets a Cache-Control header derived from the operation TTL", async () => {
+      const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22", {
+        method: "GET",
       });
       const res = (await server.router.fetch(req, env)) as Response;
-      expect(res.status).toBe(401);
-      const text = await res.text();
-      expect(text).toBe("Unauthorized");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Cache-Control")).toBe("public, max-age=86400, stale-while-revalidate=3600");
     });
 
-    it("returns 401 with no authentication and no session cookie", async () => {
-      const req = new Request("http://localhost/proxy/halo-infinite", {
+    it("returns 200 for a POST operation with arguments parsed from the JSON body", async () => {
+      vi.mocked(StaticXstsTicketTokenSpartanTokenProvider).mockClear();
+      const req = new Request("http://localhost/proxy/halo-infinite/getUsers", {
         method: "POST",
-        body: JSON.stringify({ method: "getUser", args: [] }),
+        body: JSON.stringify({ args: [["xuid0000000000001"]] }),
         headers: { "content-type": "application/json" },
       });
       const res = (await server.router.fetch(req, env)) as Response;
-      expect(res.status).toBe(401);
-      const text = await res.text();
-      expect(text).toBe("Unauthorized");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual([
+        {
+          xuid: "0000000000001",
+          gamerpic: {
+            small: "small0000000000001.png",
+            medium: "medium0000000000001.png",
+            large: "large0000000000001.png",
+            xlarge: "xlarge0000000000001.png",
+          },
+          gamertag: "gamertag0000000000001",
+        },
+      ]);
+      expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600, stale-while-revalidate=3600");
     });
 
-    it("returns 401 with expired session cookie", async () => {
+    it("returns 400 for a POST operation with an invalid JSON body", async () => {
+      const req = new Request("http://localhost/proxy/halo-infinite/getUsers", {
+        method: "POST",
+        body: "{not-json}",
+        headers: { "content-type": "application/json" },
+      });
+      const res = (await server.router.fetch(req, env)) as Response;
+      expect(res.status).toBe(400);
+      const text = await res.text();
+      expect(text).toBe("Invalid JSON body");
+    });
+
+    it("returns 400 for a POST operation when the body args field is missing", async () => {
+      const req = new Request("http://localhost/proxy/halo-infinite/getUsers", {
+        method: "POST",
+        body: JSON.stringify({ foo: "bar" }),
+        headers: { "content-type": "application/json" },
+      });
+      const res = (await server.router.fetch(req, env)) as Response;
+      expect(res.status).toBe(400);
+      const text = await res.text();
+      expect(text).toBe("Invalid request format");
+    });
+
+    it("returns 400 for a GET operation with non-JSON query arguments", async () => {
+      const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=not-json", { method: "GET" });
+      const res = (await server.router.fetch(req, env)) as Response;
+      expect(res.status).toBe(400);
+      const text = await res.text();
+      expect(text).toBe("Invalid query arguments");
+    });
+
+    it("derives the user spartan token from a valid session", async () => {
+      const fakeClient = aFakeHaloInfiniteClient();
+      let exchangeMicrosoftAccessTokenForXstsTokenSpy!: MockInstance;
+      vi.mocked(StaticXstsTicketTokenSpartanTokenProvider).mockClear();
+      vi.mocked(HaloInfiniteClient).mockClear();
+      vi.mocked(HaloInfiniteClient).mockImplementation(function () {
+        return fakeClient;
+      });
+
       const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
         const services = installFakeServicesWith({ env });
         vi.spyOn(services.authService, "validateSession").mockResolvedValue({
@@ -151,27 +195,49 @@ describe("Server", () => {
           userId: "user-123",
           accessToken: "access-token",
           refreshToken: undefined,
-          expiresAt: Date.now() - 1000,
-          isExpired: true,
+          expiresAt: Date.now() + 3600000,
+          isExpired: false,
         });
+        exchangeMicrosoftAccessTokenForXstsTokenSpy = vi
+          .spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken")
+          .mockResolvedValue({
+            XSTSToken: "valid-xsts-token",
+            userHash: "valid-user-hash",
+            expiresOn: new Date("2025-01-01T06:00:00.000Z"),
+          } satisfies TokenInfo);
         return services;
       });
       server = new Server({
         router: createApiRouter(),
         installServices: localInstallServices,
       });
-      const req = new Request("http://localhost/proxy/halo-infinite", {
-        method: "POST",
-        body: JSON.stringify({ method: "getUser", args: [] }),
-        headers: { "content-type": "application/json", cookie: "auth-session=expired-token" },
+
+      const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22", {
+        method: "GET",
+        headers: { cookie: "auth-session=valid-token", Origin: env.PAGES_URL },
       });
       const res = (await server.router.fetch(req, env)) as Response;
-      expect(res.status).toBe(401);
-      const text = await res.text();
-      expect(text).toBe("Unauthorized");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({
+        xuid: "0000000000001",
+        gamerpic: {
+          small: "small01.png",
+          medium: "medium01.png",
+          large: "large01.png",
+          xlarge: "xlarge01.png",
+        },
+        gamertag: "gamertag01",
+      });
+
+      expect(exchangeMicrosoftAccessTokenForXstsTokenSpy).toHaveBeenCalledWith("access-token");
+      expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).toHaveBeenCalledWith("valid-xsts-token");
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(env.PAGES_URL);
+      expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
     });
 
-    it("returns 200 without rotating session cookie when expired session is refreshed", async () => {
+    it("refreshes an expired session without rotating the cookie", async () => {
       const fakeClient = aFakeHaloInfiniteClient();
       let exchangeMicrosoftAccessTokenForXstsTokenSpy!: MockInstance;
       vi.mocked(StaticXstsTicketTokenSpartanTokenProvider).mockClear();
@@ -212,10 +278,9 @@ describe("Server", () => {
         installServices: localInstallServices,
       });
 
-      const req = new Request("http://localhost/proxy/halo-infinite", {
-        method: "POST",
-        body: JSON.stringify({ method: "getUser", args: ["discord_user_01"] }),
-        headers: { "content-type": "application/json", cookie: "auth-session=expired-token" },
+      const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22", {
+        method: "GET",
+        headers: { cookie: "auth-session=expired-token" },
       });
       const res = (await server.router.fetch(req, env)) as Response;
       expect(res.status).toBe(200);
@@ -226,7 +291,7 @@ describe("Server", () => {
       expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).toHaveBeenCalledWith("fresh-xsts-token");
     });
 
-    it("returns 401 when session is expired and refresh fails", async () => {
+    it("returns 401 and clears the cookie when an expired session cannot be refreshed", async () => {
       const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
         const services = installFakeServicesWith({ env });
         vi.spyOn(services.authService, "validateSession").mockResolvedValue({
@@ -245,10 +310,9 @@ describe("Server", () => {
         installServices: localInstallServices,
       });
 
-      const req = new Request("http://localhost/proxy/halo-infinite", {
-        method: "POST",
-        body: JSON.stringify({ method: "getUser", args: ["discord_user_01"] }),
-        headers: { "content-type": "application/json", cookie: "auth-session=expired-token" },
+      const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22", {
+        method: "GET",
+        headers: { cookie: "auth-session=expired-token" },
       });
       const res = (await server.router.fetch(req, env)) as Response;
       expect(res.status).toBe(401);
@@ -258,145 +322,7 @@ describe("Server", () => {
       expect(res.headers.get("Set-Cookie")).toContain("Max-Age=0");
     });
 
-    it("returns 200 and result with valid session cookie", async () => {
-      const fakeClient = aFakeHaloInfiniteClient();
-      let exchangeMicrosoftAccessTokenForXstsTokenSpy!: MockInstance;
-      vi.mocked(StaticXstsTicketTokenSpartanTokenProvider).mockClear();
-      vi.mocked(HaloInfiniteClient).mockClear();
-      vi.mocked(HaloInfiniteClient).mockImplementation(function () {
-        return fakeClient;
-      });
-
-      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
-        const services = installFakeServicesWith({ env });
-        vi.spyOn(services.authService, "validateSession").mockResolvedValue({
-          sessionId: "session-123",
-          userId: "user-123",
-          accessToken: "access-token",
-          refreshToken: undefined,
-          expiresAt: Date.now() + 3600000,
-          isExpired: false,
-        });
-        exchangeMicrosoftAccessTokenForXstsTokenSpy = vi
-          .spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken")
-          .mockResolvedValue({
-            XSTSToken: "valid-xsts-token",
-            userHash: "valid-user-hash",
-            expiresOn: new Date("2025-01-01T06:00:00.000Z"),
-          } satisfies TokenInfo);
-        return services;
-      });
-      server = new Server({
-        router: createApiRouter(),
-        installServices: localInstallServices,
-      });
-      const req = new Request("http://localhost/proxy/halo-infinite", {
-        method: "POST",
-        body: JSON.stringify({ method: "getUser", args: ["discord_user_01"] }),
-        headers: {
-          "content-type": "application/json",
-          cookie: "auth-session=valid-token",
-          Origin: env.PAGES_URL,
-        },
-      });
-      const res = (await server.router.fetch(req, env)) as Response;
-      expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body).toEqual({
-        result: {
-          xuid: "0000000000001",
-          gamerpic: {
-            small: "small01.png",
-            medium: "medium01.png",
-            large: "large01.png",
-            xlarge: "xlarge01.png",
-          },
-          gamertag: "gamertag01",
-        },
-      });
-
-      expect(exchangeMicrosoftAccessTokenForXstsTokenSpy).toHaveBeenCalledWith("access-token");
-      expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).toHaveBeenCalledWith("valid-xsts-token");
-      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(env.PAGES_URL);
-      expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
-    });
-
-    it("returns 400 with invalid JSON", async () => {
-      const req = new Request("http://localhost/proxy/halo-infinite", {
-        method: "POST",
-        body: "{not-json}",
-        headers: {
-          "content-type": "application/json",
-          "x-proxy-auth": env.PROXY_WORKER_TOKEN,
-        },
-      });
-      const res = (await server.router.fetch(req, env)) as Response;
-      expect(res.status).toBe(400);
-      const text = await res.text();
-      expect(text).toBe("Invalid JSON body");
-    });
-
-    it("returns 400 with invalid request format", async () => {
-      const req = new Request("http://localhost/proxy/halo-infinite", {
-        method: "POST",
-        body: JSON.stringify({ foo: "bar" }),
-        headers: {
-          "content-type": "application/json",
-          "x-proxy-auth": env.PROXY_WORKER_TOKEN,
-        },
-      });
-      const res = (await server.router.fetch(req, env)) as Response;
-      expect(res.status).toBe(400);
-      const text = await res.text();
-      expect(text).toBe("Invalid request format");
-    });
-
-    it("returns 404 if method does not exist on client", async () => {
-      const req = new Request("http://localhost/proxy/halo-infinite", {
-        method: "POST",
-        body: JSON.stringify({ method: "notARealMethod", args: [] }),
-        headers: {
-          "content-type": "application/json",
-          "x-proxy-auth": env.PROXY_WORKER_TOKEN,
-        },
-      });
-      const res = (await server.router.fetch(req, env)) as Response;
-      expect(res.status).toBe(404);
-      const text = await res.text();
-      expect(text).toContain("Method not found");
-    });
-
-    it("returns 200 and result for valid method", async () => {
-      vi.mocked(StaticXstsTicketTokenSpartanTokenProvider).mockClear();
-      const req = new Request("http://localhost/proxy/halo-infinite", {
-        method: "POST",
-        body: JSON.stringify({ method: "getUser", args: ["discord_user_01"] }),
-        headers: {
-          "content-type": "application/json",
-          "x-proxy-auth": env.PROXY_WORKER_TOKEN,
-        },
-      });
-      const res = (await server.router.fetch(req, env)) as Response;
-      expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body).toEqual({
-        result: {
-          xuid: "0000000000001",
-          gamerpic: {
-            small: "small01.png",
-            medium: "medium01.png",
-            large: "large01.png",
-            xlarge: "xlarge01.png",
-          },
-          gamertag: "gamertag01",
-        },
-      });
-
-      expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).not.toHaveBeenCalled();
-    });
-
-    it("returns 500 with a generic error if the method throws", async () => {
+    it("returns 500 with a generic error if the operation throws", async () => {
       const localHaloInfiniteClient = aFakeHaloInfiniteClient();
       vi.spyOn(localHaloInfiniteClient, "getUser").mockRejectedValue(new Error("fail!"));
       const localInstallServices = vi.fn<typeof installServices>(() => ({
@@ -407,13 +333,8 @@ describe("Server", () => {
         router: createApiRouter(),
         installServices: localInstallServices,
       });
-      const req = new Request("http://localhost/proxy/halo-infinite", {
-        method: "POST",
-        body: JSON.stringify({ method: "getUser", args: ["discord_user_01"] }),
-        headers: {
-          "content-type": "application/json",
-          "x-proxy-auth": env.PROXY_WORKER_TOKEN,
-        },
+      const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22", {
+        method: "GET",
       });
       const res = (await server.router.fetch(req, env)) as Response;
       expect(res.status).toBe(500);
@@ -422,9 +343,9 @@ describe("Server", () => {
     });
   });
 
-  describe("OPTIONS /proxy/halo-infinite", () => {
+  describe("OPTIONS /proxy/halo-infinite/:operation", () => {
     it("returns credentialed preflight headers for allowed origins", async () => {
-      const req = new Request("http://localhost/proxy/halo-infinite", {
+      const req = new Request("http://localhost/proxy/halo-infinite/getUser", {
         method: "OPTIONS",
         headers: {
           Origin: env.PAGES_URL,

--- a/shared/src/halo/halo-infinite-proxy-operations.ts
+++ b/shared/src/halo/halo-infinite-proxy-operations.ts
@@ -1,6 +1,6 @@
 import type { HaloInfiniteClient } from "halo-infinite-api";
 
-export type HaloProxyHttpMethod = "GET" | "POST";
+export type HaloProxyHttpMethod = "GET";
 
 interface HaloProxyOperationDefinition {
   readonly httpMethod: HaloProxyHttpMethod;
@@ -15,7 +15,7 @@ const HALO_PROXY_OPERATION_DEFINITIONS = {
   getSpecificAssetVersion: { httpMethod: "GET", cacheTtlSeconds: 604800, staleWhileRevalidateSeconds: 86400 },
   getPlaylist: { httpMethod: "GET", cacheTtlSeconds: 86400, staleWhileRevalidateSeconds: 3600 },
   getUser: { httpMethod: "GET", cacheTtlSeconds: 86400, staleWhileRevalidateSeconds: 3600 },
-  getUsers: { httpMethod: "POST", cacheTtlSeconds: 3600, staleWhileRevalidateSeconds: 3600 },
+  getUsers: { httpMethod: "GET", cacheTtlSeconds: 3600, staleWhileRevalidateSeconds: 3600 },
   getPlaylistCsr: { httpMethod: "GET", cacheTtlSeconds: 86400, staleWhileRevalidateSeconds: 3600 },
   getPlayerMatchCount: { httpMethod: "GET", cacheTtlSeconds: 60, staleWhileRevalidateSeconds: 30 },
   getPlayerMatches: { httpMethod: "GET", cacheTtlSeconds: 60, staleWhileRevalidateSeconds: 30 },
@@ -57,19 +57,6 @@ export function parseHaloProxyArgsFromUrl(url: URL): ParseHaloProxyArgsResult {
     } catch {
       return { ok: false, error: "Invalid query arguments" };
     }
-  }
-
-  return { ok: true, args };
-}
-
-export function parseHaloProxyArgsFromBody(body: unknown): ParseHaloProxyArgsResult {
-  if (typeof body !== "object" || body === null || !("args" in body)) {
-    return { ok: false, error: "Invalid request format" };
-  }
-
-  const { args } = body;
-  if (!Array.isArray(args)) {
-    return { ok: false, error: "Invalid request format" };
   }
 
   return { ok: true, args };

--- a/shared/src/halo/halo-infinite-proxy-operations.ts
+++ b/shared/src/halo/halo-infinite-proxy-operations.ts
@@ -1,0 +1,76 @@
+import type { HaloInfiniteClient } from "halo-infinite-api";
+
+export type HaloProxyHttpMethod = "GET" | "POST";
+
+interface HaloProxyOperationDefinition {
+  readonly httpMethod: HaloProxyHttpMethod;
+  readonly cacheTtlSeconds: number;
+  readonly staleWhileRevalidateSeconds: number;
+}
+
+const HALO_PROXY_OPERATION_DEFINITIONS = {
+  getMatchSkill: { httpMethod: "GET", cacheTtlSeconds: 604800, staleWhileRevalidateSeconds: 604800 },
+  getMatchStats: { httpMethod: "GET", cacheTtlSeconds: 604800, staleWhileRevalidateSeconds: 604800 },
+  getMedalsMetadataFile: { httpMethod: "GET", cacheTtlSeconds: 604800, staleWhileRevalidateSeconds: 604800 },
+  getSpecificAssetVersion: { httpMethod: "GET", cacheTtlSeconds: 604800, staleWhileRevalidateSeconds: 86400 },
+  getPlaylist: { httpMethod: "GET", cacheTtlSeconds: 86400, staleWhileRevalidateSeconds: 3600 },
+  getUser: { httpMethod: "GET", cacheTtlSeconds: 86400, staleWhileRevalidateSeconds: 3600 },
+  getUsers: { httpMethod: "POST", cacheTtlSeconds: 3600, staleWhileRevalidateSeconds: 3600 },
+  getPlaylistCsr: { httpMethod: "GET", cacheTtlSeconds: 86400, staleWhileRevalidateSeconds: 3600 },
+  getPlayerMatchCount: { httpMethod: "GET", cacheTtlSeconds: 60, staleWhileRevalidateSeconds: 30 },
+  getPlayerMatches: { httpMethod: "GET", cacheTtlSeconds: 60, staleWhileRevalidateSeconds: 30 },
+  getUserServiceRecord: { httpMethod: "GET", cacheTtlSeconds: 60, staleWhileRevalidateSeconds: 30 },
+} as const satisfies Partial<Record<keyof HaloInfiniteClient, HaloProxyOperationDefinition>>;
+
+export type HaloProxyOperationName = keyof typeof HALO_PROXY_OPERATION_DEFINITIONS;
+
+export function isHaloProxyOperationName(value: string): value is HaloProxyOperationName {
+  return Object.hasOwn(HALO_PROXY_OPERATION_DEFINITIONS, value);
+}
+
+export function resolveHaloProxyOperation(operation: string): HaloProxyOperationDefinition | null {
+  return isHaloProxyOperationName(operation) ? HALO_PROXY_OPERATION_DEFINITIONS[operation] : null;
+}
+
+export function buildHaloProxyCacheControl(operation: HaloProxyOperationDefinition): string {
+  return `public, max-age=${operation.cacheTtlSeconds.toString()}, stale-while-revalidate=${operation.staleWhileRevalidateSeconds.toString()}`;
+}
+
+export function appendHaloProxyArgsToUrl(url: URL, args: readonly unknown[]): void {
+  for (const arg of args) {
+    url.searchParams.append("arg", JSON.stringify(arg ?? null));
+  }
+}
+
+export type ParseHaloProxyArgsResult =
+  | { readonly ok: true; readonly args: unknown[] }
+  | { readonly ok: false; readonly error: string };
+
+export function parseHaloProxyArgsFromUrl(url: URL): ParseHaloProxyArgsResult {
+  const rawArgs = url.searchParams.getAll("arg");
+  const args: unknown[] = [];
+
+  for (const rawArg of rawArgs) {
+    try {
+      const parsed: unknown = JSON.parse(rawArg);
+      args.push(parsed);
+    } catch {
+      return { ok: false, error: "Invalid query arguments" };
+    }
+  }
+
+  return { ok: true, args };
+}
+
+export function parseHaloProxyArgsFromBody(body: unknown): ParseHaloProxyArgsResult {
+  if (typeof body !== "object" || body === null || !("args" in body)) {
+    return { ok: false, error: "Invalid request format" };
+  }
+
+  const { args } = body;
+  if (!Array.isArray(args)) {
+    return { ok: false, error: "Invalid request format" };
+  }
+
+  return { ok: true, args };
+}

--- a/shared/src/halo/tests/halo-infinite-proxy-operations.test.ts
+++ b/shared/src/halo/tests/halo-infinite-proxy-operations.test.ts
@@ -3,7 +3,6 @@ import {
   appendHaloProxyArgsToUrl,
   buildHaloProxyCacheControl,
   isHaloProxyOperationName,
-  parseHaloProxyArgsFromBody,
   parseHaloProxyArgsFromUrl,
   resolveHaloProxyOperation,
 } from "../halo-infinite-proxy-operations";
@@ -38,9 +37,9 @@ describe("resolveHaloProxyOperation", () => {
     });
   });
 
-  it("returns the POST definition for the multi-user operation", () => {
+  it("returns the GET definition for the multi-user operation", () => {
     expect(resolveHaloProxyOperation("getUsers")).toEqual({
-      httpMethod: "POST",
+      httpMethod: "GET",
       cacheTtlSeconds: 3600,
       staleWhileRevalidateSeconds: 3600,
     });
@@ -112,31 +111,5 @@ describe("parseHaloProxyArgsFromUrl", () => {
     const result = parseHaloProxyArgsFromUrl(url);
 
     expect(result).toEqual({ ok: true, args: ["0000000000001", null, 25] });
-  });
-});
-
-describe("parseHaloProxyArgsFromBody", () => {
-  it("returns the args array from a well-formed body", () => {
-    const result = parseHaloProxyArgsFromBody({ args: [["xuid(1)"]] });
-
-    expect(result).toEqual({ ok: true, args: [["xuid(1)"]] });
-  });
-
-  it("returns an error when args is missing", () => {
-    const result = parseHaloProxyArgsFromBody({ foo: "bar" });
-
-    expect(result).toEqual({ ok: false, error: "Invalid request format" });
-  });
-
-  it("returns an error when args is not an array", () => {
-    const result = parseHaloProxyArgsFromBody({ args: "nope" });
-
-    expect(result).toEqual({ ok: false, error: "Invalid request format" });
-  });
-
-  it("returns an error when the body is not an object", () => {
-    const result = parseHaloProxyArgsFromBody(null);
-
-    expect(result).toEqual({ ok: false, error: "Invalid request format" });
   });
 });

--- a/shared/src/halo/tests/halo-infinite-proxy-operations.test.ts
+++ b/shared/src/halo/tests/halo-infinite-proxy-operations.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  appendHaloProxyArgsToUrl,
+  buildHaloProxyCacheControl,
+  isHaloProxyOperationName,
+  parseHaloProxyArgsFromBody,
+  parseHaloProxyArgsFromUrl,
+  resolveHaloProxyOperation,
+} from "../halo-infinite-proxy-operations";
+
+describe("isHaloProxyOperationName", () => {
+  it("returns true for an allowlisted operation", () => {
+    expect(isHaloProxyOperationName("getUser")).toBe(true);
+  });
+
+  it("returns false for an operation outside the allowlist", () => {
+    expect(isHaloProxyOperationName("getCurrentUser")).toBe(false);
+  });
+
+  it("returns false for an unknown string", () => {
+    expect(isHaloProxyOperationName("notARealMethod")).toBe(false);
+  });
+
+  it("returns false for inherited Object.prototype property names", () => {
+    expect(isHaloProxyOperationName("toString")).toBe(false);
+    expect(isHaloProxyOperationName("constructor")).toBe(false);
+    expect(isHaloProxyOperationName("__proto__")).toBe(false);
+    expect(isHaloProxyOperationName("hasOwnProperty")).toBe(false);
+  });
+});
+
+describe("resolveHaloProxyOperation", () => {
+  it("returns the GET definition for an immutable match operation", () => {
+    expect(resolveHaloProxyOperation("getMatchStats")).toEqual({
+      httpMethod: "GET",
+      cacheTtlSeconds: 604800,
+      staleWhileRevalidateSeconds: 604800,
+    });
+  });
+
+  it("returns the POST definition for the multi-user operation", () => {
+    expect(resolveHaloProxyOperation("getUsers")).toEqual({
+      httpMethod: "POST",
+      cacheTtlSeconds: 3600,
+      staleWhileRevalidateSeconds: 3600,
+    });
+  });
+
+  it("returns the short-lived definition for live match data", () => {
+    expect(resolveHaloProxyOperation("getPlayerMatches")).toEqual({
+      httpMethod: "GET",
+      cacheTtlSeconds: 60,
+      staleWhileRevalidateSeconds: 30,
+    });
+  });
+
+  it("returns null for an operation outside the allowlist", () => {
+    expect(resolveHaloProxyOperation("getCurrentUser")).toBeNull();
+  });
+});
+
+describe("buildHaloProxyCacheControl", () => {
+  it("builds a public cache control directive from the operation TTL", () => {
+    expect(
+      buildHaloProxyCacheControl({ httpMethod: "GET", cacheTtlSeconds: 86400, staleWhileRevalidateSeconds: 3600 }),
+    ).toBe("public, max-age=86400, stale-while-revalidate=3600");
+  });
+});
+
+describe("appendHaloProxyArgsToUrl", () => {
+  it("encodes each argument as a JSON-serialised arg query parameter", () => {
+    const url = new URL("https://example.com/proxy/halo-infinite/getPlayerMatches");
+    appendHaloProxyArgsToUrl(url, ["0000000000001", 3, 25]);
+
+    expect(url.searchParams.getAll("arg")).toEqual(['"0000000000001"', "3", "25"]);
+  });
+
+  it("encodes an interior undefined argument as null so positional args round-trip", () => {
+    const url = new URL("https://example.com/proxy/halo-infinite/getPlayerMatches");
+    appendHaloProxyArgsToUrl(url, ["0000000000001", undefined, 25]);
+
+    expect(url.searchParams.getAll("arg")).toEqual(['"0000000000001"', "null", "25"]);
+  });
+});
+
+describe("parseHaloProxyArgsFromUrl", () => {
+  it("parses JSON-encoded query arguments in order", () => {
+    const url = new URL("https://example.com/proxy/halo-infinite/getUser?arg=%22foo%22&arg=42");
+    const result = parseHaloProxyArgsFromUrl(url);
+
+    expect(result).toEqual({ ok: true, args: ["foo", 42] });
+  });
+
+  it("returns an error when a query argument is not valid JSON", () => {
+    const url = new URL("https://example.com/proxy/halo-infinite/getUser?arg=not-json");
+    const result = parseHaloProxyArgsFromUrl(url);
+
+    expect(result).toEqual({ ok: false, error: "Invalid query arguments" });
+  });
+
+  it("returns an empty argument list when no arg parameters are present", () => {
+    const url = new URL("https://example.com/proxy/halo-infinite/getMedalsMetadataFile");
+    const result = parseHaloProxyArgsFromUrl(url);
+
+    expect(result).toEqual({ ok: true, args: [] });
+  });
+
+  it("parses a null argument back to null, preserving positional order", () => {
+    const url = new URL(
+      "https://example.com/proxy/halo-infinite/getPlayerMatches?arg=%220000000000001%22&arg=null&arg=25",
+    );
+    const result = parseHaloProxyArgsFromUrl(url);
+
+    expect(result).toEqual({ ok: true, args: ["0000000000001", null, 25] });
+  });
+});
+
+describe("parseHaloProxyArgsFromBody", () => {
+  it("returns the args array from a well-formed body", () => {
+    const result = parseHaloProxyArgsFromBody({ args: [["xuid(1)"]] });
+
+    expect(result).toEqual({ ok: true, args: [["xuid(1)"]] });
+  });
+
+  it("returns an error when args is missing", () => {
+    const result = parseHaloProxyArgsFromBody({ foo: "bar" });
+
+    expect(result).toEqual({ ok: false, error: "Invalid request format" });
+  });
+
+  it("returns an error when args is not an array", () => {
+    const result = parseHaloProxyArgsFromBody({ args: "nope" });
+
+    expect(result).toEqual({ ok: false, error: "Invalid request format" });
+  });
+
+  it("returns an error when the body is not an object", () => {
+    const result = parseHaloProxyArgsFromBody(null);
+
+    expect(result).toEqual({ ok: false, error: "Invalid request format" });
+  });
+});


### PR DESCRIPTION
## Milestone B3a — Halo proxy reshape + edge caching

Replaces the `POST /proxy/halo-infinite` `{method,args}` JSON-RPC dispatch with an explicit, allowlisted, **edge-cached** per-operation route. Prereq for the individual-tracker viewer (anonymous public reads) and DO polling.

### What changed
- **Allowlist op-map** (`shared/src/halo/halo-infinite-proxy-operations.ts`): operation → `{ httpMethod: "GET", cacheTtlSeconds, staleWhileRevalidateSeconds }`, `satisfies Partial<Record<keyof HaloInfiniteClient, …>>`. Ported the rework's 11 ops + TTLs (7d immutable match/asset → 60s live lists). **All ops are GET** (cacheable); the route is GET-only (non-GET → 405).
- **New route** `/proxy/halo-infinite/:operation` (`api/routes/halo-proxy/halo-proxy.ts`): 404 for non-allowlisted ops, args from the query (JSON-encoded), `Response.json(result)` with per-op `Cache-Control`. **No token is ever placed in any response/header.**
- **Edge caching via the Cache API**: `caches.default.match(request)` short-circuits before the upstream call; `ctx.waitUntil(cache.put(request, response.clone()))` stores **only 200s** (errors never cached). Cache key = request URL (operation + args); every op returns data keyed purely by its args, so the shared edge cache is caller-independent (can't leak one user's data to another). This is what actually keeps reads off Halo Waypoint across viewers.
- **Token resolution** isolated in `resolveHaloProxyClient`: (1) valid session → that user's spartan token (XSTS exchange + expired-session refresh/clear-cookie), (2) bot-account fallback. A marked seam sits between them for the **B3b** `gamertag → owner-token` branch.
- **Dropped `x-proxy-auth` / `PROXY_WORKER_TOKEN`** (local-dev-only; no external consumer). Browser proxy client updated to the per-operation GET contract; `createHaloInfiniteClientProxy({ env })` signature unchanged.

### Review hardening folded in
- Allowlist guard uses `Object.hasOwn` (not `in`) so prototype names (`__proto__`/`constructor`/…) can't pass.
- Interior `undefined` GET args encode as `null` (round-trip safe).
- Proxy `catch` logs message-only (a `RequestError` can embed the spartan-token-bearing request).

### Tests
Adds a Map-backed `caches` fake (`api/base/fakes/cache.fake.ts`) + fake `ExecutionContext`; covers cache miss (stores), cache hit (no second upstream call), errors-not-cached, allowlist/method/token paths, and the `Object.hasOwn`/`undefined`-arg/array-arg edges. Full suite green (1738), typecheck 0 errors, lint/prettier clean. Independent security+correctness review passed.

### Next (separate PRs)
- **B3b:** durable user-scoped encrypted credential store + `UserTokenProvider` (architected for offline auto-start) + the `gamertag → owner-token` anonymous-viewer path → unblocks **B4** (DO polling).
- **Arg-arity hardening** (optional): the public endpoint forwards a trailing `init` arg to Halo (can't override token/URL; pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)