### PR TITLE
feat(api): follow-live directory API — GET/WS /u/:gamertag/view|ws (F-1)

### DIFF
--- a/api/routes/individual-tracker/follow.ts
+++ b/api/routes/individual-tracker/follow.ts
@@ -1,0 +1,107 @@
+import { z } from "zod";
+import { parsePathParams } from "@guilty-spark/shared/base/request-parsing";
+import { errorContract } from "@guilty-spark/shared/contracts/error";
+import type { TrackerDirectory, TrackerDirectoryEntry } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import {
+  trackerDirectoryContract,
+  trackerDirectoryMessageContract,
+} from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import type { IndividualTrackersRow } from "../../services/database/types/individual_trackers";
+import type { Services } from "../../services/install";
+import type { RoutesRegisterHandler } from "../base/types";
+import { computeAccumulated, fetchTrackerDoViewState } from "./mapper";
+
+const gamertagParamsSchema = z.object({ gamertag: z.string().min(1) });
+
+function isNonStopped(row: IndividualTrackersRow): boolean {
+  return row.Status !== "stopped";
+}
+
+async function buildDirectory(env: Env, userId: string, services: Services): Promise<TrackerDirectory> {
+  const allTrackers = await services.databaseService.findIndividualTrackersByUserId(userId);
+  const nonStopped = allTrackers.filter(isNonStopped);
+
+  const [entries, streamerSettings] = await Promise.all([
+    Promise.all(
+      nonStopped.map(async (row): Promise<TrackerDirectoryEntry> => {
+        const doState = await fetchTrackerDoViewState(env, row.UserId, row.TrackerId);
+        const matches = doState?.matches ?? [];
+        return {
+          trackerId: row.TrackerId,
+          gamertag: row.Gamertag,
+          status: row.Status,
+          isLive: row.IsLive === 1,
+          accumulated: computeAccumulated(matches),
+        };
+      }),
+    ),
+    services.individualTrackerService.getSettingsForView(userId),
+  ]);
+
+  return {
+    trackers: entries,
+    streamerSettings: Object.keys(streamerSettings).length > 0 ? streamerSettings : undefined,
+  };
+}
+
+export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
+  router.get("/u/:gamertag/view", async (request, env: Env) => {
+    const services = installServices({ env });
+    const { databaseService, logService } = services;
+
+    try {
+      const parsedParams = parsePathParams(request.params, gamertagParamsSchema, "Invalid gamertag");
+      if (!parsedParams.success) {
+        return parsedParams.response;
+      }
+      const { gamertag } = parsedParams.data;
+
+      const identity = await databaseService.findActiveXboxIdentityByGamertag(gamertag);
+      if (identity == null) {
+        return errorContract.toResponse({ error: "Gamertag not found" }, { status: 404, noStore: true });
+      }
+
+      const directory = await buildDirectory(env, identity.UserId, services);
+      return trackerDirectoryContract.toResponse(directory, { noStore: true });
+    } catch (error) {
+      logService.error(error as Error, new Map([["message", "Follow view error"]]));
+      return errorContract.toResponse({ error: "Failed to fetch follow directory" }, { status: 500, noStore: true });
+    }
+  });
+
+  router.get("/u/:gamertag/ws", async (request, env: Env) => {
+    const services = installServices({ env });
+    const { databaseService, logService } = services;
+
+    try {
+      const parsedParams = parsePathParams(request.params, gamertagParamsSchema, "Invalid gamertag");
+      if (!parsedParams.success) {
+        return parsedParams.response;
+      }
+      const { gamertag } = parsedParams.data;
+
+      if (request.headers.get("Upgrade") !== "websocket") {
+        return new Response("Expected WebSocket upgrade", { status: 426 });
+      }
+
+      const identity = await databaseService.findActiveXboxIdentityByGamertag(gamertag);
+      if (identity == null) {
+        return errorContract.toResponse({ error: "Gamertag not found" }, { status: 404, noStore: true });
+      }
+
+      const directory = await buildDirectory(env, identity.UserId, services);
+
+      const { 0: client, 1: server } = new WebSocketPair();
+      server.accept();
+      server.send(trackerDirectoryMessageContract.serialize({ type: "directory", directory }));
+      // Push-on-change (tracker goes live, new tracker added) is deferred to a future PR
+      // that subscribes to individual tracker DOs. For now clients get the snapshot on
+      // connect and can reconnect to refresh.
+
+      return new Response(null, { status: 101, webSocket: client });
+    } catch (error) {
+      logService.error(error as Error, new Map([["message", "Follow WebSocket error"]]));
+      return new Response("Internal Server Error", { status: 500 });
+    }
+  });
+};

