### PR TITLE
feat(api): user-level streamer-view settings — GET/PATCH routes + view contract (A3)

### DIFF
--- a/api/routes/individual-tracker/individual-tracker.ts
+++ b/api/routes/individual-tracker/individual-tracker.ts
@@ -1,10 +1,12 @@
 import type { RoutesRegisterHandler } from "../base/types";
 import { trackerManageRoutesRegisterHandler } from "./manage";
 import { trackerProfileRoutesRegisterHandler } from "./profile";
+import { trackerSettingsRoutesRegisterHandler } from "./settings";
 import { trackerViewRoutesRegisterHandler } from "./view";
 
 export const individualTrackerRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
   trackerProfileRoutesRegisterHandler(router, installServices);
   trackerManageRoutesRegisterHandler(router, installServices);
+  trackerSettingsRoutesRegisterHandler(router, installServices);
   trackerViewRoutesRegisterHandler(router, installServices);
 };

--- a/api/routes/individual-tracker/mapper.ts
+++ b/api/routes/individual-tracker/mapper.ts
@@ -1,6 +1,7 @@
 import type { TrackerProfile } from "@guilty-spark/shared/contracts/individual-tracker/profile";
 import type { Tracker, TrackerState } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { IndividualTrackerProfilesRow } from "../../services/database/types/individual_tracker_profiles";
 import type { IndividualTrackersRow } from "../../services/database/types/individual_trackers";
 import type {
@@ -44,12 +45,14 @@ export function toTracker(row: IndividualTrackersRow, state: IndividualTrackerSt
 export function toTrackerView(
   row: IndividualTrackersRow,
   doState: IndividualTrackerViewState | null,
+  streamerSettings?: StreamerViewSettings,
 ): TrackerViewState {
   return {
     trackerId: row.TrackerId,
     gamertag: row.Gamertag,
     status: row.Status,
     isLive: row.IsLive === 1,
+    ...(streamerSettings !== undefined ? { streamerSettings } : {}),
     matches:
       doState == null
         ? []

--- a/api/routes/individual-tracker/settings.ts
+++ b/api/routes/individual-tracker/settings.ts
@@ -1,0 +1,50 @@
+import { errorContract } from "@guilty-spark/shared/contracts/error";
+import { settingsBodySchema, settingsContract } from "@guilty-spark/shared/contracts/individual-tracker/settings";
+import { parseJsonBody } from "@guilty-spark/shared/base/request-parsing";
+import type { RoutesRegisterHandler } from "../base/types";
+import { requireSession } from "../base/require-session";
+
+export const trackerSettingsRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
+  router.get("/api/individual-tracker/settings", async (request, env: Env) => {
+    const services = installServices({ env });
+    const { authService, individualTrackerService, logService } = services;
+
+    try {
+      const auth = await requireSession(request, authService);
+      if (!auth.ok) {
+        return auth.response;
+      }
+
+      const settings = await individualTrackerService.getSettings(auth.session.userId);
+
+      return settingsContract.toResponse({ settings }, { noStore: true });
+    } catch (error) {
+      logService.error(error as Error, new Map([["message", "Individual tracker settings get error"]]));
+      return errorContract.toResponse({ error: "Failed to fetch settings" }, { status: 500, noStore: true });
+    }
+  });
+
+  router.patch("/api/individual-tracker/settings", async (request, env: Env) => {
+    const services = installServices({ env });
+    const { authService, individualTrackerService, logService } = services;
+
+    try {
+      const auth = await requireSession(request, authService);
+      if (!auth.ok) {
+        return auth.response;
+      }
+
+      const parsed = await parseJsonBody(request, settingsBodySchema, "Invalid settings payload");
+      if (!parsed.success) {
+        return parsed.response;
+      }
+
+      const settings = await individualTrackerService.updateSettings(auth.session.userId, parsed.data.settings);
+
+      return settingsContract.toResponse({ settings }, { noStore: true });
+    } catch (error) {
+      logService.error(error as Error, new Map([["message", "Individual tracker settings update error"]]));
+      return errorContract.toResponse({ error: "Failed to update settings" }, { status: 500, noStore: true });
+    }
+  });
+};

--- a/api/routes/individual-tracker/tests/settings.test.ts
+++ b/api/routes/individual-tracker/tests/settings.test.ts
@@ -1,0 +1,128 @@
+import type { AutoRouterType } from "itty-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SettingsResponse } from "@guilty-spark/shared/contracts/individual-tracker/settings";
+import { createApiRouter } from "../../../base/router";
+import { aFakeEnvWith } from "../../../base/fakes/env.fake";
+import { aFakeAuthSessionWith } from "../../../services/auth/fakes/data";
+import { installFakeServicesWith } from "../../../services/fakes/services";
+import { individualTrackerRoutesRegisterHandler } from "../individual-tracker";
+
+const SESSION_USER_ID = "user-123";
+
+function withAuth(installServicesFn: typeof installFakeServicesWith): typeof installFakeServicesWith {
+  return (opts) => {
+    const services = installServicesFn(opts);
+    vi.spyOn(services.authService, "validateSession").mockResolvedValue(
+      aFakeAuthSessionWith({ userId: SESSION_USER_ID }),
+    );
+    return services;
+  };
+}
+
+describe("/api/individual-tracker/settings", () => {
+  let env: Env;
+  let router: AutoRouterType;
+
+  beforeEach(() => {
+    env = aFakeEnvWith();
+    router = createApiRouter();
+  });
+
+  describe("GET", () => {
+    it("returns 401 when not authenticated", async () => {
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => installFakeServicesWith({ env }));
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const req = new Request("http://localhost/api/individual-tracker/settings", { method: "GET" });
+      const res = (await router.fetch(req, env)) as Response;
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns empty settings when the user has no saved settings", async () => {
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = withAuth(installFakeServicesWith)({ env });
+        vi.spyOn(services.individualTrackerService, "getSettings").mockResolvedValue({});
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const req = new Request("http://localhost/api/individual-tracker/settings", { method: "GET" });
+      const res = (await router.fetch(req, env)) as Response;
+
+      expect(res.status).toBe(200);
+      const body = await res.json<SettingsResponse>();
+      expect(body.settings).toEqual({});
+    });
+
+    it("returns parsed settings when the user has saved settings", async () => {
+      const savedSettings = { styleFlags: { colorMode: "player" as const } };
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = withAuth(installFakeServicesWith)({ env });
+        vi.spyOn(services.individualTrackerService, "getSettings").mockResolvedValue(savedSettings);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const req = new Request("http://localhost/api/individual-tracker/settings", { method: "GET" });
+      const res = (await router.fetch(req, env)) as Response;
+
+      expect(res.status).toBe(200);
+      const body = await res.json<SettingsResponse>();
+      expect(body.settings).toEqual(savedSettings);
+    });
+  });
+
+  describe("PATCH", () => {
+    it("returns 401 when not authenticated", async () => {
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => installFakeServicesWith({ env }));
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const req = new Request("http://localhost/api/individual-tracker/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ settings: {} }),
+      });
+      const res = (await router.fetch(req, env)) as Response;
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 400 when the body is invalid", async () => {
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() =>
+        withAuth(installFakeServicesWith)({ env }),
+      );
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const req = new Request("http://localhost/api/individual-tracker/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ settings: { styleFlags: { colorMode: "not-a-valid-mode" } } }),
+      });
+      const res = (await router.fetch(req, env)) as Response;
+
+      expect(res.status).toBe(400);
+    });
+
+    it("updates and returns the new settings", async () => {
+      const newSettings = { layoutOptions: { viewMode: "wide" as const } };
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = withAuth(installFakeServicesWith)({ env });
+        vi.spyOn(services.individualTrackerService, "updateSettings").mockResolvedValue(newSettings);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const req = new Request("http://localhost/api/individual-tracker/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ settings: newSettings }),
+      });
+      const res = (await router.fetch(req, env)) as Response;
+
+      expect(res.status).toBe(200);
+      const body = await res.json<SettingsResponse>();
+      expect(body.settings).toEqual(newSettings);
+    });
+  });
+});

