### PR TITLE
feat(pages): OBS overlay page at /individual-tracker/:trackerId/overlay (F1-3b)

### DIFF
--- a/pages/src/apps/individual-tracker-overlay/create.tsx
+++ b/pages/src/apps/individual-tracker-overlay/create.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import type { ReactElement } from "react";
+import { ComponentLoader, ComponentLoaderStatus } from "../../components/component-loader/component-loader";
+import { ErrorState } from "../../components/error-state/error-state";
+import { LoadingState } from "../../components/loading-state/loading-state";
+import { IndividualTrackerOverlayPage } from "../../components/individual-tracker/overlay/create";
+import type { Services } from "../individual-tracker-viewer/services";
+import { installServices } from "../individual-tracker-viewer/services";
+
+interface IndividualTrackerOverlayAppProps {
+  readonly apiHost: string;
+  readonly trackerId: string;
+}
+
+export function IndividualTrackerOverlayApp({ apiHost, trackerId }: IndividualTrackerOverlayAppProps): ReactElement {
+  const [state, setState] = useState(ComponentLoaderStatus.PENDING);
+  const [services, setServices] = useState<Services | null>(null);
+
+  useEffect(() => {
+    if (trackerId === "") {
+      return;
+    }
+
+    let isCancelled = false;
+
+    setServices(null);
+    setState(ComponentLoaderStatus.PENDING);
+
+    installServices(apiHost)
+      .then((installedServices) => {
+        if (isCancelled) {
+          return;
+        }
+        setServices(installedServices);
+        setState(ComponentLoaderStatus.LOADED);
+      })
+      .catch(() => {
+        if (isCancelled) {
+          return;
+        }
+        setState(ComponentLoaderStatus.ERROR);
+      });
+
+    return (): void => {
+      isCancelled = true;
+    };
+  }, [apiHost, trackerId]);
+
+  if (trackerId === "") {
+    return <ErrorState message="Overlay page has not been opened with a valid tracker id" />;
+  }
+
+  return (
+    <ComponentLoader
+      status={state}
+      loading={<LoadingState text="Loading tracker..." />}
+      error={<ErrorState message="Failed to load tracker" />}
+      loaded={
+        services ? (
+          <IndividualTrackerOverlayPage
+            individualTrackerViewService={services.individualTrackerViewService}
+            haloClient={services.haloClient}
+            trackerId={trackerId}
+          />
+        ) : (
+          <ErrorState message="Services failed to load" />
+        )
+      }
+    />
+  );
+}

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import type { HaloInfiniteClient } from "halo-infinite-api";
+import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import { ComponentLoaderStatus } from "../../component-loader/component-loader";
+import { ErrorState } from "../../error-state/error-state";
+import { LoadingState } from "../../loading-state/loading-state";
+import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
+import { useIndividualTrackerViewer } from "../viewer/use-individual-tracker-viewer";
+import { IndividualTrackerOverlay } from "./individual-tracker-overlay";
+
+interface IndividualTrackerOverlayPageProps {
+  readonly individualTrackerViewService: IndividualTrackerViewService;
+  readonly haloClient: HaloInfiniteClient;
+  readonly trackerId: string;
+}
+
+export function IndividualTrackerOverlayPage({
+  individualTrackerViewService,
+  haloClient,
+  trackerId,
+}: IndividualTrackerOverlayPageProps): React.ReactElement {
+  const { snapshot, model, onSelectMatch, onDeselect } = useIndividualTrackerViewer({
+    individualTrackerViewService,
+    haloClient,
+    trackerId,
+  });
+
+  switch (snapshot.status) {
+    case ComponentLoaderStatus.PENDING:
+    case ComponentLoaderStatus.LOADING: {
+      return <LoadingState text="Loading tracker..." />;
+    }
+    case ComponentLoaderStatus.LOADED: {
+      if (model.renderModel != null) {
+        return (
+          <IndividualTrackerOverlay
+            renderModel={model.renderModel}
+            matchStatsState={model.matchStatsState}
+            selectedMatchId={model.selectedMatchId}
+            onSelectMatch={onSelectMatch}
+            onDeselect={onDeselect}
+          />
+        );
+      }
+      return <LoadingState />;
+    }
+    case ComponentLoaderStatus.ERROR: {
+      return <ErrorState message={snapshot.errorMessage ?? "Failed to load tracker"} />;
+    }
+    default: {
+      throw new UnreachableError(snapshot.status);
+    }
+  }
+}

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.module.css
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.module.css
@@ -1,0 +1,6 @@
+.overlayRoot {
+  background: transparent;
+  inset: 0;
+  overflow: hidden;
+  position: fixed;
+}

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -1,0 +1,148 @@
+import React, { useCallback, useMemo } from "react";
+import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
+import { getTeamColorOrDefault } from "../../team-colors/team-colors";
+import type { TickerMatchGroup } from "../../information-ticker/information-ticker";
+import { createMatchStatsPresenter } from "../../stats/create";
+import { StreamerOverlay } from "../../streamer-overlay/streamer-overlay";
+import { TopSection } from "../../streamer-overlay/top-section";
+import { TabsBar } from "../viewer/viewer-tabs";
+import { StatsPanel } from "../viewer/stats-panel";
+import type { IndividualTrackerViewerRenderModel, ViewerSeriesTab, ViewerTimelineItem } from "../viewer/types";
+import type { MatchStatsState } from "../viewer/viewer-store";
+import styles from "./individual-tracker-overlay.module.css";
+
+interface IndividualTrackerOverlayProps {
+  readonly renderModel: IndividualTrackerViewerRenderModel;
+  readonly matchStatsState: MatchStatsState | null;
+  readonly selectedMatchId: string | null;
+  readonly onSelectMatch: (matchId: string) => void;
+  readonly onDeselect: () => void;
+}
+
+function getActiveSeries(timeline: readonly ViewerTimelineItem[]): ViewerSeriesTab | null {
+  const last = timeline.at(-1);
+  if (last?.type === "series") {
+    return last.series;
+  }
+  return null;
+}
+
+function buildTickerGroups(matchStatsState: MatchStatsState | null): TickerMatchGroup[] {
+  if (matchStatsState?.status !== "loaded") {
+    return [];
+  }
+
+  const { stats } = matchStatsState;
+  const presenter = createMatchStatsPresenter(stats.MatchInfo.GameVariantCategory);
+  const playerMap = new Map(stats.Players.map((p) => [getPlayerXuid(p), getPlayerXuid(p)]));
+  const data = presenter.getData(stats, playerMap, {});
+
+  return [
+    {
+      matchIndex: 0,
+      label: "",
+      rows: data.flatMap((teamData) => [
+        {
+          type: "team" as const,
+          teamId: teamData.teamId,
+          name: `Team ${teamData.teamId.toString()}`,
+          stats: teamData.teamStats,
+          medals: teamData.teamMedals,
+        },
+        ...teamData.players.map((p) => ({
+          type: "player" as const,
+          teamId: teamData.teamId,
+          name: p.name,
+          stats: p.values,
+          medals: p.medals,
+        })),
+      ]),
+    },
+  ];
+}
+
+export function IndividualTrackerOverlay({
+  renderModel,
+  matchStatsState,
+  selectedMatchId,
+  onSelectMatch,
+  onDeselect,
+}: IndividualTrackerOverlayProps): React.ReactElement {
+  const isPanelOpen =
+    selectedMatchId != null && (matchStatsState?.status === "loaded" || matchStatsState?.status === "error");
+
+  const teamColors = useMemo(() => [getTeamColorOrDefault(undefined, 0), getTeamColorOrDefault(undefined, 1)], []);
+
+  const activeSeries = getActiveSeries(renderModel.timeline);
+
+  const topSection =
+    activeSeries != null ? (
+      <TopSection
+        title={activeSeries.title}
+        subtitle={activeSeries.subtitle}
+        iconUrl={null}
+        showScore={true}
+        seriesScore={activeSeries.score}
+        showTeamDetails={false}
+        teamColors={teamColors}
+        teamLeft={null}
+        teamRight={null}
+      />
+    ) : null;
+
+  const tickerMatchGroups = useMemo(() => buildTickerGroups(matchStatsState), [matchStatsState]);
+
+  const renderPanelContent = useCallback((): React.ReactElement | null => {
+    if (matchStatsState == null) {
+      return null;
+    }
+    return <StatsPanel state={matchStatsState} />;
+  }, [matchStatsState]);
+
+  const handleClosePanel = useCallback((): void => {
+    onDeselect();
+  }, [onDeselect]);
+
+  const tabsBarSlot = useMemo(
+    () => (
+      <TabsBar
+        timeline={renderModel.timeline}
+        selectedMatchId={selectedMatchId}
+        onSelectMatch={onSelectMatch}
+        onDeselect={onDeselect}
+      />
+    ),
+    [renderModel.timeline, selectedMatchId, onSelectMatch, onDeselect],
+  );
+
+  return (
+    <div
+      className={styles.overlayRoot}
+      style={
+        {
+          "--overlay-team-color": teamColors[0].hex,
+          "--overlay-enemy-color": teamColors[1].hex,
+        } as React.CSSProperties
+      }
+    >
+      <StreamerOverlay
+        topSection={topSection}
+        pinTopSection={activeSeries != null}
+        teamColors={teamColors}
+        tabsBarSlot={tabsBarSlot}
+        tickerMatchGroups={tickerMatchGroups}
+        showTabs={renderModel.timeline.length > 0}
+        showTicker={true}
+        showPreSeriesInfo={false}
+        matchesLength={renderModel.accumulated.total}
+        showPreview={false}
+        previewMode="observer"
+        fontSizeStyles={{}}
+        settingsUi={null}
+        panelOpen={isPanelOpen}
+        onClosePanel={handleClosePanel}
+        renderPanelContent={renderPanelContent}
+      />
+    </div>
+  );
+}

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -1,0 +1,122 @@
+import "@testing-library/jest-dom/vitest";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("../../../icons/team-icon", () => ({
+  TeamIcon: ({ teamId }: { teamId: number }): React.ReactNode => (
+    <span data-testid={`team-icon-${teamId.toString()}`} />
+  ),
+}));
+vi.mock("../../../icons/medal-icon", () => ({
+  MedalIcon: (): React.ReactNode => null,
+}));
+import {
+  aFakeTrackerMatchSummaryWith,
+  aFakeTrackerViewStateWith,
+} from "../../../../services/individual-tracker/fakes/view.fake";
+import { aFakeMatchStatsWith } from "../../../stats/fakes/data";
+import { buildViewerRenderModel } from "../../viewer/viewer-render-model";
+import { IndividualTrackerOverlay } from "../individual-tracker-overlay";
+
+function aRenderModel(
+  overrides?: Parameters<typeof aFakeTrackerViewStateWith>[0],
+): ReturnType<typeof buildViewerRenderModel> {
+  return buildViewerRenderModel({ view: aFakeTrackerViewStateWith(overrides) });
+}
+
+describe("IndividualTrackerOverlay", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders without crashing when the timeline is empty", () => {
+    const { container } = render(
+      <IndividualTrackerOverlay
+        renderModel={aRenderModel({ matches: [], series: [] })}
+        matchStatsState={null}
+        selectedMatchId={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
+
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it("renders without crashing when the timeline has items", () => {
+    const { container } = render(
+      <IndividualTrackerOverlay
+        renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
+        matchStatsState={null}
+        selectedMatchId={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
+
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it("keeps the stats panel closed when a match is selected but stats are still loading", () => {
+    render(
+      <IndividualTrackerOverlay
+        renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
+        matchStatsState={{ status: "loading" }}
+        selectedMatchId="m-1"
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "✕" })).not.toBeInTheDocument();
+  });
+
+  it("opens the stats panel when stats are loaded for a selected match", () => {
+    render(
+      <IndividualTrackerOverlay
+        renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
+        matchStatsState={{ status: "loaded", stats: aFakeMatchStatsWith() }}
+        selectedMatchId="m-1"
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "✕" })).toBeInTheDocument();
+  });
+
+  it("opens the stats panel when stats fail to load so the error is visible", () => {
+    render(
+      <IndividualTrackerOverlay
+        renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
+        matchStatsState={{ status: "error", message: "Network failure" }}
+        selectedMatchId="m-1"
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "✕" })).toBeInTheDocument();
+    expect(screen.getByText("Network failure")).toBeInTheDocument();
+  });
+
+  it("calls onDeselect when the close button is clicked", async () => {
+    const onDeselect = vi.fn();
+
+    render(
+      <IndividualTrackerOverlay
+        renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
+        matchStatsState={{ status: "loaded", stats: aFakeMatchStatsWith() }}
+        selectedMatchId="m-1"
+        onSelectMatch={() => undefined}
+        onDeselect={onDeselect}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "✕" }));
+
+    expect(onDeselect).toHaveBeenCalledOnce();
+  });
+});

