### PR TITLE
feat(pages): public viewer service + render-model for the individual tracker (F1-1)

### DIFF
--- a/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+  aFakeTrackerMatchSummaryWith,
+  aFakeTrackerSeriesGroupWith,
+  aFakeTrackerViewStateWith,
+} from "../../../../services/individual-tracker/fakes/view.fake";
+import { buildViewerRenderModel } from "../viewer-render-model";
+
+const TEAM_DEFAULT_HEX = "#FE3939";
+const ENEMY_DEFAULT_HEX = "#3B9DFF";
+
+describe("buildViewerRenderModel", () => {
+  it("emits standalone match items in order with accumulated stats", () => {
+    const view = aFakeTrackerViewStateWith({
+      matches: [
+        aFakeTrackerMatchSummaryWith({ matchId: "m1", outcome: "Win" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m2", outcome: "Loss" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m3", outcome: "Tie" }),
+      ],
+    });
+
+    const model = buildViewerRenderModel({ view });
+
+    expect(model.timeline).toHaveLength(3);
+    expect(model.timeline.map((item) => (item.type === "match" ? item.match.matchId : item.series.id))).toEqual([
+      "m1",
+      "m2",
+      "m3",
+    ]);
+    expect(model.accumulated).toEqual({ total: 3, wins: 1, losses: 1, ties: 1 });
+  });
+
+  it("emits a series item at the anchor position without duplicating members", () => {
+    expect.assertions(5);
+    const view = aFakeTrackerViewStateWith({
+      matches: [
+        aFakeTrackerMatchSummaryWith({ matchId: "m1" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m2" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m3" }),
+      ],
+      series: [aFakeTrackerSeriesGroupWith({ id: "s1", matchIds: ["m1", "m2"] })],
+    });
+
+    const model = buildViewerRenderModel({ view });
+
+    expect(model.timeline).toHaveLength(2);
+    const [first, second] = model.timeline;
+    if (first.type === "series") {
+      expect(first.series.id).toBe("s1");
+      expect(first.series.matches.map((m) => m.matchId)).toEqual(["m1", "m2"]);
+      expect(first.series.colorHex).toBeUndefined();
+    }
+    if (second.type === "match") {
+      expect(second.match.matchId).toBe("m3");
+    }
+  });
+
+  it("preserves series member order as listed in the series", () => {
+    expect.assertions(1);
+    const view = aFakeTrackerViewStateWith({
+      matches: [aFakeTrackerMatchSummaryWith({ matchId: "m1" }), aFakeTrackerMatchSummaryWith({ matchId: "m2" })],
+      series: [aFakeTrackerSeriesGroupWith({ id: "s1", matchIds: ["m2", "m1"] })],
+    });
+
+    const model = buildViewerRenderModel({ view });
+
+    const [first] = model.timeline;
+    if (first.type === "series") {
+      expect(first.series.matches.map((m) => m.matchId)).toEqual(["m2", "m1"]);
+    }
+  });
+
+  it("interleaves standalone matches and series in chronological order", () => {
+    const view = aFakeTrackerViewStateWith({
+      matches: [
+        aFakeTrackerMatchSummaryWith({ matchId: "m1" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m2" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m3" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m4" }),
+      ],
+      series: [aFakeTrackerSeriesGroupWith({ id: "s1", matchIds: ["m2", "m3"] })],
+    });
+
+    const model = buildViewerRenderModel({ view });
+
+    expect(model.timeline.map((item) => (item.type === "match" ? item.match.matchId : item.series.id))).toEqual([
+      "m1",
+      "s1",
+      "m4",
+    ]);
+  });
+
+  it("maps outcomes to colours: win team, loss enemy, others neutral", () => {
+    expect.assertions(5);
+    const view = aFakeTrackerViewStateWith({
+      matches: [
+        aFakeTrackerMatchSummaryWith({ matchId: "m1", outcome: "Win" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m2", outcome: "Loss" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m3", outcome: "Tie" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m4", outcome: "DNF" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m5", outcome: "Unknown" }),
+      ],
+    });
+
+    const model = buildViewerRenderModel({ view });
+
+    for (const item of model.timeline) {
+      if (item.type === "match") {
+        const expected =
+          item.match.matchId === "m1" ? TEAM_DEFAULT_HEX : item.match.matchId === "m2" ? ENEMY_DEFAULT_HEX : undefined;
+        expect(item.match.colorHex).toBe(expected);
+      }
+    }
+  });
+
+  it("treats an unrecognised outcome string as unknown with no colour", () => {
+    expect.assertions(2);
+    const view = aFakeTrackerViewStateWith({
+      matches: [aFakeTrackerMatchSummaryWith({ matchId: "m1", outcome: "Bananas" })],
+    });
+
+    const model = buildViewerRenderModel({ view });
+
+    const [first] = model.timeline;
+    if (first.type === "match") {
+      expect(first.match.outcome).toBe("unknown");
+      expect(first.match.colorHex).toBeUndefined();
+    }
+  });
+
+  it("falls back to standalone matches when a series references fewer than two known matches", () => {
+    const view = aFakeTrackerViewStateWith({
+      matches: [aFakeTrackerMatchSummaryWith({ matchId: "m1" }), aFakeTrackerMatchSummaryWith({ matchId: "m2" })],
+      series: [aFakeTrackerSeriesGroupWith({ id: "s1", matchIds: ["m1", "missing"] })],
+    });
+
+    const model = buildViewerRenderModel({ view });
+
+    expect(model.timeline.map((item) => (item.type === "match" ? item.match.matchId : item.series.id))).toEqual([
+      "m1",
+      "m2",
+    ]);
+  });
+
+  it("flows custom preferred colour ids into the hexes", () => {
+    expect.assertions(2);
+    const view = aFakeTrackerViewStateWith({
+      matches: [
+        aFakeTrackerMatchSummaryWith({ matchId: "m1", outcome: "Win" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m2", outcome: "Loss" }),
+      ],
+    });
+
+    const model = buildViewerRenderModel({
+      view,
+      preferredTeamColorId: "jade",
+      preferredEnemyColorId: "lime",
+    });
+
+    const [win, loss] = model.timeline;
+    if (win.type === "match") {
+      expect(win.match.colorHex).toBe("#8AFFBE");
+    }
+    if (loss.type === "match") {
+      expect(loss.match.colorHex).toBe("#8FED23");
+    }
+  });
+});

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -1,0 +1,44 @@
+import type { TrackerStatus } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+
+export type ViewerTabOutcome = "win" | "loss" | "tie" | "dnf" | "unknown";
+
+export interface ViewerMatchTab {
+  readonly matchId: string;
+  readonly mapName: string;
+  readonly gameVariantCategory: number;
+  readonly outcome: ViewerTabOutcome;
+  readonly score: string;
+  readonly colorHex: string | undefined;
+  readonly startTime: string;
+  readonly endTime: string;
+}
+
+export interface ViewerSeriesTab {
+  readonly id: string;
+  readonly title: string;
+  readonly subtitle: string;
+  readonly score: string;
+  readonly matches: readonly ViewerMatchTab[];
+  readonly colorHex: string | undefined;
+}
+
+export type ViewerTimelineItem =
+  | { readonly type: "match"; readonly match: ViewerMatchTab }
+  | { readonly type: "series"; readonly series: ViewerSeriesTab };
+
+export interface ViewerAccumulatedStats {
+  readonly total: number;
+  readonly wins: number;
+  readonly losses: number;
+  readonly ties: number;
+}
+
+export interface IndividualTrackerViewerRenderModel {
+  readonly trackerId: string;
+  readonly gamertag: string;
+  readonly status: TrackerStatus;
+  readonly isLive: boolean;
+  readonly lastUpdateTime: string;
+  readonly timeline: readonly ViewerTimelineItem[];
+  readonly accumulated: ViewerAccumulatedStats;
+}

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -1,0 +1,175 @@
+import type {
+  TrackerMatchSummary,
+  TrackerSeriesGroup,
+  TrackerViewState,
+} from "@guilty-spark/shared/contracts/individual-tracker/view";
+import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import { getTeamColorOrDefault } from "../../team-colors/team-colors";
+import type {
+  IndividualTrackerViewerRenderModel,
+  ViewerAccumulatedStats,
+  ViewerMatchTab,
+  ViewerSeriesTab,
+  ViewerTabOutcome,
+  ViewerTimelineItem,
+} from "./types";
+
+export interface BuildViewerRenderModelOptions {
+  readonly view: TrackerViewState;
+  readonly preferredTeamColorId?: string;
+  readonly preferredEnemyColorId?: string;
+}
+
+function normalizeOutcome(outcome: string): ViewerTabOutcome {
+  if (outcome === "Win") {
+    return "win";
+  }
+  if (outcome === "Loss") {
+    return "loss";
+  }
+  if (outcome === "Tie") {
+    return "tie";
+  }
+  if (outcome === "DNF") {
+    return "dnf";
+  }
+  return "unknown";
+}
+
+function colorForOutcome(outcome: ViewerTabOutcome, teamHex: string, enemyHex: string): string | undefined {
+  switch (outcome) {
+    case "win": {
+      return teamHex;
+    }
+    case "loss": {
+      return enemyHex;
+    }
+    case "tie":
+    case "dnf":
+    case "unknown": {
+      return undefined;
+    }
+    default: {
+      throw new UnreachableError(outcome);
+    }
+  }
+}
+
+function toMatchTab(summary: TrackerMatchSummary, teamHex: string, enemyHex: string): ViewerMatchTab {
+  const outcome = normalizeOutcome(summary.outcome);
+  return {
+    matchId: summary.matchId,
+    mapName: summary.mapName,
+    gameVariantCategory: summary.gameVariantCategory,
+    outcome,
+    score: summary.score,
+    colorHex: colorForOutcome(outcome, teamHex, enemyHex),
+    startTime: summary.startTime,
+    endTime: summary.endTime,
+  };
+}
+
+function accumulate(matches: readonly TrackerMatchSummary[]): ViewerAccumulatedStats {
+  let wins = 0;
+  let losses = 0;
+  let ties = 0;
+  for (const match of matches) {
+    const outcome = normalizeOutcome(match.outcome);
+    switch (outcome) {
+      case "win": {
+        wins += 1;
+        break;
+      }
+      case "loss": {
+        losses += 1;
+        break;
+      }
+      case "tie": {
+        ties += 1;
+        break;
+      }
+      case "dnf":
+      case "unknown": {
+        break;
+      }
+      default: {
+        throw new UnreachableError(outcome);
+      }
+    }
+  }
+
+  return {
+    total: matches.length,
+    wins,
+    losses,
+    ties,
+  };
+}
+
+export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): IndividualTrackerViewerRenderModel {
+  const { view, preferredTeamColorId, preferredEnemyColorId } = options;
+
+  const teamHex = getTeamColorOrDefault(preferredTeamColorId, 0).hex;
+  const enemyHex = getTeamColorOrDefault(preferredEnemyColorId, 1).hex;
+
+  const matchesById = new Map<string, TrackerMatchSummary>();
+  for (const match of view.matches) {
+    matchesById.set(match.matchId, match);
+  }
+
+  const seriesByAnchor = new Map<string, TrackerSeriesGroup>();
+  const seriesMemberIds = new Set<string>();
+  for (const series of view.series) {
+    const knownIds = series.matchIds.filter((id) => matchesById.has(id));
+    if (knownIds.length < 2) {
+      continue;
+    }
+    const [anchorId] = series.matchIds;
+    seriesByAnchor.set(anchorId, series);
+    for (const id of series.matchIds) {
+      seriesMemberIds.add(id);
+    }
+  }
+
+  const timeline: ViewerTimelineItem[] = [];
+  for (const match of view.matches) {
+    const anchoredSeries = seriesByAnchor.get(match.matchId);
+    if (anchoredSeries !== undefined) {
+      const seriesMatches: ViewerMatchTab[] = [];
+      for (const id of anchoredSeries.matchIds) {
+        const member = matchesById.get(id);
+        if (member !== undefined) {
+          seriesMatches.push(toMatchTab(member, teamHex, enemyHex));
+        }
+      }
+      const series: ViewerSeriesTab = {
+        id: anchoredSeries.id,
+        title: anchoredSeries.title,
+        subtitle: anchoredSeries.subtitle,
+        score: anchoredSeries.score,
+        matches: seriesMatches,
+        colorHex: undefined,
+      };
+      timeline.push({ type: "series", series });
+      continue;
+    }
+
+    if (seriesMemberIds.has(match.matchId)) {
+      continue;
+    }
+
+    timeline.push({ type: "match", match: toMatchTab(match, teamHex, enemyHex) });
+  }
+
+  const accumulated = accumulate(view.matches);
+
+  return {
+    trackerId: view.trackerId,
+    gamertag: view.gamertag,
+    status: view.status,
+    isLive: view.isLive,
+    lastUpdateTime: view.lastUpdateTime,
+    timeline,
+    accumulated,
+  };
+}

--- a/pages/src/services/individual-tracker/fakes/view.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/view.fake.ts
@@ -1,0 +1,175 @@
+import type {
+  TrackerLiveView,
+  TrackerMatchSummary,
+  TrackerSeriesGroup,
+  TrackerViewResponse,
+  TrackerViewState,
+} from "@guilty-spark/shared/contracts/individual-tracker/view";
+import type {
+  IndividualTrackerViewService,
+  TrackerViewConnection,
+  TrackerViewConnectionStatus,
+  TrackerViewListener,
+  TrackerViewStatusListener,
+  TrackerViewSubscription,
+} from "../view-types";
+
+interface FakeMatchOverrides {
+  readonly matchId?: string;
+  readonly startTime?: string;
+  readonly endTime?: string;
+  readonly mapAssetId?: string;
+  readonly mapVersionId?: string;
+  readonly mapName?: string;
+  readonly modeAssetId?: string;
+  readonly gameVariantCategory?: number;
+  readonly outcome?: string;
+  readonly score?: string;
+}
+
+export function aFakeTrackerMatchSummaryWith(overrides: FakeMatchOverrides = {}): TrackerMatchSummary {
+  return {
+    matchId: overrides.matchId ?? "match-1",
+    startTime: overrides.startTime ?? "2100-01-01T00:00:00.000Z",
+    endTime: overrides.endTime ?? "2100-01-01T00:10:00.000Z",
+    mapAssetId: overrides.mapAssetId ?? "map-asset-1",
+    mapVersionId: overrides.mapVersionId ?? "map-version-1",
+    mapName: overrides.mapName ?? "Live Fire",
+    modeAssetId: overrides.modeAssetId ?? "mode-asset-1",
+    gameVariantCategory: overrides.gameVariantCategory ?? 6,
+    outcome: overrides.outcome ?? "Win",
+    score: overrides.score ?? "50:42",
+  };
+}
+
+interface FakeSeriesOverrides {
+  readonly id?: string;
+  readonly matchIds?: readonly string[];
+  readonly score?: string;
+  readonly title?: string;
+  readonly subtitle?: string;
+}
+
+export function aFakeTrackerSeriesGroupWith(overrides: FakeSeriesOverrides = {}): TrackerSeriesGroup {
+  return {
+    id: overrides.id ?? "series-1",
+    matchIds: [...(overrides.matchIds ?? ["match-1", "match-2"])],
+    score: overrides.score ?? "2:1",
+    title: overrides.title ?? "Series",
+    subtitle: overrides.subtitle ?? "Best of 3",
+  };
+}
+
+interface FakeLiveViewOverrides {
+  readonly trackerId?: string;
+  readonly gamertag?: string;
+  readonly status?: TrackerLiveView["status"];
+  readonly matches?: readonly TrackerMatchSummary[];
+  readonly series?: readonly TrackerSeriesGroup[];
+  readonly lastUpdateTime?: string;
+  readonly lastMatchDiscoveredAt?: string | null;
+}
+
+export function aFakeTrackerLiveViewWith(overrides: FakeLiveViewOverrides = {}): TrackerLiveView {
+  return {
+    trackerId: overrides.trackerId ?? "fake-tracker-id",
+    gamertag: overrides.gamertag ?? "Fake Spartan",
+    status: overrides.status ?? "active",
+    matches: [...(overrides.matches ?? [aFakeTrackerMatchSummaryWith()])],
+    series: [...(overrides.series ?? [])],
+    lastUpdateTime: overrides.lastUpdateTime ?? "2100-01-01T00:10:00.000Z",
+    lastMatchDiscoveredAt: overrides.lastMatchDiscoveredAt ?? null,
+  };
+}
+
+interface FakeViewStateOverrides extends FakeLiveViewOverrides {
+  readonly isLive?: boolean;
+}
+
+export function aFakeTrackerViewStateWith(overrides: FakeViewStateOverrides = {}): TrackerViewState {
+  return {
+    ...aFakeTrackerLiveViewWith(overrides),
+    isLive: overrides.isLive ?? true,
+  };
+}
+
+class FakeTrackerViewConnection implements TrackerViewConnection {
+  private readonly listeners = new Set<TrackerViewListener>();
+  private readonly statusListeners = new Set<TrackerViewStatusListener>();
+
+  public subscribe(listener: TrackerViewListener): TrackerViewSubscription {
+    this.listeners.add(listener);
+    return {
+      unsubscribe: (): void => {
+        this.listeners.delete(listener);
+      },
+    };
+  }
+
+  public subscribeStatus(listener: TrackerViewStatusListener): TrackerViewSubscription {
+    this.statusListeners.add(listener);
+    return {
+      unsubscribe: (): void => {
+        this.statusListeners.delete(listener);
+      },
+    };
+  }
+
+  public disconnect(): void {
+    this.listeners.clear();
+    this.statusListeners.clear();
+  }
+
+  public emitStatus(status: TrackerViewConnectionStatus, detail?: string): void {
+    for (const listener of this.statusListeners) {
+      listener(status, detail);
+    }
+  }
+
+  public emitView(view: TrackerLiveView): void {
+    for (const listener of this.listeners) {
+      listener(view);
+    }
+
+    if (view.status === "stopped") {
+      this.emitStatus("stopped");
+      this.disconnect();
+    }
+  }
+}
+
+interface FakeIndividualTrackerViewServiceOptions {
+  readonly view: TrackerViewState;
+}
+
+export class FakeIndividualTrackerViewService implements IndividualTrackerViewService {
+  private readonly view: TrackerViewState;
+  public lastConnection: FakeTrackerViewConnection | null = null;
+
+  public constructor(options?: Partial<FakeIndividualTrackerViewServiceOptions>) {
+    this.view = options?.view ?? aFakeTrackerViewStateWith();
+  }
+
+  public async getView(): Promise<TrackerViewResponse> {
+    await Promise.resolve();
+    return { view: this.view };
+  }
+
+  public connect(): TrackerViewConnection {
+    const connection = new FakeTrackerViewConnection();
+    this.lastConnection = connection;
+    return connection;
+  }
+}
+
+export interface FakeIndividualTrackerViewServiceFactoryOpts {
+  readonly view?: TrackerViewState;
+}
+
+export function aFakeIndividualTrackerViewServiceWith(
+  opts: FakeIndividualTrackerViewServiceFactoryOpts = {},
+): FakeIndividualTrackerViewService {
+  return new FakeIndividualTrackerViewService({
+    ...(opts.view !== undefined ? { view: opts.view } : {}),
+  });
+}

--- a/pages/src/services/individual-tracker/install.ts
+++ b/pages/src/services/individual-tracker/install.ts
@@ -1,6 +1,8 @@
 import { getMode } from "../mode";
 import { RealIndividualTrackerService } from "./individual-tracker";
 import type { IndividualTrackerService } from "./types";
+import { RealIndividualTrackerViewService } from "./view";
+import type { IndividualTrackerViewService } from "./view-types";
 
 export async function installIndividualTrackerService(apiHost: string): Promise<IndividualTrackerService> {
   if (getMode() === "FAKE") {
@@ -10,4 +12,13 @@ export async function installIndividualTrackerService(apiHost: string): Promise<
   }
 
   return new RealIndividualTrackerService({ apiHost });
+}
+
+export async function installIndividualTrackerViewService(apiHost: string): Promise<IndividualTrackerViewService> {
+  if (getMode() === "FAKE") {
+    const { aFakeIndividualTrackerViewServiceWith } = await import("./fakes/view.fake");
+    return aFakeIndividualTrackerViewServiceWith();
+  }
+
+  return new RealIndividualTrackerViewService({ apiHost });
 }

--- a/pages/src/services/individual-tracker/tests/view-connection.test.ts
+++ b/pages/src/services/individual-tracker/tests/view-connection.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TrackerViewListener, TrackerViewStatusListener } from "../view-types";
+import { RealIndividualTrackerViewService } from "../view";
+import { aFakeTrackerLiveViewWith, aFakeTrackerMatchSummaryWith } from "../fakes/view.fake";
+
+class MockWebSocket {
+  public onopen: ((event: Event) => void) | null = null;
+  public onclose: ((event: CloseEvent) => void) | null = null;
+  public onerror: ((event: Event) => void) | null = null;
+  public onmessage: ((event: MessageEvent) => void) | null = null;
+  public readonly url: string;
+  public closed = false;
+
+  public constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  public close(): void {
+    this.closed = true;
+  }
+
+  public static instances: MockWebSocket[] = [];
+
+  public static reset(): void {
+    MockWebSocket.instances = [];
+  }
+}
+
+function viewMessageData(view: ReturnType<typeof aFakeTrackerLiveViewWith>): string {
+  return JSON.stringify({ type: "view", view });
+}
+
+describe("RealIndividualTrackerViewService.connect", () => {
+  let originalWebSocket: typeof WebSocket;
+
+  beforeEach(() => {
+    originalWebSocket = global.WebSocket;
+    global.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+    MockWebSocket.reset();
+  });
+
+  afterEach(() => {
+    global.WebSocket = originalWebSocket;
+  });
+
+  it("derives a wss URL from an https host", () => {
+    const service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+
+    service.connect("tracker 1");
+
+    expect(MockWebSocket.instances[0]?.url).toBe("wss://api.example.com/api/individual-tracker/tracker%201/ws");
+  });
+
+  it("derives a ws URL from an http host", () => {
+    const service = new RealIndividualTrackerViewService({ apiHost: "http://localhost:8787" });
+
+    service.connect("tracker-2");
+
+    expect(MockWebSocket.instances[0]?.url).toBe("ws://localhost:8787/api/individual-tracker/tracker-2/ws");
+  });
+
+  it("emits connected when the socket opens", () => {
+    const service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+    const statusListener = vi.fn<TrackerViewStatusListener>();
+
+    const connection = service.connect("tracker-1");
+    connection.subscribeStatus(statusListener);
+
+    expect(statusListener).not.toHaveBeenCalled();
+
+    const [ws] = MockWebSocket.instances;
+    ws.onopen?.(new Event("open"));
+
+    expect(statusListener).toHaveBeenCalledWith("connected", undefined);
+  });
+
+  it("emits the view to subscribers on a valid message", () => {
+    const service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+    const view = aFakeTrackerLiveViewWith({ matches: [aFakeTrackerMatchSummaryWith()] });
+    const listener = vi.fn<TrackerViewListener>();
+
+    const connection = service.connect("tracker-1");
+    connection.subscribe(listener);
+
+    const [ws] = MockWebSocket.instances;
+    ws.onmessage?.(new MessageEvent("message", { data: viewMessageData(view) }));
+
+    expect(listener).toHaveBeenCalledWith(view);
+  });
+
+  it("ignores messages that fail contract validation", () => {
+    const service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+    const listener = vi.fn<TrackerViewListener>();
+
+    const connection = service.connect("tracker-1");
+    connection.subscribe(listener);
+
+    const [ws] = MockWebSocket.instances;
+    ws.onmessage?.(new MessageEvent("message", { data: JSON.stringify({ type: "view", view: { bogus: true } }) }));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("emits the stopped status and closes the socket on a stopped view", () => {
+    const service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+    const view = aFakeTrackerLiveViewWith({ status: "stopped" });
+    const listener = vi.fn<TrackerViewListener>();
+    const statusListener = vi.fn<TrackerViewStatusListener>();
+
+    const connection = service.connect("tracker-1");
+    connection.subscribe(listener);
+    connection.subscribeStatus(statusListener);
+
+    const [ws] = MockWebSocket.instances;
+    ws.onmessage?.(new MessageEvent("message", { data: viewMessageData(view) }));
+
+    expect(listener).toHaveBeenCalledWith(view);
+    expect(statusListener).toHaveBeenCalledWith("stopped", undefined);
+    expect(ws.closed).toBe(true);
+  });
+
+  it("stops delivering views after a stopped view disconnects the connection", () => {
+    const service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+    const listener = vi.fn<TrackerViewListener>();
+
+    const connection = service.connect("tracker-1");
+    connection.subscribe(listener);
+
+    const [ws] = MockWebSocket.instances;
+    ws.onmessage?.(
+      new MessageEvent("message", { data: viewMessageData(aFakeTrackerLiveViewWith({ status: "stopped" })) }),
+    );
+    listener.mockClear();
+
+    ws.onmessage?.(
+      new MessageEvent("message", { data: viewMessageData(aFakeTrackerLiveViewWith({ status: "active" })) }),
+    );
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("emits stopped when the socket closes with the stopped reason", () => {
+    const service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+    const statusListener = vi.fn<TrackerViewStatusListener>();
+
+    const connection = service.connect("tracker-1");
+    connection.subscribeStatus(statusListener);
+
+    const [ws] = MockWebSocket.instances;
+    ws.onclose?.(new CloseEvent("close", { code: 1000, reason: "Tracker stopped" }));
+
+    expect(statusListener).toHaveBeenCalledWith("stopped", undefined);
+  });
+
+  it("emits disconnected when the socket closes normally", () => {
+    const service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+    const statusListener = vi.fn<TrackerViewStatusListener>();
+
+    const connection = service.connect("tracker-1");
+    connection.subscribeStatus(statusListener);
+
+    const [ws] = MockWebSocket.instances;
+    ws.onclose?.(new CloseEvent("close", { code: 1000 }));
+
+    expect(statusListener).toHaveBeenCalledWith("disconnected", undefined);
+  });
+
+  it("emits error with the reason when the socket closes abnormally", () => {
+    const service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+    const statusListener = vi.fn<TrackerViewStatusListener>();
+
+    const connection = service.connect("tracker-1");
+    connection.subscribeStatus(statusListener);
+
+    const [ws] = MockWebSocket.instances;
+    ws.onclose?.(new CloseEvent("close", { code: 1006, reason: "Connection lost" }));
+
+    expect(statusListener).toHaveBeenCalledWith("error", "Connection lost");
+  });
+
+  it("emits error when the socket errors", () => {
+    const service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+    const statusListener = vi.fn<TrackerViewStatusListener>();
+
+    const connection = service.connect("tracker-1");
+    connection.subscribeStatus(statusListener);
+
+    const [ws] = MockWebSocket.instances;
+    ws.onerror?.(new Event("error"));
+
+    expect(statusListener).toHaveBeenCalledWith("error", undefined);
+  });
+
+  it("stops delivering views to an unsubscribed listener", () => {
+    const service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+    const listener = vi.fn<TrackerViewListener>();
+
+    const connection = service.connect("tracker-1");
+    const subscription = connection.subscribe(listener);
+    subscription.unsubscribe();
+
+    const [ws] = MockWebSocket.instances;
+    ws.onmessage?.(new MessageEvent("message", { data: viewMessageData(aFakeTrackerLiveViewWith()) }));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("closes the socket on disconnect", () => {
+    const service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+
+    const connection = service.connect("tracker-1");
+    const [ws] = MockWebSocket.instances;
+
+    connection.disconnect();
+
+    expect(ws.closed).toBe(true);
+  });
+
+  it("closes the socket when the browser goes offline", () => {
+    const service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+
+    service.connect("tracker-1");
+    const [ws] = MockWebSocket.instances;
+
+    window.dispatchEvent(new Event("offline"));
+
+    expect(ws.closed).toBe(true);
+  });
+
+  it("stops closing the socket on offline once disconnected", () => {
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+    const service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+
+    const connection = service.connect("tracker-1");
+    connection.disconnect();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith("offline", expect.any(Function));
+    removeEventListenerSpy.mockRestore();
+  });
+});

--- a/pages/src/services/individual-tracker/tests/view.test.ts
+++ b/pages/src/services/individual-tracker/tests/view.test.ts
@@ -1,0 +1,63 @@
+import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { RealIndividualTrackerViewService } from "../view";
+
+function jsonResponse(payload: object, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const FAKE_VIEW: TrackerViewState = {
+  trackerId: "tracker-1",
+  gamertag: "Master Chief",
+  status: "active",
+  matches: [],
+  series: [],
+  lastUpdateTime: "2100-01-01T00:00:00.000Z",
+  lastMatchDiscoveredAt: null,
+  isLive: true,
+};
+
+describe("RealIndividualTrackerViewService", () => {
+  let fetchSpy: MockInstance;
+  let service: RealIndividualTrackerViewService;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    service = new RealIndividualTrackerViewService({ apiHost: "https://api.example.com" });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("gets the view without credentials", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ view: FAKE_VIEW }));
+
+    const result = await service.getView("tracker 1");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/individual-tracker/tracker%201/view",
+      expect.objectContaining({ method: "GET" }),
+    );
+    const [firstCall] = fetchSpy.mock.calls;
+    const [, init] = firstCall;
+    expect(init).not.toHaveProperty("credentials");
+    expect(result).toEqual({ view: FAKE_VIEW });
+  });
+
+  it("throws the error envelope message when the request fails", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ error: "Tracker not found" }, 404));
+
+    await expect(service.getView("tracker-1")).rejects.toThrow("Tracker not found");
+  });
+
+  it("throws a status-based error when the body is empty", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 500 }));
+
+    await expect(service.getView("tracker-1")).rejects.toThrow("Request failed (500)");
+  });
+});

