### PR TITLE
feat(pages): streamer-view settings service — GET/PATCH wrapper (E5a)

### DIFF
--- a/pages/src/services/individual-tracker/fakes/settings.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/settings.fake.ts
@@ -1,0 +1,27 @@
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import type { IndividualTrackerSettingsService } from "../settings-types";
+
+export class FakeIndividualTrackerSettingsService implements IndividualTrackerSettingsService {
+  private settings: StreamerViewSettings;
+
+  public constructor(initialSettings: StreamerViewSettings = {}) {
+    this.settings = initialSettings;
+  }
+
+  public async getSettings(): Promise<StreamerViewSettings> {
+    await Promise.resolve();
+    return this.settings;
+  }
+
+  public async updateSettings(settings: StreamerViewSettings): Promise<StreamerViewSettings> {
+    await Promise.resolve();
+    this.settings = settings;
+    return this.settings;
+  }
+}
+
+export function aFakeIndividualTrackerSettingsServiceWith(
+  initialSettings: StreamerViewSettings = {},
+): FakeIndividualTrackerSettingsService {
+  return new FakeIndividualTrackerSettingsService(initialSettings);
+}

--- a/pages/src/services/individual-tracker/fakes/settings.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/settings.fake.ts
@@ -9,14 +9,12 @@ export class FakeIndividualTrackerSettingsService implements IndividualTrackerSe
   }
 
   public async getSettings(): Promise<StreamerViewSettings> {
-    await Promise.resolve();
-    return this.settings;
+    return Promise.resolve(this.settings);
   }
 
   public async updateSettings(settings: StreamerViewSettings): Promise<StreamerViewSettings> {
-    await Promise.resolve();
     this.settings = settings;
-    return this.settings;
+    return Promise.resolve(this.settings);
   }
 }
 

--- a/pages/src/services/individual-tracker/install.ts
+++ b/pages/src/services/individual-tracker/install.ts
@@ -1,6 +1,8 @@
 import { getMode } from "../mode";
 import { RealIndividualTrackerService } from "./individual-tracker";
 import type { IndividualTrackerService } from "./types";
+import { RealIndividualTrackerSettingsService } from "./settings";
+import type { IndividualTrackerSettingsService } from "./settings-types";
 import { RealIndividualTrackerViewService } from "./view";
 import type { IndividualTrackerViewService } from "./view-types";
 
@@ -12,6 +14,17 @@ export async function installIndividualTrackerService(apiHost: string): Promise<
   }
 
   return new RealIndividualTrackerService({ apiHost });
+}
+
+export async function installIndividualTrackerSettingsService(
+  apiHost: string,
+): Promise<IndividualTrackerSettingsService> {
+  if (getMode() === "FAKE") {
+    const { aFakeIndividualTrackerSettingsServiceWith } = await import("./fakes/settings.fake");
+    return aFakeIndividualTrackerSettingsServiceWith();
+  }
+
+  return new RealIndividualTrackerSettingsService({ apiHost });
 }
 
 export async function installIndividualTrackerViewService(apiHost: string): Promise<IndividualTrackerViewService> {

--- a/pages/src/services/individual-tracker/settings-types.ts
+++ b/pages/src/services/individual-tracker/settings-types.ts
@@ -1,0 +1,6 @@
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+
+export interface IndividualTrackerSettingsService {
+  getSettings(): Promise<StreamerViewSettings>;
+  updateSettings(settings: StreamerViewSettings): Promise<StreamerViewSettings>;
+}

--- a/pages/src/services/individual-tracker/settings.ts
+++ b/pages/src/services/individual-tracker/settings.ts
@@ -1,0 +1,68 @@
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import { settingsBodySchema, settingsContract } from "@guilty-spark/shared/contracts/individual-tracker/settings";
+import { errorContract } from "@guilty-spark/shared/contracts/error";
+import type { IndividualTrackerSettingsService } from "./settings-types";
+
+interface IndividualTrackerSettingsServiceOpts {
+  readonly apiHost: string;
+}
+
+export class RealIndividualTrackerSettingsService implements IndividualTrackerSettingsService {
+  private readonly apiHost: string;
+
+  public constructor({ apiHost }: IndividualTrackerSettingsServiceOpts) {
+    this.apiHost = apiHost;
+  }
+
+  private buildUrl(path: string): string {
+    const baseUrl = this.apiHost.endsWith("/") ? this.apiHost.slice(0, -1) : this.apiHost;
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    return `${baseUrl}${normalizedPath}`;
+  }
+
+  private async readError(response: Response): Promise<Error> {
+    const body = await response.text();
+    if (body !== "") {
+      try {
+        const parsed = errorContract.safeParse(JSON.parse(body));
+        if (parsed.success && parsed.data.error !== "") {
+          return new Error(parsed.data.error);
+        }
+        return new Error(`Request failed (${String(response.status)})`);
+      } catch {
+        return new Error(body);
+      }
+    }
+    return new Error(`Request failed (${String(response.status)})`);
+  }
+
+  public async getSettings(): Promise<StreamerViewSettings> {
+    const response = await fetch(this.buildUrl("/api/individual-tracker/settings"), {
+      method: "GET",
+      credentials: "include",
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    const data = await settingsContract.fromResponse(response);
+    return data.settings;
+  }
+
+  public async updateSettings(settings: StreamerViewSettings): Promise<StreamerViewSettings> {
+    const response = await fetch(this.buildUrl("/api/individual-tracker/settings"), {
+      method: "PATCH",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(settingsBodySchema.parse({ settings })),
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    const data = await settingsContract.fromResponse(response);
+    return data.settings;
+  }
+}

--- a/pages/src/services/individual-tracker/tests/settings.test.ts
+++ b/pages/src/services/individual-tracker/tests/settings.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MockInstance } from "vitest";
 import { RealIndividualTrackerSettingsService } from "../settings";
 
@@ -15,13 +15,17 @@ describe("RealIndividualTrackerSettingsService", () => {
   let fetchSpy: MockInstance;
   let service: RealIndividualTrackerSettingsService;
 
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    service = new RealIndividualTrackerSettingsService({ apiHost: "https://api.example.com" });
+  });
+
   afterEach(() => {
     fetchSpy.mockRestore();
   });
 
   it("gets settings with credentials included", async () => {
-    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse({ settings: FAKE_SETTINGS }));
-    service = new RealIndividualTrackerSettingsService({ apiHost: "https://api.example.com" });
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ settings: FAKE_SETTINGS }));
 
     const result = await service.getSettings();
 
@@ -33,28 +37,31 @@ describe("RealIndividualTrackerSettingsService", () => {
   });
 
   it("throws when getSettings returns a non-ok response", async () => {
-    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse({ error: "Unauthorized" }, 401));
-    service = new RealIndividualTrackerSettingsService({ apiHost: "https://api.example.com" });
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ error: "Unauthorized" }, 401));
 
     await expect(service.getSettings()).rejects.toThrow("Unauthorized");
   });
 
