### PR TITLE
feat(api): public per-tracker viewer read path — view-state REST + DO projection (C2a)

### DIFF
--- a/api/base/fakes/do.fake.ts
+++ b/api/base/fakes/do.fake.ts
@@ -7,6 +7,20 @@ export function aFakeDurableObjectId(value = "fake-do-id"): DurableObjectId {
   };
 }
 
+export function aFakeDurableObjectNamespaceWith<T extends Rpc.DurableObjectBranded>(
+  stub: DurableObjectStub<T>,
+): DurableObjectNamespace<T> {
+  const id = aFakeDurableObjectId();
+  return {
+    idFromName: () => id,
+    idFromString: () => id,
+    newUniqueId: () => id,
+    getByName: () => stub,
+    get: () => stub,
+    jurisdiction: () => ({}) as DurableObjectNamespace<T>,
+  };
+}
+
 export function aFakeSqlStorage(opts: Partial<SqlStorage> = {}): SqlStorage {
   return {
     exec: vi.fn(),

--- a/api/base/fakes/env.fake.ts
+++ b/api/base/fakes/env.fake.ts
@@ -1,7 +1,6 @@
 import { aFakeLiveTrackerDOWith } from "../../durable-objects/live-tracker/fakes/live-tracker-do.fake";
 import { aFakeIndividualTrackerDOWith } from "../../durable-objects/individual-tracker/fakes/individual-tracker-do.fake";
-import type { IndividualTrackerDO, LiveTrackerDO } from "../../worker";
-import { aFakeDurableObjectId } from "./do.fake";
+import { aFakeDurableObjectNamespaceWith } from "./do.fake";
 
 const fakeNamespace = (): KVNamespace =>
   ({
@@ -59,9 +58,7 @@ const fakeDb = (): D1Database => ({
 });
 
 export function aFakeEnvWith(env: Partial<Env> = {}): Env {
-  const liveTrackerDOId = aFakeDurableObjectId();
   const liveTrackerGet = aFakeLiveTrackerDOWith();
-  const individualTrackerDOId = aFakeDurableObjectId();
   const individualTrackerGet = aFakeIndividualTrackerDOWith();
 
   const defaultOpts: Env = {
@@ -85,22 +82,8 @@ export function aFakeEnvWith(env: Partial<Env> = {}): Env {
     MICROSOFT_SCOPES: "openid email offline_access XboxLive.signin XboxLive.offline_access",
     SESSION_SECRET: "a".repeat(64),
     TOKEN_ENCRYPTION_SECRET: "c".repeat(64),
-    LIVE_TRACKER_DO: {
-      idFromName: () => liveTrackerDOId,
-      idFromString: () => liveTrackerDOId,
-      newUniqueId: () => liveTrackerDOId,
-      getByName: () => liveTrackerGet,
-      get: () => liveTrackerGet,
-      jurisdiction: () => ({}) as DurableObjectNamespace<LiveTrackerDO>,
-    },
-    INDIVIDUAL_TRACKER_DO: {
-      idFromName: () => individualTrackerDOId,
-      idFromString: () => individualTrackerDOId,
-      newUniqueId: () => individualTrackerDOId,
-      getByName: () => individualTrackerGet,
-      get: () => individualTrackerGet,
-      jurisdiction: () => ({}) as DurableObjectNamespace<IndividualTrackerDO>,
-    },
+    LIVE_TRACKER_DO: aFakeDurableObjectNamespaceWith(liveTrackerGet),
+    INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(individualTrackerGet),
   };
 
   return {

--- a/api/durable-objects/individual-tracker/fakes/individual-tracker-do.fake.ts
+++ b/api/durable-objects/individual-tracker/fakes/individual-tracker-do.fake.ts
@@ -6,6 +6,8 @@ import type {
   IndividualTrackerState,
   IndividualTrackerStatusResponse,
   IndividualTrackerStopResponse,
+  IndividualTrackerViewState,
+  IndividualTrackerViewStateResponse,
 } from "../types";
 import type { IndividualTrackerDO } from "../individual-tracker-do";
 import { aFakeDurableObjectId } from "../../../base/fakes/do.fake";
@@ -16,6 +18,7 @@ export interface FakeIndividualTrackerDOOpts {
   resumeResponse?: IndividualTrackerResumeResponse;
   stopResponse?: IndividualTrackerStopResponse;
   statusResponse?: IndividualTrackerStatusResponse;
+  viewStateResponse?: IndividualTrackerViewStateResponse;
   shouldThrowError?: boolean;
   errorMessage?: string;
 }
@@ -64,6 +67,20 @@ export function aFakeIndividualTrackerStateWith(opts: Partial<IndividualTrackerS
   };
 }
 
+export function aFakeIndividualTrackerViewStateWith(
+  opts: Partial<IndividualTrackerViewState> = {},
+): IndividualTrackerViewState {
+  return {
+    trackerId: "fake-tracker-id",
+    gamertag: "FakeGamertag",
+    status: "active",
+    matches: [],
+    lastUpdateTime: new Date().toISOString(),
+    lastMatchDiscoveredAt: null,
+    ...opts,
+  };
+}
+
 export function aFakeIndividualTrackerDOWith(opts: FakeIndividualTrackerDOOpts = {}): FakeIndividualTrackerDO {
   const defaultState = aFakeIndividualTrackerStateWith();
 
@@ -72,6 +89,9 @@ export function aFakeIndividualTrackerDOWith(opts: FakeIndividualTrackerDOOpts =
   const resumeResponse: IndividualTrackerResumeResponse = opts.resumeResponse ?? { success: true, state: defaultState };
   const stopResponse: IndividualTrackerStopResponse = opts.stopResponse ?? { success: true };
   const statusResponse: IndividualTrackerStatusResponse = opts.statusResponse ?? { state: defaultState };
+  const viewStateResponse: IndividualTrackerViewStateResponse = opts.viewStateResponse ?? {
+    state: aFakeIndividualTrackerViewStateWith(),
+  };
   const { shouldThrowError = false, errorMessage = "Fake DO error" } = opts;
 
   const fetchMock: FakeIndividualTrackerDO["fetch"] = async (input) => {
@@ -107,6 +127,9 @@ export function aFakeIndividualTrackerDOWith(opts: FakeIndividualTrackerDOOpts =
         break;
       case "/status":
         responseBody = JSON.stringify(statusResponse);
+        break;
+      case "/view-state":
+        responseBody = JSON.stringify(viewStateResponse);
         break;
       default:
         responseBody = JSON.stringify({ success: false, error: `Unknown endpoint: ${path}` });

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -13,6 +13,8 @@ import type {
   IndividualTrackerResumeResponse,
   IndividualTrackerStopResponse,
   IndividualTrackerStatusResponse,
+  IndividualTrackerViewState,
+  IndividualTrackerViewStateResponse,
 } from "./types";
 
 const DISPLAY_INTERVAL_MS = 3 * 60 * 1000;
@@ -69,6 +71,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           }
           case "status": {
             return await this.handleStatus();
+          }
+          case "view-state": {
+            return await this.handleViewState();
           }
           case undefined: {
             return new Response("Bad Request", { status: 400 });
@@ -299,6 +304,14 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     return Response.json(response);
   }
 
+  private async handleViewState(): Promise<Response> {
+    const trackerState = await this.getState();
+    const response: IndividualTrackerViewStateResponse = {
+      state: trackerState == null ? null : this.toViewState(trackerState),
+    };
+    return Response.json(response);
+  }
+
   private async getState(): Promise<IndividualTrackerInternalState | null> {
     const state = await this.state.storage.get<IndividualTrackerInternalState>(STATE_STORAGE_KEY);
     return state ?? null;
@@ -319,6 +332,17 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       startTime: state.startTime,
       lastUpdateTime: state.lastUpdateTime,
       idleTimeoutHours: state.idleTimeoutHours,
+    };
+  }
+
+  private toViewState(state: IndividualTrackerInternalState): IndividualTrackerViewState {
+    return {
+      trackerId: state.trackerId,
+      gamertag: state.gamertag,
+      status: state.status,
+      matches: state.matchIds.map((matchId) => state.discoveredMatches[matchId]).filter((match) => match != null),
+      lastUpdateTime: state.lastUpdateTime,
+      lastMatchDiscoveredAt: state.lastMatchDiscoveredAt ?? null,
     };
   }
 }

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -16,6 +16,7 @@ import type {
   IndividualTrackerPauseResponse,
   IndividualTrackerResumeResponse,
   IndividualTrackerStatusResponse,
+  IndividualTrackerViewStateResponse,
 } from "../types";
 import { aFakeIndividualTrackerInternalStateWith } from "../fakes/individual-tracker-do.fake";
 
@@ -296,6 +297,84 @@ describe("IndividualTrackerDO", () => {
         expect(body.state).not.toHaveProperty("checkCount");
         expect(body.state).not.toHaveProperty("lastMatchDiscoveredAt");
         expect(Object.keys(body.state)).toHaveLength(9);
+      }
+    });
+  });
+
+  describe("handleViewState()", () => {
+    it("returns the allowlisted projection with matches in matchIds order", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          gamertag: "ViewTag",
+          status: "active",
+          lastUpdateTime: "2024-11-26T12:00:00.000Z",
+          lastMatchDiscoveredAt: "2024-11-26T11:55:00.000Z",
+          matchIds: ["match-2", "match-1"],
+          discoveredMatches: {
+            "match-1": {
+              matchId: "match-1",
+              startTime: "2024-11-26T11:00:00.000Z",
+              endTime: "2024-11-26T11:10:00.000Z",
+              mapAssetId: "map-1",
+              modeAssetId: "mode-1",
+            },
+            "match-2": {
+              matchId: "match-2",
+              startTime: "2024-11-26T11:30:00.000Z",
+              endTime: "2024-11-26T11:40:00.000Z",
+              mapAssetId: "map-2",
+              modeAssetId: "mode-2",
+            },
+          },
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
+
+      expect(response.status).toBe(200);
+      const body: IndividualTrackerViewStateResponse = await response.json();
+      expect(body.state?.gamertag).toBe("ViewTag");
+      expect(body.state?.status).toBe("active");
+      expect(body.state?.lastMatchDiscoveredAt).toBe("2024-11-26T11:55:00.000Z");
+      expect(body.state?.matches.map((match) => match.matchId)).toEqual(["match-2", "match-1"]);
+    });
+
+    it("returns lastMatchDiscoveredAt as null when no match has been discovered", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ lastMatchDiscoveredAt: undefined }));
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect(body.state?.lastMatchDiscoveredAt).toBeNull();
+    });
+
+    it("returns null state when absent", async () => {
+      storageGetSpy.mockResolvedValue(null);
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
+
+      expect(response.status).toBe(200);
+      const body: IndividualTrackerViewStateResponse = await response.json();
+      expect(body.state).toBeNull();
+    });
+
+    it("excludes internal-only fields from the projection", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith());
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect.assertions(7);
+      if (body.state != null) {
+        expect(body.state).not.toHaveProperty("errorState");
+        expect(body.state).not.toHaveProperty("checkCount");
+        expect(body.state).not.toHaveProperty("searchStartTime");
+        expect(body.state).not.toHaveProperty("idleTimeoutHours");
+        expect(body.state).not.toHaveProperty("isPaused");
+        expect(body.state).not.toHaveProperty("userId");
+        expect(Object.keys(body.state).sort()).toEqual(
+          ["gamertag", "lastMatchDiscoveredAt", "lastUpdateTime", "matches", "status", "trackerId"].sort(),
+        );
       }
     });
   });

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -66,7 +66,20 @@ export interface IndividualTrackerStatusResponse {
   state: IndividualTrackerState | null;
 }
 
