### PR TITLE
refactor(pages): extract useIndividualTrackerViewer hook (F1-3b prep)

### DIFF
--- a/pages/src/components/individual-tracker/viewer/create.tsx
+++ b/pages/src/components/individual-tracker/viewer/create.tsx
@@ -1,12 +1,11 @@
-import React, { useEffect, useMemo, useSyncExternalStore } from "react";
+import React from "react";
 import type { HaloInfiniteClient } from "halo-infinite-api";
 import { ComponentLoader } from "../../component-loader/component-loader";
 import { ErrorState } from "../../error-state/error-state";
 import { LoadingState } from "../../loading-state/loading-state";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import { IndividualTrackerViewer } from "./individual-tracker-viewer";
-import { IndividualTrackerViewerPresenter } from "./viewer-presenter";
-import { IndividualTrackerViewerStore } from "./viewer-store";
+import { useIndividualTrackerViewer } from "./use-individual-tracker-viewer";
 
 interface IndividualTrackerViewerPageProps {
   readonly individualTrackerViewService: IndividualTrackerViewService;
@@ -19,40 +18,17 @@ export function IndividualTrackerViewerPage({
   haloClient,
   trackerId,
 }: IndividualTrackerViewerPageProps): React.ReactElement {
-  const store = useMemo(() => new IndividualTrackerViewerStore(), []);
-
-  const presenter = useMemo(() => {
-    return new IndividualTrackerViewerPresenter({ individualTrackerViewService, haloClient, store, trackerId });
-  }, [individualTrackerViewService, haloClient, store, trackerId]);
-
-  useEffect(() => {
-    presenter.start();
-
-    return (): void => {
-      presenter.dispose();
-    };
-  }, [presenter]);
-
-  const snapshot = useSyncExternalStore(
-    (listener) => store.subscribe(listener),
-    () => store.getSnapshot(),
-    () => store.getSnapshot(),
-  );
-
-  const model = useMemo(() => IndividualTrackerViewerPresenter.present(snapshot), [snapshot]);
+  const { snapshot, model, onSelectMatch, onDeselect, onRetry } = useIndividualTrackerViewer({
+    individualTrackerViewService,
+    haloClient,
+    trackerId,
+  });
 
   return (
     <ComponentLoader
       status={snapshot.status}
       loading={<LoadingState text="Loading tracker..." />}
-      error={
-        <ErrorState
-          message={snapshot.errorMessage ?? "Failed to load tracker"}
-          onRetry={() => {
-            presenter.start();
-          }}
-        />
-      }
+      error={<ErrorState message={snapshot.errorMessage ?? "Failed to load tracker"} onRetry={onRetry} />}
       loaded={
         model.renderModel != null ? (
           <IndividualTrackerViewer
@@ -60,12 +36,8 @@ export function IndividualTrackerViewerPage({
             connectionStatus={model.connectionStatus}
             selectedMatchId={model.selectedMatchId}
             matchStatsState={model.matchStatsState}
-            onSelectMatch={(matchId) => {
-              presenter.selectMatch(matchId);
-            }}
-            onDeselect={() => {
-              presenter.deselectMatch();
-            }}
+            onSelectMatch={onSelectMatch}
+            onDeselect={onDeselect}
           />
         ) : (
           <LoadingState />

--- a/pages/src/components/individual-tracker/viewer/use-individual-tracker-viewer.ts
+++ b/pages/src/components/individual-tracker/viewer/use-individual-tracker-viewer.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
+import type { HaloInfiniteClient } from "halo-infinite-api";
+import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
+import { IndividualTrackerViewerPresenter } from "./viewer-presenter";
+import type { IndividualTrackerViewerSnapshot } from "./viewer-store";
+import { IndividualTrackerViewerStore } from "./viewer-store";
+import type { IndividualTrackerViewerViewModel } from "./types";
+
+interface UseIndividualTrackerViewerOpts {
+  readonly individualTrackerViewService: IndividualTrackerViewService;
+  readonly haloClient: HaloInfiniteClient;
+  readonly trackerId: string;
+}
+
+export interface IndividualTrackerViewerHookResult {
+  readonly snapshot: IndividualTrackerViewerSnapshot;
+  readonly model: IndividualTrackerViewerViewModel;
+  readonly onSelectMatch: (matchId: string) => void;
+  readonly onDeselect: () => void;
+  readonly onRetry: () => void;
+}
+
+export function useIndividualTrackerViewer({
+  individualTrackerViewService,
+  haloClient,
+  trackerId,
+}: UseIndividualTrackerViewerOpts): IndividualTrackerViewerHookResult {
+  const store = useMemo(() => new IndividualTrackerViewerStore(), []);
+
+  const presenter = useMemo(
+    () => new IndividualTrackerViewerPresenter({ individualTrackerViewService, haloClient, store, trackerId }),
+    [individualTrackerViewService, haloClient, store, trackerId],
+  );
+
+  useEffect(() => {
+    presenter.start();
+    return (): void => {
+      presenter.dispose();
+    };
+  }, [presenter]);
+
+  const snapshot = useSyncExternalStore(
+    (listener) => store.subscribe(listener),
+    () => store.getSnapshot(),
+    () => store.getSnapshot(),
+  );
+
+  const model = useMemo(() => IndividualTrackerViewerPresenter.present(snapshot), [snapshot]);
+
+  const onSelectMatch = useCallback(
+    (matchId: string): void => {
+      presenter.selectMatch(matchId);
+    },
+    [presenter],
+  );
+
+  const onDeselect = useCallback((): void => {
+    presenter.deselectMatch();
+  }, [presenter]);
+
+  const onRetry = useCallback((): void => {
+    presenter.start();
+  }, [presenter]);
+
+  return { snapshot, model, onSelectMatch, onDeselect, onRetry };
+}


### PR DESCRIPTION
Small prep refactor for the F1-3b OBS overlay. Extracts the presenter/store/subscription wiring out of `IndividualTrackerViewerPage` into `useIndividualTrackerViewer`, so the upcoming overlay page can call the same hook without duplicating the setup.

`IndividualTrackerViewerPage` is now a thin consumer — identical rendered output, just the wiring is a hook. Uses `useCallback` (not `useMemo`) for the stable action references.

1984 tests passing; typecheck/eslint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)