### PR TITLE
fix(individual-tracker): review-hardening pass (correctness, security, AGENTS.md)

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/cloudflare";
-import { addMilliseconds, differenceInHours } from "date-fns";
+import { addMilliseconds, compareAsc, differenceInHours } from "date-fns";
 import { type HaloInfiniteClient, type MatchStats, MatchType } from "halo-infinite-api";
 import { trackerViewMessageContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import {
@@ -233,10 +233,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       }
 
       if (summary.teamOutcomes === null) {
-        await this.enrichScore(haloClient, summary);
-      }
-      if (summary.teamOutcomes !== null) {
-        viewChanged = true;
+        const enriched = await this.enrichScore(haloClient, summary);
+        if (enriched) {
+          viewChanged = true;
+        }
       }
 
       if (summary.mapName === "") {
@@ -266,7 +266,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     return discoveredNewMatch;
   }
 
-  private async enrichScore(haloClient: HaloInfiniteClient, summary: IndividualTrackerMatchSummary): Promise<void> {
+  private async enrichScore(haloClient: HaloInfiniteClient, summary: IndividualTrackerMatchSummary): Promise<boolean> {
     let matchStats: MatchStats;
     try {
       matchStats = await haloClient.getMatchStats(summary.matchId);
@@ -283,12 +283,13 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         ]),
       );
       summary.score = "";
-      return;
+      return false;
     }
 
     summary.score = buildMatchScore(matchStats);
     summary.teamRosterSignature = buildTeamRosterSignature(matchStats);
     summary.teamOutcomes = matchStats.Teams.map((team) => team.Outcome);
+    return true;
   }
 
   private async resolveMapName(assetId: string, versionId: string): Promise<string> {
@@ -470,7 +471,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     const summaries = state.matchIds
       .map((matchId) => state.discoveredMatches[matchId])
       .filter((match): match is IndividualTrackerMatchSummary => match != null)
-      .sort((left, right) => new Date(left.startTime).getTime() - new Date(right.startTime).getTime());
+      .sort((left, right) => compareAsc(new Date(left.startTime), new Date(right.startTime)));
 
     const summariesById = new Map(summaries.map((summary) => [summary.matchId, summary]));
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -151,6 +151,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         await this.setState(trackerState);
         this.broadcastViewState(trackerState);
         this.closeWebSockets("Tracker idle timeout");
+        await this.markRegistryStopped(trackerState);
         return;
       }
 
@@ -305,6 +306,23 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         ]),
       );
       return "";
+    }
+  }
+
+  private async markRegistryStopped(trackerState: IndividualTrackerInternalState): Promise<void> {
+    try {
+      const row = await this.services.databaseService.getIndividualTracker(trackerState.trackerId);
+      if (row != null) {
+        await this.services.individualTrackerService.markTrackerStatus(row, "stopped");
+      }
+    } catch (error) {
+      this.logService.warn(
+        "IndividualTracker: failed to mark registry stopped on idle timeout",
+        new Map([
+          ["trackerId", trackerState.trackerId],
+          ["error", String(error)],
+        ]),
+      );
     }
   }
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/cloudflare";
 import { addMilliseconds, compareAsc, differenceInHours } from "date-fns";
-import { type HaloInfiniteClient, type MatchStats, MatchType } from "halo-infinite-api";
+import { type HaloInfiniteClient, type MatchStats, MatchType, RequestError } from "halo-infinite-api";
 import { trackerViewMessageContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import {
   analyzeMatchGroupings,
@@ -150,6 +150,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         await this.state.storage.deleteAlarm();
         await this.setState(trackerState);
         this.broadcastViewState(trackerState);
+        this.closeWebSockets("Tracker idle timeout");
         return;
       }
 
@@ -322,6 +323,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   }
 
   private isAuthError(error: unknown): boolean {
+    if (error instanceof RequestError) {
+      return error.response.status === 401;
+    }
     const message = error instanceof Error ? error.message : String(error);
     return /\b401\b|unauthorized|expired|spartan token/i.test(message);
   }

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1002,6 +1002,23 @@ describe("IndividualTrackerDO", () => {
       expect(webSocketAdapter.broadcasts).toHaveLength(0);
     });
 
+    it("does not broadcast on a steady-state poll where an already-enriched match is unchanged", async () => {
+      ownerClient.getPlayerMatches.mockResolvedValue([aFakePlayerMatch("m1", "2024-11-26T11:30:00.000Z")]);
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1"],
+          searchStartTime: "2024-11-26T11:00:00.000Z",
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1", teamOutcomes: [2, 3], mapName: "Aquarius" }),
+          },
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      expect(webSocketAdapter.broadcasts).toHaveLength(0);
+    });
+
     it("broadcasts a stopped view and closes sockets on stop", async () => {
       storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ status: "active" }));
 

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -3,7 +3,7 @@ import type { MockInstance } from "vitest";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { trackerViewMessageContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import { aFakeCoreStatsWith, aFakeMatchStatsWith, aFakeTeamWith } from "@guilty-spark/shared/halo/fakes/data";
-import type { HaloInfiniteClient, PlayerMatchHistory } from "halo-infinite-api";
+import { type HaloInfiniteClient, type PlayerMatchHistory, RequestError } from "halo-infinite-api";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 import { IndividualTrackerDO } from "../individual-tracker-do";
@@ -752,6 +752,47 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.errorState.consecutiveErrors).toBe(1);
     });
 