-export type IndividualTrackerAction = "start" | "pause" | "resume" | "stop" | "status";
+export interface IndividualTrackerViewState {
+  trackerId: string;
+  gamertag: string;
+  status: IndividualTrackerStatus;
+  matches: IndividualTrackerMatchSummary[];
+  lastUpdateTime: string;
+  lastMatchDiscoveredAt: string | null;
+}
+
+export interface IndividualTrackerViewStateResponse {
+  state: IndividualTrackerViewState | null;
+}
+
+export type IndividualTrackerAction = "start" | "pause" | "resume" | "stop" | "status" | "view-state";
 
 export interface IndividualTrackerApiMap {
   start: {
@@ -88,6 +101,10 @@ export interface IndividualTrackerApiMap {
   status: {
     request: never;
     response: IndividualTrackerStatusResponse;
+  };
+  "view-state": {
+    request: never;
+    response: IndividualTrackerViewStateResponse;
   };
 }
 

--- a/api/routes/individual-tracker/individual-tracker.ts
+++ b/api/routes/individual-tracker/individual-tracker.ts
@@ -1,8 +1,10 @@
 import type { RoutesRegisterHandler } from "../base/types";
 import { trackerManageRoutesRegisterHandler } from "./manage";
 import { trackerProfileRoutesRegisterHandler } from "./profile";
+import { trackerViewRoutesRegisterHandler } from "./view";
 
 export const individualTrackerRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
   trackerProfileRoutesRegisterHandler(router, installServices);
   trackerManageRoutesRegisterHandler(router, installServices);
+  trackerViewRoutesRegisterHandler(router, installServices);
 };

--- a/api/routes/individual-tracker/mapper.ts
+++ b/api/routes/individual-tracker/mapper.ts
@@ -1,8 +1,12 @@
 import type { TrackerProfile } from "@guilty-spark/shared/contracts/individual-tracker/profile";
 import type { Tracker, TrackerState } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { IndividualTrackerProfilesRow } from "../../services/database/types/individual_tracker_profiles";
 import type { IndividualTrackersRow } from "../../services/database/types/individual_trackers";
-import type { IndividualTrackerState } from "../../durable-objects/individual-tracker/types";
+import type {
+  IndividualTrackerState,
+  IndividualTrackerViewState,
+} from "../../durable-objects/individual-tracker/types";
 
 export function toTrackerProfile(row: IndividualTrackerProfilesRow): TrackerProfile {
   return {
@@ -34,5 +38,20 @@ export function toTracker(row: IndividualTrackersRow, state: IndividualTrackerSt
     status: row.Status,
     isLive: row.IsLive === 1,
     state: state == null ? null : toTrackerState(state),
+  };
+}
+
+export function toTrackerView(
+  row: IndividualTrackersRow,
+  doState: IndividualTrackerViewState | null,
+): TrackerViewState {
+  return {
+    trackerId: row.TrackerId,
+    gamertag: row.Gamertag,
+    status: row.Status,
+    isLive: row.IsLive === 1,
+    matches: doState == null ? [] : doState.matches,
+    lastUpdateTime: doState == null ? "" : doState.lastUpdateTime,
+    lastMatchDiscoveredAt: doState == null ? null : doState.lastMatchDiscoveredAt,
   };
 }

--- a/api/routes/individual-tracker/tests/view.test.ts
+++ b/api/routes/individual-tracker/tests/view.test.ts
@@ -1,0 +1,133 @@
+import type { AutoRouterType } from "itty-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import { createApiRouter } from "../../../base/router";
+import { aFakeEnvWith } from "../../../base/fakes/env.fake";
+import { aFakeDurableObjectId } from "../../../base/fakes/do.fake";
+import {
+  aFakeIndividualTrackerDOWith,
+  aFakeIndividualTrackerViewStateWith,
+  type FakeIndividualTrackerDO,
+} from "../../../durable-objects/individual-tracker/fakes/individual-tracker-do.fake";
+import type { IndividualTrackerDO } from "../../../worker";
+import { aFakeIndividualTrackersRow } from "../../../services/database/fakes/database.fake";
+import { installFakeServicesWith } from "../../../services/fakes/services";
+import { individualTrackerRoutesRegisterHandler } from "../individual-tracker";
+
+function envWithTrackerDo(stub: FakeIndividualTrackerDO): Env {
+  const id = aFakeDurableObjectId();
+  return aFakeEnvWith({
+    INDIVIDUAL_TRACKER_DO: {
+      idFromName: () => id,
+      idFromString: () => id,
+      newUniqueId: () => id,
+      getByName: () => stub,
+      get: () => stub,
+      jurisdiction: () => ({}) as DurableObjectNamespace<IndividualTrackerDO>,
+    },
+  });
+}
+
+function getRequest(path: string): Request {
+  return new Request(`http://localhost${path}`, { method: "GET" });
+}
+
+describe("/api/individual-tracker view route", () => {
+  let env: Env;
+  let router: AutoRouterType;
+
+  beforeEach(() => {
+    env = aFakeEnvWith();
+    router = createApiRouter();
+  });
+
+  it("returns 404 when the tracker does not exist", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(null);
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(getRequest("/api/individual-tracker/unknown/view"), env)) as Response;
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 with the view (matches + isLive from the row) for a running tracker without a session", async () => {
+    const doStub = aFakeIndividualTrackerDOWith({
+      viewStateResponse: {
+        state: aFakeIndividualTrackerViewStateWith({
+          trackerId: "t1",
+          status: "active",
+          lastUpdateTime: "2024-11-26T12:00:00.000Z",
+          lastMatchDiscoveredAt: "2024-11-26T11:55:00.000Z",
+          matches: [
+            {
+              matchId: "match-1",
+              startTime: "2024-11-26T11:00:00.000Z",
+              endTime: "2024-11-26T11:10:00.000Z",
+              mapAssetId: "map-1",
+              modeAssetId: "mode-1",
+            },
+          ],
+        }),
+      },
+    });
+    const localEnv = envWithTrackerDo(doStub);
+
+    const row = aFakeIndividualTrackersRow({
+      TrackerId: "t1",
+      UserId: "user-123",
+      Gamertag: "MyTag",
+      Status: "active",
+      IsLive: 1,
+    });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env: localEnv });
+      vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(row);
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(getRequest("/api/individual-tracker/t1/view"), localEnv)) as Response;
+
+    expect(res.status).toBe(200);
+    const body = await res.json<TrackerViewResponse>();
+    expect(body.view.trackerId).toBe("t1");
+    expect(body.view.gamertag).toBe("MyTag");
+    expect(body.view.status).toBe("active");
+    expect(body.view.isLive).toBe(true);
+    expect(body.view.matches).toHaveLength(1);
+    expect(body.view.matches[0]?.matchId).toBe("match-1");
+    expect(body.view.lastMatchDiscoveredAt).toBe("2024-11-26T11:55:00.000Z");
+  });
+
+  it("returns 200 with empty matches and the row's status when the DO has no state", async () => {
+    const doStub = aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } });
+    const localEnv = envWithTrackerDo(doStub);
+
+    const row = aFakeIndividualTrackersRow({
+      TrackerId: "t2",
+      UserId: "user-123",
+      Gamertag: "StoppedTag",
+      Status: "stopped",
+      IsLive: 0,
+    });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env: localEnv });
+      vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(row);
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(getRequest("/api/individual-tracker/t2/view"), localEnv)) as Response;
+
+    expect(res.status).toBe(200);
+    const body = await res.json<TrackerViewResponse>();
+    expect(body.view.status).toBe("stopped");
+    expect(body.view.isLive).toBe(false);
+    expect(body.view.matches).toEqual([]);
+    expect(body.view.lastMatchDiscoveredAt).toBeNull();
+  });
+});

