### PR TITLE
feat(api): individual-tracker DO polling — discover matches, idle auto-stop, backoff (B4)

### DIFF
--- a/api/durable-objects/individual-tracker/fakes/individual-tracker-do.fake.ts
+++ b/api/durable-objects/individual-tracker/fakes/individual-tracker-do.fake.ts
@@ -37,6 +37,8 @@ export function aFakeIndividualTrackerInternalStateWith(
     searchStartTime: new Date().toISOString(),
     lastMatchDiscoveredAt: undefined,
     checkCount: 0,
+    matchIds: [],
+    discoveredMatches: {},
     idleTimeoutHours: 6,
     errorState: {
       consecutiveErrors: 0,

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1,10 +1,12 @@
 import * as Sentry from "@sentry/cloudflare";
-import { addMilliseconds } from "date-fns";
+import { addMilliseconds, differenceInHours } from "date-fns";
+import { type HaloInfiniteClient, MatchType } from "halo-infinite-api";
 import type { LogService } from "../../services/log/types";
-import { installServices as installServicesImpl } from "../../services/install";
+import { installServices as installServicesImpl, type Services } from "../../services/install";
 import type {
   IndividualTrackerStartRequest,
   IndividualTrackerInternalState,
+  IndividualTrackerMatchSummary,
   IndividualTrackerState,
   IndividualTrackerStartResponse,
   IndividualTrackerPauseResponse,
@@ -18,19 +20,25 @@ const EXECUTION_BUFFER_MS = 8 * 1000;
 const ALARM_INTERVAL_MS = DISPLAY_INTERVAL_MS - EXECUTION_BUFFER_MS;
 
 const NORMAL_INTERVAL_MINUTES = 3;
+const CONSECUTIVE_ERROR_INTERVAL_MINUTES = 5;
+const MAX_BACKOFF_INTERVAL_MINUTES = 10;
+
+const PLAYER_MATCHES_PAGE_SIZE = 25;
 
 const STATE_STORAGE_KEY = "individualTrackerState";
 
 export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   __DURABLE_OBJECT_BRAND = undefined as never;
   private readonly state: DurableObjectState;
+  private readonly services: Services;
   private readonly logService: LogService;
+  private ownerClient: HaloInfiniteClient | null = null;
 
   constructor(state: DurableObjectState, env: Env, installServices = installServicesImpl) {
     this.state = state;
 
-    const services = installServices({ env });
-    this.logService = services.logService;
+    this.services = installServices({ env });
+    this.logService = this.services.logService;
   }
 
   async fetch(request: Request): Promise<Response> {
@@ -87,12 +95,126 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         return;
       }
 
-      trackerState.lastUpdateTime = new Date().toISOString();
-      trackerState.checkCount += 1;
-      await this.setState(trackerState);
+      Sentry.setContext("trackerState", {
+        userId: trackerState.userId,
+        trackerId: trackerState.trackerId,
+        gamertag: trackerState.gamertag,
+        checkCount: trackerState.checkCount,
+        errorCount: trackerState.errorState.consecutiveErrors,
+      });
 
-      await this.state.storage.setAlarm(addMilliseconds(new Date(), ALARM_INTERVAL_MS).getTime());
+      const lastActivity = new Date(
+        Math.max(
+          new Date(trackerState.startTime).getTime(),
+          trackerState.lastMatchDiscoveredAt == null
+            ? new Date(trackerState.startTime).getTime()
+            : new Date(trackerState.lastMatchDiscoveredAt).getTime(),
+        ),
+      );
+      if (differenceInHours(new Date(), lastActivity) >= trackerState.idleTimeoutHours) {
+        trackerState.status = "stopped";
+        trackerState.lastUpdateTime = new Date().toISOString();
+        await this.state.storage.deleteAlarm();
+        await this.setState(trackerState);
+        return;
+      }
+
+      try {
+        await this.poll(trackerState);
+      } catch (error) {
+        this.logService.error("IndividualTracker: alarm poll failed", new Map([["error", String(error)]]));
+        Sentry.captureException(error);
+        this.handleError(trackerState, error);
+      }
+
+      await this.setState(trackerState);
+      await this.state.storage.setAlarm(addMilliseconds(new Date(), this.getNextAlarmInterval(trackerState)).getTime());
     });
+  }
+
+  private async poll(trackerState: IndividualTrackerInternalState): Promise<void> {
+    const haloClient = await this.getOwnerClient(trackerState.userId);
+
+    let matches: Awaited<ReturnType<HaloInfiniteClient["getPlayerMatches"]>>;
+    try {
+      matches = await haloClient.getPlayerMatches(trackerState.xuid, MatchType.All, PLAYER_MATCHES_PAGE_SIZE);
+    } catch (error) {
+      if (this.isAuthError(error)) {
+        this.ownerClient = null;
+      }
+      throw error;
+    }
+
+    const searchStart = new Date(trackerState.searchStartTime);
+    let discoveredNewMatch = false;
+    for (const match of matches) {
+      const matchId = match.MatchId;
+      if (trackerState.matchIds.includes(matchId)) {
+        continue;
+      }
+      if (new Date(match.MatchInfo.StartTime) < searchStart) {
+        continue;
+      }
+
+      const summary: IndividualTrackerMatchSummary = {
+        matchId,
+        startTime: match.MatchInfo.StartTime,
+        endTime: match.MatchInfo.EndTime,
+        mapAssetId: match.MatchInfo.MapVariant.AssetId,
+        modeAssetId: match.MatchInfo.UgcGameVariant.AssetId,
+      };
+      trackerState.discoveredMatches[matchId] = summary;
+      trackerState.matchIds.push(matchId);
+      discoveredNewMatch = true;
+    }
+
+    const now = new Date().toISOString();
+    if (discoveredNewMatch) {
+      trackerState.lastMatchDiscoveredAt = now;
+    }
+
+    trackerState.checkCount += 1;
+    trackerState.lastUpdateTime = now;
+    trackerState.errorState.consecutiveErrors = 0;
+    trackerState.errorState.backoffMinutes = NORMAL_INTERVAL_MINUTES;
+    trackerState.errorState.lastSuccessTime = now;
+    trackerState.errorState.lastErrorMessage = undefined;
+  }
+
+  private async getOwnerClient(userId: string): Promise<HaloInfiniteClient> {
+    if (this.ownerClient != null) {
+      return this.ownerClient;
+    }
+
+    const client = await this.services.userTokenProvider.getClientForUser(userId);
+    if (client == null) {
+      throw new Error("No Halo credentials available for tracker owner");
+    }
+
+    this.ownerClient = client;
+    return client;
+  }
+
+  private isAuthError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return /\b401\b|unauthorized|expired|spartan token/i.test(message);
+  }
+
+  private handleError(trackerState: IndividualTrackerInternalState, error: unknown): void {
+    trackerState.errorState.consecutiveErrors += 1;
+    trackerState.errorState.lastErrorMessage = error instanceof Error ? error.message : String(error);
+    trackerState.errorState.backoffMinutes = Math.min(
+      NORMAL_INTERVAL_MINUTES + trackerState.errorState.consecutiveErrors * CONSECUTIVE_ERROR_INTERVAL_MINUTES,
+      MAX_BACKOFF_INTERVAL_MINUTES,
+    );
+    trackerState.lastUpdateTime = new Date().toISOString();
+  }
+
+  private getNextAlarmInterval(trackerState: IndividualTrackerInternalState): number {
+    if (trackerState.errorState.consecutiveErrors > 0) {
+      return trackerState.errorState.backoffMinutes * 60 * 1000;
+    }
+    return ALARM_INTERVAL_MS;
   }
 
   private async handleStart(request: Request): Promise<Response> {
@@ -111,6 +233,8 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       searchStartTime: body.searchStartTime,
       lastMatchDiscoveredAt: undefined,
       checkCount: 0,
+      matchIds: [],
+      discoveredMatches: {},
       idleTimeoutHours: body.idleTimeoutHours,
       errorState: {
         consecutiveErrors: 0,

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1,9 +1,13 @@
 import { describe, beforeEach, it, expect, vi, afterEach } from "vitest";
 import type { MockInstance } from "vitest";
+import type { HaloInfiniteClient, PlayerMatchHistory } from "halo-infinite-api";
+import type { MockProxy } from "vitest-mock-extended";
+import { mock } from "vitest-mock-extended";
 import { IndividualTrackerDO } from "../individual-tracker-do";
 import { installFakeServicesWith } from "../../../services/fakes/services";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import type { Services } from "../../../services/install";
+import type { UserTokenProvider } from "../../../services/halo/user-token-provider";
 import { aFakeDurableObjectStateWith } from "../../../base/fakes/do.fake";
 import type {
   IndividualTrackerStartRequest,
@@ -27,6 +31,27 @@ const createMockStartRequest = (
   ...overrides,
 });
 
+const aFakePlayerMatch = (matchId: string, startTime: string): PlayerMatchHistory =>
+  ({
+    MatchId: matchId,
+    MatchInfo: {
+      StartTime: startTime,
+      EndTime: startTime,
+      MapVariant: { AssetId: "map-asset", VersionId: "v1" },
+      UgcGameVariant: { AssetId: "mode-asset", VersionId: "v1" },
+    },
+  }) as unknown as PlayerMatchHistory;
+
+const lastPersistedState = (
+  spy: MockInstance<(key: string, value: IndividualTrackerInternalState) => Promise<void>>,
+): IndividualTrackerInternalState => {
+  const lastCall = spy.mock.calls.at(-1);
+  if (lastCall == null) {
+    throw new Error("expected state to be persisted");
+  }
+  return lastCall[1];
+};
+
 describe("IndividualTrackerDO", () => {
   let individualTrackerDO: IndividualTrackerDO;
   let mockState: DurableObjectState;
@@ -38,6 +63,9 @@ describe("IndividualTrackerDO", () => {
   let storageDeleteSpy: MockInstance<typeof mockStorage.delete>;
   let storageSetAlarmSpy: MockInstance<typeof mockStorage.setAlarm>;
   let storageDeleteAlarmSpy: MockInstance<typeof mockStorage.deleteAlarm>;
+  let ownerClient: MockProxy<HaloInfiniteClient>;
+  let getClientForUser: MockInstance<UserTokenProvider["getClientForUser"]>;
+  let userTokenProvider: UserTokenProvider;
 
   beforeEach(() => {
     vi.useFakeTimers({
@@ -46,7 +74,13 @@ describe("IndividualTrackerDO", () => {
 
     mockState = aFakeDurableObjectStateWith();
     mockStorage = mockState.storage;
-    services = installFakeServicesWith();
+
+    ownerClient = mock<HaloInfiniteClient>();
+    ownerClient.getPlayerMatches.mockResolvedValue([]);
+    getClientForUser = vi.fn<UserTokenProvider["getClientForUser"]>().mockResolvedValue(ownerClient);
+    userTokenProvider = { getClientForUser } as unknown as UserTokenProvider;
+
+    services = installFakeServicesWith({ userTokenProvider });
     env = aFakeEnvWith();
 
     storageGetSpy = vi.spyOn(mockStorage, "get");
@@ -267,13 +301,182 @@ describe("IndividualTrackerDO", () => {
   });
 
   describe("alarm()", () => {
-    it("bumps check count and reschedules when active", async () => {
-      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ checkCount: 2 }));
+    const NORMAL_INTERVAL_MS = 3 * 60 * 1000 - 8 * 1000;
+    const now = new Date("2024-11-26T12:00:00.000Z");
+
+    it("bumps check count and reschedules at the normal interval on success", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({ checkCount: 2, startTime: now.toISOString() }),
+      );
 
       await individualTrackerDO.alarm();
 
       expect(storagePutSpy).toHaveBeenCalledWith("individualTrackerState", expect.objectContaining({ checkCount: 3 }));
-      expect(storageSetAlarmSpy).toHaveBeenCalled();
+      expect(storageSetAlarmSpy).toHaveBeenCalledWith(now.getTime() + NORMAL_INTERVAL_MS);
+    });
+
+    it("polls getPlayerMatches and appends only genuinely-new matches at/after searchStartTime", async () => {
+      const searchStartTime = "2024-11-26T11:00:00.000Z";
+      ownerClient.getPlayerMatches.mockResolvedValue([
+        aFakePlayerMatch("match-new", "2024-11-26T11:30:00.000Z"),
+        aFakePlayerMatch("match-existing", "2024-11-26T11:40:00.000Z"),
+        aFakePlayerMatch("match-too-old", "2024-11-26T10:00:00.000Z"),
+      ]);
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          searchStartTime,
+          matchIds: ["match-existing"],
+          discoveredMatches: {
+            "match-existing": {
+              matchId: "match-existing",
+              startTime: "2024-11-26T11:40:00.000Z",
+              endTime: "2024-11-26T11:40:00.000Z",
+              mapAssetId: "map-asset",
+              modeAssetId: "mode-asset",
+            },
+          },
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      expect(ownerClient.getPlayerMatches).toHaveBeenCalledWith("fake-xuid", 0, 25);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.matchIds).toEqual(["match-existing", "match-new"]);
+      expect(persisted.discoveredMatches["match-new"]).toMatchObject({
+        matchId: "match-new",
+        mapAssetId: "map-asset",
+        modeAssetId: "mode-asset",
+      });
+      expect(persisted.discoveredMatches).not.toHaveProperty("match-too-old");
+    });
+
+    it("sets lastMatchDiscoveredAt and resets errorState when new matches are found", async () => {
+      ownerClient.getPlayerMatches.mockResolvedValue([aFakePlayerMatch("match-new", "2024-11-26T11:30:00.000Z")]);
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          searchStartTime: "2024-11-26T11:00:00.000Z",
+          errorState: { consecutiveErrors: 2, backoffMinutes: 10, lastSuccessTime: "old", lastErrorMessage: "boom" },
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.lastMatchDiscoveredAt).toBe(now.toISOString());
+      expect(persisted.errorState.consecutiveErrors).toBe(0);
+      expect(persisted.errorState.backoffMinutes).toBe(3);
+      expect(persisted.errorState.lastErrorMessage).toBeUndefined();
+    });
+
+    it("does not set lastMatchDiscoveredAt when no new matches are found", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({ startTime: now.toISOString(), lastMatchDiscoveredAt: undefined }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.lastMatchDiscoveredAt).toBeUndefined();
+    });
+
+    it("auto-stops and deletes the alarm when idle beyond idleTimeoutHours", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          idleTimeoutHours: 6,
+          startTime: "2024-11-26T05:00:00.000Z",
+          lastMatchDiscoveredAt: "2024-11-26T05:00:00.000Z",
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      expect(storagePutSpy).toHaveBeenCalledWith(
+        "individualTrackerState",
+        expect.objectContaining({ status: "stopped" }),
+      );
+      expect(storageDeleteAlarmSpy).toHaveBeenCalled();
+      expect(storageSetAlarmSpy).not.toHaveBeenCalled();
+      expect(ownerClient.getPlayerMatches).not.toHaveBeenCalled();
+    });
+
+    it("increments consecutiveErrors, grows backoff, reschedules at backoff and does not throw on poll failure", async () => {
+      ownerClient.getPlayerMatches.mockRejectedValue(new Error("Halo unavailable"));
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          errorState: { consecutiveErrors: 0, backoffMinutes: 3, lastSuccessTime: "old" },
+        }),
+      );
+
+      await expect(individualTrackerDO.alarm()).resolves.toBeUndefined();
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.errorState.consecutiveErrors).toBe(1);
+      expect(persisted.errorState.backoffMinutes).toBe(8);
+      expect(persisted.errorState.lastErrorMessage).toBe("Halo unavailable");
+      expect(storageSetAlarmSpy).toHaveBeenCalledWith(now.getTime() + 8 * 60 * 1000);
+    });
+
+    it("caps backoff at the maximum interval", async () => {
+      ownerClient.getPlayerMatches.mockRejectedValue(new Error("still down"));
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          errorState: { consecutiveErrors: 5, backoffMinutes: 10, lastSuccessTime: "old" },
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.errorState.consecutiveErrors).toBe(6);
+      expect(persisted.errorState.backoffMinutes).toBe(10);
+    });
+
+    it("mints the owner client via userTokenProvider.getClientForUser", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({ startTime: now.toISOString(), userId: "owner-123" }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      expect(getClientForUser).toHaveBeenCalledWith("owner-123");
+    });
+
+    it("treats a null client as a poll error (backoff) without crashing", async () => {
+      getClientForUser.mockResolvedValue(null);
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ startTime: now.toISOString() }));
+
+      await expect(individualTrackerDO.alarm()).resolves.toBeUndefined();
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.errorState.consecutiveErrors).toBe(1);
+      expect(storageSetAlarmSpy).toHaveBeenCalledWith(now.getTime() + 8 * 60 * 1000);
+    });
+
+    it("reuses the cached client across polls (getClientForUser not called every alarm)", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ startTime: now.toISOString() }));
+
+      await individualTrackerDO.alarm();
+      await individualTrackerDO.alarm();
+
+      expect(getClientForUser).toHaveBeenCalledTimes(1);
+      expect(ownerClient.getPlayerMatches).toHaveBeenCalledTimes(2);
+    });
+
+    it("clears the cached client on auth failure so the next poll re-mints", async () => {
+      ownerClient.getPlayerMatches
+        .mockRejectedValueOnce(new Error("401 Unauthorized: spartan token expired"))
+        .mockResolvedValueOnce([]);
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ startTime: now.toISOString() }));
+
+      await individualTrackerDO.alarm();
+      await individualTrackerDO.alarm();
+
+      expect(getClientForUser).toHaveBeenCalledTimes(2);
     });
 
     it("does nothing when state is absent", async () => {
@@ -283,6 +486,7 @@ describe("IndividualTrackerDO", () => {
 
       expect(storagePutSpy).not.toHaveBeenCalled();
       expect(storageSetAlarmSpy).not.toHaveBeenCalled();
+      expect(getClientForUser).not.toHaveBeenCalled();
     });
 
     it("does nothing when paused", async () => {
@@ -292,6 +496,17 @@ describe("IndividualTrackerDO", () => {
 
       expect(storagePutSpy).not.toHaveBeenCalled();
       expect(storageSetAlarmSpy).not.toHaveBeenCalled();
+      expect(getClientForUser).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when stopped", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ status: "stopped" }));
+
+      await individualTrackerDO.alarm();
+
+      expect(storagePutSpy).not.toHaveBeenCalled();
+      expect(storageSetAlarmSpy).not.toHaveBeenCalled();
+      expect(getClientForUser).not.toHaveBeenCalled();
     });
   });
 });

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -21,10 +21,20 @@ export interface IndividualTrackerState {
   idleTimeoutHours: number;
 }
 
