### PR TITLE
refactor(halo): extract series-win counting into shared computeSeriesTeamWins (F1c)

### DIFF
--- a/api/services/halo/halo.ts
+++ b/api/services/halo/halo.ts
@@ -15,6 +15,8 @@ import { MatchOutcome, AssetKind, GameVariantCategory, MatchType, RequestError }
 import { differenceInDays, differenceInHours, differenceInMinutes, isAfter, isBefore } from "date-fns";
 import { getReadableDuration } from "@guilty-spark/shared/halo/duration";
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
+import type { SeriesScoreEntry } from "@guilty-spark/shared/halo/series-score";
+import { computeSeriesTeamWins } from "@guilty-spark/shared/halo/series-score";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import type { DiscordAssociationsRow } from "../database/types/discord_associations";
@@ -204,31 +206,16 @@ export class HaloService {
   }
 
   getSeriesScore(matches: MatchStats[], locale: string): string {
-    const teamScores: Record<number, number> = {};
-    const sortedMatches = [...matches].sort((a, b) =>
-      isBefore(a.MatchInfo.StartTime, b.MatchInfo.StartTime) ? -1 : 1,
-    );
-    for (const [index, match] of sortedMatches.entries()) {
-      const nextMatch = sortedMatches[index + 1];
-      if (
-        nextMatch?.MatchInfo.MapVariant.AssetId === match.MatchInfo.MapVariant.AssetId &&
-        nextMatch.MatchInfo.MapVariant.VersionId === match.MatchInfo.MapVariant.VersionId &&
-        nextMatch.MatchInfo.GameVariantCategory === match.MatchInfo.GameVariantCategory
-      ) {
-        // we only want the final game of the same map + game type
-        continue;
-      }
-      for (const [teamIndex, team] of match.Teams.entries()) {
-        teamScores[teamIndex] = (teamScores[teamIndex] ?? 0) + (team.Outcome === MatchOutcome.Win.valueOf() ? 1 : 0);
-      }
-    }
-
-    const values = Object.values(teamScores);
-    const score = values.map((value) => value.toLocaleString(locale)).join(":") || "🦅 0:0 🐍";
-    if (values.length === 2) {
-      return `🦅 ${score} 🐍`;
-    }
-    return score;
+    const entries: SeriesScoreEntry[] = matches.map((match) => ({
+      startTime: match.MatchInfo.StartTime,
+      mapAssetId: match.MatchInfo.MapVariant.AssetId,
+      mapVersionId: match.MatchInfo.MapVariant.VersionId,
+      gameVariantCategory: match.MatchInfo.GameVariantCategory,
+      teamOutcomes: match.Teams.map((team) => team.Outcome),
+    }));
+    const wins = computeSeriesTeamWins(entries);
+    const score = wins.map((value) => value.toLocaleString(locale)).join(":") || "🦅 0:0 🐍";
+    return wins.length === 2 ? `🦅 ${score} 🐍` : score;
   }
 
   wrapPlayerXuid(xuid: string): string {

--- a/shared/src/halo/series-score.ts
+++ b/shared/src/halo/series-score.ts
@@ -1,0 +1,30 @@
+import { MatchOutcome } from "halo-infinite-api";
+import { isBefore } from "date-fns";
+
+export interface SeriesScoreEntry {
+  readonly startTime: string;
+  readonly mapAssetId: string;
+  readonly mapVersionId: string;
+  readonly gameVariantCategory: number;
+  readonly teamOutcomes: readonly number[];
+}
+
+export function computeSeriesTeamWins(entries: readonly SeriesScoreEntry[]): number[] {
+  const teamScores: Record<number, number> = {};
+  const sortedEntries = [...entries].sort((a, b) => (isBefore(a.startTime, b.startTime) ? -1 : 1));
+  for (const [index, entry] of sortedEntries.entries()) {
+    const nextEntry = sortedEntries[index + 1];
+    if (
+      nextEntry?.mapAssetId === entry.mapAssetId &&
+      nextEntry.mapVersionId === entry.mapVersionId &&
+      nextEntry.gameVariantCategory === entry.gameVariantCategory
+    ) {
+      continue;
+    }
+    for (const [teamIndex, outcome] of entry.teamOutcomes.entries()) {
+      teamScores[teamIndex] = (teamScores[teamIndex] ?? 0) + (outcome === MatchOutcome.Win.valueOf() ? 1 : 0);
+    }
+  }
+
+  return Object.values(teamScores);
+}

--- a/shared/src/halo/tests/series-score.test.ts
+++ b/shared/src/halo/tests/series-score.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { MatchOutcome } from "halo-infinite-api";
+import type { SeriesScoreEntry } from "../series-score";
+import { computeSeriesTeamWins } from "../series-score";
+
+function anEntry(overrides: Partial<SeriesScoreEntry> = {}): SeriesScoreEntry {
+  return {
+    startTime: "2024-11-26T10:00:00.000Z",
+    mapAssetId: "map-a",
+    mapVersionId: "version-a",
+    gameVariantCategory: 1,
+    teamOutcomes: [MatchOutcome.Loss, MatchOutcome.Loss],
+    ...overrides,
+  };
+}
+
+describe("computeSeriesTeamWins", () => {
+  it("counts per-team wins across multiple matches", () => {
+    const entries = [
+      anEntry({
+        startTime: "2024-11-26T10:00:00.000Z",
+        gameVariantCategory: 1,
+        teamOutcomes: [MatchOutcome.Win, MatchOutcome.Loss],
+      }),
+      anEntry({
+        startTime: "2024-11-26T10:10:00.000Z",
+        gameVariantCategory: 2,
+        teamOutcomes: [MatchOutcome.Win, MatchOutcome.Loss],
+      }),
+      anEntry({
+        startTime: "2024-11-26T10:20:00.000Z",
+        gameVariantCategory: 3,
+        teamOutcomes: [MatchOutcome.Loss, MatchOutcome.Win],
+      }),
+    ];
+
+    expect(computeSeriesTeamWins(entries)).toEqual([2, 1]);
+  });
+
+  it("collapses consecutive matches of same map + version + category, counting only the final game", () => {
+    const entries = [
+      anEntry({
+        startTime: "2024-11-26T10:00:00.000Z",
+        teamOutcomes: [MatchOutcome.Win, MatchOutcome.Loss],
+      }),
+      anEntry({
+        startTime: "2024-11-26T10:05:00.000Z",
+        teamOutcomes: [MatchOutcome.Loss, MatchOutcome.Win],
+      }),
+    ];
+
+    expect(computeSeriesTeamWins(entries)).toEqual([0, 1]);
+  });
+
+  it("counts different map / version / category separately", () => {
+    const entries = [
+      anEntry({
+        startTime: "2024-11-26T10:00:00.000Z",
+        mapAssetId: "map-a",
+        teamOutcomes: [MatchOutcome.Win, MatchOutcome.Loss],
+      }),
+      anEntry({
+        startTime: "2024-11-26T10:05:00.000Z",
+        mapAssetId: "map-b",
+        teamOutcomes: [MatchOutcome.Win, MatchOutcome.Loss],
+      }),
+      anEntry({
+        startTime: "2024-11-26T10:10:00.000Z",
+        mapAssetId: "map-b",
+        mapVersionId: "version-b",
+        teamOutcomes: [MatchOutcome.Win, MatchOutcome.Loss],
+      }),
+    ];
+
+    expect(computeSeriesTeamWins(entries)).toEqual([3, 0]);
+  });
+
+  it("does not count ties or losses, leaving a team with no wins at 0", () => {
+    const entries = [
+      anEntry({
+        startTime: "2024-11-26T10:00:00.000Z",
+        gameVariantCategory: 1,
+        teamOutcomes: [MatchOutcome.Win, MatchOutcome.Loss],
+      }),
+      anEntry({
+        startTime: "2024-11-26T10:10:00.000Z",
+        gameVariantCategory: 2,
+        teamOutcomes: [MatchOutcome.Tie, MatchOutcome.Tie],
+      }),
+    ];
+
+    expect(computeSeriesTeamWins(entries)).toEqual([1, 0]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(computeSeriesTeamWins([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What
Isolated, behaviour-preserving refactor that prepares the individual-tracker DO to reuse the **live tracker's** series-score logic (your steer: don't reinvent it).

Extracts the per-team win **counting** from `HaloService.getSeriesScore` into a shared pure function `computeSeriesTeamWins(entries)` over a minimal shape (`SeriesScoreEntry { startTime, mapAssetId, mapVersionId, gameVariantCategory, teamOutcomes }`). This lets the IT DO compute series scores from a few stored fields rather than holding full `MatchStats`.

`HaloService.getSeriesScore` now maps `MatchStats[]` → entries, delegates, and reproduces its **exact** output (`🦅 x:y 🐍` for the live tracker + Discord channel names). One shared implementation — no logic duplication.

## No behaviour change
The pre-existing `getSeriesScore` tests are untouched and pass (2-team, collapse, empty, >2-team, locale cases) — same sort (`isBefore`), same collapse (final game of a same-map/version/category run), same `Object.values` ordering, same formatting.

## Stack
Stacked on **#473 (F1b)** → **#472 (F1a)** → main. Merge bottom-up. (Touches `halo.ts` + `shared` only — no overlap with F1a/F1b's IT-DO/contract files.)

## Test
`npx vitest run shared/src/halo api/services/halo` — 375 green (5 new `computeSeriesTeamWins` tests + unchanged `getSeriesScore`). Typecheck + eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)