--- a/api/routes/individual-tracker/tests/view.test.ts
+++ b/api/routes/individual-tracker/tests/view.test.ts
@@ -3,30 +3,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import { createApiRouter } from "../../../base/router";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
-import { aFakeDurableObjectId } from "../../../base/fakes/do.fake";
+import { aFakeDurableObjectNamespaceWith } from "../../../base/fakes/do.fake";
 import {
   aFakeIndividualTrackerDOWith,
   aFakeIndividualTrackerViewStateWith,
-  type FakeIndividualTrackerDO,
 } from "../../../durable-objects/individual-tracker/fakes/individual-tracker-do.fake";
-import type { IndividualTrackerDO } from "../../../worker";
 import { aFakeIndividualTrackersRow } from "../../../services/database/fakes/database.fake";
 import { installFakeServicesWith } from "../../../services/fakes/services";
 import { individualTrackerRoutesRegisterHandler } from "../individual-tracker";
-
-function envWithTrackerDo(stub: FakeIndividualTrackerDO): Env {
-  const id = aFakeDurableObjectId();
-  return aFakeEnvWith({
-    INDIVIDUAL_TRACKER_DO: {
-      idFromName: () => id,
-      idFromString: () => id,
-      newUniqueId: () => id,
-      getByName: () => stub,
-      get: () => stub,
-      jurisdiction: () => ({}) as DurableObjectNamespace<IndividualTrackerDO>,
-    },
-  });
-}
 
 function getRequest(path: string): Request {
   return new Request(`http://localhost${path}`, { method: "GET" });
@@ -74,7 +58,7 @@ describe("/api/individual-tracker view route", () => {
         }),
       },
     });
