### PR TITLE
feat(api): durable per-user credential store, captured on login + refresh (B3b-i)

### DIFF
--- a/api/services/auth/auth.ts
+++ b/api/services/auth/auth.ts
@@ -247,14 +247,24 @@ export class AuthService {
       issuedAt: now,
     };
 
+    const encryptedRefreshToken =
+      refreshedSession.refreshToken == null ? null : await this.tokenEncryptor.encrypt(refreshedSession.refreshToken);
+
     await this.databaseService.upsertUserSession({
       ...existingSession,
       AccessToken: await this.tokenEncryptor.encrypt(refreshedSession.accessToken),
-      RefreshToken:
-        refreshedSession.refreshToken == null ? null : await this.tokenEncryptor.encrypt(refreshedSession.refreshToken),
+      RefreshToken: encryptedRefreshToken,
       ExpiresAt: Math.floor(refreshedSession.expiresAt / 1000),
       LastRefreshedAt: Math.floor(now / 1000),
     });
+
+    if (encryptedRefreshToken != null) {
+      await this.databaseService.upsertUserCredentials({
+        UserId: refreshedSession.userId,
+        RefreshToken: encryptedRefreshToken,
+        UpdatedAt: Math.floor(now / 1000),
+      });
+    }
 
     return refreshedSession;
   }