--- a/pages/src/services/individual-tracker/view-connection.ts
+++ b/pages/src/services/individual-tracker/view-connection.ts
@@ -1,0 +1,84 @@
+import type { TrackerViewMessage } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import { trackerViewMessageContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import type {
+  TrackerViewConnection,
+  TrackerViewConnectionStatus,
+  TrackerViewListener,
+  TrackerViewStatusListener,
+  TrackerViewSubscription,
+} from "./view-types";
+
+function tryParseViewMessage(raw: string): TrackerViewMessage | undefined {
+  try {
+    return trackerViewMessageContract.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+export class RealTrackerViewConnection implements TrackerViewConnection {
+  private readonly listeners = new Set<TrackerViewListener>();
+  private readonly statusListeners = new Set<TrackerViewStatusListener>();
+  private ws: WebSocket | null;
+  private readonly onOffline: () => void;
+
+  public constructor(ws: WebSocket) {
+    this.ws = ws;
+    this.onOffline = (): void => {
+      this.ws?.close();
+    };
+    window.addEventListener("offline", this.onOffline);
+  }
+
+  public subscribe(listener: TrackerViewListener): TrackerViewSubscription {
+    this.listeners.add(listener);
+    return {
+      unsubscribe: (): void => {
+        this.listeners.delete(listener);
+      },
+    };
+  }
+
+  public subscribeStatus(listener: TrackerViewStatusListener): TrackerViewSubscription {
+    this.statusListeners.add(listener);
+    return {
+      unsubscribe: (): void => {
+        this.statusListeners.delete(listener);
+      },
+    };
+  }
+
+  public disconnect(): void {
+    window.removeEventListener("offline", this.onOffline);
+
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+
+    this.listeners.clear();
+    this.statusListeners.clear();
+  }
+
+  public handleStatus(status: TrackerViewConnectionStatus, detail?: string): void {
+    for (const listener of this.statusListeners) {
+      listener(status, detail);
+    }
+  }
+
+  public handleRaw(raw: string): void {
+    const message = tryParseViewMessage(raw);
+    if (message === undefined) {
+      return;
+    }
+
+    for (const listener of this.listeners) {
+      listener(message.view);
+    }
+
+    if (message.view.status === "stopped") {
+      this.handleStatus("stopped");
+      this.disconnect();
+    }
+  }
+}

--- a/pages/src/services/individual-tracker/view-types.ts
+++ b/pages/src/services/individual-tracker/view-types.ts
@@ -1,0 +1,28 @@
+import type { TrackerLiveView, TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
+
+export type TrackerViewListener = (view: TrackerLiveView) => void;
+
+export type TrackerViewConnectionStatus =
+  | "connecting"
+  | "connected"
+  | "stopped"
+  | "error"
+  | "disconnected"
+  | "not_found";
+
+export type TrackerViewStatusListener = (status: TrackerViewConnectionStatus, detail?: string) => void;
+
+export interface TrackerViewSubscription {
+  unsubscribe(): void;
+}
+
+export interface TrackerViewConnection {
+  subscribe(listener: TrackerViewListener): TrackerViewSubscription;
+  subscribeStatus(listener: TrackerViewStatusListener): TrackerViewSubscription;
+  disconnect(): void;
+}
+
+export interface IndividualTrackerViewService {
+  getView(trackerId: string): Promise<TrackerViewResponse>;
+  connect(trackerId: string): TrackerViewConnection;
+}

--- a/pages/src/services/individual-tracker/view.ts
+++ b/pages/src/services/individual-tracker/view.ts
@@ -1,95 +1,11 @@
 import { errorContract } from "@guilty-spark/shared/contracts/error";
-import type { TrackerViewMessage, TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
-import {
-  trackerViewContract,
-  trackerViewMessageContract,
-} from "@guilty-spark/shared/contracts/individual-tracker/view";
-import type {
-  IndividualTrackerViewService,
-  TrackerViewConnection,
-  TrackerViewConnectionStatus,
-  TrackerViewListener,
-  TrackerViewStatusListener,
-  TrackerViewSubscription,
-} from "./view-types";
+import type { TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import { trackerViewContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import { RealTrackerViewConnection } from "./view-connection";
+import type { IndividualTrackerViewService, TrackerViewConnection } from "./view-types";
 
 interface IndividualTrackerViewServiceOpts {
   readonly apiHost: string;
-}
-
-function tryParseViewMessage(raw: string): TrackerViewMessage | undefined {
-  try {
-    return trackerViewMessageContract.parse(raw);
-  } catch {
-    return undefined;
-  }
-}
-
-class RealTrackerViewConnection implements TrackerViewConnection {
-  private readonly listeners = new Set<TrackerViewListener>();
-  private readonly statusListeners = new Set<TrackerViewStatusListener>();
-  private ws: WebSocket | null;
-  private readonly onOffline: () => void;
-
-  public constructor(ws: WebSocket) {
-    this.ws = ws;
-    this.onOffline = (): void => {
-      this.ws?.close();
-    };
-    window.addEventListener("offline", this.onOffline);
-  }
-
-  public subscribe(listener: TrackerViewListener): TrackerViewSubscription {
-    this.listeners.add(listener);
-    return {
-      unsubscribe: (): void => {
-        this.listeners.delete(listener);
-      },
-    };
-  }
-
-  public subscribeStatus(listener: TrackerViewStatusListener): TrackerViewSubscription {
-    this.statusListeners.add(listener);
-    return {
-      unsubscribe: (): void => {
-        this.statusListeners.delete(listener);
-      },
-    };
-  }
-
-  public disconnect(): void {
-    window.removeEventListener("offline", this.onOffline);
-
-    if (this.ws) {
-      this.ws.close();
-      this.ws = null;
-    }
-
-    this.listeners.clear();
-    this.statusListeners.clear();
-  }
-
-  public handleStatus(status: TrackerViewConnectionStatus, detail?: string): void {
-    for (const listener of this.statusListeners) {
-      listener(status, detail);
-    }
-  }
-
-  public handleRaw(raw: string): void {
-    const message = tryParseViewMessage(raw);
-    if (message === undefined) {
-      return;
-    }
-
-    for (const listener of this.listeners) {
-      listener(message.view);
-    }
-
-    if (message.view.status === "stopped") {
-      this.handleStatus("stopped");
-      this.disconnect();
-    }
-  }
 }
 
 export class RealIndividualTrackerViewService implements IndividualTrackerViewService {

--- a/pages/src/services/individual-tracker/view.ts
+++ b/pages/src/services/individual-tracker/view.ts
@@ -1,0 +1,180 @@
+import { errorContract } from "@guilty-spark/shared/contracts/error";
+import type { TrackerViewMessage, TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import {
+  trackerViewContract,
+  trackerViewMessageContract,
+} from "@guilty-spark/shared/contracts/individual-tracker/view";
+import type {
+  IndividualTrackerViewService,
+  TrackerViewConnection,
+  TrackerViewConnectionStatus,
+  TrackerViewListener,
+  TrackerViewStatusListener,
+  TrackerViewSubscription,
+} from "./view-types";
+
+interface IndividualTrackerViewServiceOpts {
+  readonly apiHost: string;
+}
+
+function tryParseViewMessage(raw: string): TrackerViewMessage | undefined {
+  try {
+    return trackerViewMessageContract.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+class RealTrackerViewConnection implements TrackerViewConnection {
+  private readonly listeners = new Set<TrackerViewListener>();
+  private readonly statusListeners = new Set<TrackerViewStatusListener>();
+  private ws: WebSocket | null;
+  private readonly onOffline: () => void;
+
+  public constructor(ws: WebSocket) {
+    this.ws = ws;
+    this.onOffline = (): void => {
+      this.ws?.close();
+    };
+    window.addEventListener("offline", this.onOffline);
+  }
+
+  public subscribe(listener: TrackerViewListener): TrackerViewSubscription {
+    this.listeners.add(listener);
+    return {
+      unsubscribe: (): void => {
+        this.listeners.delete(listener);
+      },
+    };
+  }
+
+  public subscribeStatus(listener: TrackerViewStatusListener): TrackerViewSubscription {
+    this.statusListeners.add(listener);
+    return {
+      unsubscribe: (): void => {
+        this.statusListeners.delete(listener);
+      },
+    };
+  }
+
+  public disconnect(): void {
+    window.removeEventListener("offline", this.onOffline);
+
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+
+    this.listeners.clear();
+    this.statusListeners.clear();
+  }
+
+  public handleStatus(status: TrackerViewConnectionStatus, detail?: string): void {
+    for (const listener of this.statusListeners) {
+      listener(status, detail);
+    }
+  }
+
+  public handleRaw(raw: string): void {
+    const message = tryParseViewMessage(raw);
+    if (message === undefined) {
+      return;
+    }
+
+    for (const listener of this.listeners) {
+      listener(message.view);
+    }
+
+    if (message.view.status === "stopped") {
+      this.handleStatus("stopped");
+      this.disconnect();
+    }
+  }
+}
+
+export class RealIndividualTrackerViewService implements IndividualTrackerViewService {
+  private readonly apiHost: string;
+
+  public constructor({ apiHost }: IndividualTrackerViewServiceOpts) {
+    this.apiHost = apiHost;
+  }
+
+  private buildUrl(path: string): string {
+    const baseUrl = this.apiHost.endsWith("/") ? this.apiHost.slice(0, -1) : this.apiHost;
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    return `${baseUrl}${normalizedPath}`;
+  }
+
+  private async readError(response: Response): Promise<Error> {
+    const body = await response.text();
+    if (body !== "") {
+      try {
+        const parsed = errorContract.safeParse(JSON.parse(body));
+        if (parsed.success && parsed.data.error !== "") {
+          return new Error(parsed.data.error);
+        }
+        return new Error(`Request failed (${String(response.status)})`);
+      } catch {
+        return new Error(body);
+      }
+    }
+
+    return new Error(`Request failed (${String(response.status)})`);
+  }
+
+  public async getView(trackerId: string): Promise<TrackerViewResponse> {
+    const response = await fetch(this.buildUrl(`/api/individual-tracker/${encodeURIComponent(trackerId)}/view`), {
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    return trackerViewContract.fromResponse(response);
+  }
+
+  public connect(trackerId: string): TrackerViewConnection {
+    const apiUrl = new URL(this.apiHost);
+    const protocol = apiUrl.protocol === "https:" ? "wss:" : "ws:";
+    const wsUrl = `${protocol}//${apiUrl.host}/api/individual-tracker/${encodeURIComponent(trackerId)}/ws`;
+
+    const ws = new WebSocket(wsUrl);
+    const connection = new RealTrackerViewConnection(ws);
+
+    connection.handleStatus("connecting");
+
+    ws.onopen = (): void => {
+      connection.handleStatus("connected");
+    };
+
+    ws.onmessage = (event: MessageEvent): void => {
+      if (typeof event.data !== "string") {
+        return;
+      }
+
+      connection.handleRaw(event.data);
+    };
+
+    ws.onerror = (ev): void => {
+      console.error("WebSocket error", ev);
+      connection.handleStatus("error");
+    };
+
+    ws.onclose = (event: CloseEvent): void => {
+      if (event.code === 1000 && event.reason === "Tracker stopped") {
+        connection.handleStatus("stopped");
+        return;
+      }
+
+      if (event.code === 1000) {
+        connection.handleStatus("disconnected");
+        return;
+      }
+
+      connection.handleStatus("error", event.reason || undefined);
+    };
+
+    return connection;
+  }
+}


### PR DESCRIPTION
First slice of **F1 — the FE viewer + OBS overlay**. Pure data layer, **no UI** (UI lands in F1-2/F1-3). Builds on the now-complete backend tracking pipeline: the DO computes per-game tab info (outcome / score / mapName / gameVariantCategory / series) server-side and exposes it on the public `/view` REST (#469) + viewer WS (#470). This slice is the FE plumbing that consumes that contract.

## What's here

**Public viewer service** (`pages/src/services/individual-tracker/`)
- `RealIndividualTrackerViewService` — `getView(trackerId)` over `GET /api/individual-tracker/:trackerId/view` and `connect(trackerId)` over the `/ws` WebSocket. **Public/unauthenticated** — sends **no** credentials (the endpoints are capability URLs keyed by the random trackerId). Mirrors the live-tracker connection pattern (subscribe/subscribeStatus/disconnect, `ws(s)://` derivation, message-contract parse guard, auto-stop on a stopped view).
- Fake (`aFakeIndividualTrackerViewServiceWith` + `aFakeTrackerLiveViewWith`/`…MatchSummaryWith`/`…SeriesGroupWith` factories) and `installIndividualTrackerViewService` (FAKE/REAL).

**Render-model** (`pages/src/components/individual-tracker/viewer/`)
- `buildViewerRenderModel` — pure `TrackerViewState → render model`. Walks the server-sorted `matches`, anchors each series at its first member's timeline slot (members render *inside* the series item, never duplicated as standalone), maps per-game `outcome → tab colour` (preferred team hex on win, enemy hex on loss, neutral otherwise — wired to a **default** preferred colour for now; the real streamer-setting lands with A3/E5), and accumulates W/L/T. Game-type icon mapping is intentionally deferred to the UI slice — the numeric `gameVariantCategory` passes straight through.

## Review notes
- Win/loss is conveyed by the tracked player's preferred team **colour** + per-game outcome (agreed UX) — no winning-team field needed.
- Independent review pass run; one finding fixed — the **fake now replicates the real service's stopped-view side effect** (emit `"stopped"` + disconnect) so F1-2's tests can't pass against behaviour the real service doesn't share. The render-model's `<2-known-matches` series guard is defensive: the server always emits series whose members are a subset of `matches`, so a series can't silently vanish.

## Verification
- `npm run typecheck:pages` → 0 errors.
- Full suite `npx vitest run` → **1921 passing** (+11 new).
- eslint + prettier clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)