### PR TITLE
feat(api): UserTokenProvider + gamertag→owner token in the Halo proxy (B3b-ii)

### DIFF
--- a/api/routes/halo-proxy/halo-proxy.ts
+++ b/api/routes/halo-proxy/halo-proxy.ts
@@ -20,6 +20,23 @@ type ResolveHaloProxyClientResult =
   | { readonly ok: true; readonly resolved: ResolvedHaloProxyClient }
   | { readonly ok: false; readonly response: Response };
 
+async function resolveOwnerClient(request: Request, services: Services): Promise<HaloInfiniteClient | null> {
+  const gamertag = new URL(request.url).searchParams.get("gamertag");
+  if (gamertag == null || gamertag === "") {
+    return null;
+  }
+
+  try {
+    const identity = await services.databaseService.findActiveXboxIdentityByGamertag(gamertag);
+    if (identity == null) {
+      return null;
+    }
+    return await services.userTokenProvider.getClientForUser(identity.UserId);
+  } catch {
+    return null;
+  }
+}
+
 async function resolveHaloProxyClient(request: Request, services: Services): Promise<ResolveHaloProxyClientResult> {
   const session = await services.authService.validateSession(request);
 
@@ -50,10 +67,21 @@ async function resolveHaloProxyClient(request: Request, services: Services): Pro
     return { ok: true, resolved: { client } };
   }
 
-  // Future PR (B3b): insert gamertag -> owner-token resolution here, between the
-  // authenticated-session branch above and the bot-account fallback below.
+  const ownerClient = await resolveOwnerClient(request, services);
+  if (ownerClient != null) {
+    return { ok: true, resolved: { client: ownerClient } };
+  }
 
   return { ok: true, resolved: { client: services.haloInfiniteClient } };
+}
+
+function toCacheKeyRequest(request: Request): Request {
+  const url = new URL(request.url);
+  if (!url.searchParams.has("gamertag")) {
+    return request;
+  }
+  url.searchParams.delete("gamertag");
+  return new Request(url.toString(), request);
 }
 
 function readHaloProxyArgs(request: Request): { ok: true; args: unknown[] } | { ok: false; response: Response } {
@@ -91,7 +119,8 @@ export const haloProxyRoutesRegisterHandler: RoutesRegisterHandler = (router, in
       }
 
       const cache = caches.default;
-      const cached = await cache.match(request);
+      const cacheKeyRequest = toCacheKeyRequest(request);
+      const cached = await cache.match(cacheKeyRequest);
       if (cached) {
         return cached;
       }
@@ -114,7 +143,7 @@ export const haloProxyRoutesRegisterHandler: RoutesRegisterHandler = (router, in
         headers: { "Cache-Control": buildHaloProxyCacheControl(operationDefinition) },
       });
 
