### PR TITLE
feat(api): per-tracker streamer-view settings — GET/PATCH routes + view contract (A3)

### DIFF
--- a/api/routes/individual-tracker/individual-tracker.ts
+++ b/api/routes/individual-tracker/individual-tracker.ts
@@ -1,10 +1,12 @@
 import type { RoutesRegisterHandler } from "../base/types";
 import { trackerManageRoutesRegisterHandler } from "./manage";
 import { trackerProfileRoutesRegisterHandler } from "./profile";
+import { trackerSettingsRoutesRegisterHandler } from "./settings";
 import { trackerViewRoutesRegisterHandler } from "./view";
 
 export const individualTrackerRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
   trackerProfileRoutesRegisterHandler(router, installServices);
   trackerManageRoutesRegisterHandler(router, installServices);
+  trackerSettingsRoutesRegisterHandler(router, installServices);
   trackerViewRoutesRegisterHandler(router, installServices);
 };

--- a/api/routes/individual-tracker/mapper.ts
+++ b/api/routes/individual-tracker/mapper.ts
@@ -1,6 +1,7 @@
 import type { TrackerProfile } from "@guilty-spark/shared/contracts/individual-tracker/profile";
 import type { Tracker, TrackerState } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import { parseStreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { IndividualTrackerProfilesRow } from "../../services/database/types/individual_tracker_profiles";
 import type { IndividualTrackersRow } from "../../services/database/types/individual_trackers";
 import type {
@@ -77,5 +78,6 @@ export function toTrackerView(
           })),
     lastUpdateTime: doState == null ? "" : doState.lastUpdateTime,
     lastMatchDiscoveredAt: doState == null ? null : doState.lastMatchDiscoveredAt,
+    streamerSettings: parseStreamerViewSettings(row.StreamerViewSettingsJson),
   };
 }

--- a/api/routes/individual-tracker/settings.ts
+++ b/api/routes/individual-tracker/settings.ts
@@ -1,0 +1,74 @@
+import { parseJsonBody, parsePathParams } from "@guilty-spark/shared/base/request-parsing";
+import { errorContract } from "@guilty-spark/shared/contracts/error";
+import { settingsBodySchema, settingsContract } from "@guilty-spark/shared/contracts/individual-tracker/settings";
+import { trackerParamsSchema } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import { parseStreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import type { RoutesRegisterHandler } from "../base/types";
+import { requireSession } from "../base/require-session";
+
+export const trackerSettingsRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
+  router.get("/api/individual-tracker/:trackerId/settings", async (request, env: Env) => {
+    const services = installServices({ env });
+    const { authService, databaseService, logService } = services;
+
+    try {
+      const auth = await requireSession(request, authService);
+      if (!auth.ok) {
+        return auth.response;
+      }
+
+      const parsedParams = parsePathParams(request.params, trackerParamsSchema, "Invalid tracker id");
+      if (!parsedParams.success) {
+        return parsedParams.response;
+      }
+      const { trackerId } = parsedParams.data;
+
+      const row = await databaseService.getIndividualTracker(trackerId);
+      if (row?.UserId !== auth.session.userId) {
+        return errorContract.toResponse({ error: "Tracker not found" }, { status: 404, noStore: true });
+      }
+
+      const settings = parseStreamerViewSettings(row.StreamerViewSettingsJson);
+
+      return settingsContract.toResponse({ settings }, { noStore: true });
+    } catch (error) {
+      logService.error(error as Error, new Map([["message", "Individual tracker get settings error"]]));
+      return errorContract.toResponse({ error: "Failed to fetch tracker settings" }, { status: 500, noStore: true });
+    }
+  });
+
+  router.patch("/api/individual-tracker/:trackerId/settings", async (request, env: Env) => {
+    const services = installServices({ env });
+    const { authService, databaseService, logService } = services;
+
+    try {
+      const auth = await requireSession(request, authService);
+      if (!auth.ok) {
+        return auth.response;
+      }
+
+      const parsedParams = parsePathParams(request.params, trackerParamsSchema, "Invalid tracker id");
+      if (!parsedParams.success) {
+        return parsedParams.response;
+      }
+      const { trackerId } = parsedParams.data;
+
+      const row = await databaseService.getIndividualTracker(trackerId);
+      if (row?.UserId !== auth.session.userId) {
+        return errorContract.toResponse({ error: "Tracker not found" }, { status: 404, noStore: true });
+      }
+
+      const parsed = await parseJsonBody(request, settingsBodySchema, "Invalid settings payload");
+      if (!parsed.success) {
+        return parsed.response;
+      }
+
+      await databaseService.updateIndividualTrackerSettings(trackerId, JSON.stringify(parsed.data.settings));
+
+      return settingsContract.toResponse({ settings: parsed.data.settings }, { noStore: true });
+    } catch (error) {
+      logService.error(error as Error, new Map([["message", "Individual tracker update settings error"]]));
+      return errorContract.toResponse({ error: "Failed to update tracker settings" }, { status: 500, noStore: true });
+    }
+  });
+};

