### PR TITLE
feat(pages): add-tracker dialog + reusable Dialog component (E3)

### DIFF
--- a/pages/src/components/dialog/dialog.module.css
+++ b/pages/src/components/dialog/dialog.module.css
@@ -1,0 +1,40 @@
+.overlay {
+  align-items: center;
+  background: rgb(0 0 0 / 60%);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: var(--space-4);
+  position: fixed;
+  z-index: var(--z-modal);
+}
+
+.panel {
+  background: var(--halo-bg-secondary);
+  border: 1px solid var(--halo-teal-primary);
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 50%);
+  max-width: 480px;
+  padding: var(--space-6);
+  width: 100%;
+}
+
+.panel:focus-visible {
+  outline: 2px solid var(--halo-accent);
+  outline-offset: 2px;
+}
+
+.title {
+  color: var(--halo-white);
+  font-family: var(--font-heading);
+  font-size: var(--text-xl);
+  letter-spacing: 0.04em;
+  margin: 0 0 var(--space-4);
+  text-transform: uppercase;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}

--- a/pages/src/components/dialog/dialog.tsx
+++ b/pages/src/components/dialog/dialog.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useId, useRef } from "react";
+import styles from "./dialog.module.css";
+
+interface DialogProps {
+  readonly open: boolean;
+  readonly title: string;
+  readonly onClose: () => void;
+  readonly children: React.ReactNode;
+}
+
+export function Dialog({ open, title, onClose, children }: DialogProps): React.ReactElement | null {
+  const titleId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    previouslyFocused.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    panelRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+
+    return (): void => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previouslyFocused.current?.focus();
+    };
+  }, [open, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className={styles.overlay}
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        className={styles.panel}
+      >
+        <h2 id={titleId} className={styles.title}>
+          {title}
+        </h2>
+        <div className={styles.body}>{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/pages/src/components/dialog/tests/dialog.test.tsx
+++ b/pages/src/components/dialog/tests/dialog.test.tsx
@@ -1,0 +1,86 @@
+import "@testing-library/jest-dom/vitest";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { Dialog } from "../dialog";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Dialog", () => {
+  it("renders nothing when closed", () => {
+    render(
+      <Dialog open={false} title="Add tracker" onClose={() => undefined}>
+        <p>Body content</p>
+      </Dialog>,
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.queryByText("Body content")).not.toBeInTheDocument();
+  });
+
+  it("renders an accessible dialog labelled by its title when open", () => {
+    render(
+      <Dialog open title="Add tracker" onClose={() => undefined}>
+        <p>Body content</p>
+      </Dialog>,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAccessibleName("Add tracker");
+    expect(screen.getByText("Body content")).toBeInTheDocument();
+  });
+
+  it("calls onClose when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <Dialog open title="Add tracker" onClose={onClose}>
+        <p>Body content</p>
+      </Dialog>,
+    );
+
+    await user.keyboard("{Escape}");
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the overlay is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <Dialog open title="Add tracker" onClose={onClose}>
+        <p>Body content</p>
+      </Dialog>,
+    );
+
+    const overlay = screen.getByRole("dialog").parentElement;
+    expect(overlay).not.toBeNull();
+    if (overlay !== null) {
+      await user.click(overlay);
+    }
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose when content inside the panel is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <Dialog open title="Add tracker" onClose={onClose}>
+        <p>Body content</p>
+      </Dialog>,
+    );
+
+    await user.click(screen.getByText("Body content"));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/pages/src/components/individual-tracker-manager/create.tsx
+++ b/pages/src/components/individual-tracker-manager/create.tsx
@@ -40,8 +40,20 @@ export function IndividualTrackerManagerPage({
 
   const actions = useMemo(
     () => ({
+      onOpenAddDialog: (): void => {
+        presenter.openAddDialog();
+      },
+      onCloseAddDialog: (): void => {
+        presenter.closeAddDialog();
+      },
       onGamertagInputChange: (value: string): void => {
         presenter.setGamertagInput(value);
+      },
+      onSearchStartTimeChange: (value: string): void => {
+        presenter.setSearchStartTime(value);
+      },
+      onIdleTimeoutHoursChange: (value: string): void => {
+        presenter.setIdleTimeoutHours(value);
       },
       onAddTracker: (): void => {
         presenter.addTracker();

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager-context.tsx
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager-context.tsx
@@ -3,7 +3,11 @@ import type { TrackerRowAction } from "./manager-model";
 import type { IndividualTrackerManagerViewModel } from "./types";
 
 interface IndividualTrackerManagerActions {
+  readonly onOpenAddDialog: () => void;
+  readonly onCloseAddDialog: () => void;
   readonly onGamertagInputChange: (value: string) => void;
+  readonly onSearchStartTimeChange: (value: string) => void;
+  readonly onIdleTimeoutHoursChange: (value: string) => void;
   readonly onAddTracker: () => void;
   readonly onRowAction: (trackerId: string, action: TrackerRowAction) => void;
 }

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager-presenter.ts
@@ -5,7 +5,14 @@ import type {
   IndividualTrackerManagerStore,
 } from "./individual-tracker-manager-store";
 import type { TrackerRowAction } from "./manager-model";
-import { isValidGamertagInput, toManagerModel } from "./manager-model";
+import {
+  isValidGamertagInput,
+  isValidIdleTimeoutHoursInput,
+  isValidSearchStartTimeInput,
+  parseIdleTimeoutHours,
+  parseSearchStartTime,
+  toManagerModel,
+} from "./manager-model";
 import type { IndividualTrackerManagerViewModel } from "./types";
 
 interface Config {
@@ -23,13 +30,22 @@ export class IndividualTrackerManagerPresenter {
 
   public static present(snapshot: IndividualTrackerManagerSnapshot): IndividualTrackerManagerViewModel {
     const model = toManagerModel(snapshot.trackers);
+    const addDisabled =
+      !model.canAddTracker ||
+      snapshot.addPending ||
+      !isValidGamertagInput(snapshot.gamertagInput) ||
+      !isValidSearchStartTimeInput(snapshot.searchStartTime) ||
+      !isValidIdleTimeoutHoursInput(snapshot.idleTimeoutHours);
     return {
       model,
       profileName: snapshot.profileName,
+      isAddDialogOpen: snapshot.isAddDialogOpen,
       gamertagInput: snapshot.gamertagInput,
+      searchStartTime: snapshot.searchStartTime,
+      idleTimeoutHours: snapshot.idleTimeoutHours,
       addPending: snapshot.addPending,
       pendingTrackerId: snapshot.pendingTrackerId,
-      addDisabled: !model.canAddTracker || snapshot.addPending || !isValidGamertagInput(snapshot.gamertagInput),
+      addDisabled,
     };
   }
 
@@ -41,6 +57,22 @@ export class IndividualTrackerManagerPresenter {
     this.isDisposed = true;
   }
 
+  public openAddDialog(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.resetAddFields();
+    this.config.store.setAddDialogOpen(true);
+  }
+
+  public closeAddDialog(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.config.store.setAddDialogOpen(false);
+    this.resetAddFields();
+  }
+
   public setGamertagInput(value: string): void {
     if (this.isDisposed) {
       return;
@@ -48,22 +80,50 @@ export class IndividualTrackerManagerPresenter {
     this.config.store.setGamertagInput(value);
   }
 
+  public setSearchStartTime(value: string): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.config.store.setSearchStartTime(value);
+  }
+
+  public setIdleTimeoutHours(value: string): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.config.store.setIdleTimeoutHours(value);
+  }
+
   public addTracker(): void {
-    const { gamertagInput } = this.config.store.getSnapshot();
+    if (this.isDisposed) {
+      return;
+    }
+    const { gamertagInput, searchStartTime, idleTimeoutHours } = this.config.store.getSnapshot();
     if (!isValidGamertagInput(gamertagInput)) {
       return;
     }
-    const gamertag = gamertagInput.trim();
+    if (!isValidSearchStartTimeInput(searchStartTime) || !isValidIdleTimeoutHoursInput(idleTimeoutHours)) {
+      return;
+    }
+
+    const parsedSearchStartTime = parseSearchStartTime(searchStartTime);
+    const parsedIdleTimeoutHours = parseIdleTimeoutHours(idleTimeoutHours);
+    const request = {
+      gamertag: gamertagInput.trim(),
+      ...(parsedSearchStartTime !== null ? { searchStartTime: parsedSearchStartTime } : {}),
+      ...(parsedIdleTimeoutHours !== null ? { idleTimeoutHours: parsedIdleTimeoutHours } : {}),
+    };
 
     this.config.store.setAddPending(true);
     this.config.individualTrackerService
-      .startTracker({ gamertag })
+      .startTracker(request)
       .then(async () => this.refreshTrackers())
       .then(() => {
         if (this.isDisposed) {
           return;
         }
-        this.config.store.setGamertagInput("");
+        this.config.store.setAddDialogOpen(false);
+        this.resetAddFields();
       })
       .catch((error: unknown) => {
         if (this.isDisposed) {
@@ -95,6 +155,12 @@ export class IndividualTrackerManagerPresenter {
         }
         this.config.store.setPendingTrackerId(null);
       });
+  }
+
+  private resetAddFields(): void {
+    this.config.store.setGamertagInput("");
+    this.config.store.setSearchStartTime("");
+    this.config.store.setIdleTimeoutHours("");
   }
 
   private async load(): Promise<void> {

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager-store.ts
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager-store.ts
@@ -6,7 +6,10 @@ export interface IndividualTrackerManagerSnapshot {
   readonly errorMessage: string | null;
   readonly profileName: string;
   readonly trackers: readonly Tracker[];
+  readonly isAddDialogOpen: boolean;
   readonly gamertagInput: string;
+  readonly searchStartTime: string;
+  readonly idleTimeoutHours: string;
   readonly addPending: boolean;
   readonly pendingTrackerId: string | null;
 }
@@ -21,7 +24,10 @@ export class IndividualTrackerManagerStore {
       errorMessage: null,
       profileName: "",
       trackers: [],
+      isAddDialogOpen: false,
       gamertagInput: "",
+      searchStartTime: "",
+      idleTimeoutHours: "",
       addPending: false,
       pendingTrackerId: null,
     };
@@ -59,8 +65,20 @@ export class IndividualTrackerManagerStore {
     this.update({ trackers });
   }
 
+  public setAddDialogOpen(isAddDialogOpen: boolean): void {
+    this.update({ isAddDialogOpen });
+  }
+
   public setGamertagInput(gamertagInput: string): void {
     this.update({ gamertagInput });
+  }
+
+  public setSearchStartTime(searchStartTime: string): void {
+    this.update({ searchStartTime });
+  }
+
+  public setIdleTimeoutHours(idleTimeoutHours: string): void {
+    this.update({ idleTimeoutHours });
   }
 
   public setAddPending(addPending: boolean): void {

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager.module.css
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager.module.css
@@ -22,15 +22,22 @@
   margin: var(--space-2) 0 0;
 }
 
-.addForm {
-  align-items: flex-end;
+.addBar {
   display: flex;
-  gap: var(--space-3);
+  justify-content: flex-end;
   margin-bottom: var(--space-6);
 }
 
-.addInput {
-  flex: 1;
+.addForm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.dialogActions {
+  display: flex;
+  gap: var(--space-3);
+  justify-content: flex-end;
 }
 
 .list {

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager.tsx
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import classNames from "classnames";
 import { Button } from "../button/button";
+import { Dialog } from "../dialog/dialog";
 import { Input } from "../input/input";
 import type { TrackerRowAction, TrackerRowModel } from "./manager-model";
 import { MAX_TRACKERS } from "./manager-model";
@@ -93,8 +94,26 @@ function TrackerRow({ row, pending, onRowAction }: TrackerRowProps): React.React
 }
 
 export function IndividualTrackerManagerView(): React.ReactElement {
-  const { model, profileName, gamertagInput, addPending, pendingTrackerId, addDisabled } = useManagerModel();
-  const { onGamertagInputChange, onAddTracker, onRowAction } = useManagerActions();
+  const {
+    model,
+    profileName,
+    isAddDialogOpen,
+    gamertagInput,
+    searchStartTime,
+    idleTimeoutHours,
+    addPending,
+    pendingTrackerId,
+    addDisabled,
+  } = useManagerModel();
+  const {
+    onOpenAddDialog,
+    onCloseAddDialog,
+    onGamertagInputChange,
+    onSearchStartTimeChange,
+    onIdleTimeoutHoursChange,
+    onAddTracker,
+    onRowAction,
+  } = useManagerActions();
 
   return (
     <div className={styles.container}>
@@ -103,27 +122,61 @@ export function IndividualTrackerManagerView(): React.ReactElement {
         <p className={styles.subtext}>{profileName}</p>
       </div>
 
-      <form
-        className={styles.addForm}
-        onSubmit={(event) => {
-          event.preventDefault();
-          onAddTracker();
-        }}
-      >
-        <Input
-          label="Gamertag"
-          containerClassName={styles.addInput}
-          value={gamertagInput}
-          placeholder="Enter a gamertag"
-          disabled={!model.canAddTracker || addPending}
-          onChange={(event) => {
-            onGamertagInputChange(event.target.value);
-          }}
-        />
-        <Button type="submit" disabled={addDisabled}>
-          Track
+      <div className={styles.addBar}>
+        <Button type="button" disabled={!model.canAddTracker} onClick={onOpenAddDialog}>
+          Add tracker
         </Button>
-      </form>
+      </div>
+
+      <Dialog open={isAddDialogOpen} title="Add tracker" onClose={onCloseAddDialog}>
+        <form
+          className={styles.addForm}
+          onSubmit={(event) => {
+            event.preventDefault();
+            onAddTracker();
+          }}
+        >
+          <Input
+            label="Gamertag"
+            value={gamertagInput}
+            placeholder="Enter a gamertag"
+            disabled={addPending}
+            onChange={(event) => {
+              onGamertagInputChange(event.target.value);
+            }}
+          />
+          <Input
+            label="Search start time"
+            type="datetime-local"
+            hint="Optional. Only track matches from this time onward."
+            value={searchStartTime}
+            disabled={addPending}
+            onChange={(event) => {
+              onSearchStartTimeChange(event.target.value);
+            }}
+          />
+          <Input
+            label="Idle timeout (hours)"
+            type="number"
+            min={0}
+            step="any"
+            hint="Optional. Pause the tracker after this many idle hours."
+            value={idleTimeoutHours}
+            disabled={addPending}
+            onChange={(event) => {
+              onIdleTimeoutHoursChange(event.target.value);
+            }}
+          />
+          <div className={styles.dialogActions}>
+            <Button type="button" variant="secondary" onClick={onCloseAddDialog}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={addDisabled}>
+              Track
+            </Button>
+          </div>
+        </form>
+      </Dialog>
 
       {model.isAtLimit && (
         <p className={styles.limitNotice}>
@@ -132,7 +185,7 @@ export function IndividualTrackerManagerView(): React.ReactElement {
       )}
 
       {model.isEmpty ? (
-        <div className={styles.empty}>No trackers yet. Add a gamertag above to start tracking.</div>
+        <div className={styles.empty}>No trackers yet. Use Add tracker to start tracking a gamertag.</div>
       ) : (
         <div className={styles.list}>
           {model.rows.map((row) => (

--- a/pages/src/components/individual-tracker-manager/manager-model.ts
+++ b/pages/src/components/individual-tracker-manager/manager-model.ts
@@ -69,3 +69,35 @@ export function toManagerModel(trackers: readonly Tracker[]): ManagerModel {
 export function isValidGamertagInput(value: string): boolean {
   return value.trim().length > 0;
 }
+
+export function parseIdleTimeoutHours(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+}
+
+export function isValidIdleTimeoutHoursInput(value: string): boolean {
+  return value.trim().length === 0 || parseIdleTimeoutHours(value) !== null;
+}
+
+export function parseSearchStartTime(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const timestamp = Date.parse(trimmed);
+  if (Number.isNaN(timestamp)) {
+    return null;
+  }
+  return new Date(timestamp).toISOString();
+}
+
+export function isValidSearchStartTimeInput(value: string): boolean {
+  return value.trim().length === 0 || parseSearchStartTime(value) !== null;
+}

--- a/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-context.test.tsx
+++ b/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-context.test.tsx
@@ -15,7 +15,10 @@ function aFakeViewModelWith(overrides?: Partial<IndividualTrackerManagerViewMode
   return {
     model: toManagerModel([aFakeTrackerWith({ trackerId: "t-1", gamertag: "Alpha" })]),
     profileName: "Spartan Profile",
+    isAddDialogOpen: false,
     gamertagInput: "",
+    searchStartTime: "",
+    idleTimeoutHours: "",
     addPending: false,
     pendingTrackerId: null,
     addDisabled: true,
@@ -24,7 +27,11 @@ function aFakeViewModelWith(overrides?: Partial<IndividualTrackerManagerViewMode
 }
 
 const noopActions = {
+  onOpenAddDialog: (): void => undefined,
+  onCloseAddDialog: (): void => undefined,
   onGamertagInputChange: (): void => undefined,
+  onSearchStartTimeChange: (): void => undefined,
+  onIdleTimeoutHoursChange: (): void => undefined,
   onAddTracker: (): void => undefined,
   onRowAction: (): void => undefined,
 };
@@ -60,7 +67,7 @@ describe("IndividualTrackerManagerContext", () => {
       wrapper: ({ children }) => (
         <IndividualTrackerManagerProvider
           model={aFakeViewModelWith()}
-          actions={{ onAddTracker, onRowAction, onGamertagInputChange }}
+          actions={{ ...noopActions, onAddTracker, onRowAction, onGamertagInputChange }}
         >
           {children}
         </IndividualTrackerManagerProvider>

--- a/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-presenter.test.ts
@@ -104,6 +104,115 @@ describe("IndividualTrackerManagerPresenter", () => {
 
       expect(store.getSnapshot().errorMessage).toBe("Start failed");
     });
+
+    it("closes the dialog and clears all fields on success", async () => {
+      const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
+      const { store, presenter } = aHarness(service);
+
+      presenter.openAddDialog();
+      store.setGamertagInput("New Recruit");
+      store.setSearchStartTime("2026-01-02T03:04");
+      store.setIdleTimeoutHours("12");
+      presenter.addTracker();
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().addPending).toBe(false);
+      });
+
+      expect(store.getSnapshot().isAddDialogOpen).toBe(false);
+      expect(store.getSnapshot().gamertagInput).toBe("");
+      expect(store.getSnapshot().searchStartTime).toBe("");
+      expect(store.getSnapshot().idleTimeoutHours).toBe("");
+    });
+
+    it("omits idleTimeoutHours when blank and includes a parsed searchStartTime when provided", async () => {
+      const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
+      const startSpy: MockInstance = vi.spyOn(service, "startTracker");
+      const { store, presenter } = aHarness(service);
+
+      store.setGamertagInput("New Recruit");
+      store.setSearchStartTime("2026-01-02T03:04");
+      store.setIdleTimeoutHours("   ");
+      presenter.addTracker();
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().addPending).toBe(false);
+      });
+
+      expect(startSpy).toHaveBeenCalledWith({
+        gamertag: "New Recruit",
+        searchStartTime: new Date("2026-01-02T03:04").toISOString(),
+      });
+    });
+
+    it("includes a parsed idleTimeoutHours when provided", async () => {
+      const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
+      const startSpy: MockInstance = vi.spyOn(service, "startTracker");
+      const { store, presenter } = aHarness(service);
+
+      store.setGamertagInput("New Recruit");
+      store.setIdleTimeoutHours("12");
+      presenter.addTracker();
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().addPending).toBe(false);
+      });
+
+      expect(startSpy).toHaveBeenCalledWith({ gamertag: "New Recruit", idleTimeoutHours: 12 });
+    });
+
+    it("does not call the service when the searchStartTime is not a valid datetime", () => {
+      const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
+      const startSpy: MockInstance = vi.spyOn(service, "startTracker");
+      const { store, presenter } = aHarness(service);
+
+      store.setGamertagInput("New Recruit");
+      store.setSearchStartTime("not-a-date");
+      presenter.addTracker();
+
+      expect(startSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not call the service when the idleTimeoutHours is not a positive number", () => {
+      const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
+      const startSpy: MockInstance = vi.spyOn(service, "startTracker");
+      const { store, presenter } = aHarness(service);
+
+      store.setGamertagInput("New Recruit");
+      store.setIdleTimeoutHours("-3");
+      presenter.addTracker();
+
+      expect(startSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("openAddDialog / closeAddDialog", () => {
+    it("opens the dialog and resets the fields", () => {
+      const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
+      const { store, presenter } = aHarness(service);
+
+      store.setGamertagInput("Stale");
+      store.setSearchStartTime("2026-01-02T03:04");
+      store.setIdleTimeoutHours("9");
+      presenter.openAddDialog();
+
+      expect(store.getSnapshot().isAddDialogOpen).toBe(true);
+      expect(store.getSnapshot().gamertagInput).toBe("");
+      expect(store.getSnapshot().searchStartTime).toBe("");
+      expect(store.getSnapshot().idleTimeoutHours).toBe("");
+    });
+
+    it("closes the dialog and resets the fields", () => {
+      const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
+      const { store, presenter } = aHarness(service);
+
+      presenter.openAddDialog();
+      store.setGamertagInput("Stale");
+      presenter.closeAddDialog();
+
+      expect(store.getSnapshot().isAddDialogOpen).toBe(false);
+      expect(store.getSnapshot().gamertagInput).toBe("");
+    });
   });
 
   describe("runRowAction", () => {
@@ -219,6 +328,19 @@ describe("IndividualTrackerManagerPresenter", () => {
       presenter.setGamertagInput("New Recruit");
 
       expect(store.getSnapshot().gamertagInput).toBe("");
+    });
+
+    it("ignores addTracker after dispose", () => {
+      const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
+      const startSpy = vi.spyOn(service, "startTracker");
+      const { store, presenter } = aHarness(service);
+
+      presenter.setGamertagInput("New Recruit");
+      presenter.dispose();
+      presenter.addTracker();
+
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(store.getSnapshot().addPending).toBe(false);
     });
   });
 });

--- a/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager.test.tsx
+++ b/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager.test.tsx
@@ -126,11 +126,11 @@ describe("IndividualTrackerManagerView", () => {
       expect(screen.getByText("Spartan 0")).toBeInTheDocument();
     });
 
-    expect(screen.getByRole("button", { name: "Track" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add tracker" })).toBeDisabled();
     expect(screen.getByText(/reached the limit of 5 trackers/i)).toBeInTheDocument();
   });
 
-  it("invokes startTracker with the entered gamertag and adds its row after the list refreshes", async () => {
+  it("opens the add dialog and invokes startTracker with the entered gamertag, then adds its row", async () => {
     const user = userEvent.setup();
     const startSpy: MockInstance = vi.spyOn(service, "startTracker");
 
@@ -140,15 +140,49 @@ describe("IndividualTrackerManagerView", () => {
       expect(screen.getByText("Active Spartan")).toBeInTheDocument();
     });
 
-    await user.type(screen.getByLabelText("Gamertag"), "New Recruit");
-    await user.click(screen.getByRole("button", { name: "Track" }));
+    await user.click(screen.getByRole("button", { name: "Add tracker" }));
+
+    const dialog = within(screen.getByRole("dialog"));
+    await user.type(dialog.getByLabelText("Gamertag"), "New Recruit");
+    await user.click(dialog.getByRole("button", { name: "Track" }));
 
     await waitFor(() => {
       expect(startSpy).toHaveBeenCalledWith({ gamertag: "New Recruit" });
     });
 
     await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
       expect(screen.getByText("New Recruit")).toBeInTheDocument();
+    });
+  });
+
+  it("sends the optional search start time and idle timeout when provided in the dialog", async () => {
+    const user = userEvent.setup();
+    const startSpy: MockInstance = vi.spyOn(service, "startTracker");
+
+    render(<IndividualTrackerManagerPage individualTrackerService={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Spartan")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Add tracker" }));
+
+    const dialog = within(screen.getByRole("dialog"));
+    await user.type(dialog.getByLabelText("Gamertag"), "New Recruit");
+    await user.type(dialog.getByLabelText("Search start time"), "2026-01-02T03:04");
+    await user.type(dialog.getByLabelText("Idle timeout (hours)"), "12");
+    await user.click(dialog.getByRole("button", { name: "Track" }));
+
+    await waitFor(() => {
+      expect(startSpy).toHaveBeenCalledWith({
+        gamertag: "New Recruit",
+        searchStartTime: new Date("2026-01-02T03:04").toISOString(),
+        idleTimeoutHours: 12,
+      });
     });
   });
 

--- a/pages/src/components/individual-tracker-manager/tests/manager-model.test.ts
+++ b/pages/src/components/individual-tracker-manager/tests/manager-model.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { aFakeTrackerWith } from "../../../services/individual-tracker/fakes/individual-tracker.fake";
-import { MAX_TRACKERS, isValidGamertagInput, toManagerModel, toTrackerRowModel } from "../manager-model";
+import {
+  MAX_TRACKERS,
+  isValidGamertagInput,
+  isValidIdleTimeoutHoursInput,
+  isValidSearchStartTimeInput,
+  parseIdleTimeoutHours,
+  parseSearchStartTime,
+  toManagerModel,
+  toTrackerRowModel,
+} from "../manager-model";
 
 describe("toTrackerRowModel", () => {
   it("maps an active live tracker to a row with stop and pause enabled and set-live hidden", () => {
@@ -85,5 +94,61 @@ describe("isValidGamertagInput", () => {
   it("rejects an empty or whitespace-only value", () => {
     expect(isValidGamertagInput("")).toBe(false);
     expect(isValidGamertagInput("   ")).toBe(false);
+  });
+});
+
+describe("parseIdleTimeoutHours", () => {
+  it("returns null for blank input", () => {
+    expect(parseIdleTimeoutHours("")).toBeNull();
+    expect(parseIdleTimeoutHours("   ")).toBeNull();
+  });
+
+  it("returns null for a non-positive or non-numeric value", () => {
+    expect(parseIdleTimeoutHours("0")).toBeNull();
+    expect(parseIdleTimeoutHours("-2")).toBeNull();
+    expect(parseIdleTimeoutHours("abc")).toBeNull();
+  });
+
+  it("parses a positive number", () => {
+    expect(parseIdleTimeoutHours(" 12 ")).toBe(12);
+    expect(parseIdleTimeoutHours("1.5")).toBe(1.5);
+  });
+});
+
+describe("isValidIdleTimeoutHoursInput", () => {
+  it("accepts blank input and positive numbers", () => {
+    expect(isValidIdleTimeoutHoursInput("")).toBe(true);
+    expect(isValidIdleTimeoutHoursInput("6")).toBe(true);
+  });
+
+  it("rejects non-positive or non-numeric input", () => {
+    expect(isValidIdleTimeoutHoursInput("0")).toBe(false);
+    expect(isValidIdleTimeoutHoursInput("nope")).toBe(false);
+  });
+});
+
+describe("parseSearchStartTime", () => {
+  it("returns null for blank input", () => {
+    expect(parseSearchStartTime("")).toBeNull();
+    expect(parseSearchStartTime("   ")).toBeNull();
+  });
+
+  it("returns null for an unparseable datetime", () => {
+    expect(parseSearchStartTime("not-a-date")).toBeNull();
+  });
+
+  it("normalises a valid datetime to an ISO string", () => {
+    expect(parseSearchStartTime("2026-01-02T03:04")).toBe(new Date("2026-01-02T03:04").toISOString());
+  });
+});
+
+describe("isValidSearchStartTimeInput", () => {
+  it("accepts blank input and valid datetimes", () => {
+    expect(isValidSearchStartTimeInput("")).toBe(true);
+    expect(isValidSearchStartTimeInput("2026-01-02T03:04")).toBe(true);
+  });
+
+  it("rejects an unparseable datetime", () => {
+    expect(isValidSearchStartTimeInput("not-a-date")).toBe(false);
   });
 });

--- a/pages/src/components/individual-tracker-manager/types.ts
+++ b/pages/src/components/individual-tracker-manager/types.ts
@@ -3,7 +3,10 @@ import type { ManagerModel } from "./manager-model";
 export interface IndividualTrackerManagerViewModel {
   readonly model: ManagerModel;
   readonly profileName: string;
+  readonly isAddDialogOpen: boolean;
   readonly gamertagInput: string;
+  readonly searchStartTime: string;
+  readonly idleTimeoutHours: string;
   readonly addPending: boolean;
   readonly pendingTrackerId: string | null;
   readonly addDisabled: boolean;


### PR DESCRIPTION
## Milestone E3 — add-tracker dialog

Replaces the manager's inline add-tracker input with a proper dialog that also captures the API's optional start options. Pure pages, independent of the B3b backend work (off `main`).

### Changes
- **New reusable `Dialog`** (`pages/src/components/dialog/`): `role="dialog"` + `aria-modal`, labelled by title, closes on Escape + overlay click (inner clicks don't), renders null when closed, focuses the panel on open + restores focus on unmount. Built to be reused (e.g. the later game-selection dialog).
- **Add-tracker dialog** wired through the manager SPC: dialog open/close + the three form fields (`gamertagInput`, `searchStartTime`, `idleTimeoutHours`) live in the **store**; `openAddDialog`/`closeAddDialog`/`addTracker` + field parsing/validation live in the **presenter**; the view stays pure. Optional fields are sent only when set+valid — blank omitted, `idleTimeoutHours` parsed to a positive number, `searchStartTime` (datetime-local) normalised to ISO; invalid input blocks submit. 5-tracker limit still disables adding.

Reviewed independently (clean — exemplary SPC adherence, timezone-safe parsing). Folded in the one fix from review: an `isDisposed` guard at the top of `addTracker` (+ a test) to match the other presenter methods.

typecheck:pages 0 errors, full suite green (1796), eslint/prettier/stylelint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)