### PR TITLE
feat(pages): individual-tracker manager UI — list + lifecycle actions (E1/E2)

### DIFF
--- a/pages/src/apps/individual-tracker-manager/create.tsx
+++ b/pages/src/apps/individual-tracker-manager/create.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import type { ReactElement } from "react";
+import { ComponentLoader, ComponentLoaderStatus } from "../../components/component-loader/component-loader";
+import { ErrorState } from "../../components/error-state/error-state";
+import { LoadingState } from "../../components/loading-state/loading-state";
+import { IndividualTrackerManagerPage } from "../../components/individual-tracker-manager/create";
+import type { Services } from "./services";
+import { installServices } from "./services";
+
+interface IndividualTrackerManagerAppProps {
+  readonly apiHost: string;
+}
+
+function redirectToLogin(): void {
+  const loginUrl = new URL("/login", window.location.origin);
+  loginUrl.searchParams.set("redirect", window.location.pathname);
+  window.location.assign(loginUrl.toString());
+}
+
+export function IndividualTrackerManagerApp({ apiHost }: IndividualTrackerManagerAppProps): ReactElement {
+  const [state, setState] = useState(ComponentLoaderStatus.PENDING);
+  const [services, setServices] = useState<Services | null>(null);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    setServices(null);
+    setState(ComponentLoaderStatus.PENDING);
+
+    installServices(apiHost)
+      .then(async (installedServices) => {
+        const session = await installedServices.authService.getSession();
+        if (isCancelled) {
+          return;
+        }
+
+        if (!session.authenticated) {
+          redirectToLogin();
+          return;
+        }
+
+        setServices(installedServices);
+        setState(ComponentLoaderStatus.LOADED);
+      })
+      .catch(() => {
+        if (isCancelled) {
+          return;
+        }
+        setState(ComponentLoaderStatus.ERROR);
+      });
+
+    return (): void => {
+      isCancelled = true;
+    };
+  }, [apiHost]);
+
+  return (
+    <ComponentLoader
+      status={state}
+      loading={<LoadingState text="Checking current session..." />}
+      error={<ErrorState message="Failed to load trackers" />}
+      loaded={
+        services ? (
+          <IndividualTrackerManagerPage individualTrackerService={services.individualTrackerService} />
+        ) : (
+          <ErrorState message="Services failed to load" />
+        )
+      }
+    />
+  );
+}

--- a/pages/src/apps/individual-tracker-manager/services.ts
+++ b/pages/src/apps/individual-tracker-manager/services.ts
@@ -1,0 +1,18 @@
+import { installAuthService } from "../../services/auth/install";
+import type { AuthService } from "../../services/auth/types";
+import { installIndividualTrackerService } from "../../services/individual-tracker/install";
+import type { IndividualTrackerService } from "../../services/individual-tracker/types";
+
+export interface Services {
+  readonly authService: AuthService;
+  readonly individualTrackerService: IndividualTrackerService;
+}
+
+export async function installServices(apiHost: string): Promise<Services> {
+  const [authService, individualTrackerService] = await Promise.all([
+    installAuthService(apiHost),
+    installIndividualTrackerService(apiHost),
+  ]);
+
+  return { authService, individualTrackerService };
+}

--- a/pages/src/components/individual-tracker-manager/create.tsx
+++ b/pages/src/components/individual-tracker-manager/create.tsx
@@ -1,13 +1,13 @@
-import React, { useCallback, useEffect, useState } from "react";
-import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
-import type { Tracker } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
-import { ComponentLoader, ComponentLoaderStatus } from "../component-loader/component-loader";
+import React, { useEffect, useMemo, useSyncExternalStore } from "react";
+import { ComponentLoader } from "../component-loader/component-loader";
 import { ErrorState } from "../error-state/error-state";
 import { LoadingState } from "../loading-state/loading-state";
 import type { IndividualTrackerService } from "../../services/individual-tracker/types";
-import { IndividualTrackerManager } from "./individual-tracker-manager";
+import { IndividualTrackerManagerPresenter } from "./individual-tracker-manager-presenter";
+import { IndividualTrackerManagerStore } from "./individual-tracker-manager-store";
+import { IndividualTrackerManagerProvider } from "./individual-tracker-manager-context";
+import { IndividualTrackerManagerView } from "./individual-tracker-manager";
 import type { TrackerRowAction } from "./manager-model";
-import { isValidGamertagInput, toManagerModel } from "./manager-model";
 
 interface IndividualTrackerManagerPageProps {
   readonly individualTrackerService: IndividualTrackerService;
@@ -16,113 +16,59 @@ interface IndividualTrackerManagerPageProps {
 export function IndividualTrackerManagerPage({
   individualTrackerService,
 }: IndividualTrackerManagerPageProps): React.ReactElement {
-  const [state, setState] = useState(ComponentLoaderStatus.LOADING);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [profileName, setProfileName] = useState("");
-  const [trackers, setTrackers] = useState<readonly Tracker[]>([]);
-  const [gamertagInput, setGamertagInput] = useState("");
-  const [addPending, setAddPending] = useState(false);
-  const [pendingTrackerId, setPendingTrackerId] = useState<string | null>(null);
+  const store = useMemo(() => new IndividualTrackerManagerStore(), []);
 
-  const load = useCallback(async (): Promise<void> => {
-    setState(ComponentLoaderStatus.LOADING);
-    setErrorMessage(null);
-    try {
-      const [profileResponse, trackersResponse] = await Promise.all([
-        individualTrackerService.getProfile(),
-        individualTrackerService.listTrackers(),
-      ]);
-      setProfileName(profileResponse.profile.name);
-      setTrackers(trackersResponse.trackers);
-      setState(ComponentLoaderStatus.LOADED);
-    } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : "Failed to load trackers");
-      setState(ComponentLoaderStatus.ERROR);
-    }
-  }, [individualTrackerService]);
+  const presenter = useMemo(() => {
+    return new IndividualTrackerManagerPresenter({ individualTrackerService, store });
+  }, [individualTrackerService, store]);
 
   useEffect(() => {
-    void load();
-  }, [load]);
+    presenter.start();
 
-  const refreshTrackers = useCallback(async (): Promise<void> => {
-    const trackersResponse = await individualTrackerService.listTrackers();
-    setTrackers(trackersResponse.trackers);
-  }, [individualTrackerService]);
+    return (): void => {
+      presenter.dispose();
+    };
+  }, [presenter]);
 
-  const handleAddTracker = useCallback((): void => {
-    if (!isValidGamertagInput(gamertagInput)) {
-      return;
-    }
-    const gamertag = gamertagInput.trim();
+  const snapshot = useSyncExternalStore(
+    (listener) => store.subscribe(listener),
+    () => store.getSnapshot(),
+    () => store.getSnapshot(),
+  );
 
-    setAddPending(true);
-    individualTrackerService
-      .startTracker({ gamertag })
-      .then(refreshTrackers)
-      .then(() => {
-        setGamertagInput("");
-      })
-      .catch((error: unknown) => {
-        setErrorMessage(error instanceof Error ? error.message : "Failed to start tracker");
-        setState(ComponentLoaderStatus.ERROR);
-      })
-      .finally(() => {
-        setAddPending(false);
-      });
-  }, [gamertagInput, individualTrackerService, refreshTrackers]);
+  const model = useMemo(() => IndividualTrackerManagerPresenter.present(snapshot), [snapshot]);
 