--- a/api/routes/individual-tracker/view.ts
+++ b/api/routes/individual-tracker/view.ts
@@ -25,7 +25,7 @@ async function viewStateTrackerDo(
 export const trackerViewRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
   router.get("/api/individual-tracker/:trackerId/view", async (request, env: Env) => {
     const services = installServices({ env });
-    const { authService, databaseService, logService } = services;
+    const { authService, databaseService, individualTrackerService, logService } = services;
 
     try {
       const auth = await requireSession(request, authService);
@@ -44,9 +44,12 @@ export const trackerViewRoutesRegisterHandler: RoutesRegisterHandler = (router, 
         return errorContract.toResponse({ error: "Tracker not found" }, { status: 404, noStore: true });
       }
 
-      const doState = await viewStateTrackerDo(env, row.UserId, trackerId);
+      const [doState, streamerSettings] = await Promise.all([
+        viewStateTrackerDo(env, row.UserId, trackerId),
+        individualTrackerService.getSettingsForView(auth.session.userId),
+      ]);
 
-      return trackerViewContract.toResponse({ view: toTrackerView(row, doState) }, { noStore: true });
+      return trackerViewContract.toResponse({ view: toTrackerView(row, doState, streamerSettings) }, { noStore: true });
     } catch (error) {
       logService.error(error as Error, new Map([["message", "Individual tracker view error"]]));
       return errorContract.toResponse({ error: "Failed to fetch tracker view" }, { status: 500, noStore: true });

--- a/api/services/individual-tracker/fakes/individual-tracker.fake.ts
+++ b/api/services/individual-tracker/fakes/individual-tracker.fake.ts
@@ -1,9 +1,19 @@
+import type { Mocked } from "vitest";
+import { vi } from "vitest";
 import type { DatabaseService } from "../../database/database";
 import { aFakeDatabaseServiceWith } from "../../database/fakes/database.fake";
 import { IndividualTrackerService } from "../individual-tracker";
 
 export function aFakeIndividualTrackerServiceWith(
   opts: { databaseService?: DatabaseService } = {},
-): IndividualTrackerService {
-  return new IndividualTrackerService({ databaseService: opts.databaseService ?? aFakeDatabaseServiceWith() });
+): Mocked<IndividualTrackerService> {
+  const service = new IndividualTrackerService({
+    databaseService: opts.databaseService ?? aFakeDatabaseServiceWith(),
+  }) as Mocked<IndividualTrackerService>;
+
+  service.getSettings = vi.fn<IndividualTrackerService["getSettings"]>().mockResolvedValue({});
+  service.getSettingsForView = vi.fn<IndividualTrackerService["getSettingsForView"]>().mockResolvedValue({});
+  service.updateSettings = vi.fn<IndividualTrackerService["updateSettings"]>().mockResolvedValue({});
+
+  return service;
 }

--- a/api/services/individual-tracker/individual-tracker.ts
+++ b/api/services/individual-tracker/individual-tracker.ts
@@ -1,4 +1,6 @@
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import { parseStreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { DatabaseService } from "../database/database";
 import type { IndividualTrackerProfilesRow } from "../database/types/individual_tracker_profiles";
 import type { IndividualTrackerStatus, IndividualTrackersRow } from "../database/types/individual_trackers";
@@ -118,6 +120,42 @@ export class IndividualTrackerService {
     await this.databaseService.setLiveIndividualTracker(userId, trackerId);
     const refreshed = await this.databaseService.getIndividualTracker(trackerId);
     return Preconditions.checkExists(refreshed, "Tracker disappeared after setting live");
+  }
+
+  async getSettings(userId: string): Promise<StreamerViewSettings> {
+    const profile = await this.getOrCreateProfile(userId);
+    const row = await this.databaseService.getStreamerViewSettings(profile.ProfileId);
+    if (row == null) {
+      return {};
+    }
+    return parseStreamerViewSettings(row);
+  }
+
+  async getSettingsForView(userId: string): Promise<StreamerViewSettings> {
+    const profiles = await this.databaseService.findIndividualTrackerProfilesByUserId(userId);
+    const [profile] = profiles;
+    if (profile == null) {
+      return {};
+    }
+    const row = await this.databaseService.getStreamerViewSettings(profile.ProfileId);
+    if (row == null) {
+      return {};
+    }
+    return parseStreamerViewSettings(row);
+  }
+
+  async updateSettings(userId: string, settings: StreamerViewSettings): Promise<StreamerViewSettings> {
+    const profile = await this.getOrCreateProfile(userId);
+    const now = Math.floor(Date.now() / 1000);
+    const storedRow = {
+      ProfileId: profile.ProfileId,
+      LayoutOptionsJson: JSON.stringify(settings.layoutOptions ?? {}),
+      VisibleSectionsJson: JSON.stringify(settings.visibleSections ?? {}),
+      StyleFlagsJson: JSON.stringify(settings.styleFlags ?? {}),
+      UpdatedAt: now,
+    };
+    await this.databaseService.upsertStreamerViewSettings(storedRow);
+    return parseStreamerViewSettings(storedRow);
   }
 
   private async assertIdentityOwned(userId: string, activeIdentityId: string | null | undefined): Promise<void> {

--- a/api/services/individual-tracker/tests/individual-tracker.test.ts
+++ b/api/services/individual-tracker/tests/individual-tracker.test.ts
@@ -5,6 +5,7 @@ import {
   aFakeIndividualTrackerProfilesRow,
   aFakeIndividualTrackersRow,
   aFakeLinkedIdentitiesRow,
+  aFakeStreamerViewSettingsRow,
 } from "../../database/fakes/database.fake";
 import type { DatabaseService } from "../../database/database";
 import { IndividualTrackerService, MAX_TRACKERS_PER_USER } from "../individual-tracker";
@@ -258,6 +259,87 @@ describe("IndividualTrackerService", () => {
 
       expect(resumed.Status).toBe("active");
       expect(upsertSpy).toHaveBeenCalledWith(expect.objectContaining({ TrackerId: "t1", Status: "active" }));
+    });
+  });
+
+  describe("getSettings", () => {
+    it("returns empty object when no settings row exists", async () => {
+      const profile = aFakeIndividualTrackerProfilesRow({ ProfileId: "p1", UserId: "user-1" });
+      vi.spyOn(databaseService, "findIndividualTrackerProfilesByUserId").mockResolvedValue([profile]);
+      vi.spyOn(databaseService, "getStreamerViewSettings").mockResolvedValue(null);
+
+      expect(await service.getSettings("user-1")).toEqual({});
+    });
+
+    it("parses and returns settings from the row when one exists", async () => {
+      const profile = aFakeIndividualTrackerProfilesRow({ ProfileId: "p1", UserId: "user-1" });
+      const row = aFakeStreamerViewSettingsRow({
+        ProfileId: "p1",
+        StyleFlagsJson: JSON.stringify({ colorMode: "player" }),
+        VisibleSectionsJson: "{}",
+        LayoutOptionsJson: "{}",
+      });
+      vi.spyOn(databaseService, "findIndividualTrackerProfilesByUserId").mockResolvedValue([profile]);
+      vi.spyOn(databaseService, "getStreamerViewSettings").mockResolvedValue(row);
+
+      const result = await service.getSettings("user-1");
+
+      expect(result.styleFlags?.colorMode).toBe("player");
+    });
+
+    it("returns empty object when all JSON columns parse to empty objects", async () => {
+      const profile = aFakeIndividualTrackerProfilesRow({ ProfileId: "p1", UserId: "user-1" });
+      const row = aFakeStreamerViewSettingsRow({
+        ProfileId: "p1",
+        StyleFlagsJson: "{}",
+        VisibleSectionsJson: "{}",
+        LayoutOptionsJson: "{}",
+      });
+      vi.spyOn(databaseService, "findIndividualTrackerProfilesByUserId").mockResolvedValue([profile]);
+      vi.spyOn(databaseService, "getStreamerViewSettings").mockResolvedValue(row);
+
+      expect(await service.getSettings("user-1")).toEqual({});
+    });
+  });
+
+  describe("updateSettings", () => {
+    it("calls upsertStreamerViewSettings with correct JSON columns and returns the settings", async () => {
+      const profile = aFakeIndividualTrackerProfilesRow({ ProfileId: "p1", UserId: "user-1" });
+      vi.spyOn(databaseService, "findIndividualTrackerProfilesByUserId").mockResolvedValue([profile]);
+      const upsertSpy: MockInstance<DatabaseService["upsertStreamerViewSettings"]> = vi
+        .spyOn(databaseService, "upsertStreamerViewSettings")
+        .mockResolvedValue();
+
+      const settings = { styleFlags: { colorMode: "observer" as const }, layoutOptions: { viewMode: "wide" as const } };
+      const result = await service.updateSettings("user-1", settings);
+
+      expect(result).toEqual(settings);
+      expect(upsertSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ProfileId: "p1",
+          StyleFlagsJson: JSON.stringify({ colorMode: "observer" }),
+          VisibleSectionsJson: JSON.stringify({}),
+          LayoutOptionsJson: JSON.stringify({ viewMode: "wide" }),
+        }),
+      );
+    });
+
+    it("serialises missing sub-objects as empty JSON objects", async () => {
+      const profile = aFakeIndividualTrackerProfilesRow({ ProfileId: "p1", UserId: "user-1" });
+      vi.spyOn(databaseService, "findIndividualTrackerProfilesByUserId").mockResolvedValue([profile]);
+      const upsertSpy: MockInstance<DatabaseService["upsertStreamerViewSettings"]> = vi
+        .spyOn(databaseService, "upsertStreamerViewSettings")
+        .mockResolvedValue();
+
+      await service.updateSettings("user-1", {});
+
+      expect(upsertSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          StyleFlagsJson: "{}",
+          VisibleSectionsJson: "{}",
+          LayoutOptionsJson: "{}",
+        }),
+      );
     });
   });
 