--- a/pages/src/components/streamer-overlay/bottom-section.tsx
+++ b/pages/src/components/streamer-overlay/bottom-section.tsx
@@ -1,0 +1,50 @@
+import React, { memo } from "react";
+import type { TeamColor } from "../team-colors/team-colors";
+import { InformationTicker, type TickerMatchGroup } from "../information-ticker/information-ticker";
+import styles from "./streamer-overlay.module.css";
+
+interface BottomSectionProps {
+  readonly showTabs: boolean;
+  readonly showTicker: boolean;
+  readonly showPreSeriesInfo: boolean;
+  readonly matchesLength: number;
+  readonly currentMatchGroup: TickerMatchGroup | undefined;
+  readonly teamColors: TeamColor[];
+  readonly tabsBarSlot: React.ReactNode;
+  readonly onScrollComplete: () => void;
+}
+
+function BottomSectionComponent({
+  showTabs,
+  showTicker,
+  showPreSeriesInfo,
+  matchesLength,
+  currentMatchGroup,
+  teamColors,
+  tabsBarSlot,
+  onScrollComplete,
+}: BottomSectionProps): React.ReactElement | null {
+  if (!showTabs && !showTicker) {
+    return null;
+  }
+
+  return (
+    <div className={styles.bottomSection}>
+      {showTabs && tabsBarSlot}
+
+      {showTicker && currentMatchGroup != null && (
+        <InformationTicker
+          currentMatchGroup={currentMatchGroup}
+          teamColors={teamColors}
+          onScrollComplete={onScrollComplete}
+        />
+      )}
+
+      {showTicker && currentMatchGroup == null && !showPreSeriesInfo && matchesLength === 0 && (
+        <div className={styles.tickerPlaceholder}>Waiting for first match to complete...</div>
+      )}
+    </div>
+  );
+}
+
+export const BottomSection = memo(BottomSectionComponent);