+export interface IndividualTrackerMatchSummary {
+  matchId: string;
+  startTime: string;
+  endTime: string;
+  mapAssetId: string;
+  modeAssetId: string;
+}
+
 export interface IndividualTrackerInternalState extends IndividualTrackerState {
   searchStartTime: string;
   lastMatchDiscoveredAt: string | undefined;
   checkCount: number;
+  matchIds: string[];
+  discoveredMatches: Record<string, IndividualTrackerMatchSummary>;
   errorState: {
     consecutiveErrors: number;
     backoffMinutes: number;


### PR DESCRIPTION
## Milestone B4 — DO polling engine

Makes the `IndividualTrackerDO` actually track: its `alarm()` now polls Halo for the tracked player's new matches using the **owner's** token (via the merged `UserTokenProvider`). Off `main` (all of B3b is merged). Unblocks **C2** (the public viewer read path).

### What it does each alarm (when active + not paused)
- **Idle auto-stop**: if `now − max(startTime, lastMatchDiscoveredAt) ≥ idleTimeoutHours` → status `stopped`, delete the alarm, no reschedule.
- **Poll**: `getOwnerClient(userId)` (cached client; minted via `userTokenProvider.getClientForUser`, re-minted on an auth-expiry failure — `halo-infinite-api` `RequestError` is `"401 from …"`, matched to clear the cache so the next poll re-mints; non-auth outages don't churn the token) → `getPlayerMatches(xuid, All, 25)` → append matches not already stored and at/after `searchStartTime` to internal `matchIds` + `discoveredMatches`; set `lastMatchDiscoveredAt` when new.
- **Success**: reset `errorState`, reschedule at the normal ~3-min interval.
- **Error**: `alarm()` never throws; `consecutiveErrors++`, `backoffMinutes = min(3 + n·5, 10)`, reschedule at the backoff interval; a null client (no owner credentials) is treated as a poll error (backoff), not a crash.

### Scope boundary
Match data is stored **only in internal DO state** — the public sanitized `IndividualTrackerState` (the 9-field projection) is **unchanged**. Exposing matches to the public viewer (REST + WS) is the next PR (**C2**).

### Notes
- Owner client is cached on the DO instance + re-minted only on auth failure, so polling doesn't trigger a Microsoft refresh + refresh-token rotation every tick.
- Algorithm (intervals/backoff/idle/match-diff) carried over from the rework DO; token handling uses our D1-backed `UserTokenProvider` (not the rework's DO-state tokens).

31 DO tests (poll/dedupe/idle/backoff/cap/token-mint/null-client/cache-reuse/re-mint/guards); full suite green (1825); typecheck 0 errors; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)