--- a/api/routes/individual-tracker/tests/settings.test.ts
+++ b/api/routes/individual-tracker/tests/settings.test.ts
@@ -1,0 +1,211 @@
+import type { AutoRouterType } from "itty-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import type { SettingsResponse } from "@guilty-spark/shared/contracts/individual-tracker/settings";
+import type { ErrorResponse } from "@guilty-spark/shared/contracts/error";
+import type { DatabaseService } from "../../../services/database/database";
+import { createApiRouter } from "../../../base/router";
+import { aFakeEnvWith } from "../../../base/fakes/env.fake";
+import { aFakeIndividualTrackersRow } from "../../../services/database/fakes/database.fake";
+import { installFakeServicesWith } from "../../../services/fakes/services";
+import { aFakeAuthSessionWith } from "../../../services/auth/fakes/data";
+import { individualTrackerRoutesRegisterHandler } from "../individual-tracker";
+
+function getRequest(path: string): Request {
+  return new Request(`http://localhost${path}`, { method: "GET" });
+}
+
+function patchRequest(path: string, body: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/individual-tracker settings routes", () => {
+  let env: Env;
+  let router: AutoRouterType;
+
+  beforeEach(() => {
+    env = aFakeEnvWith();
+    router = createApiRouter();
+  });
+
+  describe("GET /api/individual-tracker/:trackerId/settings", () => {
+    it("returns 401 when not authenticated", async () => {
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.authService, "validateSession").mockResolvedValue(null);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/api/individual-tracker/tracker-1/settings"), env)) as Response;
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 404 when tracker does not exist", async () => {
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-1" }));
+        vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(null);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/api/individual-tracker/unknown/settings"), env)) as Response;
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 404 when tracker belongs to a different user", async () => {
+      const row = aFakeIndividualTrackersRow({ TrackerId: "tracker-1", UserId: "other-user" });
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-1" }));
+        vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(row);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/api/individual-tracker/tracker-1/settings"), env)) as Response;
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns current settings for the tracker owner", async () => {
+      const row = aFakeIndividualTrackersRow({
+        TrackerId: "tracker-1",
+        UserId: "user-1",
+        StreamerViewSettingsJson: JSON.stringify({ styleFlags: { teamColor: "#ff0000" } }),
+      });
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-1" }));
+        vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(row);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/api/individual-tracker/tracker-1/settings"), env)) as Response;
+
+      expect(res.status).toBe(200);
+      const body = await res.json<SettingsResponse>();
+      expect(body.settings.styleFlags?.teamColor).toBe("#ff0000");
+    });
+
+    it("returns empty settings when none have been stored", async () => {
+      const row = aFakeIndividualTrackersRow({ TrackerId: "tracker-1", UserId: "user-1" });
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-1" }));
+        vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(row);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/api/individual-tracker/tracker-1/settings"), env)) as Response;
+
+      expect(res.status).toBe(200);
+      const body = await res.json<SettingsResponse>();
+      expect(body.settings).toEqual({});
+    });
+  });
+
+  describe("PATCH /api/individual-tracker/:trackerId/settings", () => {
+    it("returns 401 when not authenticated", async () => {
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.authService, "validateSession").mockResolvedValue(null);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(patchRequest("/api/individual-tracker/tracker-1/settings", {}), env)) as Response;
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 404 when tracker does not exist", async () => {
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-1" }));
+        vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(null);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(patchRequest("/api/individual-tracker/unknown/settings", {}), env)) as Response;
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 404 when tracker belongs to a different user", async () => {
+      const row = aFakeIndividualTrackersRow({ TrackerId: "tracker-1", UserId: "other-user" });
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-1" }));
+        vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(row);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(patchRequest("/api/individual-tracker/tracker-1/settings", {}), env)) as Response;
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 for an invalid body", async () => {
+      const row = aFakeIndividualTrackersRow({ TrackerId: "tracker-1", UserId: "user-1" });
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-1" }));
+        vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(row);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(
+        patchRequest("/api/individual-tracker/tracker-1/settings", { settings: { styleFlags: { teamColor: 12345 } } }),
+        env,
+      )) as Response;
+
+      expect(res.status).toBe(400);
+      const body = await res.json<ErrorResponse>();
+      expect(body.error).toBe("Invalid settings payload");
+    });
+
+    it("updates settings and returns the new settings", async () => {
+      const row = aFakeIndividualTrackersRow({ TrackerId: "tracker-1", UserId: "user-1" });
+      const sharedServices = installFakeServicesWith({ env });
+      const updateSpy: MockInstance<DatabaseService["updateIndividualTrackerSettings"]> = vi.spyOn(
+        sharedServices.databaseService,
+        "updateIndividualTrackerSettings",
+      );
+      updateSpy.mockResolvedValue(undefined);
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        vi.spyOn(sharedServices.authService, "validateSession").mockResolvedValue(
+          aFakeAuthSessionWith({ userId: "user-1" }),
+        );
+        vi.spyOn(sharedServices.databaseService, "getIndividualTracker").mockResolvedValue(row);
+        return sharedServices;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const newSettings = { styleFlags: { teamColor: "#00ff00", enemyColor: "#ff0000" } };
+      const res = (await router.fetch(
+        patchRequest("/api/individual-tracker/tracker-1/settings", { settings: newSettings }),
+        env,
+      )) as Response;
+
+      expect(res.status).toBe(200);
+      const body = await res.json<SettingsResponse>();
+      expect(body.settings.styleFlags?.teamColor).toBe("#00ff00");
+      expect(body.settings.styleFlags?.enemyColor).toBe("#ff0000");
+      const [, settingsJson] = updateSpy.mock.calls[0] ?? [];
+      expect(JSON.parse(settingsJson ?? "{}")).toStrictEqual(newSettings);
+    });
+  });
+});

