### PR TITLE
feat(pages): click-through stats panel for the individual tracker viewer (F1-3a)

### DIFF
--- a/pages/src/apps/individual-tracker-viewer/create.tsx
+++ b/pages/src/apps/individual-tracker-viewer/create.tsx
@@ -59,6 +59,7 @@ export function IndividualTrackerViewerApp({ apiHost, trackerId }: IndividualTra
         services ? (
           <IndividualTrackerViewerPage
             individualTrackerViewService={services.individualTrackerViewService}
+            haloClient={services.haloClient}
             trackerId={trackerId}
           />
         ) : (

--- a/pages/src/apps/individual-tracker-viewer/services.ts
+++ b/pages/src/apps/individual-tracker-viewer/services.ts
@@ -1,11 +1,15 @@
+import type { HaloInfiniteClient } from "halo-infinite-api";
+import { createHaloInfiniteClientProxy } from "@guilty-spark/shared/halo/halo-infinite-client-proxy";
 import { installIndividualTrackerViewService } from "../../services/individual-tracker/install";
 import type { IndividualTrackerViewService } from "../../services/individual-tracker/view-types";
 
 export interface Services {
   readonly individualTrackerViewService: IndividualTrackerViewService;
+  readonly haloClient: HaloInfiniteClient;
 }
 
 export async function installServices(apiHost: string): Promise<Services> {
   const individualTrackerViewService = await installIndividualTrackerViewService(apiHost);
-  return { individualTrackerViewService };
+  const haloClient = createHaloInfiniteClientProxy({ proxyBaseUrl: apiHost, credentials: "include" });
+  return { individualTrackerViewService, haloClient };
 }

--- a/pages/src/components/individual-tracker/viewer/create.tsx
+++ b/pages/src/components/individual-tracker/viewer/create.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useSyncExternalStore } from "react";
+import type { HaloInfiniteClient } from "halo-infinite-api";
 import { ComponentLoader } from "../../component-loader/component-loader";
 import { ErrorState } from "../../error-state/error-state";
 import { LoadingState } from "../../loading-state/loading-state";
@@ -9,18 +10,20 @@ import { IndividualTrackerViewerStore } from "./viewer-store";
 
 interface IndividualTrackerViewerPageProps {
   readonly individualTrackerViewService: IndividualTrackerViewService;
+  readonly haloClient: HaloInfiniteClient;
   readonly trackerId: string;
 }
 
 export function IndividualTrackerViewerPage({
   individualTrackerViewService,
+  haloClient,
   trackerId,
 }: IndividualTrackerViewerPageProps): React.ReactElement {
   const store = useMemo(() => new IndividualTrackerViewerStore(), []);
 
   const presenter = useMemo(() => {
-    return new IndividualTrackerViewerPresenter({ individualTrackerViewService, store, trackerId });
-  }, [individualTrackerViewService, store, trackerId]);
+    return new IndividualTrackerViewerPresenter({ individualTrackerViewService, haloClient, store, trackerId });
+  }, [individualTrackerViewService, haloClient, store, trackerId]);
 
   useEffect(() => {
     presenter.start();
@@ -52,7 +55,18 @@ export function IndividualTrackerViewerPage({
       }
       loaded={
         model.renderModel != null ? (
-          <IndividualTrackerViewer renderModel={model.renderModel} connectionStatus={model.connectionStatus} />
+          <IndividualTrackerViewer
+            renderModel={model.renderModel}
+            connectionStatus={model.connectionStatus}
+            selectedMatchId={model.selectedMatchId}
+            matchStatsState={model.matchStatsState}
+            onSelectMatch={(matchId) => {
+              presenter.selectMatch(matchId);
+            }}
+            onDeselect={() => {
+              presenter.deselectMatch();
+            }}
+          />
         ) : (
           <LoadingState />
         )

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
@@ -6,12 +6,18 @@ import { Container } from "../../container/container";
 import type { TrackerViewConnectionStatus } from "../../../services/individual-tracker/view-types";
 import { relativeTime, Timeline } from "../timeline/timeline";
 import type { IndividualTrackerViewerRenderModel } from "./types";
+import type { MatchStatsState } from "./viewer-store";
 import { TabsBar } from "./viewer-tabs";
+import { StatsPanel } from "./stats-panel";
 import styles from "./individual-tracker-viewer.module.css";
 
 interface IndividualTrackerViewerProps {
   readonly renderModel: IndividualTrackerViewerRenderModel;
   readonly connectionStatus: TrackerViewConnectionStatus;
+  readonly selectedMatchId: string | null;
+  readonly matchStatsState: MatchStatsState | null;
+  readonly onSelectMatch: (matchId: string) => void;
+  readonly onDeselect: () => void;
 }
 
 function statusLabel(status: TrackerStatus): string {
@@ -66,6 +72,10 @@ function recordText(renderModel: IndividualTrackerViewerRenderModel): string {
 export function IndividualTrackerViewer({
   renderModel,
   connectionStatus,
+  selectedMatchId,
+  matchStatsState,
+  onSelectMatch,
+  onDeselect,
 }: IndividualTrackerViewerProps): React.ReactElement {
   const notice = connectionNotice(connectionStatus);
 
@@ -101,7 +111,14 @@ export function IndividualTrackerViewer({
         </p>
       )}
 
-      <TabsBar timeline={renderModel.timeline} />
+      <TabsBar
+        timeline={renderModel.timeline}
+        selectedMatchId={selectedMatchId}
+        onSelectMatch={onSelectMatch}
+        onDeselect={onDeselect}
+      />
+
+      <StatsPanel state={matchStatsState} />
 
       <Timeline timeline={renderModel.timeline} />
     </Container>

--- a/pages/src/components/individual-tracker/viewer/stats-panel.module.css
+++ b/pages/src/components/individual-tracker/viewer/stats-panel.module.css
@@ -1,0 +1,3 @@
+.wrapper {
+  margin-bottom: var(--space-6);
+}

--- a/pages/src/components/individual-tracker/viewer/stats-panel.tsx
+++ b/pages/src/components/individual-tracker/viewer/stats-panel.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
+import { Alert } from "../../alert/alert";
+import { LoadingState } from "../../loading-state/loading-state";
+import { createMatchStatsPresenter } from "../../stats/create";
+import { MatchStats } from "../../stats/match-stats";
+import type { MatchStatsData } from "../../stats/types";
+import { gameModeIconSrc } from "../game-mode-icon";
+import type { IndividualTrackerViewerViewModel } from "./types";
+import styles from "./stats-panel.module.css";
+
+interface StatsPanelProps {
+  readonly state: IndividualTrackerViewerViewModel["matchStatsState"];
+}
+
+export function StatsPanel({ state }: StatsPanelProps): React.ReactElement | null {
+  if (state == null) {
+    return null;
+  }
+
+  switch (state.status) {
+    case "loading": {
+      return (
+        <div className={styles.wrapper}>
+          <LoadingState />
+        </div>
+      );
+    }
+    case "error": {
+      return (
+        <div className={styles.wrapper}>
+          <Alert variant="error">{state.message}</Alert>
+        </div>
+      );
+    }
+    case "loaded": {
+      const { stats } = state;
+      const presenter = createMatchStatsPresenter(stats.MatchInfo.GameVariantCategory);
+      const playerMap = new Map(stats.Players.map((p) => [getPlayerXuid(p), getPlayerXuid(p)]));
+      const data: MatchStatsData[] = presenter.getData(stats, playerMap, {});
+
+      return (
+        <div className={styles.wrapper}>
+          <MatchStats
+            data={data}
+            id={stats.MatchId}
+            backgroundImageUrl=""
+            gameModeIconUrl={gameModeIconSrc(stats.MatchInfo.GameVariantCategory)}
+            gameModeAlt=""
+            matchNumber={1}
+            gameTypeAndMap=""
+            duration={stats.MatchInfo.Duration}
+            score=""
+            startTime={stats.MatchInfo.StartTime}
+            endTime={stats.MatchInfo.EndTime}
+          />
+        </div>
+      );
+    }
+    default: {
+      throw new UnreachableError(state);
+    }
+  }
+}

--- a/pages/src/components/individual-tracker/viewer/stats-panel.tsx
+++ b/pages/src/components/individual-tracker/viewer/stats-panel.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useMemo } from "react";
+import type { MatchStats as MatchStatsType } from "halo-infinite-api";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
 import { Alert } from "../../alert/alert";
@@ -9,6 +10,32 @@ import type { MatchStatsData } from "../../stats/types";
 import { gameModeIconSrc } from "../game-mode-icon";
 import type { IndividualTrackerViewerViewModel } from "./types";
 import styles from "./stats-panel.module.css";
+
+function LoadedStatsPanel({ stats }: { readonly stats: MatchStatsType }): React.ReactElement {
+  const data = useMemo<MatchStatsData[]>(() => {
+    const presenter = createMatchStatsPresenter(stats.MatchInfo.GameVariantCategory);
+    const playerMap = new Map(stats.Players.map((p) => [getPlayerXuid(p), getPlayerXuid(p)]));
+    return presenter.getData(stats, playerMap, {});
+  }, [stats]);
+
+  return (
+    <div className={styles.wrapper}>
+      <MatchStats
+        data={data}
+        id={stats.MatchId}
+        backgroundImageUrl=""
+        gameModeIconUrl={gameModeIconSrc(stats.MatchInfo.GameVariantCategory)}
+        gameModeAlt=""
+        matchNumber={1}
+        gameTypeAndMap=""
+        duration={stats.MatchInfo.Duration}
+        score=""
+        startTime={stats.MatchInfo.StartTime}
+        endTime={stats.MatchInfo.EndTime}
+      />
+    </div>
+  );
+}
 
 interface StatsPanelProps {
   readonly state: IndividualTrackerViewerViewModel["matchStatsState"];
@@ -35,28 +62,7 @@ export function StatsPanel({ state }: StatsPanelProps): React.ReactElement | nul
       );
     }
     case "loaded": {
-      const { stats } = state;
-      const presenter = createMatchStatsPresenter(stats.MatchInfo.GameVariantCategory);
-      const playerMap = new Map(stats.Players.map((p) => [getPlayerXuid(p), getPlayerXuid(p)]));
-      const data: MatchStatsData[] = presenter.getData(stats, playerMap, {});
-
-      return (
-        <div className={styles.wrapper}>
-          <MatchStats
-            data={data}
-            id={stats.MatchId}
-            backgroundImageUrl=""
-            gameModeIconUrl={gameModeIconSrc(stats.MatchInfo.GameVariantCategory)}
-            gameModeAlt=""
-            matchNumber={1}
-            gameTypeAndMap=""
-            duration={stats.MatchInfo.Duration}
-            score=""
-            startTime={stats.MatchInfo.StartTime}
-            endTime={stats.MatchInfo.EndTime}
-          />
-        </div>
-      );
+      return <LoadedStatsPanel stats={state.stats} />;
     }
     default: {
       throw new UnreachableError(state);

--- a/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
@@ -30,7 +30,16 @@ describe("IndividualTrackerViewer", () => {
       ],
     });
 
-    render(<IndividualTrackerViewer renderModel={aModel(view)} connectionStatus="connected" />);
+    render(
+      <IndividualTrackerViewer
+        renderModel={aModel(view)}
+        connectionStatus="connected"
+        selectedMatchId={null}
+        matchStatsState={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
 
     expect(screen.getByText("Spartan One")).toBeInTheDocument();
     expect(screen.getByTestId("record")).toHaveTextContent("1:1");
@@ -41,7 +50,16 @@ describe("IndividualTrackerViewer", () => {
       matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1", mapName: "Aquarius", score: "50:30" })],
     });
 
-    render(<IndividualTrackerViewer renderModel={aModel(view)} connectionStatus="connected" />);
+    render(
+      <IndividualTrackerViewer
+        renderModel={aModel(view)}
+        connectionStatus="connected"
+        selectedMatchId={null}
+        matchStatsState={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
 
     const card = screen.getByTestId("match-card");
     expect(card).toHaveTextContent("Aquarius");
@@ -54,7 +72,16 @@ describe("IndividualTrackerViewer", () => {
       series: [aFakeTrackerSeriesGroupWith({ matchIds: ["m-1", "m-2"], title: "Ranked Series", score: "1:1" })],
     });
 
-    render(<IndividualTrackerViewer renderModel={aModel(view)} connectionStatus="connected" />);
+    render(
+      <IndividualTrackerViewer
+        renderModel={aModel(view)}
+        connectionStatus="connected"
+        selectedMatchId={null}
+        matchStatsState={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
 
     const card = screen.getByTestId("series-card");
     expect(card).toHaveTextContent("Ranked Series");
@@ -65,7 +92,16 @@ describe("IndividualTrackerViewer", () => {
   it("renders a Live badge when the tracker is live", () => {
     const view = aFakeTrackerViewStateWith({ isLive: true });
 
-    render(<IndividualTrackerViewer renderModel={aModel(view)} connectionStatus="connected" />);
+    render(
+      <IndividualTrackerViewer
+        renderModel={aModel(view)}
+        connectionStatus="connected"
+        selectedMatchId={null}
+        matchStatsState={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
 
     expect(screen.getByText("Live")).toBeInTheDocument();
   });
@@ -73,7 +109,16 @@ describe("IndividualTrackerViewer", () => {
   it("renders an empty state when there are no matches", () => {
     const view = aFakeTrackerViewStateWith({ matches: [], series: [] });
 
-    render(<IndividualTrackerViewer renderModel={aModel(view)} connectionStatus="connected" />);
+    render(
+      <IndividualTrackerViewer
+        renderModel={aModel(view)}
+        connectionStatus="connected"
+        selectedMatchId={null}
+        matchStatsState={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
 
     expect(screen.getByText("No matches tracked yet.")).toBeInTheDocument();
   });
@@ -81,7 +126,16 @@ describe("IndividualTrackerViewer", () => {
   it("renders a connection notice for non-connected states", () => {
     const view = aFakeTrackerViewStateWith({ gamertag: "Spartan One" });
 
-    render(<IndividualTrackerViewer renderModel={aModel(view)} connectionStatus="disconnected" />);
+    render(
+      <IndividualTrackerViewer
+        renderModel={aModel(view)}
+        connectionStatus="disconnected"
+        selectedMatchId={null}
+        matchStatsState={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
 
     expect(screen.getByTestId("connection-notice")).toHaveTextContent("Reconnecting...");
   });
@@ -93,7 +147,16 @@ describe("IndividualTrackerViewer", () => {
       matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1", startTime: "not-a-date" })],
     });
 
-    render(<IndividualTrackerViewer renderModel={aModel(view)} connectionStatus="connected" />);
+    render(
+      <IndividualTrackerViewer
+        renderModel={aModel(view)}
+        connectionStatus="connected"
+        selectedMatchId={null}
+        matchStatsState={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
 
     expect(screen.getByText("Spartan One")).toBeInTheDocument();
     expect(screen.getByText("Last updated unknown")).toBeInTheDocument();

--- a/pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx
@@ -1,0 +1,47 @@
+import "@testing-library/jest-dom/vitest";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { aFakeMatchStatsWith } from "../../../stats/fakes/data";
+import { StatsPanel } from "../stats-panel";
+
+vi.mock("../../../icons/team-icon", () => ({
+  TeamIcon: ({ teamId }: { teamId: number }): React.ReactNode => (
+    <div data-testid={`team-icon-${teamId.toString()}`}>Team {teamId.toString()}</div>
+  ),
+}));
+
+vi.mock("../../../icons/medal-icon", () => ({
+  MedalIcon: ({ medalName }: { medalName: string }): React.ReactNode => (
+    <div data-testid={`medal-icon-${medalName}`}>{medalName}</div>
+  ),
+}));
+
+describe("StatsPanel", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing when state is null", () => {
+    const { container } = render(<StatsPanel state={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a loading indicator when status is loading", () => {
+    render(<StatsPanel state={{ status: "loading" }} />);
+    expect(screen.getByText("Establishing Connection...")).toBeInTheDocument();
+  });
+
+  it("renders an alert with the error message when status is error", () => {
+    render(<StatsPanel state={{ status: "error", message: "Match not found" }} />);
+    expect(screen.getByText("Match not found")).toBeInTheDocument();
+  });
+
+  it("renders match stats player table when status is loaded", () => {
+    const stats = aFakeMatchStatsWith();
+
+    render(<StatsPanel state={{ status: "loaded", stats }} />);
+
+    expect(screen.getByText("Players")).toBeInTheDocument();
+  });
+});

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
@@ -205,11 +205,9 @@ describe("IndividualTrackerViewerPresenter", () => {
 
       presenter.selectMatch("m-1");
       presenter.deselectMatch();
-
-      expect(store.getSnapshot().selectedMatchId).toBeNull();
-      expect(store.getSnapshot().matchStatsState).toBeNull();
-
       rejectStats(new Error("Network failure"));
+
+      await Promise.resolve();
       await Promise.resolve();
 
       expect(setMatchStatsErrorSpy).not.toHaveBeenCalled();

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
@@ -201,6 +201,7 @@ describe("IndividualTrackerViewerPresenter", () => {
           rejectStats = reject;
         }),
       );
+      const setMatchStatsErrorSpy = vi.spyOn(store, "setMatchStatsError");
 
       presenter.selectMatch("m-1");
       presenter.deselectMatch();
@@ -209,11 +210,9 @@ describe("IndividualTrackerViewerPresenter", () => {
       expect(store.getSnapshot().matchStatsState).toBeNull();
 
       rejectStats(new Error("Network failure"));
+      await Promise.resolve();
 
-      await vi.waitFor(() => {
-        expect(haloClient.getMatchStats).toHaveBeenCalledOnce();
-      });
-
+      expect(setMatchStatsErrorSpy).not.toHaveBeenCalled();
       expect(store.getSnapshot().selectedMatchId).toBeNull();
       expect(store.getSnapshot().matchStatsState).toBeNull();
     });

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
@@ -204,9 +204,15 @@ describe("IndividualTrackerViewerPresenter", () => {
 
       presenter.selectMatch("m-1");
       presenter.deselectMatch();
+
+      expect(store.getSnapshot().selectedMatchId).toBeNull();
+      expect(store.getSnapshot().matchStatsState).toBeNull();
+
       rejectStats(new Error("Network failure"));
 
-      await Promise.resolve();
+      await vi.waitFor(() => {
+        expect(haloClient.getMatchStats).toHaveBeenCalledOnce();
+      });
 
       expect(store.getSnapshot().selectedMatchId).toBeNull();
       expect(store.getSnapshot().matchStatsState).toBeNull();

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
@@ -192,6 +192,26 @@ describe("IndividualTrackerViewerPresenter", () => {
       }
     });
 
+    it("discards a stale error when the match is deselected before a rejection arrives", async () => {
+      const service = aFakeIndividualTrackerViewServiceWith();
+      let rejectStats!: (error: Error) => void;
+      const { haloClient, store, presenter } = aHarness(service);
+      haloClient.getMatchStats.mockReturnValue(
+        new Promise((_, reject) => {
+          rejectStats = reject;
+        }),
+      );
+
+      presenter.selectMatch("m-1");
+      presenter.deselectMatch();
+      rejectStats(new Error("Network failure"));
+
+      await Promise.resolve();
+
+      expect(store.getSnapshot().selectedMatchId).toBeNull();
+      expect(store.getSnapshot().matchStatsState).toBeNull();
+    });
+
     it("sets matchStatsState to error when getMatchStats rejects", async () => {
       expect.assertions(2);
       const service = aFakeIndividualTrackerViewServiceWith();

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HaloInfiniteClient } from "halo-infinite-api";
+import type { Mocked } from "vitest";
 import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import {
   aFakeIndividualTrackerViewServiceWith,
@@ -7,23 +9,30 @@ import {
   aFakeTrackerViewStateWith,
 } from "../../../../services/individual-tracker/fakes/view.fake";
 import type { FakeIndividualTrackerViewService } from "../../../../services/individual-tracker/fakes/view.fake";
+import { aFakeHaloClientWith } from "../../../../services/fakes/halo-client.fake";
+import { aFakeMatchStatsWith } from "../../../stats/fakes/data";
 import { IndividualTrackerViewerPresenter } from "../viewer-presenter";
 import { IndividualTrackerViewerStore } from "../viewer-store";
 
 interface Harness {
   readonly service: FakeIndividualTrackerViewService;
+  readonly haloClient: Mocked<Pick<HaloInfiniteClient, "getMatchStats">>;
   readonly store: IndividualTrackerViewerStore;
   readonly presenter: IndividualTrackerViewerPresenter;
 }
 
 function aHarness(service: FakeIndividualTrackerViewService): Harness {
   const store = new IndividualTrackerViewerStore();
+  const haloClient = {
+    getMatchStats: vi.fn<HaloInfiniteClient["getMatchStats"]>().mockResolvedValue(aFakeMatchStatsWith()),
+  };
   const presenter = new IndividualTrackerViewerPresenter({
     individualTrackerViewService: service,
+    haloClient: aFakeHaloClientWith(haloClient),
     store,
     trackerId: "tracker-1",
   });
-  return { service, store, presenter };
+  return { service, haloClient, store, presenter };
 }
 
 describe("IndividualTrackerViewerPresenter", () => {
@@ -105,6 +114,112 @@ describe("IndividualTrackerViewerPresenter", () => {
       service.lastConnection?.emitStatus("disconnected");
 
       expect(store.getSnapshot().connectionStatus).toBe("disconnected");
+    });
+  });
+
+  describe("selectMatch", () => {
+    it("sets selectedMatchId in the store and transitions matchStatsState to loaded", async () => {
+      expect.assertions(4);
+      const fakeStats = aFakeMatchStatsWith({ MatchId: "m-99" });
+      const service = aFakeIndividualTrackerViewServiceWith();
+      const { haloClient, store, presenter } = aHarness(service);
+      haloClient.getMatchStats.mockResolvedValue(fakeStats);
+
+      presenter.selectMatch("m-99");
+
+      expect(store.getSnapshot().selectedMatchId).toBe("m-99");
+      expect(store.getSnapshot().matchStatsState?.status).toBe("loading");
+
+      await vi.waitFor(() => store.getSnapshot().matchStatsState?.status === "loaded");
+
+      const statsState = store.getSnapshot().matchStatsState;
+      if (statsState?.status === "loaded") {
+        expect(statsState.stats.MatchId).toBe("m-99");
+      }
+      expect(store.getSnapshot().matchStatsState?.status).toBe("loaded");
+    });
+
+    it("discards a stale result when the match is deselected before the response arrives", async () => {
+      const service = aFakeIndividualTrackerViewServiceWith();
+      let resolveStats!: (stats: Awaited<ReturnType<HaloInfiniteClient["getMatchStats"]>>) => void;
+      const { haloClient, store, presenter } = aHarness(service);
+      haloClient.getMatchStats.mockReturnValue(
+        new Promise((resolve) => {
+          resolveStats = resolve;
+        }),
+      );
+
+      presenter.selectMatch("m-1");
+      presenter.deselectMatch();
+      resolveStats(aFakeMatchStatsWith({ MatchId: "m-1" }));
+
+      await Promise.resolve();
+
+      expect(store.getSnapshot().selectedMatchId).toBeNull();
+      expect(store.getSnapshot().matchStatsState).toBeNull();
+    });
+
+    it("discards a superseded result when a second selectMatch fires before the first resolves", async () => {
+      expect.assertions(2);
+      const service = aFakeIndividualTrackerViewServiceWith();
+      let resolveA!: (stats: Awaited<ReturnType<HaloInfiniteClient["getMatchStats"]>>) => void;
+      const { haloClient, store, presenter } = aHarness(service);
+      const statsA = aFakeMatchStatsWith({ MatchId: "m-A" });
+      const statsB = aFakeMatchStatsWith({ MatchId: "m-B" });
+
+      haloClient.getMatchStats
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            resolveA = resolve;
+          }),
+        )
+        .mockResolvedValueOnce(statsB);
+
+      presenter.selectMatch("m-A");
+      presenter.selectMatch("m-B");
+
+      await vi.waitFor(() => store.getSnapshot().matchStatsState?.status === "loaded");
+
+      resolveA(statsA);
+      await Promise.resolve();
+
+      const state = store.getSnapshot().matchStatsState;
+      expect(store.getSnapshot().selectedMatchId).toBe("m-B");
+      if (state?.status === "loaded") {
+        expect(state.stats.MatchId).toBe("m-B");
+      } else {
+        expect(state?.status).toBe("loaded");
+      }
+    });
+
+    it("sets matchStatsState to error when getMatchStats rejects", async () => {
+      expect.assertions(2);
+      const service = aFakeIndividualTrackerViewServiceWith();
+      const { haloClient, store, presenter } = aHarness(service);
+      haloClient.getMatchStats.mockRejectedValue(new Error("Network failure"));
+
+      presenter.selectMatch("m-err");
+
+      await vi.waitFor(() => store.getSnapshot().matchStatsState?.status === "error");
+
+      const statsState = store.getSnapshot().matchStatsState;
+      if (statsState?.status === "error") {
+        expect(statsState.message).toBe("Network failure");
+      }
+      expect(store.getSnapshot().matchStatsState?.status).toBe("error");
+    });
+  });
+
+  describe("deselectMatch", () => {
+    it("clears selectedMatchId and matchStatsState", () => {
+      const service = aFakeIndividualTrackerViewServiceWith();
+      const { store, presenter } = aHarness(service);
+
+      presenter.selectMatch("m-1");
+      presenter.deselectMatch();
+
+      expect(store.getSnapshot().selectedMatchId).toBeNull();
+      expect(store.getSnapshot().matchStatsState).toBeNull();
     });
   });
 

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-tabs.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-tabs.test.tsx
@@ -21,7 +21,14 @@ describe("TabsBar", () => {
     });
     const { timeline } = buildViewerRenderModel({ view });
 
-    render(<TabsBar timeline={timeline} />);
+    render(
+      <TabsBar
+        timeline={timeline}
+        selectedMatchId={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
 
     expect(screen.getByText("50:30")).toBeInTheDocument();
   });
@@ -33,7 +40,14 @@ describe("TabsBar", () => {
     });
     const { timeline } = buildViewerRenderModel({ view });
 
-    render(<TabsBar timeline={timeline} />);
+    render(
+      <TabsBar
+        timeline={timeline}
+        selectedMatchId={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
 
     expect(screen.getByText("Ranked Series")).toBeInTheDocument();
   });
@@ -45,7 +59,14 @@ describe("TabsBar", () => {
     });
     const { timeline } = buildViewerRenderModel({ view });
 
-    render(<TabsBar timeline={timeline} />);
+    render(
+      <TabsBar
+        timeline={timeline}
+        selectedMatchId={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
 
     expect(screen.getByText("2:1")).toBeInTheDocument();
   });
@@ -56,7 +77,14 @@ describe("TabsBar", () => {
     });
     const { timeline } = buildViewerRenderModel({ view });
 
-    const { container } = render(<TabsBar timeline={timeline} />);
+    const { container } = render(
+      <TabsBar
+        timeline={timeline}
+        selectedMatchId={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
 
     expect(container.querySelector('[title="Aquarius 50:30"]')).toBeInTheDocument();
   });

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -1,5 +1,6 @@
 import type { TrackerStatus } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import type { TrackerViewConnectionStatus } from "../../../services/individual-tracker/view-types";
+import type { MatchStatsState } from "./viewer-store";
 
 export type ViewerTabOutcome = "win" | "loss" | "tie" | "dnf" | "unknown";
 
@@ -47,4 +48,6 @@ export interface IndividualTrackerViewerRenderModel {
 export interface IndividualTrackerViewerViewModel {
   readonly renderModel: IndividualTrackerViewerRenderModel | null;
   readonly connectionStatus: TrackerViewConnectionStatus;
+  readonly selectedMatchId: string | null;
+  readonly matchStatsState: MatchStatsState | null;
 }

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -1,3 +1,4 @@
+import type { HaloInfiniteClient } from "halo-infinite-api";
 import type {
   IndividualTrackerViewService,
   TrackerViewConnection,
@@ -9,6 +10,7 @@ import type { IndividualTrackerViewerViewModel } from "./types";
 
 interface Config {
   readonly individualTrackerViewService: IndividualTrackerViewService;
+  readonly haloClient: HaloInfiniteClient;
   readonly store: IndividualTrackerViewerStore;
   readonly trackerId: string;
 }
@@ -19,6 +21,7 @@ export class IndividualTrackerViewerPresenter {
   private connection: TrackerViewConnection | null = null;
   private viewSubscription: TrackerViewSubscription | null = null;
   private statusSubscription: TrackerViewSubscription | null = null;
+  private selectedMatchId: string | null = null;
 
   public constructor(config: Config) {
     this.config = config;
@@ -28,7 +31,35 @@ export class IndividualTrackerViewerPresenter {
     return {
       renderModel: snapshot.view == null ? null : buildViewerRenderModel({ view: snapshot.view }),
       connectionStatus: snapshot.connectionStatus,
+      selectedMatchId: snapshot.selectedMatchId,
+      matchStatsState: snapshot.matchStatsState,
     };
+  }
+
+  public selectMatch(matchId: string): void {
+    this.selectedMatchId = matchId;
+    this.config.store.setSelectedMatchId(matchId);
+    void this.fetchMatchStats(matchId);
+  }
+
+  public deselectMatch(): void {
+    this.selectedMatchId = null;
+    this.config.store.setSelectedMatchId(null);
+  }
+
+  private async fetchMatchStats(matchId: string): Promise<void> {
+    try {
+      const stats = await this.config.haloClient.getMatchStats(matchId);
+      if (this.isDisposed || this.selectedMatchId !== matchId) {
+        return;
+      }
+      this.config.store.setMatchStats(matchId, stats);
+    } catch (error) {
+      if (this.isDisposed || this.selectedMatchId !== matchId) {
+        return;
+      }
+      this.config.store.setMatchStatsError(matchId, error instanceof Error ? error.message : "Failed to load stats");
+    }
   }
 
   public start(): void {

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -50,15 +50,19 @@ export class IndividualTrackerViewerPresenter {
     this.config.store.setSelectedMatchId(null);
   }
 
+  private isStale(matchId: string): boolean {
+    return this.isDisposed || this.selectedMatchId !== matchId;
+  }
+
   private async fetchMatchStats(matchId: string): Promise<void> {
     try {
       const stats = await this.config.haloClient.getMatchStats(matchId);
-      if (this.isDisposed || this.selectedMatchId !== matchId) {
+      if (this.isStale(matchId)) {
         return;
       }
       this.config.store.setMatchStats(matchId, stats);
     } catch (error) {
-      if (this.isDisposed || this.selectedMatchId !== matchId) {
+      if (this.isStale(matchId)) {
         return;
       }
       this.config.store.setMatchStatsError(matchId, error instanceof Error ? error.message : "Failed to load stats");

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -37,6 +37,9 @@ export class IndividualTrackerViewerPresenter {
   }
 
   public selectMatch(matchId: string): void {
+    if (this.selectedMatchId === matchId) {
+      return;
+    }
     this.selectedMatchId = matchId;
     this.config.store.setSelectedMatchId(matchId);
     void this.fetchMatchStats(matchId);

--- a/pages/src/components/individual-tracker/viewer/viewer-store.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-store.ts
@@ -1,12 +1,20 @@
+import type { MatchStats } from "halo-infinite-api";
 import type { TrackerLiveView, TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { TrackerViewConnectionStatus } from "../../../services/individual-tracker/view-types";
 import { ComponentLoaderStatus } from "../../component-loader/component-loader";
+
+export type MatchStatsState =
+  | { readonly status: "loading" }
+  | { readonly status: "loaded"; readonly stats: MatchStats }
+  | { readonly status: "error"; readonly message: string };
 
 export interface IndividualTrackerViewerSnapshot {
   readonly status: ComponentLoaderStatus;
   readonly errorMessage: string | null;
   readonly view: TrackerViewState | null;
   readonly connectionStatus: TrackerViewConnectionStatus;
+  readonly selectedMatchId: string | null;
+  readonly matchStatsState: MatchStatsState | null;
 }
 
 export class IndividualTrackerViewerStore {
@@ -19,6 +27,8 @@ export class IndividualTrackerViewerStore {
       errorMessage: null,
       view: null,
       connectionStatus: "connecting",
+      selectedMatchId: null,
+      matchStatsState: null,
     };
   }
 
@@ -52,6 +62,24 @@ export class IndividualTrackerViewerStore {
 
   public setConnectionStatus(connectionStatus: TrackerViewConnectionStatus): void {
     this.update({ connectionStatus });
+  }
+
+  public setSelectedMatchId(id: string | null): void {
+    this.update({ selectedMatchId: id, matchStatsState: id != null ? { status: "loading" } : null });
+  }
+
+  public setMatchStats(matchId: string, stats: MatchStats): void {
+    if (this.snapshot.selectedMatchId !== matchId) {
+      return;
+    }
+    this.update({ matchStatsState: { status: "loaded", stats } });
+  }
+
+  public setMatchStatsError(matchId: string, message: string): void {
+    if (this.snapshot.selectedMatchId !== matchId) {
+      return;
+    }
+    this.update({ matchStatsState: { status: "error", message } });
   }
 
   private update(partial: Partial<IndividualTrackerViewerSnapshot>): void {

--- a/pages/src/components/individual-tracker/viewer/viewer-tabs.module.css
+++ b/pages/src/components/individual-tracker/viewer/viewer-tabs.module.css
@@ -10,6 +10,7 @@
   background: var(--halo-bg-card);
   border: 1px solid color-mix(in srgb, var(--halo-gray) 30%, transparent);
   border-radius: var(--radius-base);
+  cursor: pointer;
   display: flex;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
@@ -45,4 +46,13 @@
   color: var(--halo-white);
   font-family: var(--font-heading);
   font-size: var(--text-sm);
+}
+
+.tab:hover {
+  border-color: color-mix(in srgb, var(--halo-teal-primary) 60%, transparent);
+}
+
+.tabSelected {
+  border-color: var(--halo-teal-primary);
+  outline: 1px solid var(--halo-teal-primary);
 }

--- a/pages/src/components/individual-tracker/viewer/viewer-tabs.tsx
+++ b/pages/src/components/individual-tracker/viewer/viewer-tabs.tsx
@@ -85,10 +85,10 @@ export function TabsBar({ timeline, selectedMatchId, onSelectMatch, onDeselect }
             );
           }
           case "series": {
-            const [firstMatch] = item.series.matches;
             if (item.series.matches.length === 0) {
               return null;
             }
+            const [firstMatch] = item.series.matches;
             const isSelected = item.series.matches.some((m) => m.matchId === selectedMatchId);
             const handleSeriesSelect = isSelected
               ? onDeselect

--- a/pages/src/components/individual-tracker/viewer/viewer-tabs.tsx
+++ b/pages/src/components/individual-tracker/viewer/viewer-tabs.tsx
@@ -6,22 +6,44 @@ import { gameModeIconSrc } from "../game-mode-icon";
 import type { ViewerMatchTab, ViewerSeriesTab, ViewerTimelineItem } from "./types";
 import styles from "./viewer-tabs.module.css";
 
-function MatchTab({ match }: { readonly match: ViewerMatchTab }): React.ReactElement {
+interface MatchTabProps {
+  readonly match: ViewerMatchTab;
+  readonly selected: boolean;
+  readonly onSelect: () => void;
+}
+
+function MatchTab({ match, selected, onSelect }: MatchTabProps): React.ReactElement {
   return (
-    <div
-      className={classNames(styles.tab, { [styles.tabAccented]: match.colorHex != null })}
+    <button
+      type="button"
+      className={classNames(styles.tab, {
+        [styles.tabAccented]: match.colorHex != null,
+        [styles.tabSelected]: selected,
+      })}
       style={accentStyle(match.colorHex)}
       title={`${match.mapName} ${match.score}`}
+      onClick={onSelect}
     >
       <img className={styles.tabIcon} src={gameModeIconSrc(match.gameVariantCategory)} alt="" />
       <span className={styles.tabScore}>{match.score}</span>
-    </div>
+    </button>
   );
 }
 
-function SeriesTab({ series }: { readonly series: ViewerSeriesTab }): React.ReactElement {
+interface SeriesTabProps {
+  readonly series: ViewerSeriesTab;
+  readonly selected: boolean;
+  readonly onSelect: () => void;
+}
+
+function SeriesTab({ series, selected, onSelect }: SeriesTabProps): React.ReactElement {
   return (
-    <div className={classNames(styles.tab, styles.tabSeries)} title={`${series.title} ${series.score}`}>
+    <button
+      type="button"
+      className={classNames(styles.tab, styles.tabSeries, { [styles.tabSelected]: selected })}
+      title={`${series.title} ${series.score}`}
+      onClick={onSelect}
+    >
       <span className={styles.tabSeriesTitle}>{series.title}</span>
       <span className={styles.tabScore}>{series.score}</span>
       <div className={styles.tabIcons}>
@@ -29,20 +51,58 @@ function SeriesTab({ series }: { readonly series: ViewerSeriesTab }): React.Reac
           <img key={match.matchId} className={styles.tabIcon} src={gameModeIconSrc(match.gameVariantCategory)} alt="" />
         ))}
       </div>
-    </div>
+    </button>
   );
 }
 
-export function TabsBar({ timeline }: { readonly timeline: readonly ViewerTimelineItem[] }): React.ReactElement {
+interface TabsBarProps {
+  readonly timeline: readonly ViewerTimelineItem[];
+  readonly selectedMatchId: string | null;
+  readonly onSelectMatch: (matchId: string) => void;
+  readonly onDeselect: () => void;
+}
+
+export function TabsBar({ timeline, selectedMatchId, onSelectMatch, onDeselect }: TabsBarProps): React.ReactElement {
   return (
     <div className={styles.tabBar}>
       {timeline.map((item) => {
         switch (item.type) {
           case "match": {
-            return <MatchTab key={item.match.matchId} match={item.match} />;
+            const { matchId } = item.match;
+            const isSelected = matchId === selectedMatchId;
+            const handleMatchSelect = isSelected
+              ? onDeselect
+              : (): void => {
+                  onSelectMatch(matchId);
+                };
+            return (
+              <MatchTab
+                key={item.match.matchId}
+                match={item.match}
+                selected={isSelected}
+                onSelect={handleMatchSelect}
+              />
+            );
           }
           case "series": {
-            return <SeriesTab key={item.series.id} series={item.series} />;
+            const [firstMatch] = item.series.matches;
+            if (item.series.matches.length === 0) {
+              return null;
+            }
+            const isSelected = item.series.matches.some((m) => m.matchId === selectedMatchId);
+            const handleSeriesSelect = isSelected
+              ? onDeselect
+              : (): void => {
+                  onSelectMatch(firstMatch.matchId);
+                };
+            return (
+              <SeriesTab
+                key={item.series.id}
+                series={item.series}
+                selected={isSelected}
+                onSelect={handleSeriesSelect}
+              />
+            );
           }
           default: {
             throw new UnreachableError(item);

--- a/pages/src/services/fakes/halo-client.fake.ts
+++ b/pages/src/services/fakes/halo-client.fake.ts
@@ -1,0 +1,16 @@
+import type { HaloInfiniteClient } from "halo-infinite-api";
+import { aFakeMatchStatsWith } from "../../components/stats/fakes/data";
+
+class FakeHaloClient implements Pick<HaloInfiniteClient, "getMatchStats"> {
+  public async getMatchStats(matchId: string): ReturnType<HaloInfiniteClient["getMatchStats"]> {
+    await Promise.resolve();
+    return aFakeMatchStatsWith({ MatchId: matchId });
+  }
+}
+
+export function aFakeHaloClientWith(
+  overrides?: Partial<Pick<HaloInfiniteClient, "getMatchStats">>,
+): HaloInfiniteClient {
+  const base = new FakeHaloClient();
+  return Object.assign(base, overrides) as unknown as HaloInfiniteClient;
+}

--- a/shared/src/halo/halo-infinite-client-proxy.ts
+++ b/shared/src/halo/halo-infinite-client-proxy.ts
@@ -27,19 +27,26 @@ function isProxyErrorResponse(data: unknown): data is { message?: string; error?
 }
 
 async function handleProxyResponse(response: Response, url: URL): Promise<unknown> {
-  const data: unknown = await response.json();
   if (!response.ok) {
     let errorMessage = "Proxy error";
-    if (isProxyErrorResponse(data)) {
-      if (typeof data.message === "string") {
-        errorMessage = data.message;
-      } else if (typeof data.error === "string") {
-        errorMessage = data.error;
+    const text = await response.text();
+    if (text !== "") {
+      try {
+        const data: unknown = JSON.parse(text);
+        if (isProxyErrorResponse(data)) {
+          if (typeof data.message === "string") {
+            errorMessage = data.message;
+          } else if (typeof data.error === "string") {
+            errorMessage = data.error;
+          }
+        }
+      } catch {
+        errorMessage = text;
       }
     }
     throw new ProxyRequestError(response.status, url.toString(), errorMessage);
   }
-  return data;
+  return response.json();
 }
 
 function resolveAdditionalHeaders(additionalHeaders?: HeadersInit | (() => HeadersInit)): Headers {

--- a/shared/src/halo/halo-infinite-client-proxy.ts
+++ b/shared/src/halo/halo-infinite-client-proxy.ts
@@ -29,24 +29,32 @@ function isProxyErrorResponse(data: unknown): data is { message?: string; error?
 async function handleProxyResponse(response: Response, url: URL): Promise<unknown> {
   if (!response.ok) {
     let errorMessage = "Proxy error";
-    const text = await response.text();
-    if (text !== "") {
-      try {
-        const data: unknown = JSON.parse(text);
-        if (isProxyErrorResponse(data)) {
-          if (typeof data.message === "string") {
-            errorMessage = data.message;
-          } else if (typeof data.error === "string") {
-            errorMessage = data.error;
+    try {
+      const text = await response.text();
+      if (text !== "") {
+        try {
+          const data: unknown = JSON.parse(text);
+          if (isProxyErrorResponse(data)) {
+            if (typeof data.message === "string") {
+              errorMessage = data.message;
+            } else if (typeof data.error === "string") {
+              errorMessage = data.error;
+            }
           }
+        } catch {
+          errorMessage = text;
         }
-      } catch {
-        errorMessage = text;
       }
+    } catch {
+      // body read failed (e.g. network drop after headers) — use the default message
     }
     throw new ProxyRequestError(response.status, url.toString(), errorMessage);
   }
-  return response.json();
+  try {
+    return await response.json();
+  } catch {
+    throw new ProxyRequestError(response.status, url.toString(), "Proxy returned a non-JSON response");
+  }
 }
 
 function resolveAdditionalHeaders(additionalHeaders?: HeadersInit | (() => HeadersInit)): Headers {

--- a/shared/src/halo/halo-infinite-client-proxy.ts
+++ b/shared/src/halo/halo-infinite-client-proxy.ts
@@ -43,7 +43,7 @@ async function readErrorMessage(response: Response): Promise<string> {
         }
       }
     } catch {
-      return text;
+      return text.slice(0, 200);
     }
   } catch {
     // body read failed (e.g. network drop after headers)

--- a/shared/src/halo/halo-infinite-client-proxy.ts
+++ b/shared/src/halo/halo-infinite-client-proxy.ts
@@ -1,6 +1,8 @@
 import type { HaloInfiniteClient } from "halo-infinite-api";
 import { appendHaloProxyArgsToUrl, resolveHaloProxyOperation } from "./halo-infinite-proxy-operations";
 
+const MAX_ERROR_BODY_DISPLAY_LENGTH = 200;
+
 export interface CreateHaloInfiniteClientProxyOpts {
   readonly proxyBaseUrl: string;
   readonly proxyPath?: string;
@@ -43,7 +45,7 @@ async function readErrorMessage(response: Response): Promise<string> {
         }
       }
     } catch {
-      return text.slice(0, 200);
+      return text.slice(0, MAX_ERROR_BODY_DISPLAY_LENGTH);
     }
   } catch {
     // body read failed (e.g. network drop after headers)

--- a/shared/src/halo/halo-infinite-client-proxy.ts
+++ b/shared/src/halo/halo-infinite-client-proxy.ts
@@ -1,0 +1,111 @@
+import type { HaloInfiniteClient } from "halo-infinite-api";
+import { appendHaloProxyArgsToUrl, resolveHaloProxyOperation } from "./halo-infinite-proxy-operations";
+
+export interface CreateHaloInfiniteClientProxyOpts {
+  readonly proxyBaseUrl: string;
+  readonly proxyPath?: string;
+  readonly credentials?: "omit" | "same-origin" | "include";
+  readonly additionalHeaders?: HeadersInit | (() => HeadersInit);
+  readonly additionalQueryParams?: Record<string, string> | (() => Record<string, string>);
+  readonly fetchFn?: typeof fetch;
+}
+
+export class ProxyRequestError extends Error {
+  public readonly statusCode: number;
+  public readonly requestUrl: string;
+
+  public constructor(statusCode: number, requestUrl: string, message: string) {
+    super(message);
+    this.name = "ProxyRequestError";
+    this.statusCode = statusCode;
+    this.requestUrl = requestUrl;
+  }
+}
+
+function isProxyErrorResponse(data: unknown): data is { message?: string; error?: string } {
+  return typeof data === "object" && data !== null && ("message" in data || "error" in data);
+}
+
+async function handleProxyResponse(response: Response, url: URL): Promise<unknown> {
+  const data: unknown = await response.json();
+  if (!response.ok) {
+    let errorMessage = "Proxy error";
+    if (isProxyErrorResponse(data)) {
+      if (typeof data.message === "string") {
+        errorMessage = data.message;
+      } else if (typeof data.error === "string") {
+        errorMessage = data.error;
+      }
+    }
+    throw new ProxyRequestError(response.status, url.toString(), errorMessage);
+  }
+  return data;
+}
+
+function resolveAdditionalHeaders(additionalHeaders?: HeadersInit | (() => HeadersInit)): Headers {
+  if (additionalHeaders == null) {
+    return new Headers();
+  }
+  const headers = typeof additionalHeaders === "function" ? additionalHeaders() : additionalHeaders;
+  return new Headers(headers);
+}
+
+function resolveProxyEndpoint(proxyBaseUrl: string, proxyPath: string): string {
+  const baseUrl = proxyBaseUrl.endsWith("/") ? proxyBaseUrl : `${proxyBaseUrl}/`;
+  return new URL(proxyPath, baseUrl).toString();
+}
+
+export function createHaloInfiniteClientProxy({
+  proxyBaseUrl,
+  proxyPath = "/proxy/halo-infinite",
+  credentials,
+  additionalHeaders,
+  additionalQueryParams,
+  fetchFn = fetch,
+}: CreateHaloInfiniteClientProxyOpts): HaloInfiniteClient {
+  const endpoint = resolveProxyEndpoint(proxyBaseUrl, proxyPath);
+
+  return new Proxy(
+    {},
+    {
+      get(_, prop): ((...args: unknown[]) => Promise<unknown>) | undefined {
+        if (typeof prop !== "string") {
+          return undefined;
+        }
+
+        const operation = resolveHaloProxyOperation(prop);
+        if (operation == null) {
+          return undefined;
+        }
+
+        return async (...args: unknown[]): Promise<unknown> => {
+          const url = new URL(`${endpoint.replace(/\/$/, "")}/${prop}`);
+          const headers = new Headers();
+
+          const resolvedAdditionalHeaders = resolveAdditionalHeaders(additionalHeaders);
+          for (const [key, value] of resolvedAdditionalHeaders.entries()) {
+            headers.set(key, value);
+          }
+
+          if (additionalQueryParams != null) {
+            const params =
+              typeof additionalQueryParams === "function" ? additionalQueryParams() : additionalQueryParams;
+            for (const [key, value] of Object.entries(params)) {
+              url.searchParams.set(key, value);
+            }
+          }
+
+          appendHaloProxyArgsToUrl(url, args);
+
+          const response = await fetchFn(url.toString(), {
+            method: "GET",
+            headers,
+            ...(credentials != null ? { credentials } : {}),
+          });
+
+          return handleProxyResponse(response, url);
+        };
+      },
+    },
+  ) as unknown as HaloInfiniteClient;
+}

--- a/shared/src/halo/halo-infinite-client-proxy.ts
+++ b/shared/src/halo/halo-infinite-client-proxy.ts
@@ -26,29 +26,34 @@ function isProxyErrorResponse(data: unknown): data is { message?: string; error?
   return typeof data === "object" && data !== null && ("message" in data || "error" in data);
 }
 
-async function handleProxyResponse(response: Response, url: URL): Promise<unknown> {
-  if (!response.ok) {
-    let errorMessage = "Proxy error";
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    if (text === "") {
+      return "Proxy error";
+    }
     try {
-      const text = await response.text();
-      if (text !== "") {
-        try {
-          const data: unknown = JSON.parse(text);
-          if (isProxyErrorResponse(data)) {
-            if (typeof data.message === "string") {
-              errorMessage = data.message;
-            } else if (typeof data.error === "string") {
-              errorMessage = data.error;
-            }
-          }
-        } catch {
-          errorMessage = text;
+      const data: unknown = JSON.parse(text);
+      if (isProxyErrorResponse(data)) {
+        if (typeof data.message === "string") {
+          return data.message;
+        }
+        if (typeof data.error === "string") {
+          return data.error;
         }
       }
     } catch {
-      // body read failed (e.g. network drop after headers) — use the default message
+      return text;
     }
-    throw new ProxyRequestError(response.status, url.toString(), errorMessage);
+  } catch {
+    // body read failed (e.g. network drop after headers)
+  }
+  return "Proxy error";
+}
+
+async function handleProxyResponse(response: Response, url: URL): Promise<unknown> {
+  if (!response.ok) {
+    throw new ProxyRequestError(response.status, url.toString(), await readErrorMessage(response));
   }
   try {
     return await response.json();

--- a/shared/src/halo/tests/halo-infinite-client-proxy.test.ts
+++ b/shared/src/halo/tests/halo-infinite-client-proxy.test.ts
@@ -68,6 +68,25 @@ describe("createHaloInfiniteClientProxy", () => {
     }
   });
 
+  it("truncates a plain-text error body to 200 chars and uses it as the error message", async () => {
+    expect.assertions(2);
+    const longBody = "x".repeat(300);
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(longBody, { status: 502, headers: { "Content-Type": "text/plain" } }));
+
+    const client = createHaloInfiniteClientProxy({ proxyBaseUrl: "https://api.example.com" });
+
+    try {
+      await client.getMatchStats("abc-123");
+    } catch (error) {
+      if (error instanceof ProxyRequestError) {
+        expect(error.statusCode).toBe(502);
+        expect(error.message).toBe("x".repeat(200));
+      }
+    }
+  });
+
   it("throws ProxyRequestError with a default message when the error response body cannot be read", async () => {
     expect.assertions(2);
     const failingResponse = {

--- a/shared/src/halo/tests/halo-infinite-client-proxy.test.ts
+++ b/shared/src/halo/tests/halo-infinite-client-proxy.test.ts
@@ -50,6 +50,45 @@ describe("createHaloInfiniteClientProxy", () => {
     }
   });
 
+  it("throws ProxyRequestError with a default message when the error response body cannot be read", async () => {
+    expect.assertions(2);
+    const failingResponse = {
+      ok: false,
+      status: 503,
+      text: vi.fn<() => Promise<string>>().mockRejectedValue(new TypeError("network error")),
+    } as unknown as Response;
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(failingResponse);
+
+    const client = createHaloInfiniteClientProxy({ proxyBaseUrl: "https://api.example.com" });
+
+    try {
+      await client.getMatchStats("abc-123");
+    } catch (error) {
+      if (error instanceof ProxyRequestError) {
+        expect(error.statusCode).toBe(503);
+        expect(error.message).toBe("Proxy error");
+      }
+    }
+  });
+
+  it("throws ProxyRequestError when a 2xx response body is not valid JSON", async () => {
+    expect.assertions(2);
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("<html>Error</html>", { status: 200, headers: { "Content-Type": "text/html" } }));
+
+    const client = createHaloInfiniteClientProxy({ proxyBaseUrl: "https://api.example.com" });
+
+    try {
+      await client.getMatchStats("abc-123");
+    } catch (error) {
+      if (error instanceof ProxyRequestError) {
+        expect(error.statusCode).toBe(200);
+        expect(error.message).toBe("Proxy returned a non-JSON response");
+      }
+    }
+  });
+
   it("sends the credentials option when specified", async () => {
     fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
 

--- a/shared/src/halo/tests/halo-infinite-client-proxy.test.ts
+++ b/shared/src/halo/tests/halo-infinite-client-proxy.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { createHaloInfiniteClientProxy, ProxyRequestError } from "../halo-infinite-client-proxy";
+
+describe("createHaloInfiniteClientProxy", () => {
+  let fetchSpy: MockInstance<typeof fetch>;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("GETs the proxy endpoint with the matchId appended as an arg query param", async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ MatchId: "abc-123" }), { status: 200 }));
+
+    const client = createHaloInfiniteClientProxy({ proxyBaseUrl: "https://api.example.com" });
+    await client.getMatchStats("abc-123");
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [calledUrl, calledInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const url = new URL(calledUrl);
+    expect(url.pathname).toBe("/proxy/halo-infinite/getMatchStats");
+    expect(url.searchParams.getAll("arg")).toEqual(['"abc-123"']);
+    expect(calledInit.method).toBe("GET");
+  });
+
+  it("returns undefined for a method outside the allowlist", () => {
+    const client = createHaloInfiniteClientProxy({ proxyBaseUrl: "https://api.example.com" });
+    const bogus = (client as unknown as Record<string, unknown>)["bogusMethod"];
+    expect(bogus).toBeUndefined();
+  });
+
+  it("throws ProxyRequestError with the parsed error message on a non-200 response", async () => {
+    expect.assertions(3);
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ message: "Match not found" }), { status: 404 }));
+
+    const client = createHaloInfiniteClientProxy({ proxyBaseUrl: "https://api.example.com" });
+
+    try {
+      await client.getMatchStats("missing-id");
+    } catch (error) {
+      if (error instanceof ProxyRequestError) {
+        expect(error.message).toBe("Match not found");
+        expect(error.statusCode).toBe(404);
+        expect(error.requestUrl).toContain("/proxy/halo-infinite/getMatchStats");
+      }
+    }
+  });
+
+  it("sends the credentials option when specified", async () => {
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    const client = createHaloInfiniteClientProxy({
+      proxyBaseUrl: "https://api.example.com",
+      credentials: "include",
+    });
+    await client.getMatchStats("abc-123");
+
+    const [, calledInit] = fetchSpy.mock.calls[0] as [string, Record<string, unknown>];
+    expect(calledInit["credentials"]).toBe("include");
+  });
+});

--- a/shared/src/halo/tests/halo-infinite-client-proxy.test.ts
+++ b/shared/src/halo/tests/halo-infinite-client-proxy.test.ts
@@ -50,6 +50,24 @@ describe("createHaloInfiniteClientProxy", () => {
     }
   });
 
+  it("throws ProxyRequestError with a default message when the error body is valid JSON without a message or error field", async () => {
+    expect.assertions(2);
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ code: 42 }), { status: 429 }));
+
+    const client = createHaloInfiniteClientProxy({ proxyBaseUrl: "https://api.example.com" });
+
+    try {
+      await client.getMatchStats("abc-123");
+    } catch (error) {
+      if (error instanceof ProxyRequestError) {
+        expect(error.statusCode).toBe(429);
+        expect(error.message).toBe("Proxy error");
+      }
+    }
+  });
+
   it("throws ProxyRequestError with a default message when the error response body cannot be read", async () => {
     expect.assertions(2);
     const failingResponse = {


### PR DESCRIPTION
Third viewer slice. Clicking a match or series tab now fetches `getMatchStats` **client-side** through the existing Halo proxy route and renders the per-match stats breakdown using the stats presenter layer already on main. The DO/WS carry no `rawMatchStats` — same approach as the live tracker, no new API/DO changes.

## What's here

**`shared/src/halo/halo-infinite-client-proxy.ts` (new)**
`createHaloInfiniteClientProxy` — a dynamic `Proxy` that routes `HaloInfiniteClient` method calls to `GET /proxy/halo-infinite/:operation`. GET-only (all ops have been cacheable GETs since B3a), no `authToken` (dropped in B3a), `credentials` opt-in. The `as unknown as HaloInfiniteClient` cast on the `Proxy` return is unavoidable for dynamic dispatch — established repo exception.

**Viewer app services**
Wires `createHaloInfiniteClientProxy({ proxyBaseUrl: apiHost, credentials: "include" })` as `haloClient` in the viewer app. Fake services get `aFakeHaloClientWith` for tests.

**Presenter: `selectMatch` / `deselectMatch`**
`selectMatch(matchId)` sets the selected state and fire-and-forgets `fetchMatchStats`. Stale-result guard: if `selectedMatchId` changed before the response arrives, the result is discarded. Covered by both the deselect-before-resolve test and a new **race test** (`selectMatch("A")` → `selectMatch("B")` before A resolves → A's result discarded, B's survives).

**Store**
`selectedMatchId` + `matchStatsState` (`loading | loaded | error | null`). `setMatchStats`/`setMatchStatsError` discard results that arrived for a no-longer-selected match.

**Tabs → clickable buttons**
`viewer-tabs.tsx` converts tabs from `<div>` to `<button>` with `onClick` wired to `selectMatch`/`deselectMatch`. Selected state styled via `tabSelected` CSS class. Empty-series guard (returns `null` if `matches.length === 0` — dead in practice but type-safe).

**`StatsPanel`**
`null` → renders nothing. `loading` → `<LoadingState />`. `error` → `<Alert variant="error">`. `loaded` → `createMatchStatsPresenter(category).getData(stats, playerMap, {})` → `<MatchStats />`. `playerMap` uses XUID→XUID as placeholder names (no gamertag lookup without match history; medals degrade to raw NameId — both intentional, noted in commit).

## Review gate
Independent review before commit; findings fixed:
- `Alert variant="info"` on error → corrected to `"error"`
- Race test added (superseded-fetch guard was previously only proven by the deselect path, not the selectA→selectB race)
- Empty-series tab guard (`return null` on `matches.length === 0`)
- `gameModeIconSrc` import inadvertently removed during `gamertag` prop cleanup → restored

## Verification
- `npm run typecheck:pages` → 0 errors; eslint + prettier + stylelint clean
- Full suite `npx vitest run` → **1979 passing** (+1 new race test + shared proxy test)
- `wrangler deploy --dry-run` (from `pages/`) → still bundles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)