@@ -330,11 +340,13 @@ export class AuthService {
     if (preferredUsername != null) {
       authMetadata.preferredUsername = preferredUsername;
     }
+    const encryptedRefreshToken =
+      payload.refreshToken == null ? null : await this.tokenEncryptor.encrypt(payload.refreshToken);
     const sessionRow: UserSessionsRow = {
       SessionId: payload.sessionId,
       UserId: payload.userId,
       AccessToken: await this.tokenEncryptor.encrypt(payload.accessToken),
-      RefreshToken: payload.refreshToken == null ? null : await this.tokenEncryptor.encrypt(payload.refreshToken),
+      RefreshToken: encryptedRefreshToken,
       ExpiresAt: Math.floor(payload.expiresAt / 1000),
       CreatedAt: Math.floor(payload.issuedAt / 1000),
       LastRefreshedAt: Math.floor(payload.issuedAt / 1000),
@@ -342,6 +354,14 @@ export class AuthService {
     };
 
     await this.databaseService.upsertUserSession(sessionRow);
+
+    if (encryptedRefreshToken != null) {
+      await this.databaseService.upsertUserCredentials({
+        UserId: payload.userId,
+        RefreshToken: encryptedRefreshToken,
+        UpdatedAt: Math.floor(payload.issuedAt / 1000),
+      });
+    }
   }
 
   private parseAuthMetadata(authMetadataJson: string): z.infer<typeof authMetadataSchema> {

--- a/api/services/auth/tests/auth.test.ts
+++ b/api/services/auth/tests/auth.test.ts
@@ -100,6 +100,7 @@ describe("AuthService", () => {
       );
 
     const upsertUserSessionSpy = vi.spyOn(databaseService, "upsertUserSession").mockResolvedValue();
+    const upsertUserCredentialsSpy = vi.spyOn(databaseService, "upsertUserCredentials").mockResolvedValue();
 
     const { state, codeVerifier } = aFakePKCEState();
     const response = new Response();
@@ -129,6 +130,13 @@ describe("AuthService", () => {
     expect(persistedSession?.AccessToken).not.toContain("access-token");
     expect(persistedSession?.RefreshToken).toContain("enc-v1.");
     expect(persistedSession?.RefreshToken).not.toContain("refresh-token");
+
+    expect(upsertUserCredentialsSpy).toHaveBeenCalled();
+    const persistedCredentials = upsertUserCredentialsSpy.mock.calls[0]?.[0];
+    expect(persistedCredentials?.UserId).toBe("user-123");
+    expect(persistedCredentials?.RefreshToken).toBe(persistedSession?.RefreshToken);
+    expect(persistedCredentials?.RefreshToken).not.toContain("refresh-token");
+    expect(typeof persistedCredentials?.UpdatedAt).toBe("number");
   });
 
   it("normalizes a backslash open-redirect payload to root through the callback round-trip", async () => {
@@ -333,6 +341,7 @@ describe("AuthService", () => {
       aFakeUserSessionsRow({ SessionId: session.sessionId }),
     );
     const upsertUserSessionSpy = vi.spyOn(databaseService, "upsertUserSession").mockResolvedValue();
+    const upsertUserCredentialsSpy = vi.spyOn(databaseService, "upsertUserCredentials").mockResolvedValue();
 
     const refreshed = await service.refreshSession(session);
 
@@ -346,6 +355,12 @@ describe("AuthService", () => {
     const persistedSession = upsertUserSessionSpy.mock.calls[0]?.[0];
     expect(persistedSession?.AccessToken).toContain("enc-v1.");
     expect(persistedSession?.RefreshToken).toContain("enc-v1.");
+
+    expect(upsertUserCredentialsSpy).toHaveBeenCalled();
+    const persistedCredentials = upsertUserCredentialsSpy.mock.calls[0]?.[0];
+    expect(persistedCredentials?.UserId).toBe("user-123");
+    expect(persistedCredentials?.RefreshToken).toBe(persistedSession?.RefreshToken);
+    expect(persistedCredentials?.RefreshToken).not.toContain("new-refresh-token");
   });
 
   it("merges xbox profile into the persisted session metadata", async () => {

--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -6,6 +6,7 @@ import type { GuildConfigRow } from "./types/guild_config";
 import { StatsReturnType, MapsPostType, MapsPlaylistType, MapsFormatType } from "./types/guild_config";
 import type { NeatQueueConfigRow, NeatQueuePostSeriesDisplayMode } from "./types/neat_queue_config";
 import type { UserSessionsRow } from "./types/user_sessions";
+import type { UserCredentialsRow } from "./types/user_credentials";
 import type { LinkedIdentitiesRow, IdentityProvider } from "./types/linked_identities";
 import type { IndividualTrackerProfilesRow } from "./types/individual_tracker_profiles";
 import type { IndividualTrackerGamesRow } from "./types/individual_tracker_games";
@@ -269,6 +270,27 @@ export class DatabaseService {
     const sessionExpiryCutoffEpochSeconds = nowEpochSeconds - SESSION_COOKIE_MAX_AGE_SECONDS;
     const query = "DELETE FROM UserSessions WHERE CreatedAt <= ?";
     const stmt = this.DB.prepare(query).bind(sessionExpiryCutoffEpochSeconds);
+    await stmt.run();
+  }
+
+  async getUserCredentials(userId: string): Promise<UserCredentialsRow | null> {
+    const query = "SELECT * FROM UserCredentials WHERE UserId = ?";
+    const stmt = this.DB.prepare(query).bind(userId);
+    return await stmt.first<UserCredentialsRow>();
+  }
+
+  async upsertUserCredentials(row: UserCredentialsRow): Promise<void> {
+    const query = `
+      INSERT INTO UserCredentials (UserId, RefreshToken, UpdatedAt) VALUES (?, ?, ?)
+      ON CONFLICT(UserId) DO UPDATE SET RefreshToken=excluded.RefreshToken, UpdatedAt=excluded.UpdatedAt
+    `;
+    const stmt = this.DB.prepare(query).bind(row.UserId, row.RefreshToken, row.UpdatedAt);
+    await stmt.run();
+  }
+
+  async deleteUserCredentials(userId: string): Promise<void> {
+    const query = "DELETE FROM UserCredentials WHERE UserId = ?";
+    const stmt = this.DB.prepare(query).bind(userId);
     await stmt.run();
   }
 

--- a/api/services/database/fakes/database.fake.ts
+++ b/api/services/database/fakes/database.fake.ts
@@ -8,6 +8,7 @@ import { StatsReturnType, MapsPostType, MapsPlaylistType, MapsFormatType } from 
 import type { NeatQueueConfigRow } from "../types/neat_queue_config";
 import { NeatQueuePostSeriesDisplayMode } from "../types/neat_queue_config";
 import type { UserSessionsRow } from "../types/user_sessions";
+import type { UserCredentialsRow } from "../types/user_credentials";
 import type { LinkedIdentitiesRow } from "../types/linked_identities";
 import type { IndividualTrackerProfilesRow } from "../types/individual_tracker_profiles";
 import type { IndividualTrackerGamesRow } from "../types/individual_tracker_games";
@@ -82,6 +83,19 @@ export function aFakeUserSessionsRow(opts: Partial<UserSessionsRow> = {}): UserS
     CreatedAt: Math.floor(Date.now() / 1000),
     LastRefreshedAt: null,
     AuthMetadataJson: "{}",
+  };
+
+  return {
+    ...defaultOpts,
+    ...opts,
+  };
+}
+
+export function aFakeUserCredentialsRow(opts: Partial<UserCredentialsRow> = {}): UserCredentialsRow {
+  const defaultOpts: UserCredentialsRow = {
+    UserId: "user-1",
+    RefreshToken: "encrypted-refresh-token",
+    UpdatedAt: Math.floor(Date.now() / 1000),
   };
 
   return {

--- a/api/services/database/schema.sql
+++ b/api/services/database/schema.sql
@@ -44,6 +44,12 @@ CREATE TABLE IF NOT EXISTS UserSessions (
 CREATE INDEX IF NOT EXISTS IdxUserSessionsUserId ON UserSessions (UserId);
 CREATE INDEX IF NOT EXISTS IdxUserSessionsExpiresAt ON UserSessions (ExpiresAt);
 
+CREATE TABLE IF NOT EXISTS UserCredentials (
+    UserId TEXT PRIMARY KEY NOT NULL,
+    RefreshToken TEXT NOT NULL,
+    UpdatedAt INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
 CREATE TABLE IF NOT EXISTS LinkedIdentities (
     IdentityId TEXT PRIMARY KEY NOT NULL,
     UserId TEXT NOT NULL,

--- a/api/services/database/tests/database.test.ts
+++ b/api/services/database/tests/database.test.ts
@@ -5,6 +5,7 @@ import { DatabaseService } from "../database";
 import {
   aFakeDiscordAssociationsRow,
   aFakeUserSessionsRow,
+  aFakeUserCredentialsRow,
   aFakeLinkedIdentitiesRow,
   aFakeIndividualTrackerProfilesRow,
   aFakeIndividualTrackerGamesRow,
@@ -509,6 +510,95 @@ describe("Database Service", () => {
 
       expect(prepareSpy).toHaveBeenCalledWith("DELETE FROM UserSessions WHERE CreatedAt <= ?");
       expect(bindSpy).toHaveBeenCalledWith(12345 - SESSION_COOKIE_MAX_AGE_SECONDS);
+      expect(runSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("getUserCredentials()", () => {
+    it("returns user credentials by user id", async () => {
+      const credentials = aFakeUserCredentialsRow();
+      const fakePreparedStatement = new FakePreparedStatement();
+      const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      const bindSpy = vi.spyOn(fakePreparedStatement, "bind").mockReturnThis();
+      vi.spyOn(fakePreparedStatement, "first").mockResolvedValue(credentials);
+
+      const result = await databaseService.getUserCredentials(credentials.UserId);
+
+      expect(prepareSpy).toHaveBeenCalledWith("SELECT * FROM UserCredentials WHERE UserId = ?");
+      expect(bindSpy).toHaveBeenCalledWith(credentials.UserId);
+      expect(result).toEqual(credentials);
+    });
+
+    it("returns null when no credentials exist for the user", async () => {
+      const fakePreparedStatement = new FakePreparedStatement();
+      vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      vi.spyOn(fakePreparedStatement, "bind").mockReturnThis();
+      vi.spyOn(fakePreparedStatement, "first").mockResolvedValue(null);
+
+      const result = await databaseService.getUserCredentials("unknown-user");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("upsertUserCredentials()", () => {
+    it("upserts user credentials", async () => {
+      const credentials = aFakeUserCredentialsRow();
+      const fakePreparedStatement = new FakePreparedStatement();
+      const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      const bindSpy = vi.spyOn(fakePreparedStatement, "bind");
+      const runSpy = vi.spyOn(fakePreparedStatement, "run");
+
+      await databaseService.upsertUserCredentials(credentials);
+
+      expect(prepareSpy).toHaveBeenCalledWith(
+        `
+      INSERT INTO UserCredentials (UserId, RefreshToken, UpdatedAt) VALUES (?, ?, ?)
+      ON CONFLICT(UserId) DO UPDATE SET RefreshToken=excluded.RefreshToken, UpdatedAt=excluded.UpdatedAt
+    `,
+      );
+      expect(bindSpy).toHaveBeenCalledWith(credentials.UserId, credentials.RefreshToken, credentials.UpdatedAt);
+      expect(runSpy).toHaveBeenCalled();
+    });
+
+    it("round-trips the upserted credentials via get", async () => {
+      const credentials = aFakeUserCredentialsRow({ RefreshToken: "encrypted-1", UpdatedAt: 1000 });
+      const upsertStatement = new FakePreparedStatement();
+      const getStatement = new FakePreparedStatement();
+      vi.spyOn(env.DB, "prepare").mockReturnValueOnce(upsertStatement).mockReturnValueOnce(getStatement);
+      vi.spyOn(upsertStatement, "bind").mockReturnThis();
+      vi.spyOn(getStatement, "bind").mockReturnThis();
+      vi.spyOn(getStatement, "first").mockResolvedValue(credentials);
+
+      await databaseService.upsertUserCredentials(credentials);
+      const result = await databaseService.getUserCredentials(credentials.UserId);
+
+      expect(result).toEqual(credentials);
+    });
+
+    it("updates the token and UpdatedAt on conflict", async () => {
+      const updated = aFakeUserCredentialsRow({ RefreshToken: "encrypted-2", UpdatedAt: 2000 });
+      const fakePreparedStatement = new FakePreparedStatement();
+      const bindSpy = vi.spyOn(fakePreparedStatement, "bind");
+      vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+
+      await databaseService.upsertUserCredentials(updated);
+
+      expect(bindSpy).toHaveBeenCalledWith(updated.UserId, "encrypted-2", 2000);
+    });
+  });
+
+  describe("deleteUserCredentials()", () => {
+    it("deletes user credentials by user id", async () => {
+      const fakePreparedStatement = new FakePreparedStatement();
+      const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      const bindSpy = vi.spyOn(fakePreparedStatement, "bind");
+      const runSpy = vi.spyOn(fakePreparedStatement, "run");
+
+      await databaseService.deleteUserCredentials("user-1");
+
+      expect(prepareSpy).toHaveBeenCalledWith("DELETE FROM UserCredentials WHERE UserId = ?");
+      expect(bindSpy).toHaveBeenCalledWith("user-1");
       expect(runSpy).toHaveBeenCalled();
     });
   });

--- a/api/services/database/types/user_credentials.ts
+++ b/api/services/database/types/user_credentials.ts
@@ -1,0 +1,5 @@
+export interface UserCredentialsRow {
+  UserId: string;
+  RefreshToken: string;
+  UpdatedAt: number;
+}


### PR DESCRIPTION
## Milestone B3b-i — durable credential store

First of two PRs for B3b. Adds a durable, per-user encrypted credential store so a tracker can later be auto-started from an external event (Discord presence / Twitch go-live) **without the user re-logging in** — the owner's refresh token must outlive the browser session. **This PR only persists + captures; nothing reads it yet** (the `UserTokenProvider` consumer + the gamertag→owner proxy branch land in B3b-ii).

### Changes
- **Schema**: new `UserCredentials` table (`UserId` PK, `RefreshToken` AES-encrypted, `UpdatedAt`). ⚠️ **Needs a manual `wrangler d1 execute --file=schema.sql` apply** (idempotent `CREATE … IF NOT EXISTS`, per the repo's no-migrations convention).
- **DatabaseService**: `getUserCredentials` / `upsertUserCredentials` (INSERT … ON CONFLICT(UserId) DO UPDATE) / `deleteUserCredentials` — parameterized, mirroring the existing methods; + `UserCredentialsRow` type + fake.
- **Capture** (`auth.ts`): `persistSession` (login) and `refreshSession` (refresh) now also upsert the owner's refresh token into `UserCredentials`, **reusing the exact value already AES-encrypted for the session row** (no double-encrypt, no plaintext), only when a refresh token is present.

### Security notes
- Stored value is the encrypted token (tests assert it equals the encryptor output and never contains the raw token).
- **Logout does NOT delete credentials** (offline auto-start requires persistence). `deleteUserCredentials` exists for a future "disconnect" feature but is intentionally not wired to logout — flagging for review since it's a deliberate tradeoff aligned with the agreed B4 auto-start goal.

97 auth+database tests green; full api+shared suite green (1490); typecheck 0 errors; lint clean.

### Next
**B3b-ii**: server-side `UserTokenProvider` (reads `UserCredentials`, refreshes the access token, derives a spartan token, bot fallback) + the `gamertag → owner-token` branch in the Halo proxy (resolving the owner via `LinkedIdentities`). Then **B4** (DO polling) consumes the provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)