+    it("treats a typed RequestError 401 as an auth error and clears the cached client", async () => {
+      ownerClient.getPlayerMatches.mockResolvedValue([aFakePlayerMatch("match-new", "2024-11-26T11:30:00.000Z", 2)]);
+      ownerClient.getMatchStats.mockRejectedValue(
+        new RequestError(new URL("https://halo"), new Response(null, { status: 401 })),
+      );
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          searchStartTime: "2024-11-26T11:00:00.000Z",
+          matchIds: [],
+          discoveredMatches: {},
+          errorState: { consecutiveErrors: 0, backoffMinutes: 3, lastSuccessTime: "old" },
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+      await individualTrackerDO.alarm();
+
+      expect(getClientForUser).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not treat a non-401 RequestError as an auth error", async () => {
+      ownerClient.getPlayerMatches.mockResolvedValue([aFakePlayerMatch("match-new", "2024-11-26T11:30:00.000Z", 2)]);
+      ownerClient.getMatchStats.mockRejectedValue(
+        new RequestError(new URL("https://halo"), new Response(null, { status: 500 })),
+      );
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          searchStartTime: "2024-11-26T11:00:00.000Z",
+          matchIds: [],
+          discoveredMatches: {},
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+      await individualTrackerDO.alarm();
+
+      expect(getClientForUser).toHaveBeenCalledTimes(1);
+    });
+
     it("sets lastMatchDiscoveredAt and resets errorState when new matches are found", async () => {
       ownerClient.getPlayerMatches.mockResolvedValue([aFakePlayerMatch("match-new", "2024-11-26T11:30:00.000Z")]);
       storageGetSpy.mockResolvedValue(
@@ -1028,6 +1069,21 @@ describe("IndividualTrackerDO", () => {
       const parsed = trackerViewMessageContract.parse(Preconditions.checkExists(webSocketAdapter.broadcasts[0]));
       expect(parsed.view.status).toBe("stopped");
       expect(webSocketAdapter.closes[0]?.code).toBe(1000);
+    });
+
+    it("closes sockets when the tracker auto-stops on idle timeout", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          status: "active",
+          idleTimeoutHours: 6,
+          startTime: "2024-11-26T05:00:00.000Z",
+          lastMatchDiscoveredAt: "2024-11-26T05:00:00.000Z",
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      expect(webSocketAdapter.closes).toHaveLength(1);
     });
 
     it("ignores client messages and does not throw on close/error", () => {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -29,6 +29,7 @@ import {
   aFakeIndividualTrackerInternalStateWith,
   aFakeIndividualTrackerMatchSummaryWith,
 } from "../fakes/individual-tracker-do.fake";
+import { aFakeIndividualTrackersRow } from "../../../services/database/fakes/database.fake";
 
 const aFakeWinMatchStats = (): ReturnType<typeof aFakeMatchStatsWith> =>
   aFakeMatchStatsWith({
@@ -841,6 +842,24 @@ describe("IndividualTrackerDO", () => {
       expect(storageDeleteAlarmSpy).toHaveBeenCalled();
       expect(storageSetAlarmSpy).not.toHaveBeenCalled();
       expect(ownerClient.getPlayerMatches).not.toHaveBeenCalled();
+    });
+
+    it("marks the registry row stopped when it auto-stops on idle timeout", async () => {
+      const row = aFakeIndividualTrackersRow({ TrackerId: "idle-tracker", Status: "active" });
+      vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(row);
+      const markSpy = vi.spyOn(services.individualTrackerService, "markTrackerStatus");
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          trackerId: "idle-tracker",
+          idleTimeoutHours: 6,
+          startTime: "2024-11-26T05:00:00.000Z",
+          lastMatchDiscoveredAt: "2024-11-26T05:00:00.000Z",
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      expect(markSpy).toHaveBeenCalledWith(row, "stopped");
     });
 
     it("increments consecutiveErrors, grows backoff, reschedules at backoff and does not throw on poll failure", async () => {

--- a/api/routes/halo-proxy/tests/halo-proxy.test.ts
+++ b/api/routes/halo-proxy/tests/halo-proxy.test.ts
@@ -1,0 +1,247 @@
+import type { AutoRouterType } from "itty-router";
+import type { MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as HaloInfiniteApi from "halo-infinite-api";
+import { HaloInfiniteClient, StaticXstsTicketTokenSpartanTokenProvider } from "halo-infinite-api";
+import type { TokenInfo } from "../../../services/xbox/types";
+import type { XboxService } from "../../../services/xbox/xbox";
+import type { UserTokenProvider } from "../../../services/halo/user-token-provider";
+import { createApiRouter } from "../../../base/router";
+import { aFakeEnvWith } from "../../../base/fakes/env.fake";
+import { aFakeCacheStorage } from "../../../base/fakes/cache.fake";
+import { aFakeHaloInfiniteClient } from "../../../services/halo/fakes/infinite-client.fake";
+import { aFakeLinkedIdentitiesRow } from "../../../services/database/fakes/database.fake";
+import { installFakeServicesWith } from "../../../services/fakes/services";
+import { haloProxyRoutesRegisterHandler } from "../halo-proxy";
+
+vi.mock("halo-infinite-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof HaloInfiniteApi>();
+  return {
+    ...actual,
+    StaticXstsTicketTokenSpartanTokenProvider: vi.fn(),
+    HaloInfiniteClient: vi.fn(),
+  };
+});
+
+function getRequest(url: string): Request {
+  return new Request(url, { method: "GET" });
+}
+
+describe("/proxy/halo-infinite/:operation route", () => {
+  let env: Env;
+  let router: AutoRouterType;
+  let ctx: ExecutionContext;
+
+  beforeEach(() => {
+    env = aFakeEnvWith();
+    router = createApiRouter();
+    ctx = { waitUntil: vi.fn(), passThroughOnException: vi.fn() } as unknown as ExecutionContext;
+    vi.stubGlobal("caches", aFakeCacheStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 404 for an operation outside the allowlist", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => installFakeServicesWith({ env }));
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(
+      getRequest("http://localhost/proxy/halo-infinite/deleteUser"),
+      env,
+      ctx,
+    )) as Response;
+
+    expect(res.status).toBe(404);
+    expect(await res.text()).toContain("Operation not found");
+  });
+
+  it("returns 405 for a non-GET method on an allowlisted operation", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => installFakeServicesWith({ env }));
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const req = new Request("http://localhost/proxy/halo-infinite/getUser", { method: "POST" });
+    const res = (await router.fetch(req, env, ctx)) as Response;
+
+    expect(res.status).toBe(405);
+    expect(await res.text()).toBe("Method not allowed");
+  });
+
+  it("derives the client from a valid session via the session XSTS token", async () => {
+    const sessionClient = aFakeHaloInfiniteClient();
+    const sessionGetUserSpy = vi.spyOn(sessionClient, "getUser");
+    let exchangeSpy!: MockInstance<XboxService["exchangeMicrosoftAccessTokenForXstsToken"]>;
+    vi.mocked(StaticXstsTicketTokenSpartanTokenProvider).mockClear();
+    vi.mocked(HaloInfiniteClient).mockClear();
+    vi.mocked(HaloInfiniteClient).mockImplementation(function () {
+      return sessionClient;
+    });
+
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue({
+        sessionId: "session-123",
+        userId: "user-123",
+        accessToken: "access-token",
+        refreshToken: undefined,
+        expiresAt: Date.now() + 3600000,
+        isExpired: false,
+      });
+      exchangeSpy = vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockResolvedValue({
+        XSTSToken: "session-xsts-token",
+        userHash: "session-user-hash",
+        expiresOn: new Date("2025-01-01T06:00:00.000Z"),
+      } satisfies TokenInfo);
+      return services;
+    });
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22", {
+      method: "GET",
+      headers: { cookie: "auth-session=valid-token" },
+    });
+    const res = (await router.fetch(req, env, ctx)) as Response;
+
+    expect(res.status).toBe(200);
+    expect(exchangeSpy).toHaveBeenCalledWith("access-token");
+    expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).toHaveBeenCalledWith("session-xsts-token");
+    expect(sessionGetUserSpy).toHaveBeenCalledWith("discord_user_01");
+  });
+
+  it("uses the owner client when a gamertag resolves to an active xbox identity without a session", async () => {
+    const ownerClient = aFakeHaloInfiniteClient();
+    const ownerGetUserSpy = vi.spyOn(ownerClient, "getUser");
+    let getClientForUserSpy!: MockInstance<UserTokenProvider["getClientForUser"]>;
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(
+        aFakeLinkedIdentitiesRow({ UserId: "owner-user-1", Gamertag: "OwnerTag", IsActive: 1, Provider: "xbox" }),
+      );
+      getClientForUserSpy = vi.spyOn(services.userTokenProvider, "getClientForUser").mockResolvedValue(ownerClient);
+      return services;
+    });
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const req = getRequest("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22&gamertag=OwnerTag");
+    const res = (await router.fetch(req, env, ctx)) as Response;
+
+    expect(res.status).toBe(200);
+    expect(getClientForUserSpy).toHaveBeenCalledWith("owner-user-1");
+    expect(ownerGetUserSpy).toHaveBeenCalledWith("discord_user_01");
+    const body = await res.json();
+    expect(JSON.stringify(body)).not.toContain("token");
+    expect(JSON.stringify(body)).not.toContain("xsts");
+  });
+
+  it("falls back to the bot client when there is no session and no gamertag", async () => {
+    const botClient = aFakeHaloInfiniteClient();
+    const botGetUserSpy = vi.spyOn(botClient, "getUser");
+    vi.mocked(StaticXstsTicketTokenSpartanTokenProvider).mockClear();
+    let getClientForUserSpy!: MockInstance<UserTokenProvider["getClientForUser"]>;
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env, haloInfiniteClient: botClient });
+      getClientForUserSpy = vi.spyOn(services.userTokenProvider, "getClientForUser");
+      return services;
+    });
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const req = getRequest("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22");
+    const res = (await router.fetch(req, env, ctx)) as Response;
+
+    expect(res.status).toBe(200);
+    expect(botGetUserSpy).toHaveBeenCalledWith("discord_user_01");
+    expect(getClientForUserSpy).not.toHaveBeenCalled();
+    expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the bot client when the gamertag has no active xbox identity", async () => {
+    const botClient = aFakeHaloInfiniteClient();
+    const botGetUserSpy = vi.spyOn(botClient, "getUser");
+    let getClientForUserSpy!: MockInstance<UserTokenProvider["getClientForUser"]>;
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env, haloInfiniteClient: botClient });
+      vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(null);
+      getClientForUserSpy = vi.spyOn(services.userTokenProvider, "getClientForUser");
+      return services;
+    });
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const req = getRequest("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22&gamertag=Unknown");
+    const res = (await router.fetch(req, env, ctx)) as Response;
+
+    expect(res.status).toBe(200);
+    expect(botGetUserSpy).toHaveBeenCalledWith("discord_user_01");
+    expect(getClientForUserSpy).not.toHaveBeenCalled();
+  });
+
+  it("serves a second request with a different gamertag from the gamertag-stripped cache entry", async () => {
+    const cache = caches.default;
+    const ownerClient = aFakeHaloInfiniteClient();
+    const ownerGetUserSpy = vi.spyOn(ownerClient, "getUser");
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(
+        aFakeLinkedIdentitiesRow({ UserId: "owner-user-1", Gamertag: "OwnerTag" }),
+      );
+      vi.spyOn(services.userTokenProvider, "getClientForUser").mockResolvedValue(ownerClient);
+      return services;
+    });
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const baseUrl = "http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22";
+
+    const firstRes = (await router.fetch(getRequest(`${baseUrl}&gamertag=OwnerTag`), env, ctx)) as Response;
+    expect(firstRes.status).toBe(200);
+    expect(ownerGetUserSpy).toHaveBeenCalledTimes(1);
+
+    const stored = await cache.match(getRequest(baseUrl));
+    expect(stored).toBeDefined();
+
+    const secondRes = (await router.fetch(getRequest(`${baseUrl}&gamertag=SomeoneElse`), env, ctx)) as Response;
+    expect(secondRes.status).toBe(200);
+    expect(ownerGetUserSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("stores a successful 200 response in the cache", async () => {
+    const cache = caches.default;
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => installFakeServicesWith({ env }));
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const url = "http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22";
+    const res = (await router.fetch(getRequest(url), env, ctx)) as Response;
+    expect(res.status).toBe(200);
+
+    const stored = await cache.match(getRequest(url));
+    expect(stored).toBeDefined();
+    expect(stored?.status).toBe(200);
+  });
+
+  it("does not cache a non-200 error response", async () => {
+    const cache = caches.default;
+    const botClient = aFakeHaloInfiniteClient();
+    vi.spyOn(botClient, "getUser").mockRejectedValue(new Error("fail!"));
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() =>
+      installFakeServicesWith({ env, haloInfiniteClient: botClient }),
+    );
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const url = "http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22";
+    const res = (await router.fetch(getRequest(url), env, ctx)) as Response;
+    expect(res.status).toBe(500);
+
+    const stored = await cache.match(getRequest(url));
+    expect(stored).toBeUndefined();
+  });
+
+  it("sets the per-operation Cache-Control header on a successful response", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => installFakeServicesWith({ env }));
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const url = "http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22";
+    const res = (await router.fetch(getRequest(url), env, ctx)) as Response;
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=86400, stale-while-revalidate=3600");
+  });
+});