-  it("patches settings and returns the updated value", async () => {
-    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse({ settings: FAKE_SETTINGS }));
-    service = new RealIndividualTrackerSettingsService({ apiHost: "https://api.example.com" });
+  it("patches settings with the correct method, credentials, content-type, and wrapped body", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ settings: FAKE_SETTINGS }));
 
     const result = await service.updateSettings(FAKE_SETTINGS);
 
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/individual-tracker/settings",
+      expect.objectContaining({
+        method: "PATCH",
+        credentials: "include",
+        headers: expect.objectContaining({ "Content-Type": "application/json" }),
+      }),
+    );
     const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-    expect(init.method).toBe("PATCH");
-    expect(init.credentials).toBe("include");
     expect(JSON.parse(init.body as string)).toEqual({ settings: FAKE_SETTINGS });
     expect(result).toEqual(FAKE_SETTINGS);
   });
 
   it("throws when updateSettings returns a non-ok response", async () => {
-    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response("", { status: 500 }));
-    service = new RealIndividualTrackerSettingsService({ apiHost: "https://api.example.com" });
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 500 }));
 
     await expect(service.updateSettings({})).rejects.toThrow("Request failed (500)");
   });

--- a/pages/src/services/individual-tracker/tests/settings.test.ts
+++ b/pages/src/services/individual-tracker/tests/settings.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { RealIndividualTrackerSettingsService } from "../settings";
+
+function jsonResponse(payload: object, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const FAKE_SETTINGS = { styleFlags: { teamColor: "eagle", colorMode: "observer" as const } };
+
+describe("RealIndividualTrackerSettingsService", () => {
+  let fetchSpy: MockInstance;
+  let service: RealIndividualTrackerSettingsService;
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("gets settings with credentials included", async () => {
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse({ settings: FAKE_SETTINGS }));
+    service = new RealIndividualTrackerSettingsService({ apiHost: "https://api.example.com" });
+
+    const result = await service.getSettings();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/individual-tracker/settings",
+      expect.objectContaining({ method: "GET", credentials: "include" }),
+    );
+    expect(result).toEqual(FAKE_SETTINGS);
+  });
+
+  it("throws when getSettings returns a non-ok response", async () => {
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse({ error: "Unauthorized" }, 401));
+    service = new RealIndividualTrackerSettingsService({ apiHost: "https://api.example.com" });
+
+    await expect(service.getSettings()).rejects.toThrow("Unauthorized");
+  });
+
+  it("patches settings and returns the updated value", async () => {
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse({ settings: FAKE_SETTINGS }));
+    service = new RealIndividualTrackerSettingsService({ apiHost: "https://api.example.com" });
+
+    const result = await service.updateSettings(FAKE_SETTINGS);
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe("PATCH");
+    expect(init.credentials).toBe("include");
+    expect(JSON.parse(init.body as string)).toEqual({ settings: FAKE_SETTINGS });
+    expect(result).toEqual(FAKE_SETTINGS);
+  });
+
+  it("throws when updateSettings returns a non-ok response", async () => {
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response("", { status: 500 }));
+    service = new RealIndividualTrackerSettingsService({ apiHost: "https://api.example.com" });
+
+    await expect(service.updateSettings({})).rejects.toThrow("Request failed (500)");
+  });
+});


### PR DESCRIPTION
Pages-layer data service for the user-level settings API ([#486](https://github.com/davidhouweling/guilty-spark/pull/486)).

- `RealIndividualTrackerSettingsService` — `getSettings()` (GET) + `updateSettings(settings)` (PATCH), both with `credentials: include`; body serialised as `{ settings: ... }` to match the API contract
- `FakeIndividualTrackerSettingsService` — in-memory store, deterministic for tests
- `installIndividualTrackerSettingsService` — FAKE/REAL install helper alongside the existing manager and view service installers

Code review: one `readError` divergence fixed (fallback inside try was missing, causing raw JSON to leak as error message on empty-error-field responses).

2002 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)