--- a/api/routes/individual-tracker/individual-tracker.ts
+++ b/api/routes/individual-tracker/individual-tracker.ts
@@ -1,4 +1,5 @@
 import type { RoutesRegisterHandler } from "../base/types";
+import { trackerFollowRoutesRegisterHandler } from "./follow";
 import { trackerManageRoutesRegisterHandler } from "./manage";
 import { trackerProfileRoutesRegisterHandler } from "./profile";
 import { trackerSettingsRoutesRegisterHandler } from "./settings";
@@ -9,4 +10,5 @@ export const individualTrackerRoutesRegisterHandler: RoutesRegisterHandler = (ro
   trackerManageRoutesRegisterHandler(router, installServices);
   trackerSettingsRoutesRegisterHandler(router, installServices);
   trackerViewRoutesRegisterHandler(router, installServices);
+  trackerFollowRoutesRegisterHandler(router, installServices);
 };

--- a/api/routes/individual-tracker/mapper.ts
+++ b/api/routes/individual-tracker/mapper.ts
@@ -7,7 +7,41 @@ import type { IndividualTrackersRow } from "../../services/database/types/indivi
 import type {
   IndividualTrackerState,
   IndividualTrackerViewState,
+  IndividualTrackerViewStateResponse,
 } from "../../durable-objects/individual-tracker/types";