--- a/api/routes/halo-proxy/tests/halo-proxy.test.ts
+++ b/api/routes/halo-proxy/tests/halo-proxy.test.ts
@@ -6,6 +6,7 @@ import { HaloInfiniteClient, StaticXstsTicketTokenSpartanTokenProvider } from "h
 import type { TokenInfo } from "../../../services/xbox/types";
 import type { XboxService } from "../../../services/xbox/xbox";
 import type { UserTokenProvider } from "../../../services/halo/user-token-provider";
+import type { DatabaseService } from "../../../services/database/database";
 import { createApiRouter } from "../../../base/router";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import { aFakeCacheStorage } from "../../../base/fakes/cache.fake";
@@ -107,6 +108,51 @@ describe("/proxy/halo-infinite/:operation route", () => {
     expect(exchangeSpy).toHaveBeenCalledWith("access-token");
     expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).toHaveBeenCalledWith("session-xsts-token");
     expect(sessionGetUserSpy).toHaveBeenCalledWith("discord_user_01");
+  });
+
+  it("prefers the session client and ignores the gamertag when both are present", async () => {
+    const sessionClient = aFakeHaloInfiniteClient();
+    const sessionGetUserSpy = vi.spyOn(sessionClient, "getUser");
+    vi.mocked(HaloInfiniteClient).mockClear();
+    vi.mocked(HaloInfiniteClient).mockImplementation(function () {
+      return sessionClient;
+    });
+    let getClientForUserSpy!: MockInstance<UserTokenProvider["getClientForUser"]>;
+    let findIdentitySpy!: MockInstance<DatabaseService["findActiveXboxIdentityByGamertag"]>;
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue({
+        sessionId: "session-123",
+        userId: "user-123",
+        accessToken: "access-token",
+        refreshToken: undefined,
+        expiresAt: Date.now() + 3600000,
+        isExpired: false,
+      });
+      vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockResolvedValue({
+        XSTSToken: "session-xsts-token",
+        userHash: "session-user-hash",
+        expiresOn: new Date("2025-01-01T06:00:00.000Z"),
+      } satisfies TokenInfo);
+      findIdentitySpy = vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag");
+      getClientForUserSpy = vi.spyOn(services.userTokenProvider, "getClientForUser");
+      return services;
+    });
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const req = new Request(
+      "http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22&gamertag=OwnerTag",
+      {
+        method: "GET",
+        headers: { cookie: "auth-session=valid-token" },
+      },
+    );
+    const res = (await router.fetch(req, env, ctx)) as Response;
+
+    expect(res.status).toBe(200);
+    expect(sessionGetUserSpy).toHaveBeenCalledWith("discord_user_01");
+    expect(findIdentitySpy).not.toHaveBeenCalled();
+    expect(getClientForUserSpy).not.toHaveBeenCalled();
   });
 
   it("uses the owner client when a gamertag resolves to an active xbox identity without a session", async () => {

--- a/api/routes/individual-tracker/manage.ts
+++ b/api/routes/individual-tracker/manage.ts
@@ -88,7 +88,14 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
       let xboxUser: Awaited<ReturnType<typeof xboxService.getUserByGamertag>>;
       try {
         xboxUser = await xboxService.getUserByGamertag(parsed.data.gamertag);
-      } catch {
+      } catch (error) {
+        logService.warn(
+          "Individual tracker start: gamertag lookup failed",
+          new Map([
+            ["gamertag", parsed.data.gamertag],
+            ["error", String(error)],
+          ]),
+        );
         return errorContract.toResponse({ error: "Gamertag not found" }, { status: 404, noStore: true });
       }
 

--- a/api/routes/individual-tracker/manage.ts
+++ b/api/routes/individual-tracker/manage.ts
@@ -85,7 +85,12 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
         return parsed.response;
       }
 
-      const xboxUser = await xboxService.getUserByGamertag(parsed.data.gamertag);
+      let xboxUser: Awaited<ReturnType<typeof xboxService.getUserByGamertag>>;
+      try {
+        xboxUser = await xboxService.getUserByGamertag(parsed.data.gamertag);
+      } catch {
+        return errorContract.toResponse({ error: "Gamertag not found" }, { status: 404, noStore: true });
+      }
 
       const createOptions: CreateTrackerOptions = {
         userId: auth.session.userId,
@@ -283,7 +288,7 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
       const rows = await individualTrackerService.listTrackers(auth.session.userId);
       const trackers = await Promise.all(
         rows.map(async (row) => {
-          const state = await statusTrackerDo(env, auth.session.userId, row.TrackerId);
+          const state = await statusTrackerDo(env, auth.session.userId, row.TrackerId).catch(() => null);
           return toTracker(row, state);
         }),
       );

--- a/api/routes/individual-tracker/tests/view.test.ts
+++ b/api/routes/individual-tracker/tests/view.test.ts
@@ -114,6 +114,9 @@ describe("/api/individual-tracker view route", () => {
     expect(body.view.series[0]?.title).toBe("Eagle vs Cobra");
     expect(body.view.series[0]?.subtitle).toBe("Best of 3");
     expect(body.view.lastMatchDiscoveredAt).toBe("2024-11-26T11:55:00.000Z");
+    expect(body.view).not.toHaveProperty("userId");
+    expect(body.view).not.toHaveProperty("xuid");
+    expect(JSON.stringify(body)).not.toContain("user-123");
   });
 
   it("returns 200 with empty matches and the row's status when the DO has no state", async () => {

--- a/api/services/halo/fakes/user-token-provider.fake.ts
+++ b/api/services/halo/fakes/user-token-provider.fake.ts
@@ -1,11 +1,13 @@
 import type { UserTokenProviderOpts } from "../user-token-provider";
 import { UserTokenProvider } from "../user-token-provider";
 import { aFakeAuthServiceWith } from "../../auth/fakes/auth.fake";
+import { aFakeLogServiceWith } from "../../log/fakes/log.fake";
 import { aFakeXboxServiceWith } from "../../xbox/fakes/xbox.fake";
 
 export function aFakeUserTokenProviderWith(opts: Partial<UserTokenProviderOpts> = {}): UserTokenProvider {
   return new UserTokenProvider({
     authService: opts.authService ?? aFakeAuthServiceWith(),
     xboxService: opts.xboxService ?? aFakeXboxServiceWith(),
+    logService: opts.logService ?? aFakeLogServiceWith(),
   });
 }

--- a/api/services/halo/tests/user-token-provider.test.ts
+++ b/api/services/halo/tests/user-token-provider.test.ts
@@ -3,6 +3,7 @@ import { HaloInfiniteClient, StaticXstsTicketTokenSpartanTokenProvider } from "h
 import type * as HaloInfiniteApi from "halo-infinite-api";
 import { UserTokenProvider } from "../user-token-provider";
 import { aFakeAuthServiceWith } from "../../auth/fakes/auth.fake";
+import { aFakeLogServiceWith } from "../../log/fakes/log.fake";
 import { aFakeXboxServiceWith } from "../../xbox/fakes/xbox.fake";
 import type { TokenInfo } from "../../xbox/types";
 
@@ -31,7 +32,7 @@ describe("UserTokenProvider", () => {
       expiresOn: new Date("2030-01-01T00:00:00.000Z"),
     } satisfies TokenInfo);
 
-    const provider = new UserTokenProvider({ authService, xboxService });
+    const provider = new UserTokenProvider({ authService, xboxService, logService: aFakeLogServiceWith() });
     const client = await provider.getClientForUser("user-123");
 
     expect(exchangeSpy).toHaveBeenCalledWith("owner-access-token");
@@ -46,22 +47,25 @@ describe("UserTokenProvider", () => {
     vi.spyOn(authService, "getMicrosoftAccessTokenForUser").mockResolvedValue(null);
     const exchangeSpy = vi.spyOn(xboxService, "exchangeMicrosoftAccessTokenForXstsToken");
 
-    const provider = new UserTokenProvider({ authService, xboxService });
+    const provider = new UserTokenProvider({ authService, xboxService, logService: aFakeLogServiceWith() });
     const client = await provider.getClientForUser("user-123");
 
     expect(client).toBeNull();
     expect(exchangeSpy).not.toHaveBeenCalled();
   });
 
-  it("fails closed (returns null) when the xbox exchange throws", async () => {
+  it("fails closed (returns null) and logs when the xbox exchange throws", async () => {
     const authService = aFakeAuthServiceWith();
     const xboxService = aFakeXboxServiceWith();
+    const logService = aFakeLogServiceWith();
+    const warnSpy = vi.spyOn(logService, "warn");
     vi.spyOn(authService, "getMicrosoftAccessTokenForUser").mockResolvedValue("owner-access-token");
     vi.spyOn(xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockRejectedValue(new Error("xbox down"));
 
-    const provider = new UserTokenProvider({ authService, xboxService });
+    const provider = new UserTokenProvider({ authService, xboxService, logService });
     const client = await provider.getClientForUser("user-123");
 
     expect(client).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/api/services/halo/user-token-provider.ts
+++ b/api/services/halo/user-token-provider.ts
@@ -1,19 +1,23 @@
 import { HaloInfiniteClient, StaticXstsTicketTokenSpartanTokenProvider } from "halo-infinite-api";
 import type { AuthService } from "../auth/auth";
+import type { LogService } from "../log/types";
 import type { XboxService } from "../xbox/xbox";
 
 export interface UserTokenProviderOpts {
   authService: AuthService;
   xboxService: XboxService;
+  logService: LogService;
 }
 
 export class UserTokenProvider {
   private readonly authService: AuthService;
   private readonly xboxService: XboxService;
+  private readonly logService: LogService;
 
-  constructor({ authService, xboxService }: UserTokenProviderOpts) {
+  constructor({ authService, xboxService, logService }: UserTokenProviderOpts) {
     this.authService = authService;
     this.xboxService = xboxService;
+    this.logService = logService;
   }
 
   async getClientForUser(userId: string): Promise<HaloInfiniteClient | null> {
@@ -25,7 +29,14 @@ export class UserTokenProvider {
 
       const xstsTokenInfo = await this.xboxService.exchangeMicrosoftAccessTokenForXstsToken(accessToken);
       return new HaloInfiniteClient(new StaticXstsTicketTokenSpartanTokenProvider(xstsTokenInfo.XSTSToken));
-    } catch {
+    } catch (error) {
+      this.logService.warn(
+        "UserTokenProvider: failed to mint Halo client for user",
+        new Map([
+          ["userId", userId],
+          ["error", String(error)],
+        ]),
+      );
       return null;
     }
   }

--- a/api/services/install.ts
+++ b/api/services/install.ts
@@ -85,7 +85,7 @@ export function installServices({ env }: InstallServicesOpts): Services {
     infiniteClient: haloInfiniteClient,
     playerMatchesRateLimiter: new PlayerMatchesRateLimiter({ logService, maxCallsPerSecond: 2 }),
   });
-  const userTokenProvider = new UserTokenProvider({ authService, xboxService });
+  const userTokenProvider = new UserTokenProvider({ authService, xboxService, logService });
   const liveTrackerService = new LiveTrackerService({ env, logService, discordService });
   const individualTrackerService = new IndividualTrackerService({ databaseService });
   const neatQueueService = new NeatQueueService({

--- a/pages/src/components/dialog/tests/dialog.test.tsx
+++ b/pages/src/components/dialog/tests/dialog.test.tsx
@@ -51,6 +51,7 @@ describe("Dialog", () => {
   });
 
   it("calls onClose when the overlay is clicked", async () => {
+    expect.assertions(2);
     const user = userEvent.setup();
     const onClose = vi.fn();
 

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager-presenter.ts
@@ -146,6 +146,9 @@ export class IndividualTrackerManagerPresenter {
     if (this.isDisposed) {
       return;
     }
+    if (this.config.store.getSnapshot().pendingTrackerId !== null) {
+      return;
+    }
     this.config.store.setPendingTrackerId(trackerId);
     this.invokeRowAction(trackerId, action)
       .then(async () => this.refreshTrackers())

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager-presenter.ts
@@ -98,7 +98,10 @@ export class IndividualTrackerManagerPresenter {
     if (this.isDisposed) {
       return;
     }
-    const { gamertagInput, searchStartTime, idleTimeoutHours } = this.config.store.getSnapshot();
+    const { gamertagInput, searchStartTime, idleTimeoutHours, addPending } = this.config.store.getSnapshot();
+    if (addPending) {
+      return;
+    }
     if (!isValidGamertagInput(gamertagInput)) {
       return;
     }
@@ -140,6 +143,9 @@ export class IndividualTrackerManagerPresenter {
   }
 
   public runRowAction(trackerId: string, action: TrackerRowAction): void {
+    if (this.isDisposed) {
+      return;
+    }
     this.config.store.setPendingTrackerId(trackerId);
     this.invokeRowAction(trackerId, action)
       .then(async () => this.refreshTrackers())

--- a/pages/src/services/individual-tracker/individual-tracker.ts
+++ b/pages/src/services/individual-tracker/individual-tracker.ts
@@ -41,10 +41,10 @@ export class RealIndividualTrackerService implements IndividualTrackerService {
         if (parsed.success && parsed.data.error !== "") {
           return new Error(parsed.data.error);
         }
+        return new Error(`Request failed (${String(response.status)})`);
       } catch {
         return new Error(body);
       }
-      return new Error(body);
     }
 
     return new Error(`Request failed (${String(response.status)})`);

--- a/shared/src/halo/match-enrichment.ts
+++ b/shared/src/halo/match-enrichment.ts
@@ -1,5 +1,6 @@
 import type { MatchStats } from "halo-infinite-api";
 import { GameVariantCategory } from "halo-infinite-api";
+import { compareAsc } from "date-fns";
 import { getPlayerXuid } from "./match-stats";
 
 export function getMatchOutcomeLabel(outcomeCode: number | null): "Win" | "Loss" | "Tie" | "DNF" | "Unknown" {
@@ -138,8 +139,8 @@ function haveSameSequentialSeriesSignature(
 }
 
 export function collapseSequentialSeriesEntries<T extends SequentialSeriesEntry>(entries: readonly T[]): T[] {
-  const sortedEntries = [...entries].sort(
-    (left, right) => new Date(left.startTime).getTime() - new Date(right.startTime).getTime(),
+  const sortedEntries = [...entries].sort((left, right) =>
+    compareAsc(new Date(left.startTime), new Date(right.startTime)),
   );
   const collapsedEntries: T[] = [];
 

--- a/shared/src/halo/series-score.ts
+++ b/shared/src/halo/series-score.ts
@@ -1,5 +1,5 @@
 import { MatchOutcome } from "halo-infinite-api";
-import { isBefore } from "date-fns";
+import { collapseSequentialSeriesEntries } from "./match-enrichment";
 
 export interface SeriesScoreEntry {
   readonly startTime: string;
@@ -11,16 +11,7 @@ export interface SeriesScoreEntry {
 
 export function computeSeriesTeamWins(entries: readonly SeriesScoreEntry[]): number[] {
   const teamScores: Record<number, number> = {};
-  const sortedEntries = [...entries].sort((a, b) => (isBefore(a.startTime, b.startTime) ? -1 : 1));
-  for (const [index, entry] of sortedEntries.entries()) {
-    const nextEntry = sortedEntries[index + 1];
-    if (
-      nextEntry?.mapAssetId === entry.mapAssetId &&
-      nextEntry.mapVersionId === entry.mapVersionId &&
-      nextEntry.gameVariantCategory === entry.gameVariantCategory
-    ) {
-      continue;
-    }
+  for (const entry of collapseSequentialSeriesEntries(entries)) {
     for (const [teamIndex, outcome] of entry.teamOutcomes.entries()) {
       teamScores[teamIndex] = (teamScores[teamIndex] ?? 0) + (outcome === MatchOutcome.Win.valueOf() ? 1 : 0);
     }


### PR DESCRIPTION
## What
A holistic review + AGENTS.md adherence pass over the merged individual-tracker feature surface (DO, routes, services, shared helpers, Halo proxy, pages manager). Ran an iterative multi-angle review → fix → re-review loop **until convergence** — **5 rounds; the final sweep returned no findings**. All fixes on this single branch. `npm test` → **1910 passing**; typecheck + eslint + prettier clean.

## Correctness
- **DO broadcast storm (HIGH):** the re-enrichment loop set `viewChanged` for *every* already-enriched match on *every* poll (a flattened `if`), so a populated tracker broadcast + re-persisted every 3 min forever. `enrichScore` now returns whether it enriched; `viewChanged` flips only on a real transition.
- **DO idle auto-stop** now (a) closes WebSockets (parity with `handleStop`) and (b) **reconciles the registry** — marks the `IndividualTrackers` row `stopped` (best-effort), so `/view` + `/manage/trackers` no longer report a timed-out tracker as `active` forever (only the route-driven stop updated the DB before).
- **`manage/start`**: unknown gamertag → **404** (was a generic 500) and the failure is **logged** (Xbox outages were previously invisible).
- **`manage/list`**: one unhealthy tracker DO no longer fails the whole list (per-row fallback to `null`).
- **pages manager**: `addTracker` guards double-submit (Enter while pending); `runRowAction` guards a disposed presenter **and** a concurrent in-flight action (the single `pendingTrackerId` was clobbered by overlapping row actions).
- **pages service `readError`**: no longer surfaces a raw JSON blob; status-based fallback for non-envelope JSON.

## Security / observability
- **`UserTokenProvider`** logs swallowed token-mint failures (still fails closed; no token material logged).
- **`isAuthError`** detects 401 via typed `RequestError.status` first (codebase pattern), regex only as fallback.
- **Halo proxy route tests added** — the security-critical route had **none**. Covers allowlist → 404, GET-only → 405, token precedence (session → owner-via-`gamertag` → bot, failing closed, **and session-wins-when-both-present**), gamertag-stripped (caller-independent) cache key, only-200s-cached, per-op `Cache-Control`.

## AGENTS.md / consistency
- Unified the series sort+collapse into one shared helper on date-fns `compareAsc` (`computeSeriesTeamWins` reuses `collapseSequentialSeriesEntries`), removing duplicated logic + the unstable `isBefore`-on-ties comparator; `toViewState` sorts via `compareAsc`.
- Test cleanups: `/view` omits owner-internal fields, UTP logs-on-failure, dialog overlay-click `expect.assertions`, typed-`RequestError`-401 + idle-reconcile + steady-state-no-broadcast tests.

## Consciously deferred (documented, not silently dropped)
- `/view` + `/ws` are intentionally unauthenticated public capability-URLs keyed by a `crypto.randomUUID` `trackerId`.
- `matchIds`/`discoveredMatches` growth is bounded in practice by the idle-timeout; summaries are small.
- The proxy's caller-independent shared cache is by-design for arg-determined read ops (the IT viewer uses immutable `getMatchStats`) — flagged for future consideration if privacy-scoped ops are ever cached.
- `error as Error` in route catch blocks is the repo-wide convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)