--- a/shared/src/contracts/individual-tracker/settings.ts
+++ b/shared/src/contracts/individual-tracker/settings.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+import { defineContract } from "../base";
+import { streamerViewSettingsSchema } from "../../individual-tracker/streamer-view-settings";
+
+export const settingsBodySchema = z.object({ settings: streamerViewSettingsSchema });
+export const settingsContract = defineContract(settingsBodySchema);
+export type SettingsResponse = z.infer<typeof settingsContract.schema>;

--- a/shared/src/contracts/individual-tracker/view.ts
+++ b/shared/src/contracts/individual-tracker/view.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { streamerViewSettingsSchema } from "../../individual-tracker/streamer-view-settings";
 import { defineContract, defineMessageContract } from "../base";
 import { trackerStatusSchema } from "./tracker";
 
@@ -36,7 +37,10 @@ export const trackerLiveViewSchema = z.object({
 });
 export type TrackerLiveView = z.infer<typeof trackerLiveViewSchema>;
 
-export const trackerViewStateSchema = trackerLiveViewSchema.extend({ isLive: z.boolean() });
+export const trackerViewStateSchema = trackerLiveViewSchema.extend({
+  isLive: z.boolean(),
+  streamerSettings: streamerViewSettingsSchema.optional(),
+});
 export type TrackerViewState = z.infer<typeof trackerViewStateSchema>;
 
 export const trackerViewContract = defineContract(z.object({ view: trackerViewStateSchema }));