+
+export async function fetchTrackerDoViewState(
+  env: Env,
+  userId: string,
+  trackerId: string,
+): Promise<IndividualTrackerViewState | null> {
+  const doId = env.INDIVIDUAL_TRACKER_DO.idFromName(`${userId}:${trackerId}`);
+  const stub = env.INDIVIDUAL_TRACKER_DO.get(doId);
+  const response = await stub.fetch("http://do/view-state", { method: "GET" });
+  const result = await response.json<IndividualTrackerViewStateResponse>();
+  return result.state;
+}
+
+export function computeAccumulated(matches: readonly { outcome: string }[]): {
+  total: number;
+  wins: number;
+  losses: number;
+  ties: number;
+} {
+  let wins = 0;
+  let losses = 0;
+  let ties = 0;
+  for (const match of matches) {
+    if (match.outcome === "Win") {
+      wins++;
+    } else if (match.outcome === "Loss") {
+      losses++;
+    } else if (match.outcome === "Tie") {
+      ties++;
+    }
+  }
+  return { total: matches.length, wins, losses, ties };
+}
 
 export function toTrackerProfile(row: IndividualTrackerProfilesRow): TrackerProfile {
   return {

--- a/api/routes/individual-tracker/tests/follow.test.ts
+++ b/api/routes/individual-tracker/tests/follow.test.ts
@@ -1,5 +1,5 @@
 import type { AutoRouterType } from "itty-router";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TrackerDirectoryResponse } from "@guilty-spark/shared/contracts/individual-tracker/follow";
 import { trackerDirectoryMessageContract } from "@guilty-spark/shared/contracts/individual-tracker/follow";
 import { createApiRouter } from "../../../base/router";
@@ -46,6 +46,10 @@ describe("/u/:gamertag follow routes", () => {
     vi.stubGlobal("WebSocketPair", function () {
       return { 0: client, 1: server };
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   describe("GET /u/:gamertag/view", () => {
@@ -261,12 +265,11 @@ describe("/u/:gamertag follow routes", () => {
 
       const res = (await router.fetch(getRequest("/u/SettingsPlayer/view"), localEnv)) as Response;
 
-      expect.assertions(2);
+      expect.assertions(3);
       expect(res.status).toBe(200);
       const body = await res.json<TrackerDirectoryResponse>();
-      if (body.streamerSettings != null) {
-        expect(body.streamerSettings.layoutOptions?.viewMode).toBe("wide");
-      }
+      expect(body.streamerSettings).toBeDefined();
+      expect(body.streamerSettings?.layoutOptions?.viewMode).toBe("wide");
     });
   });
 
@@ -282,6 +285,52 @@ describe("/u/:gamertag follow routes", () => {
       const res = (await router.fetch(wsRequest("/u/UnknownTag/ws"), env)) as Response;
 
       expect(res.status).toBe(404);
+    });
+
+    it("returns 101 with empty trackers array when user has no active trackers", async () => {
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "EmptyWsTag" });
+      const stoppedTracker = aFakeIndividualTrackersRow({ UserId: "user-1", Status: "stopped" });
+
+      let capturedServer: WebSocket | undefined;
+      const client = makeFakeWebSocket();
+      const server = makeFakeWebSocket();
+      vi.stubGlobal("WebSocketPair", function () {
+        capturedServer = server;
+        return { 0: client, 1: server };
+      });
+
+      const OriginalResponse = globalThis.Response;
+      vi.stubGlobal(
+        "Response",
+        class FakeResponse extends OriginalResponse {
+          constructor(body: BodyInit | null, init?: ResponseInit & { webSocket?: WebSocket }) {
+            super(body, { ...init, status: init?.status === 101 ? 200 : (init?.status ?? 200) });
+            if (init?.status === 101) {
+              Object.defineProperty(this, "status", { value: 101 });
+            }
+          }
+        },
+      );
+
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
+        vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([stoppedTracker]);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(wsRequest("/u/EmptyWsTag/ws"), env)) as Response;
+
+      expect.assertions(4);
+      expect(res.status).toBe(101);
+      const serverMocks = capturedServer as unknown as Record<string, ReturnType<typeof vi.fn>> | undefined;
+      const sendMock = serverMocks?.["send"];
+      expect(sendMock).toHaveBeenCalledOnce();
+      const [[sentArg]] = sendMock?.mock.calls ?? [];
+      expect(typeof sentArg).toBe("string");
+      const msg = trackerDirectoryMessageContract.parse(sentArg as string);
+      expect(msg.directory.trackers).toEqual([]);
     });
 
     it("returns 426 when the request is not a websocket upgrade", async () => {
@@ -342,7 +391,7 @@ describe("/u/:gamertag follow routes", () => {
 
       const res = (await router.fetch(wsRequest("/u/WsPlayer/ws"), localEnv)) as Response;
 
-      expect.assertions(4);
+      expect.assertions(5);
       expect(res.status).toBe(101);
 
       type MockRecord = Record<string, ReturnType<typeof vi.fn>>;
@@ -353,10 +402,9 @@ describe("/u/:gamertag follow routes", () => {
       expect(sendMock).toHaveBeenCalledOnce();
       const firstCall = sendMock?.mock.calls[0] as unknown[] | undefined;
       const [sentArg] = firstCall ?? [];
-      if (typeof sentArg === "string") {
-        const msg = trackerDirectoryMessageContract.parse(sentArg);
-        expect(msg.type).toBe("directory");
-      }
+      expect(typeof sentArg).toBe("string");
+      const msg = trackerDirectoryMessageContract.parse(sentArg as string);
+      expect(msg.type).toBe("directory");
     });
   });
 });

--- a/api/routes/individual-tracker/tests/follow.test.ts
+++ b/api/routes/individual-tracker/tests/follow.test.ts
@@ -1,0 +1,362 @@
+import type { AutoRouterType } from "itty-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TrackerDirectoryResponse } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import { trackerDirectoryMessageContract } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import { createApiRouter } from "../../../base/router";
+import { aFakeEnvWith } from "../../../base/fakes/env.fake";
+import { aFakeDurableObjectNamespaceWith } from "../../../base/fakes/do.fake";
+import {
+  aFakeIndividualTrackerDOWith,
+  aFakeIndividualTrackerViewStateWith,
+} from "../../../durable-objects/individual-tracker/fakes/individual-tracker-do.fake";
+import { aFakeIndividualTrackersRow, aFakeLinkedIdentitiesRow } from "../../../services/database/fakes/database.fake";
+import { installFakeServicesWith } from "../../../services/fakes/services";
+import { individualTrackerRoutesRegisterHandler } from "../individual-tracker";
+
+function getRequest(path: string): Request {
+  return new Request(`http://localhost${path}`, { method: "GET" });
+}
+
+function wsRequest(path: string): Request {
+  return new Request(`http://localhost${path}`, { method: "GET", headers: { Upgrade: "websocket" } });
+}
+
+function makeFakeWebSocket(): WebSocket {
+  return {
+    accept: vi.fn(),
+    send: vi.fn(),
+    close: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    readyState: 0,
+  } as unknown as WebSocket;
+}
+
+describe("/u/:gamertag follow routes", () => {
+  let env: Env;
+  let router: AutoRouterType;
+
+  beforeEach(() => {
+    env = aFakeEnvWith();
+    router = createApiRouter();
+
+    const client = makeFakeWebSocket();
+    const server = makeFakeWebSocket();
+    vi.stubGlobal("WebSocketPair", function () {
+      return { 0: client, 1: server };
+    });
+  });
+
+  describe("GET /u/:gamertag/view", () => {
+    it("returns 404 when gamertag is not found", async () => {
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(null);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/u/UnknownTag/view"), env)) as Response;
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 200 with empty trackers array when user has no active trackers", async () => {
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "KnownTag" });
+      const stoppedTracker = aFakeIndividualTrackersRow({ UserId: "user-1", Status: "stopped" });
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
+        vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([stoppedTracker]);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/u/KnownTag/view"), env)) as Response;
+
+      expect(res.status).toBe(200);
+      const body = await res.json<TrackerDirectoryResponse>();
+      expect(body.trackers).toEqual([]);
+    });
+
+    it("includes active and paused trackers but excludes stopped trackers", async () => {
+      const doStub = aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } });
+      const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "MultiTag" });
+      const activeTracker = aFakeIndividualTrackersRow({
+        TrackerId: "t-active",
+        UserId: "user-1",
+        Status: "active",
+        IsLive: 1,
+      });
+      const pausedTracker = aFakeIndividualTrackersRow({
+        TrackerId: "t-paused",
+        UserId: "user-1",
+        Status: "paused",
+        IsLive: 0,
+      });
+      const stoppedTracker = aFakeIndividualTrackersRow({
+        TrackerId: "t-stopped",
+        UserId: "user-1",
+        Status: "stopped",
+        IsLive: 0,
+      });
+
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env: localEnv });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
+        vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([
+          activeTracker,
+          pausedTracker,
+          stoppedTracker,
+        ]);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/u/MultiTag/view"), localEnv)) as Response;
+
+      expect(res.status).toBe(200);
+      const body = await res.json<TrackerDirectoryResponse>();
+      expect(body.trackers).toHaveLength(2);
+      const trackerIds = body.trackers.map((t) => t.trackerId);
+      expect(trackerIds).toContain("t-active");
+      expect(trackerIds).toContain("t-paused");
+      expect(trackerIds).not.toContain("t-stopped");
+    });
+
+    it("returns correct accumulated counts and isLive flag from DO state", async () => {
+      const doStub = aFakeIndividualTrackerDOWith({
+        viewStateResponse: {
+          state: aFakeIndividualTrackerViewStateWith({
+            trackerId: "t1",
+            matches: [
+              {
+                matchId: "m1",
+                startTime: "2024-11-26T11:00:00.000Z",
+                endTime: "2024-11-26T11:10:00.000Z",
+                mapAssetId: "map-1",
+                mapVersionId: "map-v-1",
+                mapName: "Aquarius",
+                modeAssetId: "mode-1",
+                gameVariantCategory: 6,
+                outcome: "Win",
+                score: "50:42",
+              },
+              {
+                matchId: "m2",
+                startTime: "2024-11-26T11:15:00.000Z",
+                endTime: "2024-11-26T11:25:00.000Z",
+                mapAssetId: "map-1",
+                mapVersionId: "map-v-1",
+                mapName: "Aquarius",
+                modeAssetId: "mode-1",
+                gameVariantCategory: 6,
+                outcome: "Loss",
+                score: "40:50",
+              },
+              {
+                matchId: "m3",
+                startTime: "2024-11-26T11:30:00.000Z",
+                endTime: "2024-11-26T11:40:00.000Z",
+                mapAssetId: "map-1",
+                mapVersionId: "map-v-1",
+                mapName: "Aquarius",
+                modeAssetId: "mode-1",
+                gameVariantCategory: 6,
+                outcome: "Tie",
+                score: "50:50",
+              },
+            ],
+          }),
+        },
+      });
+      const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "LivePlayer" });
+      const row = aFakeIndividualTrackersRow({
+        TrackerId: "t1",
+        UserId: "user-1",
+        Gamertag: "LivePlayer",
+        Status: "active",
+        IsLive: 1,
+      });
+
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env: localEnv });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
+        vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([row]);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/u/LivePlayer/view"), localEnv)) as Response;
+
+      expect.assertions(8);
+      expect(res.status).toBe(200);
+      const body = await res.json<TrackerDirectoryResponse>();
+      expect(body.trackers).toHaveLength(1);
+      const [entry] = body.trackers;
+      if (entry != null) {
+        expect(entry.isLive).toBe(true);
+        expect(entry.accumulated.total).toBe(3);
+        expect(entry.accumulated.wins).toBe(1);
+        expect(entry.accumulated.losses).toBe(1);
+        expect(entry.accumulated.ties).toBe(1);
+        expect(entry.gamertag).toBe("LivePlayer");
+      }
+    });
+
+    it("returns zeros for accumulated when DO has no state", async () => {
+      const doStub = aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } });
+      const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "PausedPlayer" });
+      const row = aFakeIndividualTrackersRow({
+        TrackerId: "t2",
+        UserId: "user-1",
+        Gamertag: "PausedPlayer",
+        Status: "paused",
+        IsLive: 0,
+      });
+
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env: localEnv });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
+        vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([row]);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/u/PausedPlayer/view"), localEnv)) as Response;
+
+      expect.assertions(6);
+      expect(res.status).toBe(200);
+      const body = await res.json<TrackerDirectoryResponse>();
+      const [entry] = body.trackers;
+      if (entry != null) {
+        expect(entry.accumulated.total).toBe(0);
+        expect(entry.accumulated.wins).toBe(0);
+        expect(entry.accumulated.losses).toBe(0);
+        expect(entry.accumulated.ties).toBe(0);
+        expect(entry.isLive).toBe(false);
+      }
+    });
+
+    it("includes streamerSettings when getSettingsForView returns non-empty settings", async () => {
+      const doStub = aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } });
+      const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "SettingsPlayer" });
+      const row = aFakeIndividualTrackersRow({ TrackerId: "t3", UserId: "user-1", Status: "active" });
+
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env: localEnv });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
+        vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([row]);
+        vi.spyOn(services.individualTrackerService, "getSettingsForView").mockResolvedValue({
+          layoutOptions: { viewMode: "wide" },
+        });
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/u/SettingsPlayer/view"), localEnv)) as Response;
+
+      expect.assertions(2);
+      expect(res.status).toBe(200);
+      const body = await res.json<TrackerDirectoryResponse>();
+      if (body.streamerSettings != null) {
+        expect(body.streamerSettings.layoutOptions?.viewMode).toBe("wide");
+      }
+    });
+  });
+
+  describe("GET /u/:gamertag/ws", () => {
+    it("returns 404 when gamertag is not found", async () => {
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(null);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(wsRequest("/u/UnknownTag/ws"), env)) as Response;
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 426 when the request is not a websocket upgrade", async () => {
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "SomeTag" });
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/u/SomeTag/ws"), env)) as Response;
+
+      expect(res.status).toBe(426);
+    });
+
+    it("returns 101 and sends initial directory message on upgrade", async () => {
+      const doStub = aFakeIndividualTrackerDOWith({
+        viewStateResponse: {
+          state: aFakeIndividualTrackerViewStateWith({
+            trackerId: "t1",
+            matches: [],
+          }),
+        },
+      });
+      const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "WsPlayer" });
+      const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1", Status: "active", IsLive: 1 });
+
+      let capturedServer: WebSocket | undefined;
+      const client = makeFakeWebSocket();
+      const server = makeFakeWebSocket();
+      vi.stubGlobal("WebSocketPair", function () {
+        capturedServer = server;
+        return { 0: client, 1: server };
+      });
+
+      const OriginalResponse = globalThis.Response;
+      vi.stubGlobal(
+        "Response",
+        class FakeResponse extends OriginalResponse {
+          constructor(body: BodyInit | null, init?: ResponseInit & { webSocket?: WebSocket }) {
+            super(body, { ...init, status: init?.status === 101 ? 200 : (init?.status ?? 200) });
+            if (init?.status === 101) {
+              Object.defineProperty(this, "status", { value: 101 });
+            }
+          }
+        },
+      );
+
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env: localEnv });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
+        vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([row]);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(wsRequest("/u/WsPlayer/ws"), localEnv)) as Response;
+
+      expect.assertions(4);
+      expect(res.status).toBe(101);
+
+      type MockRecord = Record<string, ReturnType<typeof vi.fn>>;
+      const serverMocks = capturedServer as unknown as MockRecord | undefined;
+      const acceptMock = serverMocks?.["accept"];
+      const sendMock = serverMocks?.["send"];
+      expect(acceptMock).toHaveBeenCalled();
+      expect(sendMock).toHaveBeenCalledOnce();
+      const firstCall = sendMock?.mock.calls[0] as unknown[] | undefined;
+      const [sentArg] = firstCall ?? [];
+      if (typeof sentArg === "string") {
+        const msg = trackerDirectoryMessageContract.parse(sentArg);
+        expect(msg.type).toBe("directory");
+      }
+    });
+  });
+});

