### PR TITLE
ci(pages): branch-specific preview URLs + drop dead wrangler config

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -43,6 +43,26 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy
 
+      - name: Compute preview alias
+        if: github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'davidhouweling')
+        id: preview-alias
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          # Cloudflare preview-alias URLs are "<alias>-<worker>.<subdomain>.workers.dev";
+          # the leftmost DNS label (alias + "-guilty-spark-web") must be <= 63 chars, so
+          # cap the alias at 40 and reduce the branch to lowercase [a-z0-9-].
+          alias=$(printf '%s' "$HEAD_REF" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+            | cut -c1-40 \
+            | sed -E 's/-+$//')
+          if [ -z "$alias" ]; then
+            alias="pr-${PR_NUMBER}"
+          fi
+          echo "alias=$alias" >> "$GITHUB_OUTPUT"
+
       - name: Deploy Preview (Dependabot only)
         if: github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'davidhouweling')
         id: deploy-preview
@@ -51,7 +71,27 @@ jobs:
           workingDirectory: "pages"
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --env preview
+          # Upload a per-branch preview version (does not touch the production
+          # deployment); --preview-alias gives a stable branch-specific URL.
+          command: versions upload --preview-alias ${{ steps.preview-alias.outputs.alias }}
+
+      - name: Resolve preview URL
+        if: github.event_name == 'pull_request_target' && (github.actor == 'dependabot[bot]' || github.actor == 'davidhouweling')
+        id: preview-url
+        env:
+          WRANGLER_OUTPUT: ${{ steps.deploy-preview.outputs.command-output }}
+          ALIAS: ${{ steps.preview-alias.outputs.alias }}
+        run: |
+          # Prefer the stable branch alias URL; fall back to the per-version preview URL.
+          url=$(printf '%s' "$WRANGLER_OUTPUT" \
+            | grep -oE "https://${ALIAS}-guilty-spark-web\.[a-z0-9-]+\.workers\.dev" \
+            | head -1)
+          if [ -z "$url" ]; then
+            url=$(printf '%s' "$WRANGLER_OUTPUT" \
+              | grep -oE 'https://[a-z0-9.-]+\.workers\.dev' \
+              | head -1)
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
 
       - name: Update GitHub deployment
         if: github.event_name == 'push' || github.actor == 'dependabot[bot]' || github.actor == 'davidhouweling'
@@ -60,6 +100,6 @@ jobs:
         with:
           token: "${{ secrets.DEPLOY_TOKEN }}"
           environment: ${{ github.event_name == 'push' && 'production' || 'preview' }}
-          environment-url: ${{ steps.deploy-production.outputs.deployment-url || steps.deploy-preview.outputs.deployment-url }}
+          environment-url: ${{ steps.deploy-production.outputs.deployment-url || steps.preview-url.outputs.url }}
           initial-status: success
           transient-environment: ${{ github.event_name != 'push' }}

--- a/pages/wrangler.jsonc
+++ b/pages/wrangler.jsonc
@@ -1,13 +1,11 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "guilty-spark-web",
-  "main": "@astrojs/cloudflare/entrypoints/server",
+  // `main` and `assets` are intentionally omitted: the @astrojs/cloudflare adapter
+  // generates them (dist/server/entry.mjs + the dist/client assets dir bound to ASSETS)
+  // into dist/server/wrangler.json and redirects wrangler to that config on deploy.
   "compatibility_date": "2026-05-15",
   "compatibility_flags": ["global_fetch_strictly_public"],
-  "assets": {
-    "directory": "./dist",
-    "binding": "ASSETS",
-  },
   // The @astrojs/cloudflare adapter enables Astro KV sessions and binds them to "SESSION".
   // Declaring the existing namespace by id stops Wrangler from re-provisioning it on every deploy.
   "kv_namespaces": [


### PR DESCRIPTION
Separate fix off main, from the deploy-config review during F1-2.

## 1. Branch-specific preview URLs
The preview step ran `wrangler deploy --env preview`. With `legacy_env: true` and no `[env.preview]` block, that targets a single shared worker `guilty-spark-web-preview` — so **every PR resolves to the same preview URL**, which is the behaviour you flagged.

Switched to **`wrangler versions upload --preview-alias <branch>`**:
- Uploads a per-branch **preview version** of the production worker **without** changing the live (production) deployment.
- `--preview-alias` gives a stable, branch-specific URL: `https://<alias>-guilty-spark-web.<subdomain>.workers.dev`.
- A new **Compute preview alias** step derives a DNS-safe alias from `github.head_ref` (lowercase, `[a-z0-9-]`, capped at 40 chars so the `<alias>-guilty-spark-web` label stays ≤ 63), falling back to `pr-<number>`.
- A **Resolve preview URL** step parses the alias URL from wrangler's output (falling back to the per-version preview URL) and feeds it to the GitHub deployment, so the deployment links straight to the branch preview.

Gating is unchanged (Dependabot / davidhouweling on `pull_request_target`).

## 2. Drop dead `main`/`assets` from `pages/wrangler.jsonc`
The `@astrojs/cloudflare` adapter reads `pages/wrangler.jsonc` as the *source*, then generates `dist/server/wrangler.json` (with `main: entry.mjs` + `assets: {directory: ../client, binding: ASSETS}`) and writes a `.wrangler/deploy/config.json` **redirect** that `wrangler deploy`/`versions upload` automatically use. So the hand-written `main: "@astrojs/cloudflare/entrypoints/server"` and `assets.directory: "./dist"` were **overridden and misleading**. Removed them (kept name / compat / SESSION KV / observability / source-maps). Verified the adapter still emits `main`, the `ASSETS` binding, and `dist/client` after removal (dry-run reads the 262 client files and binds SESSION + ASSETS).

## ⚠️ Prerequisite (Cloudflare dashboard)
`--preview-alias` needs the **`guilty-spark-web` worker to have Preview URLs enabled** (Workers → the worker → Settings → enable preview URLs) and a workers.dev subdomain. If that's off, the upload step will error. Also: the old shared `guilty-spark-web-preview` worker is now orphaned and can be deleted.

## ⚠️ This change can't self-test on its own PR
`pull_request_target` runs the workflow definition from the **base branch (main)**, not from the PR — so #480's own CI still uses the old `deploy --env preview`. The new preview behaviour first runs on the **next** PR after this merges.

## Validation (local)
- `wrangler deploy --dry-run` and `wrangler versions upload --dry-run --preview-alias …` both bundle cleanly via the adapter's redirected config (assets from `dist/client`, SESSION/ASSETS/IMAGES bound).
- Workflow YAML parses; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)