### PR TITLE
refactor(api): validate :trackerId via parsePathParams in the merged control routes

### DIFF
--- a/api/routes/individual-tracker/manage.ts
+++ b/api/routes/individual-tracker/manage.ts
@@ -1,13 +1,13 @@
-import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { errorContract } from "@guilty-spark/shared/contracts/error";
 import {
   selectActiveTrackerRequestSchema,
   startTrackerRequestSchema,
   stopTrackerContract,
   trackerContract,
+  trackerParamsSchema,
   trackersContract,
 } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
-import { parseJsonBody } from "@guilty-spark/shared/base/request-parsing";
+import { parseJsonBody, parsePathParams } from "@guilty-spark/shared/base/request-parsing";
 import type {
   IndividualTrackerPauseResponse,
   IndividualTrackerResumeResponse,
@@ -134,7 +134,11 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
         return auth.response;
       }
 
-      const trackerId = Preconditions.checkExists(request.params["trackerId"], "Missing trackerId");
+      const parsedParams = parsePathParams(request.params, trackerParamsSchema, "Invalid tracker id");
+      if (!parsedParams.success) {
+        return parsedParams.response;
+      }
+      const { trackerId } = parsedParams.data;
 
       let tracker: IndividualTrackersRow;
       try {
@@ -166,7 +170,11 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
         return auth.response;
       }
 
-      const trackerId = Preconditions.checkExists(request.params["trackerId"], "Missing trackerId");
+      const parsedParams = parsePathParams(request.params, trackerParamsSchema, "Invalid tracker id");
+      if (!parsedParams.success) {
+        return parsedParams.response;
+      }
+      const { trackerId } = parsedParams.data;
 
       let tracker: IndividualTrackersRow;
       try {
@@ -198,7 +206,11 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
         return auth.response;
       }
 
-      const trackerId = Preconditions.checkExists(request.params["trackerId"], "Missing trackerId");
+      const parsedParams = parsePathParams(request.params, trackerParamsSchema, "Invalid tracker id");
+      if (!parsedParams.success) {
+        return parsedParams.response;
+      }
+      const { trackerId } = parsedParams.data;
 
       let tracker: IndividualTrackersRow;
       try {
@@ -293,7 +305,11 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
         return auth.response;
       }
 