--- a/shared/src/individual-tracker/streamer-view-settings.ts
+++ b/shared/src/individual-tracker/streamer-view-settings.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+
+const streamerViewColorModeSchema = z.enum(["player", "observer"]);
+
+const streamerViewObserverColorOverrideSchema = z.object({
+  teamColor: z.string().optional(),
+  enemyColor: z.string().optional(),
+});
+
+const streamerViewObserverColorOverridesSchema = z.record(z.string(), streamerViewObserverColorOverrideSchema);
+
+const streamerViewFontSizesSchema = z.object({
+  queueInfo: z.number().optional(),
+  score: z.number().optional(),
+  teams: z.number().optional(),
+  tabs: z.number().optional(),
+  ticker: z.number().optional(),
+});
+
+export const streamerViewLayoutOptionsSchema = z.object({
+  viewMode: z.enum(["standard", "wide", "streamer"]).optional(),
+  defaultColorMode: streamerViewColorModeSchema.optional(),
+  fontSizes: streamerViewFontSizesSchema.optional(),
+});
+export type StreamerViewLayoutOptions = z.infer<typeof streamerViewLayoutOptionsSchema>;
+
+export const streamerViewVisibleSectionsSchema = z.object({
+  showTicker: z.boolean().optional(),
+  showTabs: z.boolean().optional(),
+  showTeamDetails: z.boolean().optional(),
+  showDiscordNames: z.boolean().optional(),
+  showXboxNames: z.boolean().optional(),
+  showServerIcon: z.boolean().optional(),
+  showTitle: z.boolean().optional(),
+  showSubtitle: z.boolean().optional(),
+  showScore: z.boolean().optional(),
+  topBarStatSlots: z.array(z.string()).optional(),
+  showPreSeriesInfo: z.boolean().optional(),
+  selectedSlayerStats: z.array(z.string()).optional(),
+  showObjectiveStats: z.boolean().optional(),
+  medalRarityFilter: z.array(z.number()).optional(),
+});
+export type StreamerViewVisibleSections = z.infer<typeof streamerViewVisibleSectionsSchema>;
+
+export const streamerViewStyleFlagsSchema = z.object({
+  colorMode: streamerViewColorModeSchema.optional(),
+  playerTeamColor: z.string().optional(),
+  playerEnemyColor: z.string().optional(),
+  observerTeamColor: z.string().optional(),
+  observerEnemyColor: z.string().optional(),
+  teamColor: z.string().optional(),
+  enemyColor: z.string().optional(),
+  observerColorOverrides: streamerViewObserverColorOverridesSchema.optional(),
+  showPreSeriesInfo: z.boolean().optional(),
+  selectedSlayerStats: z.array(z.string()).optional(),
+  showObjectiveStats: z.boolean().optional(),
+  medalRarityFilter: z.array(z.number()).optional(),
+  showMatchmakingStatsOnly: z.boolean().optional(),
+});
+export type StreamerViewStyleFlags = z.infer<typeof streamerViewStyleFlagsSchema>;
+
+export const streamerViewSettingsSchema = z.object({
+  styleFlags: streamerViewStyleFlagsSchema.optional(),
+  visibleSections: streamerViewVisibleSectionsSchema.optional(),
+  layoutOptions: streamerViewLayoutOptionsSchema.optional(),
+});
+export type StreamerViewSettings = z.infer<typeof streamerViewSettingsSchema>;
+
+export type StreamerViewColorMode = z.infer<typeof streamerViewColorModeSchema>;
+export type StreamerViewObserverColorOverride = z.infer<typeof streamerViewObserverColorOverrideSchema>;
+export type StreamerViewObserverColorOverrides = z.infer<typeof streamerViewObserverColorOverridesSchema>;
+export type StreamerViewFontSizes = z.infer<typeof streamerViewFontSizesSchema>;
+
+export function parseStreamerViewSettings(row: {
+  StyleFlagsJson: string;
+  VisibleSectionsJson: string;
+  LayoutOptionsJson: string;
+}): StreamerViewSettings {
+  const styleFlags = streamerViewStyleFlagsSchema.safeParse(JSON.parse(row.StyleFlagsJson));
+  const visibleSections = streamerViewVisibleSectionsSchema.safeParse(JSON.parse(row.VisibleSectionsJson));
+  const layoutOptions = streamerViewLayoutOptionsSchema.safeParse(JSON.parse(row.LayoutOptionsJson));
+  return {
+    ...(styleFlags.success && Object.keys(styleFlags.data).length > 0 ? { styleFlags: styleFlags.data } : {}),
+    ...(visibleSections.success && Object.keys(visibleSections.data).length > 0
+      ? { visibleSections: visibleSections.data }
+      : {}),
+    ...(layoutOptions.success && Object.keys(layoutOptions.data).length > 0
+      ? { layoutOptions: layoutOptions.data }
+      : {}),
+  };
+}