-    const localEnv = envWithTrackerDo(doStub);
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
 
     const row = aFakeIndividualTrackersRow({
       TrackerId: "t1",
@@ -105,7 +89,7 @@ describe("/api/individual-tracker view route", () => {
 
   it("returns 200 with empty matches and the row's status when the DO has no state", async () => {
     const doStub = aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } });
-    const localEnv = envWithTrackerDo(doStub);
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
 
     const row = aFakeIndividualTrackersRow({
       TrackerId: "t2",

--- a/api/routes/individual-tracker/view.ts
+++ b/api/routes/individual-tracker/view.ts
@@ -1,0 +1,44 @@
+import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import { errorContract } from "@guilty-spark/shared/contracts/error";
+import { trackerViewContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import type {
+  IndividualTrackerViewState,
+  IndividualTrackerViewStateResponse,
+} from "../../durable-objects/individual-tracker/types";
+import type { RoutesRegisterHandler } from "../base/types";
+import { toTrackerView } from "./mapper";
+
+async function viewStateTrackerDo(
+  env: Env,
+  userId: string,
+  trackerId: string,
+): Promise<IndividualTrackerViewState | null> {
+  const doId = env.INDIVIDUAL_TRACKER_DO.idFromName(`${userId}:${trackerId}`);
+  const stub = env.INDIVIDUAL_TRACKER_DO.get(doId);
+  const response = await stub.fetch("http://do/view-state", { method: "GET" });
+  const result = await response.json<IndividualTrackerViewStateResponse>();
+  return result.state;
+}
+
+export const trackerViewRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
+  router.get("/api/individual-tracker/:trackerId/view", async (request, env: Env) => {
+    const services = installServices({ env });
+    const { databaseService, logService } = services;
+
+    try {
+      const trackerId = Preconditions.checkExists(request.params["trackerId"], "Missing trackerId");
+
+      const row = await databaseService.getIndividualTracker(trackerId);
+      if (row == null) {
+        return errorContract.toResponse({ error: "Tracker not found" }, { status: 404, noStore: true });
+      }
+
+      const doState = await viewStateTrackerDo(env, row.UserId, trackerId);
+
+      return trackerViewContract.toResponse({ view: toTrackerView(row, doState) }, { noStore: true });
+    } catch (error) {
+      logService.error(error as Error, new Map([["message", "Individual tracker view error"]]));
+      return errorContract.toResponse({ error: "Failed to fetch tracker view" }, { status: 500, noStore: true });
+    }
+  });
+};

--- a/api/routes/individual-tracker/view.ts
+++ b/api/routes/individual-tracker/view.ts
@@ -1,5 +1,6 @@
-import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import { parsePathParams } from "@guilty-spark/shared/base/request-parsing";
 import { errorContract } from "@guilty-spark/shared/contracts/error";
+import { trackerIdParamsSchema } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import { trackerViewContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type {
   IndividualTrackerViewState,
@@ -26,7 +27,11 @@ export const trackerViewRoutesRegisterHandler: RoutesRegisterHandler = (router, 
     const { databaseService, logService } = services;
 
     try {
-      const trackerId = Preconditions.checkExists(request.params["trackerId"], "Missing trackerId");
+      const parsedParams = parsePathParams(request.params, trackerIdParamsSchema, "Invalid tracker id");
+      if (!parsedParams.success) {
+        return parsedParams.response;
+      }
+      const { trackerId } = parsedParams.data;
 
       const row = await databaseService.getIndividualTracker(trackerId);
       if (row == null) {

--- a/api/routes/individual-tracker/view.ts
+++ b/api/routes/individual-tracker/view.ts
@@ -1,6 +1,6 @@
 import { parsePathParams } from "@guilty-spark/shared/base/request-parsing";
 import { errorContract } from "@guilty-spark/shared/contracts/error";
-import { trackerIdParamsSchema } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import { trackerParamsSchema } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import { trackerViewContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type {
   IndividualTrackerViewState,
@@ -27,7 +27,7 @@ export const trackerViewRoutesRegisterHandler: RoutesRegisterHandler = (router, 
     const { databaseService, logService } = services;
 
     try {
-      const parsedParams = parsePathParams(request.params, trackerIdParamsSchema, "Invalid tracker id");
+      const parsedParams = parsePathParams(request.params, trackerParamsSchema, "Invalid tracker id");
       if (!parsedParams.success) {
         return parsedParams.response;
       }

--- a/shared/src/base/request-parsing.ts
+++ b/shared/src/base/request-parsing.ts
@@ -55,3 +55,23 @@ export async function parseJsonBody<T>(
     data: parsedBody.data,
   };
 }
+
+export function parsePathParams<T>(
+  params: Record<string, string | undefined>,
+  schema: ZodType<T>,
+  invalidPayloadMessage: string,
+): ParsedBodyResult<T> {
+  const parsed = schema.safeParse(params);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      response: errorContract.toResponse({ error: invalidPayloadMessage }, { status: 400, noStore: true }),
+    };
+  }
+
+  return {
+    success: true,
+    data: parsed.data,
+  };
+}

--- a/shared/src/base/tests/request-parsing.test.ts
+++ b/shared/src/base/tests/request-parsing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { parseJsonBody, parseQueryParams } from "../request-parsing";
+import { parseJsonBody, parsePathParams, parseQueryParams } from "../request-parsing";
 
 const schema = z.object({ name: z.string() });
 
@@ -59,6 +59,28 @@ describe("parseJsonBody", () => {
   it("returns a 400 response when the body fails schema validation", async () => {
     expect.assertions(2);
     const result = await parseJsonBody(jsonRequest(JSON.stringify({ wrong: true })), schema, "bad payload");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.response.status).toBe(400);
+    }
+  });
+});
+
+describe("parsePathParams", () => {
+  it("returns parsed data for valid path params", () => {
+    expect.assertions(2);
+    const result = parsePathParams({ name: "spartan" }, schema, "bad params");
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ name: "spartan" });
+    }
+  });
+
+  it("returns a 400 response when path params fail schema validation", () => {
+    expect.assertions(2);
+    const result = parsePathParams({}, schema, "bad params");
 
     expect(result.success).toBe(false);
     if (!result.success) {

--- a/shared/src/contracts/individual-tracker/tests/view.test.ts
+++ b/shared/src/contracts/individual-tracker/tests/view.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { trackerViewContract, type TrackerViewResponse } from "../view";
+
+describe("trackerViewContract", () => {
+  const validResponse: TrackerViewResponse = {
+    view: {
+      trackerId: "t1",
+      gamertag: "MyTag",
+      status: "active",
+      isLive: true,
+      matches: [
+        {
+          matchId: "match-1",
+          startTime: "2024-11-26T11:00:00.000Z",
+          endTime: "2024-11-26T11:10:00.000Z",
+          mapAssetId: "map-1",
+          modeAssetId: "mode-1",
+        },
+      ],
+      lastUpdateTime: "2024-11-26T12:00:00.000Z",
+      lastMatchDiscoveredAt: "2024-11-26T11:55:00.000Z",
+    },
+  };
+
+  it("parses a valid view response", () => {
+    expect(trackerViewContract.parse(validResponse)).toEqual(validResponse);
+  });
+
+  it("round-trips through toResponse/fromResponse", async () => {
+    const response = trackerViewContract.toResponse(validResponse, { noStore: true });
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    await expect(trackerViewContract.fromResponse(response)).resolves.toEqual(validResponse);
+  });
+
+  it("accepts a null lastMatchDiscoveredAt and empty matches", () => {
+    const result = trackerViewContract.safeParse({
+      view: {
+        trackerId: "t2",
+        gamertag: "StoppedTag",
+        status: "stopped",
+        isLive: false,
+        matches: [],
+        lastUpdateTime: "",
+        lastMatchDiscoveredAt: null,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown status", () => {
+    const result = trackerViewContract.safeParse({
+      ...validResponse,
+      view: { ...validResponse.view, status: "bogus" },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/shared/src/contracts/individual-tracker/tracker.ts
+++ b/shared/src/contracts/individual-tracker/tracker.ts
@@ -39,6 +39,11 @@ export const selectActiveTrackerRequestSchema = z.object({
 });
 export type SelectActiveTrackerRequest = z.infer<typeof selectActiveTrackerRequestSchema>;
 
+export const trackerIdParamsSchema = z.object({
+  trackerId: z.string().min(1),
+});
+export type TrackerIdParams = z.infer<typeof trackerIdParamsSchema>;
+
 export const trackerContract = defineContract(z.object({ tracker: trackerSchema }));
 export type TrackerResponse = z.infer<typeof trackerContract.schema>;
 

--- a/shared/src/contracts/individual-tracker/tracker.ts
+++ b/shared/src/contracts/individual-tracker/tracker.ts
@@ -39,10 +39,10 @@ export const selectActiveTrackerRequestSchema = z.object({
 });
 export type SelectActiveTrackerRequest = z.infer<typeof selectActiveTrackerRequestSchema>;
 
-export const trackerIdParamsSchema = z.object({
+export const trackerParamsSchema = z.object({
   trackerId: z.string().min(1),
 });
-export type TrackerIdParams = z.infer<typeof trackerIdParamsSchema>;
+export type TrackerParams = z.infer<typeof trackerParamsSchema>;
 
 export const trackerContract = defineContract(z.object({ tracker: trackerSchema }));
 export type TrackerResponse = z.infer<typeof trackerContract.schema>;

--- a/shared/src/contracts/individual-tracker/view.ts
+++ b/shared/src/contracts/individual-tracker/view.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import { defineContract } from "../base";
+import { trackerStatusSchema } from "./tracker";
+
+export const trackerMatchSummarySchema = z.object({
+  matchId: z.string(),
+  startTime: z.string(),
+  endTime: z.string(),
+  mapAssetId: z.string(),
+  modeAssetId: z.string(),
+});
+export type TrackerMatchSummary = z.infer<typeof trackerMatchSummarySchema>;
+
+export const trackerViewStateSchema = z.object({
+  trackerId: z.string(),
+  gamertag: z.string(),
+  status: trackerStatusSchema,
+  isLive: z.boolean(),
+  matches: z.array(trackerMatchSummarySchema),
+  lastUpdateTime: z.string(),
+  lastMatchDiscoveredAt: z.string().nullable(),
+});
+export type TrackerViewState = z.infer<typeof trackerViewStateSchema>;
+
+export const trackerViewContract = defineContract(z.object({ view: trackerViewStateSchema }));
+export type TrackerViewResponse = z.infer<typeof trackerViewContract.schema>;


### PR DESCRIPTION
## Milestone C2a — public viewer read path (REST)

Surfaces the matches the DO discovers (B4) to **anonymous viewer pages**. First half of C2; the live WebSocket push is **C2b**. This makes a poll-based viewer possible now.

### Changes
- **Contract** (`shared/.../individual-tracker/view.ts`): `trackerMatchSummary` (`matchId`, `startTime`, `endTime`, `mapAssetId`, `modeAssetId`) + `trackerViewState` (`trackerId`, `gamertag`, `status`, `isLive`, `matches[]`, `lastUpdateTime`, `lastMatchDiscoveredAt`) + `trackerViewContract`.
- **DO `view-state` action**: `toViewState` — an **explicit-allowlist** projection (6 fields: trackerId/gamertag/status/matches/lastUpdateTime/lastMatchDiscoveredAt), matches built from `discoveredMatches` in `matchIds` order. Deliberately excludes `errorState`/`checkCount`/`searchStartTime`/`idleTimeoutHours`/`isPaused`/`userId`.
- **Public route** `GET /api/individual-tracker/:trackerId/view` — **no session**: resolve `trackerId`→owner via the registry (404 if unknown), read the DO's matches, and build the view from the registry **row** for identity/status (`gamertag`/`status`/`isLive`) + the DO for runtime data. A stopped/offline tracker (DO storage cleared) resolves with `matches: []` + the row's status rather than 404. `noStore`.

### Safety
Triple allowlist (DO `toViewState` → mapper `toTrackerView` → contract schema parse), so nothing internal/owner-private (tokens, xuid, userId, error/poll internals) can reach the response. The `trackerId` is an unguessable UUID and match summaries are public Halo data, so public access is appropriate; the route never calls Halo or touches a token (it reads the DO's already-stored matches — the FE fetches per-match stats later via the cached proxy).

DO `handleViewState` (4 tests, incl. a key-set assertion that internal fields are excluded), route (3: running→matches+isLive, null-DO-state→empty, unknown→404, no cookie needed), contract (4). Full suite green (1836); typecheck 0 errors; lint clean.

### Next
**C2b** — WebSocket: the DO accepts viewer connections and broadcasts the view-state on change (each poll that discovers matches) → live push, replacing polling. Then **F** (user-level `/u/<gamertag>` follow-live) + the FE viewer (F1) + E4 (game include/exclude, now that matches exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)