-  const handleRowAction = useCallback(
-    (trackerId: string, action: TrackerRowAction): void => {
-      const run = async (): Promise<void> => {
-        switch (action) {
-          case "stop":
-            await individualTrackerService.stopTracker(trackerId);
-            return;
-          case "pause":
-            await individualTrackerService.pauseTracker(trackerId);
-            return;
-          case "resume":
-            await individualTrackerService.resumeTracker(trackerId);
-            return;
-          case "setLive":
-            await individualTrackerService.selectActive(trackerId);
-            return;
-          default:
-            throw new UnreachableError(action);
-        }
-      };
-
-      setPendingTrackerId(trackerId);
-      run()
-        .then(refreshTrackers)
-        .catch((error: unknown) => {
-          setErrorMessage(error instanceof Error ? error.message : "Tracker action failed");
-          setState(ComponentLoaderStatus.ERROR);
-        })
-        .finally(() => {
-          setPendingTrackerId(null);
-        });
-    },
-    [individualTrackerService, refreshTrackers],
+  const actions = useMemo(
+    () => ({
+      onGamertagInputChange: (value: string): void => {
+        presenter.setGamertagInput(value);
+      },
+      onAddTracker: (): void => {
+        presenter.addTracker();
+      },
+      onRowAction: (trackerId: string, action: TrackerRowAction): void => {
+        presenter.runRowAction(trackerId, action);
+      },
+    }),
+    [presenter],
   );
 
   return (
     <ComponentLoader
-      status={state}
+      status={snapshot.status}
       loading={<LoadingState text="Loading your trackers..." />}
-      error={<ErrorState message={errorMessage ?? "Failed to load trackers"} onRetry={() => void load()} />}
-      loaded={
-        <IndividualTrackerManager
-          model={toManagerModel(trackers)}
-          profileName={profileName}
-          gamertagInput={gamertagInput}
-          addPending={addPending}
-          pendingTrackerId={pendingTrackerId}
-          onGamertagInputChange={setGamertagInput}
-          onAddTracker={handleAddTracker}
-          onRowAction={handleRowAction}
+      error={
+        <ErrorState
+          message={snapshot.errorMessage ?? "Failed to load trackers"}
+          onRetry={() => {
+            presenter.start();
+          }}
         />
+      }
+      loaded={
+        <IndividualTrackerManagerProvider model={model} actions={actions}>
+          <IndividualTrackerManagerView />
+        </IndividualTrackerManagerProvider>
       }
     />
   );

--- a/pages/src/components/individual-tracker-manager/create.tsx
+++ b/pages/src/components/individual-tracker-manager/create.tsx
@@ -1,0 +1,129 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import type { Tracker } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import { ComponentLoader, ComponentLoaderStatus } from "../component-loader/component-loader";
+import { ErrorState } from "../error-state/error-state";
+import { LoadingState } from "../loading-state/loading-state";
+import type { IndividualTrackerService } from "../../services/individual-tracker/types";
+import { IndividualTrackerManager } from "./individual-tracker-manager";
+import type { TrackerRowAction } from "./manager-model";
+import { isValidGamertagInput, toManagerModel } from "./manager-model";
+
+interface IndividualTrackerManagerPageProps {
+  readonly individualTrackerService: IndividualTrackerService;
+}
+
+export function IndividualTrackerManagerPage({
+  individualTrackerService,
+}: IndividualTrackerManagerPageProps): React.ReactElement {
+  const [state, setState] = useState(ComponentLoaderStatus.LOADING);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [profileName, setProfileName] = useState("");
+  const [trackers, setTrackers] = useState<readonly Tracker[]>([]);
+  const [gamertagInput, setGamertagInput] = useState("");
+  const [addPending, setAddPending] = useState(false);
+  const [pendingTrackerId, setPendingTrackerId] = useState<string | null>(null);
+
+  const load = useCallback(async (): Promise<void> => {
+    setState(ComponentLoaderStatus.LOADING);
+    setErrorMessage(null);
+    try {
+      const [profileResponse, trackersResponse] = await Promise.all([
+        individualTrackerService.getProfile(),
+        individualTrackerService.listTrackers(),
+      ]);
+      setProfileName(profileResponse.profile.name);
+      setTrackers(trackersResponse.trackers);
+      setState(ComponentLoaderStatus.LOADED);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Failed to load trackers");
+      setState(ComponentLoaderStatus.ERROR);
+    }
+  }, [individualTrackerService]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const refreshTrackers = useCallback(async (): Promise<void> => {
+    const trackersResponse = await individualTrackerService.listTrackers();
+    setTrackers(trackersResponse.trackers);
+  }, [individualTrackerService]);
+
+  const handleAddTracker = useCallback((): void => {
+    if (!isValidGamertagInput(gamertagInput)) {
+      return;
+    }
+    const gamertag = gamertagInput.trim();
+
+    setAddPending(true);
+    individualTrackerService
+      .startTracker({ gamertag })
+      .then(refreshTrackers)
+      .then(() => {
+        setGamertagInput("");
+      })
+      .catch((error: unknown) => {
+        setErrorMessage(error instanceof Error ? error.message : "Failed to start tracker");
+        setState(ComponentLoaderStatus.ERROR);
+      })
+      .finally(() => {
+        setAddPending(false);
+      });
+  }, [gamertagInput, individualTrackerService, refreshTrackers]);
+
+  const handleRowAction = useCallback(
+    (trackerId: string, action: TrackerRowAction): void => {
+      const run = async (): Promise<void> => {
+        switch (action) {
+          case "stop":
+            await individualTrackerService.stopTracker(trackerId);
+            return;
+          case "pause":
+            await individualTrackerService.pauseTracker(trackerId);
+            return;
+          case "resume":
+            await individualTrackerService.resumeTracker(trackerId);
+            return;
+          case "setLive":
+            await individualTrackerService.selectActive(trackerId);
+            return;
+          default:
+            throw new UnreachableError(action);
+        }
+      };
+
+      setPendingTrackerId(trackerId);
+      run()
+        .then(refreshTrackers)
+        .catch((error: unknown) => {
+          setErrorMessage(error instanceof Error ? error.message : "Tracker action failed");
+          setState(ComponentLoaderStatus.ERROR);
+        })
+        .finally(() => {
+          setPendingTrackerId(null);
+        });
+    },
+    [individualTrackerService, refreshTrackers],
+  );
+
+  return (
+    <ComponentLoader
+      status={state}
+      loading={<LoadingState text="Loading your trackers..." />}
+      error={<ErrorState message={errorMessage ?? "Failed to load trackers"} onRetry={() => void load()} />}
+      loaded={
+        <IndividualTrackerManager
+          model={toManagerModel(trackers)}
+          profileName={profileName}
+          gamertagInput={gamertagInput}
+          addPending={addPending}
+          pendingTrackerId={pendingTrackerId}
+          onGamertagInputChange={setGamertagInput}
+          onAddTracker={handleAddTracker}
+          onRowAction={handleRowAction}
+        />
+      }
+    />
+  );
+}

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager-context.tsx
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager-context.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useMemo } from "react";
+import type { TrackerRowAction } from "./manager-model";
+import type { IndividualTrackerManagerViewModel } from "./types";
+
+interface IndividualTrackerManagerActions {
+  readonly onGamertagInputChange: (value: string) => void;
+  readonly onAddTracker: () => void;
+  readonly onRowAction: (trackerId: string, action: TrackerRowAction) => void;
+}
+
+interface IndividualTrackerManagerContextValue {
+  readonly model: IndividualTrackerManagerViewModel;
+  readonly actions: IndividualTrackerManagerActions;
+}
+
+const IndividualTrackerManagerContext = createContext<IndividualTrackerManagerContextValue | null>(null);
+
+interface IndividualTrackerManagerProviderProps {
+  readonly model: IndividualTrackerManagerViewModel;
+  readonly actions: IndividualTrackerManagerActions;
+  readonly children: React.ReactNode;
+}
+
+export function IndividualTrackerManagerProvider({
+  model,
+  actions,
+  children,
+}: IndividualTrackerManagerProviderProps): React.ReactElement {
+  const value = useMemo(() => ({ model, actions }), [model, actions]);
+
+  return <IndividualTrackerManagerContext.Provider value={value}>{children}</IndividualTrackerManagerContext.Provider>;
+}
+
+function useIndividualTrackerManagerContext(): IndividualTrackerManagerContextValue {
+  const context = useContext(IndividualTrackerManagerContext);
+  if (context === null) {
+    throw new Error("useIndividualTrackerManagerContext must be used within IndividualTrackerManagerProvider");
+  }
+  return context;
+}
+
+export function useManagerModel(): IndividualTrackerManagerViewModel {
+  return useIndividualTrackerManagerContext().model;
+}
+
+export function useManagerActions(): IndividualTrackerManagerActions {
+  return useIndividualTrackerManagerContext().actions;
+}

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager-presenter.ts
@@ -1,0 +1,150 @@
+import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import type { IndividualTrackerService } from "../../services/individual-tracker/types";
+import type {
+  IndividualTrackerManagerSnapshot,
+  IndividualTrackerManagerStore,
+} from "./individual-tracker-manager-store";
+import type { TrackerRowAction } from "./manager-model";
+import { isValidGamertagInput, toManagerModel } from "./manager-model";
+import type { IndividualTrackerManagerViewModel } from "./types";
+
+interface Config {
+  readonly individualTrackerService: IndividualTrackerService;
+  readonly store: IndividualTrackerManagerStore;
+}
+
+export class IndividualTrackerManagerPresenter {
+  private readonly config: Config;
+  private isDisposed = false;
+
+  public constructor(config: Config) {
+    this.config = config;
+  }
+
+  public static present(snapshot: IndividualTrackerManagerSnapshot): IndividualTrackerManagerViewModel {
+    const model = toManagerModel(snapshot.trackers);
+    return {
+      model,
+      profileName: snapshot.profileName,
+      gamertagInput: snapshot.gamertagInput,
+      addPending: snapshot.addPending,
+      pendingTrackerId: snapshot.pendingTrackerId,
+      addDisabled: !model.canAddTracker || snapshot.addPending || !isValidGamertagInput(snapshot.gamertagInput),
+    };
+  }
+
+  public start(): void {
+    void this.load();
+  }
+
+  public dispose(): void {
+    this.isDisposed = true;
+  }
+
+  public setGamertagInput(value: string): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.config.store.setGamertagInput(value);
+  }
+
+  public addTracker(): void {
+    const { gamertagInput } = this.config.store.getSnapshot();
+    if (!isValidGamertagInput(gamertagInput)) {
+      return;
+    }
+    const gamertag = gamertagInput.trim();
+
+    this.config.store.setAddPending(true);
+    this.config.individualTrackerService
+      .startTracker({ gamertag })
+      .then(async () => this.refreshTrackers())
+      .then(() => {
+        if (this.isDisposed) {
+          return;
+        }
+        this.config.store.setGamertagInput("");
+      })
+      .catch((error: unknown) => {
+        if (this.isDisposed) {
+          return;
+        }
+        this.config.store.setError(error instanceof Error ? error.message : "Failed to start tracker");
+      })
+      .finally(() => {
+        if (this.isDisposed) {
+          return;
+        }
+        this.config.store.setAddPending(false);
+      });
+  }
+
+  public runRowAction(trackerId: string, action: TrackerRowAction): void {
+    this.config.store.setPendingTrackerId(trackerId);
+    this.invokeRowAction(trackerId, action)
+      .then(async () => this.refreshTrackers())
+      .catch((error: unknown) => {
+        if (this.isDisposed) {
+          return;
+        }
+        this.config.store.setError(error instanceof Error ? error.message : "Tracker action failed");
+      })
+      .finally(() => {
+        if (this.isDisposed) {
+          return;
+        }
+        this.config.store.setPendingTrackerId(null);
+      });
+  }
+
+  private async load(): Promise<void> {
+    this.config.store.setLoading();
+    try {
+      const [profileResponse, trackersResponse] = await Promise.all([
+        this.config.individualTrackerService.getProfile(),
+        this.config.individualTrackerService.listTrackers(),
+      ]);
+      if (this.isDisposed) {
+        return;
+      }
+      this.config.store.setLoaded(profileResponse.profile.name, trackersResponse.trackers);
+    } catch (error) {
+      if (this.isDisposed) {
+        return;
+      }
+      this.config.store.setError(error instanceof Error ? error.message : "Failed to load trackers");
+    }
+  }
+
+  private async refreshTrackers(): Promise<void> {
+    const trackersResponse = await this.config.individualTrackerService.listTrackers();
+    if (this.isDisposed) {
+      return;
+    }
+    this.config.store.setTrackers(trackersResponse.trackers);
+  }
+
+  private async invokeRowAction(trackerId: string, action: TrackerRowAction): Promise<void> {
+    switch (action) {
+      case "stop": {
+        await this.config.individualTrackerService.stopTracker(trackerId);
+        return;
+      }
+      case "pause": {
+        await this.config.individualTrackerService.pauseTracker(trackerId);
+        return;
+      }
+      case "resume": {
+        await this.config.individualTrackerService.resumeTracker(trackerId);
+        return;
+      }
+      case "setLive": {
+        await this.config.individualTrackerService.selectActive(trackerId);
+        return;
+      }
+      default: {
+        throw new UnreachableError(action);
+      }
+    }
+  }
+}

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager-store.ts
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager-store.ts
@@ -1,0 +1,80 @@
+import type { Tracker } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import { ComponentLoaderStatus } from "../component-loader/component-loader";
+
+export interface IndividualTrackerManagerSnapshot {
+  readonly status: ComponentLoaderStatus;
+  readonly errorMessage: string | null;
+  readonly profileName: string;
+  readonly trackers: readonly Tracker[];
+  readonly gamertagInput: string;
+  readonly addPending: boolean;
+  readonly pendingTrackerId: string | null;
+}
+
+export class IndividualTrackerManagerStore {
+  private snapshot: IndividualTrackerManagerSnapshot;
+  private readonly subscribers = new Set<() => void>();
+
+  public constructor() {
+    this.snapshot = {
+      status: ComponentLoaderStatus.LOADING,
+      errorMessage: null,
+      profileName: "",
+      trackers: [],
+      gamertagInput: "",
+      addPending: false,
+      pendingTrackerId: null,
+    };
+  }
+
+  public subscribe(listener: () => void): () => void {
+    this.subscribers.add(listener);
+    return (): void => {
+      this.subscribers.delete(listener);
+    };
+  }
+
+  public getSnapshot(): IndividualTrackerManagerSnapshot {
+    return this.snapshot;
+  }
+
+  public setLoading(): void {
+    this.update({ status: ComponentLoaderStatus.LOADING, errorMessage: null });
+  }
+
+  public setLoaded(profileName: string, trackers: readonly Tracker[]): void {
+    this.update({
+      status: ComponentLoaderStatus.LOADED,
+      errorMessage: null,
+      profileName,
+      trackers,
+    });
+  }
+
+  public setError(errorMessage: string): void {
+    this.update({ status: ComponentLoaderStatus.ERROR, errorMessage });
+  }
+
+  public setTrackers(trackers: readonly Tracker[]): void {
+    this.update({ trackers });
+  }
+
+  public setGamertagInput(gamertagInput: string): void {
+    this.update({ gamertagInput });
+  }
+
+  public setAddPending(addPending: boolean): void {
+    this.update({ addPending });
+  }
+
+  public setPendingTrackerId(pendingTrackerId: string | null): void {
+    this.update({ pendingTrackerId });
+  }
+
+  private update(partial: Partial<IndividualTrackerManagerSnapshot>): void {
+    this.snapshot = { ...this.snapshot, ...partial };
+    for (const subscriber of this.subscribers) {
+      subscriber();
+    }
+  }
+}

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager.module.css
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager.module.css
@@ -1,0 +1,180 @@
+.container {
+  margin: 0 auto;
+  max-width: 720px;
+  padding: var(--space-6) var(--gutter-mobile);
+}
+
+.header {
+  margin-bottom: var(--space-6);
+}
+
+.heading {
+  color: var(--halo-white);
+  font-family: var(--font-heading);
+  font-size: var(--text-3xl);
+  letter-spacing: 0.04em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.subtext {
+  color: var(--halo-gray);
+  margin: var(--space-2) 0 0;
+}
+
+.addForm {
+  align-items: flex-end;
+  display: flex;
+  gap: var(--space-3);
+  margin-bottom: var(--space-6);
+}
+
+.addInput {
+  flex: 1;
+}
+
+.list {
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 25%, transparent);
+  border-radius: var(--radius-md);
+}
+
+.row {
+  align-items: center;
+  background: var(--halo-bg-secondary);
+  border-bottom: 1px solid color-mix(in srgb, var(--halo-teal-primary) 18%, transparent);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+}
+
+.row:last-child {
+  border-bottom: none;
+}
+
+.rowMain {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.rowGamertag {
+  color: var(--halo-white);
+  font-family: var(--font-heading);
+  font-size: var(--text-base);
+}
+
+.rowBadges {
+  align-items: center;
+  display: flex;
+  gap: var(--space-2);
+}
+
+.rowActions {
+  display: flex;
+  flex-shrink: 0;
+  gap: var(--space-2);
+}
+
+.statusBadge {
+  border-radius: var(--radius-full);
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  padding: 2px var(--space-2);
+  text-transform: uppercase;
+}
+
+.statusActive {
+  background: color-mix(in srgb, var(--color-success) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-success) 50%, transparent);
+  color: var(--color-success);
+}
+
+.statusPaused {
+  background: color-mix(in srgb, var(--color-warning) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-warning) 50%, transparent);
+  color: var(--color-warning);
+}
+
+.statusStopped {
+  background: color-mix(in srgb, var(--halo-gray) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--halo-gray) 40%, transparent);
+  color: var(--halo-gray);
+}
+
+.liveBadge {
+  background: color-mix(in srgb, var(--halo-teal-primary) 20%, transparent);
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 60%, transparent);
+  border-radius: var(--radius-full);
+  color: var(--halo-teal-primary);
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  padding: 2px var(--space-2);
+  text-transform: uppercase;
+}
+
+.actionButton {
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 30%, transparent);
+  border-radius: var(--radius-sm);
+  color: var(--halo-teal-primary);
+  cursor: pointer;
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  padding: var(--space-1) var(--space-3);
+  text-transform: uppercase;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.actionButton:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--halo-teal-primary) 14%, transparent);
+  color: var(--halo-white);
+}
+
+.actionButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.actionDestructive {
+  border-color: color-mix(in srgb, var(--color-error) 40%, transparent);
+  color: var(--color-error);
+}
+
+.actionDestructive:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-error) 12%, transparent);
+  color: var(--halo-white);
+}
+
+.empty {
+  border: 1px dashed color-mix(in srgb, var(--halo-teal-primary) 30%, transparent);
+  border-radius: var(--radius-md);
+  color: var(--halo-gray);
+  font-family: var(--font-body);
+  padding: var(--space-6);
+  text-align: center;
+}
+
+.limitNotice {
+  color: var(--halo-gray);
+  font-size: var(--text-sm);
+  margin: var(--space-3) 0 0;
+}
+
+@media (--tablet-viewport) {
+  .container {
+    padding: var(--space-8) var(--gutter-desktop);
+  }
+}

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager.tsx
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import classNames from "classnames";
+import { Button } from "../button/button";
+import { Input } from "../input/input";
+import type { ManagerModel, TrackerRowAction, TrackerRowModel } from "./manager-model";
+import { MAX_TRACKERS, isValidGamertagInput } from "./manager-model";
+import styles from "./individual-tracker-manager.module.css";
+
+interface IndividualTrackerManagerProps {
+  readonly model: ManagerModel;
+  readonly profileName: string;
+  readonly gamertagInput: string;
+  readonly addPending: boolean;
+  readonly pendingTrackerId: string | null;
+  readonly onGamertagInputChange: (value: string) => void;
+  readonly onAddTracker: () => void;
+  readonly onRowAction: (trackerId: string, action: TrackerRowAction) => void;
+}
+
+function StatusBadge({ row }: { readonly row: TrackerRowModel }): React.ReactElement {
+  return (
+    <span
+      className={classNames(styles.statusBadge, {
+        [styles.statusActive]: row.status === "active",
+        [styles.statusPaused]: row.status === "paused",
+        [styles.statusStopped]: row.status === "stopped",
+      })}
+    >
+      {row.statusLabel}
+    </span>
+  );
+}
+
+interface TrackerRowProps {
+  readonly row: TrackerRowModel;
+  readonly pending: boolean;
+  readonly onRowAction: (trackerId: string, action: TrackerRowAction) => void;
+}
+
+function TrackerRow({ row, pending, onRowAction }: TrackerRowProps): React.ReactElement {
+  return (
+    <div className={styles.row} data-testid="tracker-row">
+      <div className={styles.rowMain}>
+        <span className={styles.rowGamertag}>{row.gamertag}</span>
+        <div className={styles.rowBadges}>
+          <StatusBadge row={row} />
+          {row.isLive && <span className={styles.liveBadge}>Live</span>}
+        </div>
+      </div>
+
+      <div className={styles.rowActions}>
+        {row.canSetLive && (
+          <button
+            type="button"
+            className={styles.actionButton}
+            disabled={pending}
+            onClick={() => {
+              onRowAction(row.trackerId, "setLive");
+            }}
+          >
+            Set live
+          </button>
+        )}
+        {row.canPause && (
+          <button
+            type="button"
+            className={styles.actionButton}
+            disabled={pending}
+            onClick={() => {
+              onRowAction(row.trackerId, "pause");
+            }}
+          >
+            Pause
+          </button>
+        )}
+        {row.canResume && (
+          <button
+            type="button"
+            className={styles.actionButton}
+            disabled={pending}
+            onClick={() => {
+              onRowAction(row.trackerId, "resume");
+            }}
+          >
+            Resume
+          </button>
+        )}
+        {row.canStop && (
+          <button
+            type="button"
+            className={classNames(styles.actionButton, styles.actionDestructive)}
+            disabled={pending}
+            onClick={() => {
+              onRowAction(row.trackerId, "stop");
+            }}
+          >
+            Stop
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function IndividualTrackerManager({
+  model,
+  profileName,
+  gamertagInput,
+  addPending,
+  pendingTrackerId,
+  onGamertagInputChange,
+  onAddTracker,
+  onRowAction,
+}: IndividualTrackerManagerProps): React.ReactElement {
+  const addDisabled = !model.canAddTracker || addPending || !isValidGamertagInput(gamertagInput);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <h1 className={styles.heading}>Trackers</h1>
+        <p className={styles.subtext}>{profileName}</p>
+      </div>
+
+      <form
+        className={styles.addForm}
+        onSubmit={(event) => {
+          event.preventDefault();
+          onAddTracker();
+        }}
+      >
+        <Input
+          label="Gamertag"
+          containerClassName={styles.addInput}
+          value={gamertagInput}
+          placeholder="Enter a gamertag"
+          disabled={!model.canAddTracker || addPending}
+          onChange={(event) => {
+            onGamertagInputChange(event.target.value);
+          }}
+        />
+        <Button type="submit" disabled={addDisabled}>
+          Track
+        </Button>
+      </form>
+
+      {model.isAtLimit && (
+        <p className={styles.limitNotice}>
+          You have reached the limit of {MAX_TRACKERS} trackers. Stop one to add another.
+        </p>
+      )}
+
+      {model.isEmpty ? (
+        <div className={styles.empty}>No trackers yet. Add a gamertag above to start tracking.</div>
+      ) : (
+        <div className={styles.list}>
+          {model.rows.map((row) => (
+            <TrackerRow
+              key={row.trackerId}
+              row={row}
+              pending={pendingTrackerId === row.trackerId}
+              onRowAction={onRowAction}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager.tsx
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager.tsx
@@ -2,20 +2,10 @@ import React from "react";
 import classNames from "classnames";
 import { Button } from "../button/button";
 import { Input } from "../input/input";
-import type { ManagerModel, TrackerRowAction, TrackerRowModel } from "./manager-model";
-import { MAX_TRACKERS, isValidGamertagInput } from "./manager-model";
+import type { TrackerRowAction, TrackerRowModel } from "./manager-model";
+import { MAX_TRACKERS } from "./manager-model";
+import { useManagerActions, useManagerModel } from "./individual-tracker-manager-context";
 import styles from "./individual-tracker-manager.module.css";
-
-interface IndividualTrackerManagerProps {
-  readonly model: ManagerModel;
-  readonly profileName: string;
-  readonly gamertagInput: string;
-  readonly addPending: boolean;
-  readonly pendingTrackerId: string | null;
-  readonly onGamertagInputChange: (value: string) => void;
-  readonly onAddTracker: () => void;
-  readonly onRowAction: (trackerId: string, action: TrackerRowAction) => void;
-}
 
 function StatusBadge({ row }: { readonly row: TrackerRowModel }): React.ReactElement {
   return (
@@ -102,17 +92,9 @@ function TrackerRow({ row, pending, onRowAction }: TrackerRowProps): React.React
   );
 }
 
-export function IndividualTrackerManager({
-  model,
-  profileName,
-  gamertagInput,
-  addPending,
-  pendingTrackerId,
-  onGamertagInputChange,
-  onAddTracker,
-  onRowAction,
-}: IndividualTrackerManagerProps): React.ReactElement {
-  const addDisabled = !model.canAddTracker || addPending || !isValidGamertagInput(gamertagInput);
+export function IndividualTrackerManagerView(): React.ReactElement {
+  const { model, profileName, gamertagInput, addPending, pendingTrackerId, addDisabled } = useManagerModel();
+  const { onGamertagInputChange, onAddTracker, onRowAction } = useManagerActions();
 
   return (
     <div className={styles.container}>

--- a/pages/src/components/individual-tracker-manager/manager-model.ts
+++ b/pages/src/components/individual-tracker-manager/manager-model.ts
@@ -1,0 +1,71 @@
+import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import type { Tracker, TrackerStatus } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+
+export const MAX_TRACKERS = 5;
+
+export type TrackerRowAction = "stop" | "pause" | "resume" | "setLive";
+
+export interface TrackerRowModel {
+  readonly trackerId: string;
+  readonly gamertag: string;
+  readonly status: TrackerStatus;
+  readonly statusLabel: string;
+  readonly isLive: boolean;
+  readonly canStop: boolean;
+  readonly canPause: boolean;
+  readonly canResume: boolean;
+  readonly canSetLive: boolean;
+}
+
+export interface ManagerModel {
+  readonly rows: readonly TrackerRowModel[];
+  readonly trackerCount: number;
+  readonly isAtLimit: boolean;
+  readonly canAddTracker: boolean;
+  readonly isEmpty: boolean;
+}
+
+function statusLabel(status: TrackerStatus): string {
+  switch (status) {
+    case "active":
+      return "Active";
+    case "paused":
+      return "Paused";
+    case "stopped":
+      return "Stopped";
+    default:
+      throw new UnreachableError(status);
+  }
+}
+
+export function toTrackerRowModel(tracker: Tracker): TrackerRowModel {
+  const isStopped = tracker.status === "stopped";
+  return {
+    trackerId: tracker.trackerId,
+    gamertag: tracker.gamertag,
+    status: tracker.status,
+    statusLabel: statusLabel(tracker.status),
+    isLive: tracker.isLive,
+    canStop: !isStopped,
+    canPause: tracker.status === "active",
+    canResume: tracker.status === "paused",
+    canSetLive: !isStopped && !tracker.isLive,
+  };
+}
+
+export function toManagerModel(trackers: readonly Tracker[]): ManagerModel {
+  const rows = trackers.map(toTrackerRowModel);
+  const trackerCount = trackers.length;
+  const isAtLimit = trackerCount >= MAX_TRACKERS;
+  return {
+    rows,
+    trackerCount,
+    isAtLimit,
+    canAddTracker: !isAtLimit,
+    isEmpty: trackerCount === 0,
+  };
+}
+
+export function isValidGamertagInput(value: string): boolean {
+  return value.trim().length > 0;
+}

--- a/pages/src/components/individual-tracker-manager/tests/create.test.tsx
+++ b/pages/src/components/individual-tracker-manager/tests/create.test.tsx
@@ -1,0 +1,170 @@
+import "@testing-library/jest-dom/vitest";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  aFakeIndividualTrackerServiceWith,
+  aFakeTrackerWith,
+} from "../../../services/individual-tracker/fakes/individual-tracker.fake";
+import type { FakeIndividualTrackerService } from "../../../services/individual-tracker/fakes/individual-tracker.fake";
+import { IndividualTrackerManagerPage } from "../create";
+
+describe("IndividualTrackerManagerPage", () => {
+  let service: FakeIndividualTrackerService;
+
+  beforeEach(() => {
+    service = aFakeIndividualTrackerServiceWith({
+      trackers: [
+        aFakeTrackerWith({ trackerId: "t-1", gamertag: "Active Spartan", status: "active", isLive: true }),
+        aFakeTrackerWith({ trackerId: "t-2", gamertag: "Paused Spartan", status: "paused", isLive: false }),
+      ],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders a row per tracker with gamertag, status badge, and a live indicator", async () => {
+    render(<IndividualTrackerManagerPage individualTrackerService={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Spartan")).toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByTestId("tracker-row");
+    expect(rows).toHaveLength(2);
+
+    const activeRow = within(rows[0]);
+    expect(activeRow.getByText("Active")).toBeInTheDocument();
+    expect(activeRow.getByText("Live")).toBeInTheDocument();
+
+    const pausedRow = within(rows[1]);
+    expect(pausedRow.getByText("Paused Spartan")).toBeInTheDocument();
+    expect(pausedRow.getByText("Paused")).toBeInTheDocument();
+  });
+
+  it("invokes pauseTracker when the pause action of an active row is clicked", async () => {
+    const user = userEvent.setup();
+    const pauseSpy: MockInstance = vi.spyOn(service, "pauseTracker");
+
+    render(<IndividualTrackerManagerPage individualTrackerService={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Spartan")).toBeInTheDocument();
+    });
+
+    const activeRow = within(screen.getAllByTestId("tracker-row")[0]);
+    await user.click(activeRow.getByRole("button", { name: "Pause" }));
+
+    await waitFor(() => {
+      expect(pauseSpy).toHaveBeenCalledWith("t-1");
+    });
+  });
+
+  it("stops a tracker and removes its row after the list refreshes", async () => {
+    const user = userEvent.setup();
+    const stopSpy: MockInstance = vi.spyOn(service, "stopTracker");
+
+    render(<IndividualTrackerManagerPage individualTrackerService={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Paused Spartan")).toBeInTheDocument();
+    });
+
+    const pausedRow = within(screen.getAllByTestId("tracker-row")[1]);
+    await user.click(pausedRow.getByRole("button", { name: "Stop" }));
+
+    await waitFor(() => {
+      expect(stopSpy).toHaveBeenCalledWith("t-2");
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Paused Spartan")).not.toBeInTheDocument();
+    });
+    expect(screen.getAllByTestId("tracker-row")).toHaveLength(1);
+  });
+
+  it("sets a tracker live and moves the live indicator to its row after the list refreshes", async () => {
+    const user = userEvent.setup();
+    const selectActiveSpy: MockInstance = vi.spyOn(service, "selectActive");
+
+    render(<IndividualTrackerManagerPage individualTrackerService={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Paused Spartan")).toBeInTheDocument();
+    });
+
+    const pausedRow = within(screen.getAllByTestId("tracker-row")[1]);
+    await user.click(pausedRow.getByRole("button", { name: "Set live" }));
+
+    await waitFor(() => {
+      expect(selectActiveSpy).toHaveBeenCalledWith("t-2");
+    });
+
+    await waitFor(() => {
+      const refreshedPausedRow = within(screen.getAllByTestId("tracker-row")[1]);
+      expect(refreshedPausedRow.getByText("Live")).toBeInTheDocument();
+    });
+    const refreshedActiveRow = within(screen.getAllByTestId("tracker-row")[0]);
+    expect(refreshedActiveRow.queryByText("Live")).not.toBeInTheDocument();
+  });
+
+  it("disables the add control when the tracker limit is reached", async () => {
+    const fullService = aFakeIndividualTrackerServiceWith({
+      trackers: Array.from({ length: 5 }, (_unused, index) =>
+        aFakeTrackerWith({ trackerId: `full-${index.toString()}`, gamertag: `Spartan ${index.toString()}` }),
+      ),
+    });
+
+    render(<IndividualTrackerManagerPage individualTrackerService={fullService} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Spartan 0")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: "Track" })).toBeDisabled();
+  });
+
+  it("invokes startTracker with the entered gamertag when adding a tracker", async () => {
+    const user = userEvent.setup();
+    const startSpy: MockInstance = vi.spyOn(service, "startTracker");
+
+    render(<IndividualTrackerManagerPage individualTrackerService={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Spartan")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText("Gamertag"), "New Recruit");
+    await user.click(screen.getByRole("button", { name: "Track" }));
+
+    await waitFor(() => {
+      expect(startSpy).toHaveBeenCalledWith({ gamertag: "New Recruit" });
+    });
+  });
+
+  it("shows an empty state when the owner has no trackers", async () => {
+    const emptyService = aFakeIndividualTrackerServiceWith({ trackers: [] });
+
+    render(<IndividualTrackerManagerPage individualTrackerService={emptyService} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No trackers yet/i)).toBeInTheDocument();
+    });
+    expect(screen.queryAllByTestId("tracker-row")).toHaveLength(0);
+  });
+
+  it("renders the error state when loading trackers fails", async () => {
+    vi.spyOn(service, "listTrackers").mockRejectedValue(new Error("Trackers unavailable"));
+
+    render(<IndividualTrackerManagerPage individualTrackerService={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Trackers unavailable")).toBeInTheDocument();
+    });
+  });
+});

--- a/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-context.test.tsx
+++ b/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-context.test.tsx
@@ -1,0 +1,78 @@
+import "@testing-library/jest-dom/vitest";
+
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { aFakeTrackerWith } from "../../../services/individual-tracker/fakes/individual-tracker.fake";
+import { toManagerModel } from "../manager-model";
+import type { IndividualTrackerManagerViewModel } from "../types";
+import {
+  IndividualTrackerManagerProvider,
+  useManagerActions,
+  useManagerModel,
+} from "../individual-tracker-manager-context";
+
+function aFakeViewModelWith(overrides?: Partial<IndividualTrackerManagerViewModel>): IndividualTrackerManagerViewModel {
+  return {
+    model: toManagerModel([aFakeTrackerWith({ trackerId: "t-1", gamertag: "Alpha" })]),
+    profileName: "Spartan Profile",
+    gamertagInput: "",
+    addPending: false,
+    pendingTrackerId: null,
+    addDisabled: true,
+    ...overrides,
+  };
+}
+
+const noopActions = {
+  onGamertagInputChange: (): void => undefined,
+  onAddTracker: (): void => undefined,
+  onRowAction: (): void => undefined,
+};
+
+describe("IndividualTrackerManagerContext", () => {
+  it("throws when the model hook is used outside the provider", () => {
+    expect(() => {
+      renderHook(() => useManagerModel());
+    }).toThrow("useIndividualTrackerManagerContext must be used within IndividualTrackerManagerProvider");
+  });
+
+  it("provides the view model to the model hook", () => {
+    const model = aFakeViewModelWith();
+
+    const { result } = renderHook(() => useManagerModel(), {
+      wrapper: ({ children }) => (
+        <IndividualTrackerManagerProvider model={model} actions={noopActions}>
+          {children}
+        </IndividualTrackerManagerProvider>
+      ),
+    });
+
+    expect(result.current.profileName).toBe("Spartan Profile");
+    expect(result.current.model.rows[0]?.gamertag).toBe("Alpha");
+  });
+
+  it("provides the bound actions to the actions hook", () => {
+    const onAddTracker = vi.fn();
+    const onRowAction = vi.fn();
+    const onGamertagInputChange = vi.fn();
+
+    const { result } = renderHook(() => useManagerActions(), {
+      wrapper: ({ children }) => (
+        <IndividualTrackerManagerProvider
+          model={aFakeViewModelWith()}
+          actions={{ onAddTracker, onRowAction, onGamertagInputChange }}
+        >
+          {children}
+        </IndividualTrackerManagerProvider>
+      ),
+    });
+
+    result.current.onAddTracker();
+    result.current.onRowAction("t-1", "stop");
+    result.current.onGamertagInputChange("Bravo");
+
+    expect(onAddTracker).toHaveBeenCalledTimes(1);
+    expect(onRowAction).toHaveBeenCalledWith("t-1", "stop");
+    expect(onGamertagInputChange).toHaveBeenCalledWith("Bravo");
+  });
+});

--- a/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-presenter.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { ComponentLoaderStatus } from "../../component-loader/component-loader";
+import {
+  aFakeIndividualTrackerServiceWith,
+  aFakeTrackerProfileWith,
+  aFakeTrackerWith,
+} from "../../../services/individual-tracker/fakes/individual-tracker.fake";
+import type { FakeIndividualTrackerService } from "../../../services/individual-tracker/fakes/individual-tracker.fake";
+import { IndividualTrackerManagerPresenter } from "../individual-tracker-manager-presenter";
+import { IndividualTrackerManagerStore } from "../individual-tracker-manager-store";
+
+interface Harness {
+  readonly service: FakeIndividualTrackerService;
+  readonly store: IndividualTrackerManagerStore;
+  readonly presenter: IndividualTrackerManagerPresenter;
+}
+
+function aHarness(service: FakeIndividualTrackerService): Harness {
+  const store = new IndividualTrackerManagerStore();
+  const presenter = new IndividualTrackerManagerPresenter({ individualTrackerService: service, store });
+  return { service, store, presenter };
+}
+
+describe("IndividualTrackerManagerPresenter", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("start", () => {
+    it("loads the profile and trackers into a loaded snapshot", async () => {
+      const { store, presenter } = aHarness(
+        aFakeIndividualTrackerServiceWith({
+          profile: aFakeTrackerProfileWith({ name: "Spartan Profile" }),
+          trackers: [aFakeTrackerWith({ trackerId: "t-1", gamertag: "Alpha" })],
+        }),
+      );
+
+      presenter.start();
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().status).toBe(ComponentLoaderStatus.LOADED);
+      });
+
+      const snapshot = store.getSnapshot();
+      expect(snapshot.profileName).toBe("Spartan Profile");
+      expect(snapshot.trackers.map((tracker) => tracker.gamertag)).toStrictEqual(["Alpha"]);
+      expect(snapshot.errorMessage).toBeNull();
+    });
+
+    it("sets an error snapshot when loading the tracker list fails", async () => {
+      const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
+      vi.spyOn(service, "listTrackers").mockRejectedValue(new Error("Trackers unavailable"));
+      const { store, presenter } = aHarness(service);
+
+      presenter.start();
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().status).toBe(ComponentLoaderStatus.ERROR);
+      });
+
+      expect(store.getSnapshot().errorMessage).toBe("Trackers unavailable");
+    });
+  });
+
+  describe("addTracker", () => {
+    it("does not call the service when the gamertag input is empty", () => {
+      const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
+      const startSpy: MockInstance = vi.spyOn(service, "startTracker");
+      const { store, presenter } = aHarness(service);
+
+      store.setGamertagInput("   ");
+      presenter.addTracker();
+
+      expect(startSpy).not.toHaveBeenCalled();
+    });
+
+    it("starts a tracker with the trimmed gamertag, refreshes the list, and clears the input", async () => {
+      const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
+      const startSpy: MockInstance = vi.spyOn(service, "startTracker");
+      const { store, presenter } = aHarness(service);
+
+      store.setGamertagInput("  New Recruit  ");
+      presenter.addTracker();
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().addPending).toBe(false);
+      });
+
+      expect(startSpy).toHaveBeenCalledWith({ gamertag: "New Recruit" });
+      expect(store.getSnapshot().trackers.map((tracker) => tracker.gamertag)).toStrictEqual(["New Recruit"]);
+      expect(store.getSnapshot().gamertagInput).toBe("");
+    });
+
+    it("sets an error snapshot when starting the tracker fails", async () => {
+      const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
+      vi.spyOn(service, "startTracker").mockRejectedValue(new Error("Start failed"));
+      const { store, presenter } = aHarness(service);
+
+      store.setGamertagInput("New Recruit");
+      presenter.addTracker();
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().status).toBe(ComponentLoaderStatus.ERROR);
+      });
+
+      expect(store.getSnapshot().errorMessage).toBe("Start failed");
+    });
+  });
+
+  describe("runRowAction", () => {
+    it("calls stopTracker then refreshes the list", async () => {
+      const service = aFakeIndividualTrackerServiceWith({
+        trackers: [aFakeTrackerWith({ trackerId: "t-1", gamertag: "Alpha" })],
+      });
+      const stopSpy: MockInstance = vi.spyOn(service, "stopTracker");
+      const { store, presenter } = aHarness(service);
+
+      presenter.runRowAction("t-1", "stop");
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().pendingTrackerId).toBeNull();
+      });
+      expect(stopSpy).toHaveBeenCalledWith("t-1");
+      expect(store.getSnapshot().trackers).toHaveLength(0);
+    });
+
+    it("calls pauseTracker then refreshes the list", async () => {
+      const service = aFakeIndividualTrackerServiceWith({
+        trackers: [aFakeTrackerWith({ trackerId: "t-1", status: "active" })],
+      });
+      const pauseSpy: MockInstance = vi.spyOn(service, "pauseTracker");
+      const listSpy: MockInstance = vi.spyOn(service, "listTrackers");
+      const { store, presenter } = aHarness(service);
+
+      presenter.runRowAction("t-1", "pause");
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().pendingTrackerId).toBeNull();
+      });
+      expect(pauseSpy).toHaveBeenCalledWith("t-1");
+      expect(listSpy).toHaveBeenCalled();
+    });
+
+    it("calls resumeTracker then refreshes the list", async () => {
+      const service = aFakeIndividualTrackerServiceWith({
+        trackers: [aFakeTrackerWith({ trackerId: "t-1", status: "paused" })],
+      });
+      const resumeSpy: MockInstance = vi.spyOn(service, "resumeTracker");
+      const listSpy: MockInstance = vi.spyOn(service, "listTrackers");
+      const { store, presenter } = aHarness(service);
+
+      presenter.runRowAction("t-1", "resume");
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().pendingTrackerId).toBeNull();
+      });
+      expect(resumeSpy).toHaveBeenCalledWith("t-1");
+      expect(listSpy).toHaveBeenCalled();
+    });
+
+    it("calls selectActive then refreshes the list", async () => {
+      const service = aFakeIndividualTrackerServiceWith({
+        trackers: [
+          aFakeTrackerWith({ trackerId: "t-1", isLive: true }),
+          aFakeTrackerWith({ trackerId: "t-2", isLive: false }),
+        ],
+      });
+      const selectActiveSpy: MockInstance = vi.spyOn(service, "selectActive");
+      const { store, presenter } = aHarness(service);
+
+      presenter.runRowAction("t-2", "setLive");
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().pendingTrackerId).toBeNull();
+      });
+      expect(selectActiveSpy).toHaveBeenCalledWith("t-2");
+      const live = store.getSnapshot().trackers.find((tracker) => tracker.isLive);
+      expect(live?.trackerId).toBe("t-2");
+    });
+
+    it("sets an error snapshot when the row action fails", async () => {
+      const service = aFakeIndividualTrackerServiceWith({
+        trackers: [aFakeTrackerWith({ trackerId: "t-1" })],
+      });
+      vi.spyOn(service, "stopTracker").mockRejectedValue(new Error("Stop failed"));
+      const { store, presenter } = aHarness(service);
+
+      presenter.runRowAction("t-1", "stop");
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().status).toBe(ComponentLoaderStatus.ERROR);
+      });
+      expect(store.getSnapshot().errorMessage).toBe("Stop failed");
+    });
+  });
+
+  describe("dispose", () => {
+    it("ignores store writes from a load that resolves after dispose", async () => {
+      const service = aFakeIndividualTrackerServiceWith({
+        trackers: [aFakeTrackerWith({ trackerId: "t-1", gamertag: "Alpha" })],
+      });
+      const { store, presenter } = aHarness(service);
+
+      presenter.start();
+      presenter.dispose();
+
+      await vi.waitFor(() => {
+        expect(service).toBeDefined();
+      });
+
+      expect(store.getSnapshot().status).toBe(ComponentLoaderStatus.LOADING);
+      expect(store.getSnapshot().trackers).toHaveLength(0);
+    });
+
+    it("ignores gamertag input updates after dispose", () => {
+      const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
+      const { store, presenter } = aHarness(service);
+
+      presenter.dispose();
+      presenter.setGamertagInput("New Recruit");
+
+      expect(store.getSnapshot().gamertagInput).toBe("");
+    });
+  });
+});
+
+describe("IndividualTrackerManagerPresenter.present", () => {
+  it("derives a view model that disables adding while a request is pending", () => {
+    const store = new IndividualTrackerManagerStore();
+    store.setGamertagInput("New Recruit");
+    store.setAddPending(true);
+
+    const model = IndividualTrackerManagerPresenter.present(store.getSnapshot());
+
+    expect(model.profileName).toBe("");
+    expect(model.gamertagInput).toBe("New Recruit");
+    expect(model.addPending).toBe(true);
+    expect(model.addDisabled).toBe(true);
+  });
+
+  it("enables adding when there is valid input below the limit and no pending request", () => {
+    const store = new IndividualTrackerManagerStore();
+    store.setLoaded("Profile", [aFakeTrackerWith({ trackerId: "t-1" })]);
+    store.setGamertagInput("New Recruit");
+
+    const model = IndividualTrackerManagerPresenter.present(store.getSnapshot());
+
+    expect(model.model.rows).toHaveLength(1);
+    expect(model.addDisabled).toBe(false);
+  });
+});