--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -477,7 +477,7 @@ export class DatabaseService {
 
   async upsertIndividualTracker(tracker: IndividualTrackersRow): Promise<void> {
     const query = `
-      INSERT INTO IndividualTrackers (TrackerId, UserId, Gamertag, Xuid, Status, IsLive, CreatedAt, UpdatedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO IndividualTrackers (TrackerId, UserId, Gamertag, Xuid, Status, IsLive, StreamerViewSettingsJson, CreatedAt, UpdatedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(TrackerId) DO UPDATE SET Gamertag=excluded.Gamertag, Xuid=excluded.Xuid, Status=excluded.Status, IsLive=excluded.IsLive, UpdatedAt=excluded.UpdatedAt
     `;
     const stmt = this.DB.prepare(query).bind(
@@ -487,6 +487,7 @@ export class DatabaseService {
       tracker.Xuid,
       tracker.Status,
       tracker.IsLive,
+      tracker.StreamerViewSettingsJson,
       tracker.CreatedAt,
       tracker.UpdatedAt,
     );
@@ -496,6 +497,13 @@ export class DatabaseService {
   async deleteIndividualTracker(trackerId: string): Promise<void> {
     const stmt = this.DB.prepare("DELETE FROM IndividualTrackers WHERE TrackerId = ?").bind(trackerId);
     await stmt.run();
+  }
+
+  async updateIndividualTrackerSettings(trackerId: string, settingsJson: string): Promise<void> {
+    const query = "UPDATE IndividualTrackers SET StreamerViewSettingsJson = ?, UpdatedAt = ? WHERE TrackerId = ?";
+    await this.DB.prepare(query)
+      .bind(settingsJson, Math.floor(Date.now() / 1000), trackerId)
+      .run();
   }
 
   async setLiveIndividualTracker(userId: string, trackerId: string): Promise<void> {

--- a/api/services/database/fakes/database.fake.ts
+++ b/api/services/database/fakes/database.fake.ts
@@ -189,6 +189,7 @@ export function aFakeIndividualTrackersRow(opts: Partial<IndividualTrackersRow> 
     IsLive: 0,
     CreatedAt: nowEpoch,
     UpdatedAt: nowEpoch,
+    StreamerViewSettingsJson: "{}",
   };
 
   return {

--- a/api/services/database/schema.sql
+++ b/api/services/database/schema.sql
@@ -112,9 +112,13 @@ CREATE TABLE IF NOT EXISTS IndividualTrackers (
     Status TEXT NOT NULL DEFAULT 'stopped' CHECK (Status IN ('active', 'paused', 'stopped')),
     IsLive INTEGER NOT NULL DEFAULT 0 CHECK (IsLive IN (0, 1)),
     CreatedAt INTEGER NOT NULL DEFAULT (unixepoch()),
-    UpdatedAt INTEGER NOT NULL DEFAULT (unixepoch())
+    UpdatedAt INTEGER NOT NULL DEFAULT (unixepoch()),
+    StreamerViewSettingsJson TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(StreamerViewSettingsJson))
 );
 
 CREATE INDEX IF NOT EXISTS IdxIndividualTrackersUserId ON IndividualTrackers (UserId);
 CREATE INDEX IF NOT EXISTS IdxIndividualTrackersXuid ON IndividualTrackers (Xuid);
 CREATE UNIQUE INDEX IF NOT EXISTS UqIndividualTrackersLivePerUser ON IndividualTrackers (UserId) WHERE IsLive = 1;
+
+-- Migration: apply to existing deployments
+-- ALTER TABLE IndividualTrackers ADD COLUMN StreamerViewSettingsJson TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(StreamerViewSettingsJson));

--- a/api/services/database/tests/database.test.ts
+++ b/api/services/database/tests/database.test.ts
@@ -992,6 +992,7 @@ describe("Database Service", () => {
         tracker.Xuid,
         tracker.Status,
         tracker.IsLive,
+        tracker.StreamerViewSettingsJson,
         tracker.CreatedAt,
         tracker.UpdatedAt,
       );

--- a/api/services/database/types/individual_trackers.ts
+++ b/api/services/database/types/individual_trackers.ts
@@ -9,4 +9,5 @@ export interface IndividualTrackersRow {
   IsLive: 0 | 1;
   CreatedAt: number;
   UpdatedAt: number;
+  StreamerViewSettingsJson: string;
 }

--- a/api/services/individual-tracker/individual-tracker.ts
+++ b/api/services/individual-tracker/individual-tracker.ts
@@ -86,6 +86,7 @@ export class IndividualTrackerService {
       IsLive: alreadyTracked?.IsLive ?? 0,
       CreatedAt: alreadyTracked?.CreatedAt ?? nowEpoch,
       UpdatedAt: nowEpoch,
+      StreamerViewSettingsJson: alreadyTracked?.StreamerViewSettingsJson ?? "{}",
     };
     await this.databaseService.upsertIndividualTracker(tracker);
     return tracker;

--- a/shared/src/contracts/individual-tracker/settings.ts
+++ b/shared/src/contracts/individual-tracker/settings.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+import { defineContract } from "../base";
+import { streamerViewSettingsSchema } from "../../individual-tracker/streamer-view-settings";
+
+export const settingsBodySchema = z.object({ settings: streamerViewSettingsSchema });
+
+export const settingsContract = defineContract(settingsBodySchema);
+export type SettingsResponse = z.infer<typeof settingsContract.schema>;

--- a/shared/src/contracts/individual-tracker/view.ts
+++ b/shared/src/contracts/individual-tracker/view.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { defineContract, defineMessageContract } from "../base";
+import { streamerViewSettingsSchema } from "../../individual-tracker/streamer-view-settings";
 import { trackerStatusSchema } from "./tracker";
 
 export const trackerMatchSummarySchema = z.object({
@@ -36,7 +37,10 @@ export const trackerLiveViewSchema = z.object({
 });
 export type TrackerLiveView = z.infer<typeof trackerLiveViewSchema>;
 
-export const trackerViewStateSchema = trackerLiveViewSchema.extend({ isLive: z.boolean() });
+export const trackerViewStateSchema = trackerLiveViewSchema.extend({
+  isLive: z.boolean(),
+  streamerSettings: streamerViewSettingsSchema.optional(),
+});
 export type TrackerViewState = z.infer<typeof trackerViewStateSchema>;
 
 export const trackerViewContract = defineContract(z.object({ view: trackerViewStateSchema }));

--- a/shared/src/individual-tracker/streamer-view-settings.ts
+++ b/shared/src/individual-tracker/streamer-view-settings.ts
@@ -1,0 +1,140 @@
+import { z } from "zod";
+
+export type StreamerViewColorMode = "player" | "observer";
+
+export interface StreamerViewObserverColorOverride {
+  readonly teamColor?: string;
+  readonly enemyColor?: string;
+}
+
+export type StreamerViewObserverColorOverrides = Readonly<Record<string, StreamerViewObserverColorOverride>>;
+
+export interface StreamerViewFontSizes {
+  readonly queueInfo?: number;
+  readonly score?: number;
+  readonly teams?: number;
+  readonly tabs?: number;
+  readonly ticker?: number;
+}
+
+export interface StreamerViewLayoutOptions {
+  readonly viewMode?: "standard" | "wide" | "streamer";
+  readonly defaultColorMode?: StreamerViewColorMode;
+  readonly fontSizes?: StreamerViewFontSizes;
+}
+
+export interface StreamerViewVisibleSections {
+  readonly showTicker?: boolean;
+  readonly showTabs?: boolean;
+  readonly showTeamDetails?: boolean;
+  readonly showDiscordNames?: boolean;
+  readonly showXboxNames?: boolean;
+  readonly showServerIcon?: boolean;
+  readonly showTitle?: boolean;
+  readonly showSubtitle?: boolean;
+  readonly showScore?: boolean;
+  readonly topBarStatSlots?: readonly string[];
+  readonly showPreSeriesInfo?: boolean;
+  readonly selectedSlayerStats?: readonly string[];
+  readonly showObjectiveStats?: boolean;
+  readonly medalRarityFilter?: readonly number[];
+}
+
+export interface StreamerViewStyleFlags {
+  readonly colorMode?: StreamerViewColorMode;
+  readonly playerTeamColor?: string;
+  readonly playerEnemyColor?: string;
+  readonly observerTeamColor?: string;
+  readonly observerEnemyColor?: string;
+  readonly teamColor?: string;
+  readonly enemyColor?: string;
+  readonly observerColorOverrides?: StreamerViewObserverColorOverrides;
+  readonly showPreSeriesInfo?: boolean;
+  readonly selectedSlayerStats?: readonly string[];
+  readonly showObjectiveStats?: boolean;
+  readonly medalRarityFilter?: readonly number[];
+  readonly showMatchmakingStatsOnly?: boolean;
+}
+
+export interface StreamerViewEffectiveDefaults {
+  readonly colorMode: StreamerViewColorMode;
+}
+
+export const streamerViewFontSizesSchema = z.object({
+  queueInfo: z.number().optional(),
+  score: z.number().optional(),
+  teams: z.number().optional(),
+  tabs: z.number().optional(),
+  ticker: z.number().optional(),
+});
+
+export const streamerViewLayoutOptionsSchema = z.object({
+  viewMode: z.enum(["standard", "wide", "streamer"]).optional(),
+  defaultColorMode: z.enum(["player", "observer"]).optional(),
+  fontSizes: streamerViewFontSizesSchema.optional(),
+});
+
+export const streamerViewVisibleSectionsSchema = z.object({
+  showTicker: z.boolean().optional(),
+  showTabs: z.boolean().optional(),
+  showTeamDetails: z.boolean().optional(),
+  showDiscordNames: z.boolean().optional(),
+  showXboxNames: z.boolean().optional(),
+  showServerIcon: z.boolean().optional(),
+  showTitle: z.boolean().optional(),
+  showSubtitle: z.boolean().optional(),
+  showScore: z.boolean().optional(),
+  topBarStatSlots: z.array(z.string()).optional(),
+  showPreSeriesInfo: z.boolean().optional(),
+  selectedSlayerStats: z.array(z.string()).optional(),
+  showObjectiveStats: z.boolean().optional(),
+  medalRarityFilter: z.array(z.number()).optional(),
+});
+
+export const streamerViewColorModeSchema = z.enum(["player", "observer"]);
+
+export const streamerViewStyleFlagsSchema = z.object({
+  colorMode: streamerViewColorModeSchema.optional(),
+  playerTeamColor: z.string().optional(),
+  playerEnemyColor: z.string().optional(),
+  observerTeamColor: z.string().optional(),
+  observerEnemyColor: z.string().optional(),
+  teamColor: z.string().optional(),
+  enemyColor: z.string().optional(),
+  observerColorOverrides: z
+    .record(
+      z.string(),
+      z.object({
+        teamColor: z.string().optional(),
+        enemyColor: z.string().optional(),
+      }),
+    )
+    .optional(),
+  showPreSeriesInfo: z.boolean().optional(),
+  showObjectiveStats: z.boolean().optional(),
+  showMatchmakingStatsOnly: z.boolean().optional(),
+  selectedSlayerStats: z.array(z.string()).optional(),
+  medalRarityFilter: z.array(z.number()).optional(),
+});
+
+export const streamerViewSettingsSchema = z.object({
+  styleFlags: streamerViewStyleFlagsSchema.optional(),
+  visibleSections: streamerViewVisibleSectionsSchema.optional(),
+  layoutOptions: streamerViewLayoutOptionsSchema.optional(),
+});
+
+export type StreamerViewSettings = z.infer<typeof streamerViewSettingsSchema>;
+
+export function parseStreamerViewSettings(json: string): StreamerViewSettings {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return {};
+  }
+  const result = streamerViewSettingsSchema.safeParse(parsed);
+  if (!result.success) {
+    return {};
+  }
+  return result.data;
+}

--- a/shared/src/individual-tracker/tests/streamer-view-settings.test.ts
+++ b/shared/src/individual-tracker/tests/streamer-view-settings.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { parseStreamerViewSettings } from "../streamer-view-settings";
+
+describe("parseStreamerViewSettings", () => {
+  it("returns valid settings for a well-formed JSON string", () => {
+    const json = JSON.stringify({
+      styleFlags: { teamColor: "#ff0000", enemyColor: "#0000ff" },
+      visibleSections: { showTicker: true, showScore: false },
+      layoutOptions: { viewMode: "wide", fontSizes: { score: 24 } },
+    });
+
+    const result = parseStreamerViewSettings(json);
+
+    expect(result.styleFlags?.teamColor).toBe("#ff0000");
+    expect(result.styleFlags?.enemyColor).toBe("#0000ff");
+    expect(result.visibleSections?.showTicker).toBe(true);
+    expect(result.visibleSections?.showScore).toBe(false);
+    expect(result.layoutOptions?.viewMode).toBe("wide");
+    expect(result.layoutOptions?.fontSizes?.score).toBe(24);
+  });
+
+  it("returns empty object for invalid JSON", () => {
+    const result = parseStreamerViewSettings("not valid json {{{");
+
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object for an empty JSON object", () => {
+    const result = parseStreamerViewSettings("{}");
+
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object when settings schema validation fails", () => {
+    const json = JSON.stringify({ styleFlags: { teamColor: 12345 } });
+
+    const result = parseStreamerViewSettings(json);
+
+    expect(result).toEqual({});
+  });
+
+  it("handles partial settings with missing optional fields", () => {
+    const json = JSON.stringify({ styleFlags: { teamColor: "#aabbcc" } });
+
+    const result = parseStreamerViewSettings(json);
+
+    expect(result.styleFlags?.teamColor).toBe("#aabbcc");
+    expect(result.visibleSections).toBeUndefined();
+    expect(result.layoutOptions).toBeUndefined();
+  });
+
+  it("handles unknown extra fields by stripping them", () => {
+    const json = JSON.stringify({ styleFlags: { teamColor: "#ff0000", unknownField: true } });
+
+    const result = parseStreamerViewSettings(json);
+
+    expect(result.styleFlags?.teamColor).toBe("#ff0000");
+  });
+});


### PR DESCRIPTION
Per-tracker streamer settings (colorMode, team/enemy colours, visible sections, font sizes, ticker preferences). Settings are stored on the `IndividualTrackers` row and returned in the REST viewer response — the WS stream is unchanged (public viewers refresh on settings change, which is acceptable for V1).

## What's here

**Schema:** `StreamerViewSettingsJson TEXT NOT NULL DEFAULT '{}'` on `IndividualTrackers`. Migration comment included for existing deployments:
```sql
ALTER TABLE IndividualTrackers ADD COLUMN StreamerViewSettingsJson TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(StreamerViewSettingsJson));
```

**Shared types** (`shared/src/individual-tracker/streamer-view-settings.ts`): Full settings model ported from rework — `StreamerViewStyleFlags` (colorMode, team/enemy colours, observer overrides), `StreamerViewVisibleSections` (showTabs, showTicker, showTeamDetails, showTitle/subtitle/score, ticker settings), `StreamerViewLayoutOptions` (fontSizes), plus Zod schemas and `parseStreamerViewSettings` (degrades to `{}` on bad/missing JSON).

**Contract** (`shared/src/contracts/individual-tracker/settings.ts`): Single `settingsContract` wrapping `{ settings: streamerViewSettings }`, used for both GET response and PATCH response. `settingsBodySchema` used for PATCH body validation so the request shape matches the response shape.

**Routes (owner-only):**
- `GET /api/individual-tracker/:trackerId/settings` → current settings
- `PATCH /api/individual-tracker/:trackerId/settings` → full replace, returns new settings

**View contract:** `TrackerViewState.streamerSettings?: StreamerViewSettings` (REST-only). `trackerLiveViewSchema` / WS message schema unchanged.

## Review findings fixed
- `upsertIndividualTracker` INSERT omitted `StreamerViewSettingsJson` — added (not in ON CONFLICT UPDATE — preserves settings on gamertag refresh)
- PATCH handler validated bare `streamerViewSettingsSchema` instead of wrapped `{ settings: {...} }` — sending `{ settings: {colorMode:"observer"} }` would have silently written `{}`
- `updateSettingsContract` was a duplicate of `getSettingsContract`; `UpdateSettingsRequest`/`UpdateSettingsResponse` were dead — consolidated to single `settingsContract`

## Notes
- ⚠️ Requires D1 migration to be applied manually (ALTER TABLE above) before deploying
- Settings are full-replace on PATCH (not partial merge) — consistent with REST semantics; clients should GET first then PATCH the merged object if partial updates are wanted
- `upsertIndividualTracker` ON CONFLICT preserves existing settings (does not overwrite on gamertag refresh)

## Verification
- `npm run typecheck` → 0 errors; eslint + prettier clean
- `npx vitest run` → **2000 passing** (+16 new: 10 route tests + 6 unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)