--- a/api/routes/individual-tracker/tests/mapper.test.ts
+++ b/api/routes/individual-tracker/tests/mapper.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { computeAccumulated } from "../mapper";
+
+describe("computeAccumulated", () => {
+  it("returns zeros for an empty match list", () => {
+    expect(computeAccumulated([])).toEqual({ total: 0, wins: 0, losses: 0, ties: 0 });
+  });
+
+  it("counts wins, losses and ties correctly", () => {
+    const matches = [{ outcome: "Win" }, { outcome: "Win" }, { outcome: "Loss" }, { outcome: "Tie" }];
+    expect(computeAccumulated(matches)).toEqual({ total: 4, wins: 2, losses: 1, ties: 1 });
+  });
+
+  it("counts DNF and Unknown in total but not in wins/losses/ties", () => {
+    const matches = [{ outcome: "Win" }, { outcome: "DNF" }, { outcome: "Unknown" }];
+    expect(computeAccumulated(matches)).toEqual({ total: 3, wins: 1, losses: 0, ties: 0 });
+  });
+
+  it("handles a mix of all outcome types", () => {
+    const matches = [
+      { outcome: "Win" },
+      { outcome: "Loss" },
+      { outcome: "Tie" },
+      { outcome: "DNF" },
+      { outcome: "Unknown" },
+    ];
+    expect(computeAccumulated(matches)).toEqual({ total: 5, wins: 1, losses: 1, ties: 1 });
+  });
+});