-      ctx.waitUntil(cache.put(request, response.clone()));
+      ctx.waitUntil(cache.put(cacheKeyRequest, response.clone()));
 
       return response;
     } catch (error) {

--- a/api/services/auth/auth.ts
+++ b/api/services/auth/auth.ts
@@ -270,6 +270,36 @@ export class AuthService {
   }
 
   /**
+   * Mint a fresh Microsoft access token for a user from their durable credential store.
+   * Fails closed: returns null on missing credentials or any failure (never throws to callers).
+   * The decrypted token is returned only to in-process callers; the stored value stays encrypted,
+   * and a rotated refresh token is re-encrypted on persist.
+   */
+  public async getMicrosoftAccessTokenForUser(userId: string): Promise<string | null> {
+    try {
+      const credentials = await this.databaseService.getUserCredentials(userId);
+      if (credentials == null) {
+        return null;
+      }
+
+      const refreshToken = await this.tokenEncryptor.decrypt(credentials.RefreshToken);
+      const tokens = await this.microsoftAuth.refreshAccessToken(refreshToken);
+
+      if (tokens.refresh_token != null && tokens.refresh_token !== "") {
+        await this.databaseService.upsertUserCredentials({
+          UserId: userId,
+          RefreshToken: await this.tokenEncryptor.encrypt(tokens.refresh_token),
+          UpdatedAt: Math.floor(Date.now() / 1000),
+        });
+      }
+
+      return tokens.access_token;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Set session cookie in response.
    */
   public setSessionCookie(response: Response, token: string): void {

--- a/api/services/auth/tests/auth.test.ts
+++ b/api/services/auth/tests/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import type { MockInstance } from "vitest";
 import { AuthService } from "../auth";
+import { TokenEncryptor } from "../token-encryptor";
 import { aFakeSessionTokenPayload, aFakePKCEState } from "../fakes/data";
 import type { AuthSession } from "../types";
 import {
@@ -361,6 +362,71 @@ describe("AuthService", () => {
     expect(persistedCredentials?.UserId).toBe("user-123");
     expect(persistedCredentials?.RefreshToken).toBe(persistedSession?.RefreshToken);
     expect(persistedCredentials?.RefreshToken).not.toContain("new-refresh-token");
+  });
+
+  describe("getMicrosoftAccessTokenForUser()", () => {
+    const tokenEncryptionSecret = "b".repeat(64);
+
+    it("returns the access token and re-persists a rotated refresh token encrypted", async () => {
+      const encryptor = new TokenEncryptor(tokenEncryptionSecret);
+      const encryptedStored = await encryptor.encrypt("stored-refresh-token");
+
+      vi.spyOn(databaseService, "getUserCredentials").mockResolvedValue({
+        UserId: "user-123",
+        RefreshToken: encryptedStored,
+        UpdatedAt: Math.floor(Date.now() / 1000),
+      });
+      const upsertUserCredentialsSpy = vi.spyOn(databaseService, "upsertUserCredentials").mockResolvedValue();
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            access_token: "fresh-access-token",
+            expires_in: 3600,
+            refresh_token: "rotated-refresh-token",
+            token_type: "Bearer",
+            scope: "openid profile",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      const result = await service.getMicrosoftAccessTokenForUser("user-123");
+
+      expect(result).toBe("fresh-access-token");
+      expect(upsertUserCredentialsSpy).toHaveBeenCalledTimes(1);
+      const persisted = upsertUserCredentialsSpy.mock.calls[0]?.[0];
+      expect(persisted?.UserId).toBe("user-123");
+      expect(persisted?.RefreshToken).toContain("enc-v1.");
+      expect(persisted?.RefreshToken).not.toContain("rotated-refresh-token");
+      expect(await encryptor.decrypt(persisted?.RefreshToken ?? "")).toBe("rotated-refresh-token");
+    });
+
+    it("returns null when the user has no stored credentials", async () => {
+      vi.spyOn(databaseService, "getUserCredentials").mockResolvedValue(null);
+      const upsertUserCredentialsSpy = vi.spyOn(databaseService, "upsertUserCredentials").mockResolvedValue();
+
+      const result = await service.getMicrosoftAccessTokenForUser("unknown-user");
+
+      expect(result).toBeNull();
+      expect(upsertUserCredentialsSpy).not.toHaveBeenCalled();
+    });
+
+    it("fails closed (returns null) when the refresh request throws", async () => {
+      const encryptor = new TokenEncryptor(tokenEncryptionSecret);
+      vi.spyOn(databaseService, "getUserCredentials").mockResolvedValue({
+        UserId: "user-123",
+        RefreshToken: await encryptor.encrypt("revoked-refresh-token"),
+        UpdatedAt: Math.floor(Date.now() / 1000),
+      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("invalid_grant", { status: 400, statusText: "Bad Request" }),
+      );
+
+      const result = await service.getMicrosoftAccessTokenForUser("user-123");
+
+      expect(result).toBeNull();
+    });
   });
 
   it("merges xbox profile into the persisted session metadata", async () => {

--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -310,6 +310,13 @@ export class DatabaseService {
     return await stmt.first<LinkedIdentitiesRow>();
   }
 
+  async findActiveXboxIdentityByGamertag(gamertag: string): Promise<LinkedIdentitiesRow | null> {
+    const query =
+      "SELECT * FROM LinkedIdentities WHERE Provider = 'xbox' AND IsActive = 1 AND Gamertag = ? ORDER BY UpdatedAt DESC";
+    const stmt = this.DB.prepare(query).bind(gamertag);
+    return await stmt.first<LinkedIdentitiesRow>();
+  }
+
   async upsertLinkedIdentity(identity: LinkedIdentitiesRow): Promise<void> {
     const query = `
       INSERT INTO LinkedIdentities (IdentityId, UserId, Provider, ProviderUserId, Gamertag, TwitchId, IsActive, CreatedAt, UpdatedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/api/services/database/tests/database.test.ts
+++ b/api/services/database/tests/database.test.ts
@@ -639,6 +639,35 @@ describe("Database Service", () => {
     });
   });
 
+  describe("findActiveXboxIdentityByGamertag()", () => {
+    it("returns the active xbox identity matching the gamertag", async () => {
+      const identity: LinkedIdentitiesRow = aFakeLinkedIdentitiesRow({ Gamertag: "OwnerGamertag" });
+      const fakePreparedStatement = new FakePreparedStatement<LinkedIdentitiesRow>();
+      const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      const bindSpy = vi.spyOn(fakePreparedStatement, "bind").mockReturnThis();
+      vi.spyOn(fakePreparedStatement, "first").mockResolvedValue(identity);
+
+      const result = await databaseService.findActiveXboxIdentityByGamertag("OwnerGamertag");
+
+      expect(prepareSpy).toHaveBeenCalledWith(
+        "SELECT * FROM LinkedIdentities WHERE Provider = 'xbox' AND IsActive = 1 AND Gamertag = ? ORDER BY UpdatedAt DESC",
+      );
+      expect(bindSpy).toHaveBeenCalledWith("OwnerGamertag");
+      expect(result).toEqual(identity);
+    });
+
+    it("returns null when no active xbox identity matches (inactive or non-xbox filtered by the query)", async () => {
+      const fakePreparedStatement = new FakePreparedStatement();
+      vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      vi.spyOn(fakePreparedStatement, "bind").mockReturnThis();
+      vi.spyOn(fakePreparedStatement, "first").mockResolvedValue(null);
+
+      const result = await databaseService.findActiveXboxIdentityByGamertag("Nobody");
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe("upsertLinkedIdentity()", () => {
     it("upserts linked identity", async () => {
       const identity = aFakeLinkedIdentitiesRow();

--- a/api/services/fakes/services.ts
+++ b/api/services/fakes/services.ts
@@ -3,6 +3,7 @@ import { aFakeDatabaseServiceWith } from "../database/fakes/database.fake";
 import { aFakeDiscordServiceWith } from "../discord/fakes/discord.fake";
 import { aFakeHaloServiceWith } from "../halo/fakes/halo.fake";
 import { aFakeHaloInfiniteClient } from "../halo/fakes/infinite-client.fake";
+import { aFakeUserTokenProviderWith } from "../halo/fakes/user-token-provider.fake";
 import type { Services } from "../install";
 import { aFakeLogServiceWith } from "../log/fakes/log.fake";
 import { aFakeNeatQueueServiceWith } from "../neatqueue/fakes/neatqueue.fake";
@@ -20,6 +21,7 @@ export function installFakeServicesWith(opts: Partial<Services & { env: Env }> =
   const xboxService = opts.xboxService ?? aFakeXboxServiceWith({ env });
   const haloInfiniteClient = opts.haloInfiniteClient ?? aFakeHaloInfiniteClient();
   const haloService = opts.haloService ?? aFakeHaloServiceWith({ infiniteClient: haloInfiniteClient, databaseService });
+  const userTokenProvider = opts.userTokenProvider ?? aFakeUserTokenProviderWith({ authService, xboxService });
   const liveTrackerService =
     opts.liveTrackerService ?? aFakeLiveTrackerServiceWith({ logService, discordService, env });
   const neatQueueService =
@@ -36,6 +38,7 @@ export function installFakeServicesWith(opts: Partial<Services & { env: Env }> =
     xboxService,
     haloService,
     haloInfiniteClient,
+    userTokenProvider,
     liveTrackerService,
     neatQueueService,
     individualTrackerService,

--- a/api/services/halo/fakes/user-token-provider.fake.ts
+++ b/api/services/halo/fakes/user-token-provider.fake.ts
@@ -1,0 +1,11 @@
+import type { UserTokenProviderOpts } from "../user-token-provider";
+import { UserTokenProvider } from "../user-token-provider";
+import { aFakeAuthServiceWith } from "../../auth/fakes/auth.fake";
+import { aFakeXboxServiceWith } from "../../xbox/fakes/xbox.fake";
+
+export function aFakeUserTokenProviderWith(opts: Partial<UserTokenProviderOpts> = {}): UserTokenProvider {
+  return new UserTokenProvider({
+    authService: opts.authService ?? aFakeAuthServiceWith(),
+    xboxService: opts.xboxService ?? aFakeXboxServiceWith(),
+  });
+}

--- a/api/services/halo/tests/user-token-provider.test.ts
+++ b/api/services/halo/tests/user-token-provider.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { HaloInfiniteClient, StaticXstsTicketTokenSpartanTokenProvider } from "halo-infinite-api";
+import type * as HaloInfiniteApi from "halo-infinite-api";
+import { UserTokenProvider } from "../user-token-provider";
+import { aFakeAuthServiceWith } from "../../auth/fakes/auth.fake";
+import { aFakeXboxServiceWith } from "../../xbox/fakes/xbox.fake";
+import type { TokenInfo } from "../../xbox/types";
+
+vi.mock("halo-infinite-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof HaloInfiniteApi>();
+  return {
+    ...actual,
+    StaticXstsTicketTokenSpartanTokenProvider: vi.fn(),
+    HaloInfiniteClient: vi.fn(),
+  };
+});
+
+describe("UserTokenProvider", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("returns a Halo client built from the user's XSTS token", async () => {
+    const authService = aFakeAuthServiceWith();
+    const xboxService = aFakeXboxServiceWith();
+    vi.spyOn(authService, "getMicrosoftAccessTokenForUser").mockResolvedValue("owner-access-token");
+    const exchangeSpy = vi.spyOn(xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockResolvedValue({
+      XSTSToken: "owner-xsts-token",
+      userHash: "owner-user-hash",
+      expiresOn: new Date("2030-01-01T00:00:00.000Z"),
+    } satisfies TokenInfo);
+
+    const provider = new UserTokenProvider({ authService, xboxService });
+    const client = await provider.getClientForUser("user-123");
+
+    expect(exchangeSpy).toHaveBeenCalledWith("owner-access-token");
+    expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).toHaveBeenCalledWith("owner-xsts-token");
+    expect(vi.mocked(HaloInfiniteClient)).toHaveBeenCalledTimes(1);
+    expect(client).not.toBeNull();
+  });
+
+  it("returns null when no access token can be minted for the user", async () => {
+    const authService = aFakeAuthServiceWith();
+    const xboxService = aFakeXboxServiceWith();
+    vi.spyOn(authService, "getMicrosoftAccessTokenForUser").mockResolvedValue(null);
+    const exchangeSpy = vi.spyOn(xboxService, "exchangeMicrosoftAccessTokenForXstsToken");
+
+    const provider = new UserTokenProvider({ authService, xboxService });
+    const client = await provider.getClientForUser("user-123");
+
+    expect(client).toBeNull();
+    expect(exchangeSpy).not.toHaveBeenCalled();
+  });
+
+  it("fails closed (returns null) when the xbox exchange throws", async () => {
+    const authService = aFakeAuthServiceWith();
+    const xboxService = aFakeXboxServiceWith();
+    vi.spyOn(authService, "getMicrosoftAccessTokenForUser").mockResolvedValue("owner-access-token");
+    vi.spyOn(xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockRejectedValue(new Error("xbox down"));
+
+    const provider = new UserTokenProvider({ authService, xboxService });
+    const client = await provider.getClientForUser("user-123");
+
+    expect(client).toBeNull();
+  });
+});

--- a/api/services/halo/user-token-provider.ts
+++ b/api/services/halo/user-token-provider.ts
@@ -1,0 +1,32 @@
+import { HaloInfiniteClient, StaticXstsTicketTokenSpartanTokenProvider } from "halo-infinite-api";
+import type { AuthService } from "../auth/auth";
+import type { XboxService } from "../xbox/xbox";
+
+export interface UserTokenProviderOpts {
+  authService: AuthService;
+  xboxService: XboxService;
+}
+
+export class UserTokenProvider {
+  private readonly authService: AuthService;
+  private readonly xboxService: XboxService;
+
+  constructor({ authService, xboxService }: UserTokenProviderOpts) {
+    this.authService = authService;
+    this.xboxService = xboxService;
+  }
+
+  async getClientForUser(userId: string): Promise<HaloInfiniteClient | null> {
+    try {
+      const accessToken = await this.authService.getMicrosoftAccessTokenForUser(userId);
+      if (accessToken == null) {
+        return null;
+      }
+
+      const xstsTokenInfo = await this.xboxService.exchangeMicrosoftAccessTokenForXstsToken(accessToken);
+      return new HaloInfiniteClient(new StaticXstsTicketTokenSpartanTokenProvider(xstsTokenInfo.XSTSToken));
+    } catch {
+      return null;
+    }
+  }
+}

--- a/api/services/install.ts
+++ b/api/services/install.ts
@@ -17,6 +17,7 @@ import { SentryLogClient } from "./log/sentry-log-client";
 import { createHaloInfiniteClientProxy } from "./halo/halo-infinite-client-proxy";
 import { createResilientFetch } from "./halo/resilient-fetch";
 import { PlayerMatchesRateLimiter } from "./halo/player-matches-rate-limiter";
+import { UserTokenProvider } from "./halo/user-token-provider";
 
 export interface Services {
   logService: LogService;
@@ -26,6 +27,7 @@ export interface Services {
   xboxService: XboxService;
   haloService: HaloService;
   haloInfiniteClient: HaloInfiniteClient;
+  userTokenProvider: UserTokenProvider;
   liveTrackerService: LiveTrackerService;
   neatQueueService: NeatQueueService;
   individualTrackerService: IndividualTrackerService;
@@ -83,6 +85,7 @@ export function installServices({ env }: InstallServicesOpts): Services {
     infiniteClient: haloInfiniteClient,
     playerMatchesRateLimiter: new PlayerMatchesRateLimiter({ logService, maxCallsPerSecond: 2 }),
   });
+  const userTokenProvider = new UserTokenProvider({ authService, xboxService });
   const liveTrackerService = new LiveTrackerService({ env, logService, discordService });
   const individualTrackerService = new IndividualTrackerService({ databaseService });
   const neatQueueService = new NeatQueueService({
@@ -102,6 +105,7 @@ export function installServices({ env }: InstallServicesOpts): Services {
     xboxService,
     haloService,
     haloInfiniteClient,
+    userTokenProvider,
     liveTrackerService,
     neatQueueService,
     individualTrackerService,

--- a/api/tests/server.test.ts
+++ b/api/tests/server.test.ts
@@ -8,6 +8,7 @@ import { Server } from "../server";
 import { aFakeEnvWith } from "../base/fakes/env.fake";
 import { aFakeCacheStorage } from "../base/fakes/cache.fake";
 import { aFakeHaloInfiniteClient } from "../services/halo/fakes/infinite-client.fake";
+import { aFakeLinkedIdentitiesRow } from "../services/database/fakes/database.fake";
 import type { TokenInfo } from "../services/xbox/types";
 
 vi.mock("halo-infinite-api", async (importOriginal) => {
@@ -405,6 +406,139 @@ describe("Server", () => {
 
       const stored = await cache.match(new Request(url, { method: "GET" }));
       expect(stored).toBeUndefined();
+    });
+
+    it("uses the owner's client when a known gamertag resolves to an active xbox identity", async () => {
+      const ownerClient = aFakeHaloInfiniteClient();
+      let getClientForUserSpy!: MockInstance;
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(
+          aFakeLinkedIdentitiesRow({ UserId: "owner-user-1", Gamertag: "OwnerTag", IsActive: 1, Provider: "xbox" }),
+        );
+        getClientForUserSpy = vi.spyOn(services.userTokenProvider, "getClientForUser").mockResolvedValue(ownerClient);
+        return services;
+      });
+      server = new Server({
+        router: createApiRouter(),
+        installServices: localInstallServices,
+      });
+
+      const req = new Request(
+        "http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22&gamertag=OwnerTag",
+        {
+          method: "GET",
+        },
+      );
+      const res = (await server.router.fetch(req, env, ctx)) as Response;
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(getClientForUserSpy).toHaveBeenCalledWith("owner-user-1");
+      expect(ownerClient.getUser).toHaveBeenCalledWith("discord_user_01");
+      // The owner's spartan/XSTS/access token is never returned to the browser; only the Halo result is.
+      expect(JSON.stringify(body)).not.toContain("xsts");
+      expect(JSON.stringify(body)).not.toContain("token");
+    });
+
+    it("falls back to the bot client when the gamertag has no active xbox identity", async () => {
+      const botClient = aFakeHaloInfiniteClient();
+      const botGetUserSpy = vi.spyOn(botClient, "getUser");
+      let getClientForUserSpy!: MockInstance;
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env, haloInfiniteClient: botClient });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(null);
+        getClientForUserSpy = vi.spyOn(services.userTokenProvider, "getClientForUser");
+        return services;
+      });
+      server = new Server({
+        router: createApiRouter(),
+        installServices: localInstallServices,
+      });
+
+      const req = new Request(
+        "http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22&gamertag=Unknown",
+        {
+          method: "GET",
+        },
+      );
+      const res = (await server.router.fetch(req, env, ctx)) as Response;
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({ xuid: "0000000000001", gamertag: "gamertag01" });
+
+      expect(getClientForUserSpy).not.toHaveBeenCalled();
+      expect(botGetUserSpy).toHaveBeenCalledWith("discord_user_01");
+    });
+
+    it("falls back to the bot client when owner credentials cannot mint a client", async () => {
+      const botClient = aFakeHaloInfiniteClient();
+      const botGetUserSpy = vi.spyOn(botClient, "getUser");
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env, haloInfiniteClient: botClient });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(
+          aFakeLinkedIdentitiesRow({ UserId: "owner-user-1", Gamertag: "OwnerTag" }),
+        );
+        vi.spyOn(services.userTokenProvider, "getClientForUser").mockResolvedValue(null);
+        return services;
+      });
+      server = new Server({
+        router: createApiRouter(),
+        installServices: localInstallServices,
+      });
+
+      const req = new Request(
+        "http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22&gamertag=OwnerTag",
+        {
+          method: "GET",
+        },
+      );
+      const res = (await server.router.fetch(req, env, ctx)) as Response;
+      expect(res.status).toBe(200);
+      expect(botGetUserSpy).toHaveBeenCalledWith("discord_user_01");
+    });
+
+    it("shares the same cache key whether or not the gamertag query param is present", async () => {
+      const cache = caches.default;
+      const ownerClient = aFakeHaloInfiniteClient();
+      const ownerGetUserSpy = vi.spyOn(ownerClient, "getUser");
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(
+          aFakeLinkedIdentitiesRow({ UserId: "owner-user-1", Gamertag: "OwnerTag" }),
+        );
+        vi.spyOn(services.userTokenProvider, "getClientForUser").mockResolvedValue(ownerClient);
+        return services;
+      });
+      server = new Server({
+        router: createApiRouter(),
+        installServices: localInstallServices,
+      });
+
+      const baseUrl = "http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22";
+
+      // Populate the cache via a request that carries ?gamertag=.
+      const ownerReq = new Request(`${baseUrl}&gamertag=OwnerTag`, { method: "GET" });
+      const ownerRes = (await server.router.fetch(ownerReq, env, ctx)) as Response;
+      expect(ownerRes.status).toBe(200);
+      expect(ownerGetUserSpy).toHaveBeenCalledTimes(1);
+
+      // The cache entry is keyed without the gamertag param, so a plain request hits the SAME entry.
+      const storedWithoutGamertag = await cache.match(new Request(baseUrl, { method: "GET" }));
+      expect(storedWithoutGamertag).toBeDefined();
+
+      // A subsequent route request with a DIFFERENT gamertag is served from that shared entry
+      // (the gamertag is stripped before keying), so the Halo client is not invoked again.
+      const otherReq = new Request(`${baseUrl}&gamertag=SomeoneElse`, { method: "GET" });
+      const otherRes = (await server.router.fetch(otherReq, env, ctx)) as Response;
+      expect(otherRes.status).toBe(200);
+      expect(ownerGetUserSpy).toHaveBeenCalledTimes(1);
+
+      // And a plain request (no gamertag) is likewise served from the same shared entry.
+      const plainReq = new Request(baseUrl, { method: "GET" });
+      const plainRes = (await server.router.fetch(plainReq, env, ctx)) as Response;
+      expect(plainRes.status).toBe(200);
+      expect(ownerGetUserSpy).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Milestone B3b-ii — credential consumer

Stacked on **#465 (B3b-i credential store)**. Lets the public Halo proxy serve anonymous viewers using the tracker **owner's** server-side token, so a streamer's public view/overlay reads are attributed to their account (not the shared bot). Unblocks **B4** (DO polling will reuse `UserTokenProvider`).

### Flow
`?gamertag=` → `findActiveXboxIdentityByGamertag` (owning user) → `UserTokenProvider.getClientForUser(userId)` → `AuthService.getMicrosoftAccessTokenForUser` (decrypt stored refresh token → `refreshAccessToken` → re-persist rotated token, encrypted) → XSTS exchange → `HaloInfiniteClient`.

### Security (independently reviewed — no confidentiality issue)
- **Token never leaves the server**: the owner's access/XSTS/spartan/refresh token is consumed in-process only; the response is the public Halo result, same as the session branch; nothing is logged.
- **Fails closed**: every owner-resolution miss/error (incl. a transient D1 error — owner branch wrapped in `resolveOwnerClient`'s try/catch) falls through to the bot account with a normal 200; never a 500 or token leak.
- **Cache stays shared**: `toCacheKeyRequest` strips `gamertag` from the cache key (responses depend only on operation+args, not which token fetched them), so owner-token and bot-token callers share one entry — no fragmentation, no cross-serving of private data (all allowlisted ops are public, args-keyed reads).
- **No injection**: gamertag is parameterized; `Provider='xbox' AND IsActive=1` are literals. Resolution is `ORDER BY UpdatedAt DESC` (gamertag isn't globally unique; this only selects whose public-read token funds the call).
- Concurrency: a rotated-refresh-token race degrades to a benign transient bot fallback; a stale token can't overwrite a valid stored one (re-persist only on successful refresh).

### Note (by design, agreed)
The proxy remains an open, allowlisted, read-only proxy; rate-limiting/abuse-prevention is out of scope. An anonymous caller can cause public reads (and token refreshes) attributed to a streamer by passing their gamertag — acceptable given the allowlist exposes only public data and the token is never returned.

`UserTokenProvider` wired into `installServices` (+ fake). Full api+shared suite green (1502), typecheck 0 errors, lint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)