--- a/pages/src/components/streamer-overlay/overlay-stats-panel.tsx
+++ b/pages/src/components/streamer-overlay/overlay-stats-panel.tsx
@@ -1,0 +1,48 @@
+import React, { memo } from "react";
+import { CSSTransition } from "react-transition-group";
+import styles from "./streamer-overlay.module.css";
+
+interface OverlayStatsPanelProps {
+  readonly isPanelOpen: boolean;
+  readonly nodeRef: React.RefObject<HTMLDivElement | null>;
+  readonly onClosePanel: () => void;
+  readonly panelContent: React.ReactElement | null;
+}
+
+function OverlayStatsPanelComponent({
+  isPanelOpen,
+  nodeRef,
+  onClosePanel,
+  panelContent,
+}: OverlayStatsPanelProps): React.ReactElement {
+  return (
+    <CSSTransition
+      in={isPanelOpen}
+      timeout={300}
+      classNames={{
+        enter: styles.panelEnter,
+        enterActive: styles.panelEnterActive,
+        exit: styles.panelExit,
+        exitActive: styles.panelExitActive,
+      }}
+      nodeRef={nodeRef}
+      unmountOnExit
+    >
+      <div ref={nodeRef} className={styles.statsPanel} onClick={onClosePanel}>
+        <div
+          className={styles.statsPanelContent}
+          onClick={(e): void => {
+            e.stopPropagation();
+          }}
+        >
+          <button type="button" className={styles.closeButton} onClick={onClosePanel}>
+            ✕
+          </button>
+          {panelContent}
+        </div>
+      </div>
+    </CSSTransition>
+  );
+}
+
+export const OverlayStatsPanel = memo(OverlayStatsPanelComponent);