### PR DESCRIPTION
User-level streamer settings (one set per profile, shared across all trackers). Settings control how the public `/u/<gamertag>/view|overlay` renders: team/enemy colours, colorMode, visible sections (ticker, tabs, team details, etc.), font sizes.

## What's here

**`shared/src/individual-tracker/streamer-view-settings.ts`**: Full settings types + Zod schemas ported from rework — `StreamerViewStyleFlags`, `StreamerViewVisibleSections`, `StreamerViewLayoutOptions`, `StreamerViewFontSizes`, plus `parseStreamerViewSettings(row)` which parses the three-column DB row and strips empty sub-objects.

**Routes (auth-required):**
- `GET /api/individual-tracker/settings` → owner's current settings
- `PATCH /api/individual-tracker/settings` → full replace; body is `{ settings: {...} }`; response is normalised so PATCH and GET always return the same shape

**`TrackerViewState.streamerSettings?`**: The REST viewer response (owner-only, `/view`) now includes the owner's settings so the viewer page can apply their preferred colours. WS messages (`trackerLiveViewSchema`) unchanged — no settings in the live push stream.

## Key design decisions

**`getSettingsForView` vs `getSettings`:** The view endpoint uses a read-only profile lookup (`getSettingsForView`) that returns `{}` if no profile exists, without INSERTing one. `getSettings` (used by the dedicated settings endpoint) auto-creates the profile via `getOrCreateProfile` — which is appropriate when the user is actively managing settings. A GET /view should never trigger a write.

**Normalised PATCH return:** `updateSettings` returns the value through `parseStreamerViewSettings` rather than echoing the raw input, so empty sub-objects (`{}`) are stripped and PATCH/GET responses are structurally consistent for the same stored state.

## Storage

Existing `StreamerViewSettings` table (per-profile, three JSON columns: `StyleFlagsJson`, `VisibleSectionsJson`, `LayoutOptionsJson`). No schema migration needed — table already exists.

## Verification
- `npm run typecheck` → 0 errors; eslint + prettier clean
- `npx vitest run` → **1998 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)