-      const trackerId = Preconditions.checkExists(request.params["trackerId"], "Missing trackerId");
+      const parsedParams = parsePathParams(request.params, trackerParamsSchema, "Invalid tracker id");
+      if (!parsedParams.success) {
+        return parsedParams.response;
+      }
+      const { trackerId } = parsedParams.data;
 
       let tracker: IndividualTrackersRow;
       try {

--- a/api/routes/individual-tracker/tests/manage.test.ts
+++ b/api/routes/individual-tracker/tests/manage.test.ts
@@ -10,33 +10,18 @@ import type {
 import type { ErrorResponse } from "@guilty-spark/shared/contracts/error";
 import { createApiRouter } from "../../../base/router";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
-import { aFakeDurableObjectId } from "../../../base/fakes/do.fake";
+import { aFakeDurableObjectNamespaceWith } from "../../../base/fakes/do.fake";
 import {
   aFakeIndividualTrackerDOWith,
   aFakeIndividualTrackerStateWith,
   type FakeIndividualTrackerDO,
 } from "../../../durable-objects/individual-tracker/fakes/individual-tracker-do.fake";
-import type { IndividualTrackerDO } from "../../../worker";
 import { aFakeIndividualTrackersRow } from "../../../services/database/fakes/database.fake";
 import { installFakeServicesWith } from "../../../services/fakes/services";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/individual-tracker";
 import { TrackerLimitReachedError, TrackerNotFoundError } from "../../../services/individual-tracker/errors";
 import { individualTrackerRoutesRegisterHandler } from "../individual-tracker";
 import { aFakeAuthSessionWith } from "../../../services/auth/fakes/data";
-
-function envWithTrackerDo(stub: FakeIndividualTrackerDO): Env {
-  const id = aFakeDurableObjectId();
-  return aFakeEnvWith({
-    INDIVIDUAL_TRACKER_DO: {
-      idFromName: () => id,
-      idFromString: () => id,
-      newUniqueId: () => id,
-      getByName: () => stub,
-      get: () => stub,
-      jurisdiction: () => ({}) as DurableObjectNamespace<IndividualTrackerDO>,
-    },
-  });
-}
 
 function postRequest(path: string, body: unknown): Request {
   return new Request(`http://localhost${path}`, {
@@ -93,7 +78,7 @@ describe("/api/individual-tracker manage routes", () => {
       },
     });
     const startSpy: MockInstance<FakeIndividualTrackerDO["fetch"]> = vi.spyOn(doStub, "fetch");
-    const localEnv = envWithTrackerDo(doStub);
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
 
     const row = aFakeIndividualTrackersRow({
       TrackerId: "new-tracker",
@@ -176,7 +161,7 @@ describe("/api/individual-tracker manage routes", () => {
   it("stops a tracker: calls the DO stop and marks the registry row stopped", async () => {
     const doStub = aFakeIndividualTrackerDOWith();
     const stopSpy: MockInstance<FakeIndividualTrackerDO["fetch"]> = vi.spyOn(doStub, "fetch");
-    const localEnv = envWithTrackerDo(doStub);
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
 
     const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "active" });
     let markStatusSpy: MockInstance<IndividualTrackerService["markTrackerStatus"]> | null = null;
@@ -222,7 +207,7 @@ describe("/api/individual-tracker manage routes", () => {
       },
     });
     const pauseSpy: MockInstance<FakeIndividualTrackerDO["fetch"]> = vi.spyOn(doStub, "fetch");
-    const localEnv = envWithTrackerDo(doStub);
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
 
     const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "active" });
     let markStatusSpy: MockInstance<IndividualTrackerService["markTrackerStatus"]> | null = null;
@@ -268,7 +253,7 @@ describe("/api/individual-tracker manage routes", () => {
       },
     });
     const resumeSpy: MockInstance<FakeIndividualTrackerDO["fetch"]> = vi.spyOn(doStub, "fetch");
-    const localEnv = envWithTrackerDo(doStub);
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
 
     const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "paused" });
     let markStatusSpy: MockInstance<IndividualTrackerService["markTrackerStatus"]> | null = null;
@@ -326,7 +311,7 @@ describe("/api/individual-tracker manage routes", () => {
     const doStub = aFakeIndividualTrackerDOWith({
       statusResponse: { state: aFakeIndividualTrackerStateWith({ trackerId: "t1", status: "active" }) },
     });
-    const localEnv = envWithTrackerDo(doStub);
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
 
     const liveRow = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "active", IsLive: 1 });
     let setLiveSpy: MockInstance<IndividualTrackerService["setLiveTracker"]> | null = null;
@@ -354,7 +339,7 @@ describe("/api/individual-tracker manage routes", () => {
     const doStub = aFakeIndividualTrackerDOWith({
       statusResponse: { state: aFakeIndividualTrackerStateWith({ trackerId: "t1", status: "active" }) },
     });
-    const localEnv = envWithTrackerDo(doStub);
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
 
     const rows = [
       aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "active" }),
@@ -402,7 +387,7 @@ describe("/api/individual-tracker manage routes", () => {
         state: aFakeIndividualTrackerStateWith({ trackerId: "t1", gamertag: "MyTag", status: "active" }),
       },
     });
-    const localEnv = envWithTrackerDo(doStub);
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
 
     const row = aFakeIndividualTrackersRow({
       TrackerId: "t1",


### PR DESCRIPTION
## Consistency cleanup — `parsePathParams` for the merged control routes

Follow-up to the #469 review (zod-validate request input instead of raw `Preconditions.checkExists`). #469 added a `parsePathParams` helper + `trackerIdParamsSchema` and applied it to the viewer route; #470 to the `ws` route. This PR applies the same to the **already-merged** control routes that were carried in during this work.

### Changes
- `api/routes/individual-tracker/manage.ts` — the 4 routes (`stop`/`pause`/`resume`/`status`) now read `:trackerId` via `parsePathParams(request.params, trackerIdParamsSchema, …)` instead of `Preconditions.checkExists`. Drops the now-unused `Preconditions` import.

No behaviour change for valid trackerIds (a malformed/empty param now returns a clean 400 rather than relying on `checkExists`/the catch). Full api+shared suite green (1541); typecheck 0 errors; lint clean.

### Stacking note
Depends on the `parsePathParams` helper + `trackerIdParamsSchema` introduced in **#469**, so it's stacked on the C2 train (#469 → #470 → this). It rebases to `main` once the train merges.

(Scope = the individual-tracker routes from this work. The pre-existing `/ws/tracker/:guildId/:queueNumber` live-tracker route in `server.ts` uses the same raw-param style but is out of scope here — flagging in case you want it folded in too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)