--- a/api/routes/individual-tracker/view.ts
+++ b/api/routes/individual-tracker/view.ts
@@ -2,24 +2,8 @@ import { parsePathParams } from "@guilty-spark/shared/base/request-parsing";
 import { errorContract } from "@guilty-spark/shared/contracts/error";
 import { trackerParamsSchema } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import { trackerViewContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
-import type {
-  IndividualTrackerViewState,
-  IndividualTrackerViewStateResponse,
-} from "../../durable-objects/individual-tracker/types";
 import type { RoutesRegisterHandler } from "../base/types";
-import { toTrackerView } from "./mapper";
-
-async function viewStateTrackerDo(
-  env: Env,
-  userId: string,
-  trackerId: string,
-): Promise<IndividualTrackerViewState | null> {
-  const doId = env.INDIVIDUAL_TRACKER_DO.idFromName(`${userId}:${trackerId}`);
-  const stub = env.INDIVIDUAL_TRACKER_DO.get(doId);
-  const response = await stub.fetch("http://do/view-state", { method: "GET" });
-  const result = await response.json<IndividualTrackerViewStateResponse>();
-  return result.state;
-}
+import { fetchTrackerDoViewState, toTrackerView } from "./mapper";
 
 export const trackerViewRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
   router.get("/api/individual-tracker/:trackerId/view", async (request, env: Env) => {
@@ -39,7 +23,7 @@ export const trackerViewRoutesRegisterHandler: RoutesRegisterHandler = (router, 
       }
 
       const [doState, streamerSettings] = await Promise.all([
-        viewStateTrackerDo(env, row.UserId, trackerId),
+        fetchTrackerDoViewState(env, row.UserId, trackerId),
         individualTrackerService.getSettingsForView(row.UserId),
       ]);
 

--- a/shared/src/contracts/individual-tracker/follow.ts
+++ b/shared/src/contracts/individual-tracker/follow.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import { streamerViewSettingsSchema } from "../../individual-tracker/streamer-view-settings";
+import { defineContract, defineMessageContract } from "../base";
+import { trackerStatusSchema } from "./tracker";
+
+export const trackerDirectoryEntrySchema = z.object({
+  trackerId: z.string(),
+  gamertag: z.string(),
+  status: trackerStatusSchema,
+  isLive: z.boolean(),
+  accumulated: z.object({
+    total: z.number(),
+    wins: z.number(),
+    losses: z.number(),
+    ties: z.number(),
+  }),
+});
+export type TrackerDirectoryEntry = z.infer<typeof trackerDirectoryEntrySchema>;
+
+export const trackerDirectorySchema = z.object({
+  trackers: z.array(trackerDirectoryEntrySchema),
+  streamerSettings: streamerViewSettingsSchema.optional(),
+});
+export type TrackerDirectory = z.infer<typeof trackerDirectorySchema>;
+
+export const trackerDirectoryContract = defineContract(trackerDirectorySchema);
+export type TrackerDirectoryResponse = z.infer<typeof trackerDirectoryContract.schema>;
+
+export const trackerDirectoryMessageSchema = z.object({
+  type: z.literal("directory"),
+  directory: trackerDirectorySchema,
+});
+export type TrackerDirectoryMessage = z.infer<typeof trackerDirectoryMessageSchema>;
+
+export const trackerDirectoryMessageContract = defineMessageContract(trackerDirectoryMessageSchema);

--- a/shared/src/contracts/individual-tracker/tests/follow.test.ts
+++ b/shared/src/contracts/individual-tracker/tests/follow.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { trackerDirectoryContract, trackerDirectoryMessageContract, type TrackerDirectoryResponse } from "../follow";
+
+const validEntry = {
+  trackerId: "t1",
+  gamertag: "Spartan",
+  status: "active" as const,
+  isLive: true,
+  accumulated: { total: 3, wins: 2, losses: 1, ties: 0 },
+};
+
+const validDirectory: TrackerDirectoryResponse = {
+  trackers: [validEntry],
+};
+
+describe("trackerDirectoryContract", () => {
+  it("parses a valid directory response", () => {
+    const result = trackerDirectoryContract.parse(validDirectory);
+    expect(result.trackers).toHaveLength(1);
+    expect(result.trackers[0]?.trackerId).toBe("t1");
+  });
+
+  it("parses a directory with no trackers", () => {
+    const result = trackerDirectoryContract.parse({ trackers: [] });
+    expect(result.trackers).toEqual([]);
+  });
+
+  it("parses a directory with streamerSettings", () => {
+    const result = trackerDirectoryContract.parse({
+      trackers: [],
+      streamerSettings: { styleFlags: { colorMode: "observer" } },
+    });
+    expect(result.streamerSettings?.styleFlags?.colorMode).toBe("observer");
+  });
+
+  it("serialises to and from a Response", async () => {
+    const response = trackerDirectoryContract.toResponse(validDirectory, { noStore: true });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+
+    const parsed = await trackerDirectoryContract.fromResponse(response);
+    expect(parsed.trackers[0]?.gamertag).toBe("Spartan");
+    expect(parsed.trackers[0]?.accumulated.wins).toBe(2);
+  });
+
+  it("rejects an entry with an invalid status", () => {
+    expect(() =>
+      trackerDirectoryContract.parse({
+        trackers: [{ ...validEntry, status: "invalid" }],
+      }),
+    ).toThrow();
+  });
+});
+
+describe("trackerDirectoryMessageContract", () => {
+  it("serialises and parses a directory message", () => {
+    const msg = trackerDirectoryMessageContract.serialize({
+      type: "directory",
+      directory: { trackers: [validEntry] },
+    });
+    expect(typeof msg).toBe("string");
+
+    const parsed = trackerDirectoryMessageContract.parse(msg);
+    expect(parsed.type).toBe("directory");
+    expect(parsed.directory.trackers[0]?.trackerId).toBe("t1");
+  });
+
+  it("rejects a message with the wrong type", () => {
+    expect(() =>
+      trackerDirectoryMessageContract.parse(JSON.stringify({ type: "wrong", directory: { trackers: [] } })),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
**Stacked on [#490](https://github.com/davidhouweling/guilty-spark/pull/490)** (F-0 — loosen per-tracker view routes to public reads). Merge F-0 first.

Adds the public API that powers the `/u/<gamertag>` follow-live viewer and OBS overlay. Both routes are public (no session required) — the gamertag is the entry point, not a secret capability key.

## Routes

### `GET /u/:gamertag/view`
Returns a directory of the owner's non-stopped trackers with tab-bar data:
```json
{
  "trackers": [
    { "trackerId": "...", "gamertag": "Spartan", "status": "active", "isLive": true,
      "accumulated": { "total": 5, "wins": 3, "losses": 2, "ties": 0 } }
  ],
  "streamerSettings": { "styleFlags": { "colorMode": "observer" } }
}
```
`accumulated` is computed server-side from the DO's match list. `streamerSettings` is omitted when the owner hasn't configured settings.

### `GET /u/:gamertag/ws`
WebSocket that sends the same directory payload as a single push on open (`{ type: "directory", directory: ... }`). Connection stays open. **Push-on-change** (when the live tracker switches, a tracker starts/stops) is deferred — a future PR will subscribe to individual tracker DOs to push updates. For now clients can reconnect to refresh.

## Resolution chain
`gamertag` → `findActiveXboxIdentityByGamertag` → `UserId` → `findIndividualTrackersByUserId` (filter non-stopped) → parallel DO `view-state` fetches → `computeAccumulated` → directory

## Shared contract (`shared/src/contracts/individual-tracker/follow.ts`)
`TrackerDirectoryEntry`, `TrackerDirectory`, `trackerDirectoryContract`, `TrackerDirectoryMessage`, `trackerDirectoryMessageContract`.

## Also: `fetchTrackerDoViewState` extracted to `mapper.ts`
Was duplicated between `view.ts` and `follow.ts`. Now a single shared export.

## Tests added
- `shared/src/contracts/individual-tracker/tests/follow.test.ts` — contract parse/serialize/toResponse/fromResponse, streamerSettings, invalid status, Cache-Control header
- `api/routes/individual-tracker/tests/mapper.test.ts` — `computeAccumulated` with empty list, Win/Loss/Tie, DNF+Unknown (counted in total only), all outcomes mixed
- `api/routes/individual-tracker/tests/follow.test.ts` — WS empty-trackers case, stub lifecycle (`vi.unstubAllGlobals`), non-vacuous assertion patterns

## Verification
- `npm run typecheck` → 0 errors; eslint + prettier clean
- `npx vitest run` → **2040 passing** (+21 new across 3 test files)
- `/code-review --fix` × 3 rounds until `[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)