### PR TITLE
feat(pages): wire streamer settings colours into viewer tabs (E5b)

### DIFF
--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -1,4 +1,5 @@
 import type { TrackerStatus } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { TrackerViewConnectionStatus } from "../../../services/individual-tracker/view-types";
 import type { MatchStatsState } from "./viewer-store";
 
@@ -50,4 +51,5 @@ export interface IndividualTrackerViewerViewModel {
   readonly connectionStatus: TrackerViewConnectionStatus;
   readonly selectedMatchId: string | null;
   readonly matchStatsState: MatchStatsState | null;
+  readonly streamerSettings: StreamerViewSettings | undefined;
 }

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -28,11 +28,21 @@ export class IndividualTrackerViewerPresenter {
   }
 
   public static present(snapshot: IndividualTrackerViewerSnapshot): IndividualTrackerViewerViewModel {
+    const streamerSettings = snapshot.view?.streamerSettings;
+    const styleFlags = streamerSettings?.styleFlags;
     return {
-      renderModel: snapshot.view == null ? null : buildViewerRenderModel({ view: snapshot.view }),
+      renderModel:
+        snapshot.view == null
+          ? null
+          : buildViewerRenderModel({
+              view: snapshot.view,
+              preferredTeamColorId: styleFlags?.playerTeamColor ?? styleFlags?.teamColor,
+              preferredEnemyColorId: styleFlags?.playerEnemyColor ?? styleFlags?.enemyColor,
+            }),
       connectionStatus: snapshot.connectionStatus,
       selectedMatchId: snapshot.selectedMatchId,
       matchStatsState: snapshot.matchStatsState,
+      streamerSettings,
     };
   }
 

--- a/pages/src/components/individual-tracker/viewer/viewer-store.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-store.ts
@@ -57,7 +57,8 @@ export class IndividualTrackerViewerStore {
 
   public setView(view: TrackerLiveView): void {
     const isLive = this.snapshot.view?.isLive ?? false;
-    this.update({ status: ComponentLoaderStatus.LOADED, view: { ...view, isLive } });
+    const streamerSettings = this.snapshot.view?.streamerSettings;
+    this.update({ status: ComponentLoaderStatus.LOADED, view: { ...view, isLive, streamerSettings } });
   }
 
   public setConnectionStatus(connectionStatus: TrackerViewConnectionStatus): void {


### PR DESCRIPTION
Connects the owner's configured streamer settings to the viewer page tabs, so win/loss accent colours are real rather than hardcoded defaults.

**What changed:**

`present(snapshot)` now reads `view.streamerSettings.styleFlags` and passes `playerTeamColor ?? teamColor` / `playerEnemyColor ?? enemyColor` to `buildViewerRenderModel`. The viewer render model already accepted these optional IDs ([F1-1](https://github.com/davidhouweling/guilty-spark/pull/478)) — this just supplies real values.

**Two review findings fixed before commit:**
- Used `playerTeamColor`/`playerEnemyColor` (player-mode fields) with fallback to `teamColor`/`enemyColor`, instead of the bare legacy fields — the viewer page is always player-mode (owner watching their own tracker)
- `setView` (WS live push) now preserves `streamerSettings` from the prior snapshot — without this, any WS update would silently drop the settings and revert colours to defaults for the rest of the session

`IndividualTrackerViewerViewModel` gains `streamerSettings?` for use by the upcoming overlay work.

1998 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)