--- a/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager.test.tsx
+++ b/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager.test.tsx
@@ -11,7 +11,7 @@ import {
 import type { FakeIndividualTrackerService } from "../../../services/individual-tracker/fakes/individual-tracker.fake";
 import { IndividualTrackerManagerPage } from "../create";
 
-describe("IndividualTrackerManagerPage", () => {
+describe("IndividualTrackerManagerView", () => {
   let service: FakeIndividualTrackerService;
 
   beforeEach(() => {
@@ -127,9 +127,10 @@ describe("IndividualTrackerManagerPage", () => {
     });
 
     expect(screen.getByRole("button", { name: "Track" })).toBeDisabled();
+    expect(screen.getByText(/reached the limit of 5 trackers/i)).toBeInTheDocument();
   });
 
-  it("invokes startTracker with the entered gamertag when adding a tracker", async () => {
+  it("invokes startTracker with the entered gamertag and adds its row after the list refreshes", async () => {
     const user = userEvent.setup();
     const startSpy: MockInstance = vi.spyOn(service, "startTracker");
 
@@ -144,6 +145,10 @@ describe("IndividualTrackerManagerPage", () => {
 
     await waitFor(() => {
       expect(startSpy).toHaveBeenCalledWith({ gamertag: "New Recruit" });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("New Recruit")).toBeInTheDocument();
     });
   });
 

--- a/pages/src/components/individual-tracker-manager/tests/manager-model.test.ts
+++ b/pages/src/components/individual-tracker-manager/tests/manager-model.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { aFakeTrackerWith } from "../../../services/individual-tracker/fakes/individual-tracker.fake";
+import { MAX_TRACKERS, isValidGamertagInput, toManagerModel, toTrackerRowModel } from "../manager-model";
+
+describe("toTrackerRowModel", () => {
+  it("maps an active live tracker to a row with stop and pause enabled and set-live hidden", () => {
+    const row = toTrackerRowModel(aFakeTrackerWith({ status: "active", isLive: true }));
+
+    expect(row.statusLabel).toBe("Active");
+    expect(row.isLive).toBe(true);
+    expect(row.canStop).toBe(true);
+    expect(row.canPause).toBe(true);
+    expect(row.canResume).toBe(false);
+    expect(row.canSetLive).toBe(false);
+  });
+
+  it("enables set-live for an active tracker that is not currently live", () => {
+    const row = toTrackerRowModel(aFakeTrackerWith({ status: "active", isLive: false }));
+
+    expect(row.canSetLive).toBe(true);
+  });
+
+  it("maps a paused tracker so resume is enabled and pause is disabled", () => {
+    const row = toTrackerRowModel(aFakeTrackerWith({ status: "paused", isLive: false }));
+
+    expect(row.statusLabel).toBe("Paused");
+    expect(row.canPause).toBe(false);
+    expect(row.canResume).toBe(true);
+    expect(row.canStop).toBe(true);
+    expect(row.canSetLive).toBe(true);
+  });
+
+  it("disables all actions except none for a stopped tracker", () => {
+    const row = toTrackerRowModel(aFakeTrackerWith({ status: "stopped", isLive: false }));
+
+    expect(row.statusLabel).toBe("Stopped");
+    expect(row.canStop).toBe(false);
+    expect(row.canPause).toBe(false);
+    expect(row.canResume).toBe(false);
+    expect(row.canSetLive).toBe(false);
+  });
+});
+
+describe("toManagerModel", () => {
+  it("reports an empty model when there are no trackers", () => {
+    const model = toManagerModel([]);
+
+    expect(model.isEmpty).toBe(true);
+    expect(model.rows).toHaveLength(0);
+    expect(model.trackerCount).toBe(0);
+    expect(model.isAtLimit).toBe(false);
+    expect(model.canAddTracker).toBe(true);
+  });
+
+  it("maps each tracker to a row and allows adding below the limit", () => {
+    const model = toManagerModel([
+      aFakeTrackerWith({ trackerId: "a", gamertag: "Alpha" }),
+      aFakeTrackerWith({ trackerId: "b", gamertag: "Bravo" }),
+    ]);
+
+    expect(model.isEmpty).toBe(false);
+    expect(model.rows.map((row) => row.gamertag)).toStrictEqual(["Alpha", "Bravo"]);
+    expect(model.trackerCount).toBe(2);
+    expect(model.canAddTracker).toBe(true);
+  });
+
+  it("flags the limit and blocks adding at the maximum number of trackers", () => {
+    const trackers = Array.from({ length: MAX_TRACKERS }, (_unused, index) =>
+      aFakeTrackerWith({ trackerId: `t-${index.toString()}` }),
+    );
+
+    const model = toManagerModel(trackers);
+
+    expect(model.trackerCount).toBe(MAX_TRACKERS);
+    expect(model.isAtLimit).toBe(true);
+    expect(model.canAddTracker).toBe(false);
+  });
+});
+
+describe("isValidGamertagInput", () => {
+  it("accepts a non-empty trimmed value", () => {
+    expect(isValidGamertagInput("Master Chief")).toBe(true);
+  });
+
+  it("rejects an empty or whitespace-only value", () => {
+    expect(isValidGamertagInput("")).toBe(false);
+    expect(isValidGamertagInput("   ")).toBe(false);
+  });
+});

--- a/pages/src/components/individual-tracker-manager/types.ts
+++ b/pages/src/components/individual-tracker-manager/types.ts
@@ -1,0 +1,10 @@
+import type { ManagerModel } from "./manager-model";
+
+export interface IndividualTrackerManagerViewModel {
+  readonly model: ManagerModel;
+  readonly profileName: string;
+  readonly gamertagInput: string;
+  readonly addPending: boolean;
+  readonly pendingTrackerId: string | null;
+  readonly addDisabled: boolean;
+}

--- a/pages/src/pages/individual-tracker.astro
+++ b/pages/src/pages/individual-tracker.astro
@@ -1,0 +1,9 @@
+---
+import Layout from "../layouts/layout.astro";
+import { API_HOST } from "../constants";
+import { IndividualTrackerManagerApp } from "../apps/individual-tracker-manager/create";
+---
+
+<Layout title="Trackers - Guilty Spark" description="Manage your individual live trackers">
+  <IndividualTrackerManagerApp client:load apiHost={API_HOST} />
+</Layout>

--- a/pages/src/services/fakes/install.fake.ts
+++ b/pages/src/services/fakes/install.fake.ts
@@ -9,19 +9,47 @@ interface FakeServices {
 }
 
 export async function installFakeServices(): Promise<FakeServices> {
-  const [{ FakeAuthService }, { FakeIndividualTrackerService }, { FakeLiveTrackerService }, { createSampleScenario }] =
-    await Promise.all([
-      import("../auth/fakes/auth.fake"),
-      import("../individual-tracker/fakes/individual-tracker.fake"),
-      import("../live-tracker/fakes/live-tracker.fake"),
-      import("../live-tracker/fakes/scenario"),
-    ]);
+  const [
+    { FakeAuthService },
+    { FakeIndividualTrackerService, aFakeTrackerWith },
+    { FakeLiveTrackerService },
+    { createSampleScenario },
+  ] = await Promise.all([
+    import("../auth/fakes/auth.fake"),
+    import("../individual-tracker/fakes/individual-tracker.fake"),
+    import("../live-tracker/fakes/live-tracker.fake"),
+    import("../live-tracker/fakes/scenario"),
+  ]);
 
   const scenario = createSampleScenario();
 
   return {
     authService: new FakeAuthService(),
-    individualTrackerService: new FakeIndividualTrackerService(),
+    individualTrackerService: new FakeIndividualTrackerService({
+      trackers: [
+        aFakeTrackerWith({
+          trackerId: "fake-tracker-1",
+          gamertag: "Fake Spartan",
+          xuid: "2533274800000001",
+          status: "active",
+          isLive: true,
+        }),
+        aFakeTrackerWith({
+          trackerId: "fake-tracker-2",
+          gamertag: "Master Chief",
+          xuid: "2533274800000002",
+          status: "paused",
+          isLive: false,
+        }),
+        aFakeTrackerWith({
+          trackerId: "fake-tracker-3",
+          gamertag: "Cortana",
+          xuid: "2533274800000003",
+          status: "stopped",
+          isLive: false,
+        }),
+      ],
+    }),
     liveTrackerService: new FakeLiveTrackerService(scenario),
   };
 }

--- a/pages/src/services/individual-tracker/fakes/individual-tracker.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/individual-tracker.fake.ts
@@ -112,16 +112,17 @@ export class FakeIndividualTrackerService implements IndividualTrackerService {
 
   public async pauseTracker(trackerId: string): Promise<TrackerResponse> {
     await Promise.resolve();
-    return { tracker: this.findTracker(trackerId, "paused") };
+    return { tracker: this.mutateTrackerStatus(trackerId, "paused") };
   }
 
   public async resumeTracker(trackerId: string): Promise<TrackerResponse> {
     await Promise.resolve();
-    return { tracker: this.findTracker(trackerId, "active") };
+    return { tracker: this.mutateTrackerStatus(trackerId, "active") };
   }
 
   public async selectActive(trackerId: string): Promise<TrackerResponse> {
     await Promise.resolve();
+    this.trackers = this.trackers.map((tracker) => ({ ...tracker, isLive: tracker.trackerId === trackerId }));
     return { tracker: this.findTracker(trackerId) };
   }
 
@@ -130,10 +131,21 @@ export class FakeIndividualTrackerService implements IndividualTrackerService {
     return { tracker: this.findTracker(trackerId) };
   }
 
-  private findTracker(trackerId: string, status?: Tracker["status"]): Tracker {
+  private findTracker(trackerId: string): Tracker {
+    return this.trackers.find((tracker) => tracker.trackerId === trackerId) ?? aFakeTrackerWith({ trackerId });
+  }
+
+  private mutateTrackerStatus(trackerId: string, status: Tracker["status"]): Tracker {
     const existing = this.trackers.find((tracker) => tracker.trackerId === trackerId);
-    const base = existing ?? aFakeTrackerWith({ trackerId });
-    return status !== undefined ? aFakeTrackerWith({ ...base, status }) : base;
+    const updated = aFakeTrackerWith({
+      trackerId,
+      gamertag: existing?.gamertag ?? "Fake Spartan",
+      xuid: existing?.xuid ?? "2533274800000001",
+      isLive: existing?.isLive ?? false,
+      status,
+    });
+    this.trackers = this.trackers.map((tracker) => (tracker.trackerId === trackerId ? updated : tracker));
+    return updated;
   }
 }
 


### PR DESCRIPTION
## Milestone E (E1+E2) — individual-tracker manager UI

A signed-in owner's control panel at `/individual-tracker`, built entirely on the merged D3 `IndividualTrackerService` + fakes. **Independent of the B3 proxy work** (pages-only; both branch off `main`), so it can land in parallel.

### What's here
- **App + route**: `pages/src/apps/individual-tracker-manager/` (installs `AuthService` + `IndividualTrackerService` from `API_HOST`, gates on `getSession()` → redirects unauthenticated owners to `/login`) and `pages/src/pages/individual-tracker.astro` mounting the island in the standard `Layout`.
- **Tracker list + actions**: each tracker row shows gamertag, status badge, and a LIVE indicator; row actions Stop / Pause (active) / Resume (paused) / Set live (select-active), plus inline add-by-gamertag. The 5-tracker limit disables add.
- **Tested render-model** (`manager-model.ts`): derives per-row view-models + which actions are enabled/visible from `status` × `isLive`, the at-limit flag, and `isValidGamertagInput`. The component stays thin; loading/empty/error (with retry) states handled via the shared `ComponentLoader`/`ErrorState`.
- **FAKE mode** seeds a populated list (one live), and the fake's `pause`/`resume`/`select-active` now persist so actions visibly reflect after the list refreshes (`npm run dev --workspace=pages -- --mode fake`).

### Review fixes folded in
- Fake `pause`/`resume`/`selectActive` mutate stored trackers (demo fidelity).
- Deduped the gamertag validation to the model's `isValidGamertagInput` (no inline `.trim().length` checks left in the components).
- Added component tests: list refreshes after Stop (row removed), Set live moves the LIVE indicator, add disabled at the limit.

Built in a worktree in parallel with B3a, then reviewed (independent) + fixed. typecheck:pages 0 errors, full suite green (1738), eslint/prettier/stylelint clean.

### Not in this slice (later E milestones)
Richer add-tracker dialog (search-start-time / idle options), game include/exclude dialog (E4), streamer-settings UI + A3 settings routes (E5). Nav-link wiring to the page is intentionally minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)