--- a/pages/src/components/streamer-overlay/streamer-overlay.module.css
+++ b/pages/src/components/streamer-overlay/streamer-overlay.module.css
@@ -1,0 +1,509 @@
+/* ============================================ */
+
+/* Streamer Overlay - OBS Mode Layout          */
+
+/* ============================================ */
+
+.overlay {
+  background: transparent;
+  color: var(--halo-white);
+  font-family: var(--font-body);
+  inset: 0;
+  overflow: hidden;
+  position: fixed;
+  z-index: var(--z-overlay);
+}
+
+.topSectionPinnedWrapper {
+  left: 50%;
+  position: fixed;
+  top: 0;
+  transform: translateX(-50%);
+  width: 100%;
+  z-index: 22;
+}
+
+/* View Mode Selector positioned in top-right */
+.viewModeContainer {
+  position: absolute;
+  right: var(--space-2);
+  top: var(--space-2);
+  z-index: 100;
+}
+
+/* Preview backgrounds for development */
+.previewPlayer {
+  background-image: url("/in-game-player.jpg");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+.previewObserver {
+  background-image: url("/in-game-observer.jpg");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+/* ============================================ */
+
+/* Top Section: Teams and Score                 */
+
+/* ============================================ */
+
+.topSection {
+  align-items: center;
+  display: grid;
+  gap: 0;
+  grid-template: "teamLeft scoreLeft serverIcon scoreRight teamRight" min-content "title title serverIcon subtitle subtitle" min-content / 1fr min-content min-content min-content 1fr;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 100%;
+  z-index: 10;
+}
+
+.title,
+.subtitle {
+  border: 2px solid var(--halo-bg-primary);
+  border-top: 0;
+  color: var(--halo-white);
+  font-family: var(--font-heading);
+  font-size: calc(var(--text-base) * var(--font-size-queue-info, 1));
+  font-weight: 700;
+  padding: 0 var(--space-3);
+  white-space: nowrap;
+}
+
+.title {
+  border-right: 0;
+  grid-area: title;
+  justify-self: end;
+}
+
+.subtitle {
+  border-left: 0;
+  grid-area: subtitle;
+  justify-self: start;
+}
+
+.serverIconSlot {
+  aspect-ratio: 1;
+  grid-area: serverIcon;
+  place-self: stretch center;
+}
+
+.serverIcon {
+  display: block;
+  height: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  width: 100%;
+}
+
+.teamLeftScore,
+.teamRightScore {
+  align-items: center;
+  align-self: stretch;
+  background-color: color-mix(in srgb, var(--team-color, transparent) 80%, transparent);
+  border: 2px solid var(--team-color, var(--halo-teal-primary));
+  border-radius: var(--radius-sm);
+  border-top: 0;
+  color: var(--halo-white);
+  font-family: var(--font-heading);
+  font-size: calc(var(--text-2xl) * var(--font-size-score, 1));
+  font-weight: 700;
+  line-height: 1;
+  padding: var(--space-1) var(--space-3);
+}
+
+.teamLeftScore {
+  grid-area: scoreLeft;
+  justify-self: end;
+}
+
+.teamRightScore {
+  grid-area: scoreRight;
+  justify-self: start;
+}
+
+.teamLeft,
+.teamRight {
+  --team-icon-size: calc(var(--text-base) * var(--font-size-teams, 1) * 1.25);
+  --team-icon-shadow-offset: calc(var(--team-icon-size) * 3);
+
+  align-items: center;
+  align-self: stretch;
+  background-color: color-mix(in srgb, var(--team-color, transparent) 40%, transparent);
+  border: 2px solid var(--team-color, var(--halo-teal-primary));
+  border-top: 0;
+  display: flex;
+  flex-direction: row;
+  gap: var(--space-2);
+  overflow: hidden;
+  padding: var(--space-1) var(--space-3);
+  position: relative;
+  width: 675px;
+
+  > img {
+    filter: drop-shadow(0 var(--team-icon-shadow-offset) 0 var(--team-color));
+    height: var(--team-icon-size);
+    margin-bottom: calc(var(--space-1) * -1);
+    margin-top: calc(var(--space-1) * -1);
+    transform: translateY(calc(var(--team-icon-shadow-offset) * -1));
+    width: var(--team-icon-size);
+  }
+}
+
+.teamLeft {
+  border-right: 0;
+  display: flex;
+  flex-direction: row-reverse;
+  grid-area: teamLeft;
+  justify-self: end;
+  padding-left: calc(var(--space-3) + 10px);
+}
+
+.teamRight {
+  border-left: 0;
+  grid-area: teamRight;
+  justify-self: start;
+  padding-right: calc(var(--space-3) + 10px);
+}
+
+.teamWithPlayers {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  position: relative;
+}
+
+.teamWithPlayers .teamName,
+.teamWithPlayers .teamPlayersScroll {
+  grid-area: 1 / 1;
+  justify-self: center;
+}
+
+.animateTeamNames .teamName {
+  animation: fadeTeamName 40s infinite;
+  z-index: 2;
+}
+
+.animateTeamNames .teamPlayersScroll {
+  animation: fadePlayerNames 40s infinite;
+  z-index: 1;
+}
+
+@keyframes fadeTeamName {
+  0% {
+    opacity: 1;
+  }
+
+  47% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0;
+  }
+
+  97% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes fadePlayerNames {
+  0% {
+    opacity: 0;
+  }
+
+  47% {
+    opacity: 0;
+  }
+
+  50% {
+    opacity: 1;
+  }
+
+  97% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+  }
+}
+
+.teamName,
+.teamPlayers {
+  color: var(--halo-white);
+  flex: 1 1 auto;
+  font-size: calc(var(--text-base) * var(--font-size-teams, 1));
+  font-weight: 700;
+  position: relative;
+  text-align: center;
+  text-shadow:
+    0 1px 2px rgb(0 0 0 / 80%),
+    0 0 10px rgb(0 0 0 / 60%);
+}
+
+.teamPlayers {
+  overflow: hidden;
+}
+
+.playerIcon {
+  display: inline-block;
+  height: 16px;
+  margin-inline: 2px;
+  vertical-align: middle;
+  width: 16px;
+}
+
+/* ============================================ */
+
+/* Bottom Tab Bar                               */
+
+/* ============================================ */
+
+.bottomSection {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  z-index: 10;
+}
+
+.tabBar {
+  display: flex;
+  font-size: calc(var(--text-sm) * var(--font-size-tabs, 1));
+  gap: var(--space-1);
+  justify-content: center;
+}
+
+.tickerPlaceholder {
+  align-items: center;
+  background: rgb(15 40 48 / 90%);
+  color: var(--halo-gray);
+  display: flex;
+  font-size: calc(var(--text-sm) * var(--font-size-ticker, 1));
+  justify-content: center;
+  min-height: 60px;
+  padding: var(--space-3);
+  text-align: center;
+}
+
+.title,
+.subtitle,
+.tab {
+  background: rgb(15 40 48 / 90%);
+  background-color: color-mix(in srgb, var(--tab-team-color, transparent) 20%, rgb(15 40 48 / 90%));
+  background-image:
+    linear-gradient(
+      to bottom,
+      color-mix(in srgb, var(--tab-team-color, transparent) 30%, transparent),
+      color-mix(in srgb, var(--tab-team-color, transparent) 30%, transparent)
+    ),
+    radial-gradient(circle at 1px 1px, color-mix(in srgb, var(--halo-white) 15%, transparent) 1px, transparent 1.5px);
+  background-position:
+    center,
+    0 0,
+    center;
+  background-repeat: no-repeat, repeat, no-repeat;
+  background-size:
+    100% 100%,
+    10px 10px,
+    cover;
+}
+
+.tab {
+  align-items: center;
+  border: 2px solid var(--tab-team-color, var(--halo-bg-primary));
+  border-bottom: 0;
+  color: var(--halo-white);
+  cursor: pointer;
+  display: flex;
+  font-family: var(--font-body);
+  font-size: inherit;
+  font-weight: 700;
+  justify-content: center;
+  min-width: 80px;
+  padding: var(--space-1) var(--space-2);
+  text-shadow:
+    0 1px 2px rgb(0 0 0 / 80%),
+    0 0 10px rgb(0 0 0 / 60%);
+  transition: all var(--transition-fast);
+}
+
+.tabSeries {
+  font-family: var(--font-heading);
+  min-width: 100px;
+}
+
+.tabContent {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  gap: var(--space-1);
+}
+
+.tabIcons {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  gap: 2px;
+}
+
+.tab:hover {
+  background-color: color-mix(in srgb, var(--tab-team-color, var(--halo-bg-primary)) 30%, rgb(15 40 48 / 90%));
+  border-color: var(--halo-accent);
+  transform: translateY(-2px);
+}
+
+.tabActive {
+  outline: 2px solid var(--tab-team-color, var(--halo-bg-primary));
+  position: relative;
+}
+
+.tabActive::after {
+  border-color: var(--tab-team-color, var(--halo-bg-primary)) transparent transparent;
+  border-style: solid;
+  border-width: 12px 9px 0;
+  bottom: -12px;
+  content: "";
+  left: 50%;
+  position: absolute;
+  transform: translateX(-50%);
+}
+
+.tabActive::before {
+  border-color: color-mix(in srgb, var(--tab-team-color, var(--halo-bg-primary)) 40%, rgb(15 40 48 / 90%)) transparent
+    transparent;
+  border-style: solid;
+  border-width: 9px 6px 0;
+  bottom: -9px;
+  content: "";
+  left: 50%;
+  position: absolute;
+  transform: translateX(-50%);
+  z-index: 1;
+}
+
+.tabSelected {
+  border-color: var(--halo-accent);
+  box-shadow: 0 0 30px color-mix(in srgb, var(--halo-accent) 50%, transparent);
+}
+
+.tabIcon {
+  height: 20px;
+  width: 20px;
+}
+
+.tabIconDimmed {
+  opacity: 0.5;
+}
+
+.tabLabel {
+  font-weight: 600;
+}
+
+.tabScore {
+  font-weight: 700;
+}
+
+/* ============================================ */
+
+/* Sliding Stats Panel                          */
+
+/* ============================================ */
+
+.statsPanel {
+  align-items: flex-end;
+  background: rgb(0 0 0 / 70%);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: var(--space-8) var(--space-8) 0;
+  position: fixed;
+  z-index: 100;
+}
+
+/* Transition classes for enter/exit animations */
+.panelEnter {
+  opacity: 0;
+}
+
+.panelEnter .statsPanelContent {
+  transform: translateY(100%);
+}
+
+.panelEnterActive {
+  opacity: 1;
+  transition: opacity 300ms ease-out;
+}
+
+.panelEnterActive .statsPanelContent {
+  transform: translateY(0);
+  transition: transform 300ms ease-out;
+}
+
+.panelExit {
+  opacity: 1;
+}
+
+.panelExit .statsPanelContent {
+  transform: translateY(0);
+}
+
+.panelExitActive {
+  opacity: 0;
+  transition: opacity 300ms ease-in;
+}
+
+.panelExitActive .statsPanelContent {
+  transform: translateY(100%);
+  transition: transform 300ms ease-in;
+}
+
+.statsPanelContent {
+  background: rgb(15 40 48 / 98%);
+  border: 2px solid var(--halo-teal-primary);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  box-shadow: 0 -4px 40px rgb(0 0 0 / 60%);
+  max-height: 95vh;
+  max-width: 1400px;
+  overflow-y: auto;
+  padding: var(--space-6);
+  position: relative;
+  width: 100%;
+}
+
+.closeButton {
+  background: transparent;
+  border: 2px solid var(--halo-teal-primary);
+  border-radius: var(--radius-base);
+  color: var(--halo-white);
+  cursor: pointer;
+  font-size: var(--text-xl);
+  line-height: 1;
+  padding: var(--space-2);
+  position: absolute;
+  right: var(--space-4);
+  top: var(--space-4);
+  transition: all var(--transition-fast);
+}
+
+.closeButton:hover {
+  background: var(--halo-teal-primary);
+  border-color: var(--halo-accent);
+  color: var(--halo-bg-primary);
+}
+
+.closeButton:focus-visible {
+  outline: 2px solid var(--halo-accent);
+  outline-offset: 2px;
+}

--- a/pages/src/components/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/streamer-overlay/streamer-overlay.tsx
@@ -1,0 +1,131 @@
+import React, { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import classNames from "classnames";
+import type { TeamColor } from "../team-colors/team-colors";
+import type { TickerMatchGroup } from "../information-ticker/information-ticker";
+import { BottomSection } from "./bottom-section";
+import { OverlayStatsPanel } from "./overlay-stats-panel";
+import styles from "./streamer-overlay.module.css";
+
+export interface StreamerOverlayProps {
+  readonly topSection: React.ReactNode;
+  readonly pinTopSection?: boolean;
+  readonly teamColors: TeamColor[];
+  readonly tabsBarSlot: React.ReactNode;
+  readonly tickerMatchGroups: readonly TickerMatchGroup[];
+  readonly showTabs: boolean;
+  readonly showTicker: boolean;
+  readonly showPreSeriesInfo: boolean;
+  readonly matchesLength: number;
+  readonly showPreview: boolean;
+  readonly previewMode: "player" | "observer";
+  readonly fontSizeStyles: React.CSSProperties;
+  readonly settingsUi: React.ReactNode;
+  readonly panelOpen?: boolean;
+  readonly renderPanelContent: () => React.ReactElement | null;
+  readonly onClosePanel?: () => void;
+}
+
+export function StreamerOverlay({
+  topSection,
+  pinTopSection = false,
+  teamColors,
+  tabsBarSlot,
+  tickerMatchGroups,
+  showTabs,
+  showTicker,
+  showPreSeriesInfo,
+  matchesLength,
+  showPreview,
+  previewMode,
+  fontSizeStyles,
+  settingsUi,
+  panelOpen,
+  renderPanelContent,
+  onClosePanel,
+}: StreamerOverlayProps): React.ReactElement {
+  const [internalIsPanelOpen, setInternalIsPanelOpen] = useState(false);
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const [previousMatchCount, setPreviousMatchCount] = useState(0);
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+
+  const isPanelOpen = panelOpen ?? internalIsPanelOpen;
+
+  const handleScrollComplete = (): void => {
+    if (tickerMatchGroups.length === 0) {
+      return;
+    }
+
+    setCurrentMatchIndex((prevIndex) => (prevIndex + 1) % tickerMatchGroups.length);
+  };
+
+  useEffect(() => {
+    if (currentMatchIndex < tickerMatchGroups.length) {
+      return;
+    }
+
+    setCurrentMatchIndex(0);
+  }, [currentMatchIndex, tickerMatchGroups.length]);
+
+  useEffect(() => {
+    if (!showTicker) {
+      return;
+    }
+
+    const currentMatchCount = matchesLength;
+
+    if (currentMatchCount > previousMatchCount && previousMatchCount > 0) {
+      const latestMatchIndex = tickerMatchGroups.findIndex((group) => group.matchIndex === currentMatchCount - 1);
+      if (latestMatchIndex !== -1) {
+        setCurrentMatchIndex(latestMatchIndex);
+      }
+    }
+
+    setPreviousMatchCount(currentMatchCount);
+  }, [matchesLength, showTicker, tickerMatchGroups, previousMatchCount]);
+
+  const handleClosePanel = useCallback((): void => {
+    if (onClosePanel !== undefined) {
+      onClosePanel();
+    } else {
+      setInternalIsPanelOpen(false);
+    }
+  }, [onClosePanel]);
+
+  const hasTickerGroups = tickerMatchGroups.length > 0;
+  const currentMatchGroup = hasTickerGroups
+    ? tickerMatchGroups[currentMatchIndex % tickerMatchGroups.length]
+    : undefined;
+  const panelContent = useMemo<React.ReactElement | null>(() => renderPanelContent(), [renderPanelContent]);
+
+  return (
+    <div
+      className={classNames(styles.overlay, {
+        [styles.previewPlayer]: showPreview && previewMode === "player",
+        [styles.previewObserver]: showPreview && previewMode === "observer",
+      })}
+      style={fontSizeStyles}
+    >
+      {settingsUi}
+
+      <div className={classNames({ [styles.topSectionPinnedWrapper]: pinTopSection })}>{topSection}</div>
+
+      <BottomSection
+        showTabs={showTabs}
+        showTicker={showTicker}
+        showPreSeriesInfo={showPreSeriesInfo}
+        matchesLength={matchesLength}
+        currentMatchGroup={currentMatchGroup}
+        teamColors={teamColors}
+        tabsBarSlot={tabsBarSlot}
+        onScrollComplete={handleScrollComplete}
+      />
+
+      <OverlayStatsPanel
+        isPanelOpen={isPanelOpen}
+        nodeRef={nodeRef}
+        onClosePanel={handleClosePanel}
+        panelContent={panelContent}
+      />
+    </div>
+  );
+}

--- a/pages/src/components/streamer-overlay/top-section.tsx
+++ b/pages/src/components/streamer-overlay/top-section.tsx
@@ -1,0 +1,64 @@
+import React, { memo } from "react";
+import type { TeamColor } from "../team-colors/team-colors";
+import { TeamIcon } from "../icons/team-icon";
+import styles from "./streamer-overlay.module.css";
+
+interface TopSectionProps {
+  readonly title: string | null;
+  readonly subtitle: string | null;
+  readonly iconUrl: string | null;
+  readonly showScore: boolean;
+  readonly showTeamDetails: boolean;
+  readonly seriesScore: string;
+  readonly teamColors: TeamColor[];
+  readonly teamLeft: React.ReactNode;
+  readonly teamRight: React.ReactNode;
+}
+
+function TopSectionComponent({
+  title,
+  subtitle,
+  iconUrl,
+  showScore,
+  showTeamDetails,
+  seriesScore,
+  teamColors,
+  teamLeft,
+  teamRight,
+}: TopSectionProps): React.ReactElement {
+  return (
+    <div className={styles.topSection}>
+      {title != null && <div className={styles.title}>{title}</div>}
+      {iconUrl != null && (
+        <div className={styles.serverIconSlot}>
+          <img src={iconUrl} alt="Server" className={styles.serverIcon} />
+        </div>
+      )}
+      {subtitle != null && <div className={styles.subtitle}>{subtitle}</div>}
+      {showScore && (
+        <>
+          <div className={styles.teamLeftScore} style={{ "--team-color": teamColors[0]?.hex } as React.CSSProperties}>
+            {seriesScore.split(":")[0]}
+          </div>
+          <div className={styles.teamRightScore} style={{ "--team-color": teamColors[1]?.hex } as React.CSSProperties}>
+            {seriesScore.split(":")[1]}
+          </div>
+        </>
+      )}
+      {showTeamDetails && (
+        <>
+          <div className={styles.teamLeft} style={{ "--team-color": teamColors[0]?.hex } as React.CSSProperties}>
+            <TeamIcon teamId={0} />
+            <div className={styles.teamPlayers}>{teamLeft}</div>
+          </div>
+          <div className={styles.teamRight} style={{ "--team-color": teamColors[1]?.hex } as React.CSSProperties}>
+            <TeamIcon teamId={1} />
+            <div className={styles.teamPlayers}>{teamRight}</div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export const TopSection = memo(TopSectionComponent);

--- a/pages/src/layouts/overlay-layout.astro
+++ b/pages/src/layouts/overlay-layout.astro
@@ -1,0 +1,36 @@
+---
+import GuiltySparkIcon from "../assets/guilty-spark-icon.png";
+
+interface Props {
+  title?: string;
+  description?: string;
+}
+
+const { title = "Guilty Spark Overlay", description = "Guilty Spark Individual Tracker Overlay" } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="description" content={description} />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="icon" type="image/png" href={GuiltySparkIcon.src} />
+    <meta name="generator" content={Astro.generator} />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;500;600;700&family=Saira+Condensed:wght@600;700;800&family=Orbitron:wght@600;700;800;900&display=swap"
+      rel="stylesheet"
+    />
+
+    <title>{title}</title>
+  </head>
+  <body data-view-mode="streamer">
+    <slot />
+  </body>
+</html>
+<style is:global>
+  @import url("../styles/base.css");
+</style>

--- a/pages/src/pages/individual-tracker/[trackerId]/overlay.astro
+++ b/pages/src/pages/individual-tracker/[trackerId]/overlay.astro
@@ -1,0 +1,13 @@
+---
+export const prerender = false;
+
+import OverlayLayout from "../../../layouts/overlay-layout.astro";
+import { API_HOST } from "../../../constants";
+import { IndividualTrackerOverlayApp } from "../../../apps/individual-tracker-overlay/create";
+
+const { trackerId } = Astro.params;
+---
+
+<OverlayLayout title="Tracker Overlay - Guilty Spark">
+  <IndividualTrackerOverlayApp client:only="react" apiHost={API_HOST} trackerId={trackerId ?? ""} />
+</OverlayLayout>


### PR DESCRIPTION
**Stacked on #482** (viewer hook extraction — merge that first).

OBS browser-source overlay at `/individual-tracker/<trackerId>/overlay`. Transparent background, no header, Halo fonts — designed to be added as a browser source in OBS with the tracker URL.

## Architecture
Reuses everything from the viewer data layer: same `useIndividualTrackerViewer` hook (WS connection, stats fetching, presenter/store). The overlay is just a different visual component over the same state — no new API/DO needed.

## What's new
**`streamer-overlay/` components** (ported from rework, adapted):
- `StreamerOverlay` — shell with transparent overlay CSS; `tabsBarSlot: React.ReactNode` instead of a separate `OverlayTabsBar`, so our existing `TabsBar` plugs in directly; panel state externally controlled via `panelOpen`
- `BottomSection` — tabs + information ticker; dead props removed (`activeTabIndex`/`selectedTab`/`isPanelOpen` were declared but never used in the body)
- `TopSection` — series score / title strip (shows when the latest timeline item is a series)
- `OverlayStatsPanel` — renamed from rework's `StatsPanel` to avoid collision with `viewer/stats-panel.tsx`

**`individual-tracker/overlay/`** (new):
- `isPanelOpen` is **derived**: `selectedMatchId != null && (status === "loaded" || status === "error")` — auto-opens when stats load, **also opens on error so the error is visible**, auto-closes when match is deselected
- `handleClosePanel` calls `onDeselect()` — clears `selectedMatchId` so stale stats don't persist in the ticker after panel close
- `tabsBarSlot` wrapped in `useMemo` so `BottomSection.memo` is effective

**Astro page**: `overlay-layout.astro` (new — transparent body, no header), `[trackerId]/overlay.astro` (`prerender = false`, `client:only`).

## Ticker note
The ticker shows stats for the **currently-selected match** (not all matches). To show all-match stats would require pre-fetching stats for every match, which contradicts the agreed architecture (client fetches on demand). This is intentional — the ticker activates when a match tab is clicked and stats load.

## Review findings fixed (2 code-review rounds)
- `hasPanelContent` was a dead prop (never called in `StreamerOverlay`); removed
- `isPanelOpen` initially derived without the error case (silent failure); fixed to include error
- `handleClosePanel` initially didn't call `onDeselect`; stale selectedMatchId left ticker showing closed-match stats; fixed
- `handleSelectMatch` was a no-op wrapper; removed, `onSelectMatch` passed directly
- `tabsBarSlot` was inline JSX busting `BottomSection.memo`; wrapped in `useMemo`
- `BottomSection` had 3 dead props; removed
- Tests upgraded from smoke-only to covering panel open/closed/error/close-button states

## Verification
- `npm run build --workspace=pages` → complete (both dynamic routes build)
- `npm run typecheck:pages` → 0 errors; eslint + stylelint + prettier clean
- `npx vitest run` → **1990 passing** (+6 overlay tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)