### PR TITLE
feat(pages): follow-live service layer — directory GET/WS + tracker view (F-2)

### DIFF
--- a/pages/src/services/follow/fakes/follow.fake.ts
+++ b/pages/src/services/follow/fakes/follow.fake.ts
@@ -1,0 +1,90 @@
+import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import type { TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import { aFakeTrackerViewStateWith } from "../../individual-tracker/fakes/view.fake";
+import type {
+  DirectoryConnection,
+  DirectoryConnectionStatus,
+  DirectoryListener,
+  DirectoryStatusListener,
+  DirectorySubscription,
+  FollowLiveService,
+} from "../follow-types";
+
+class FakeDirectoryConnection implements DirectoryConnection {
+  private readonly listeners = new Set<DirectoryListener>();
+  private readonly statusListeners = new Set<DirectoryStatusListener>();
+
+  public subscribe(listener: DirectoryListener): DirectorySubscription {
+    this.listeners.add(listener);
+    return {
+      unsubscribe: (): void => {
+        this.listeners.delete(listener);
+      },
+    };
+  }
+
+  public subscribeStatus(listener: DirectoryStatusListener): DirectorySubscription {
+    this.statusListeners.add(listener);
+    return {
+      unsubscribe: (): void => {
+        this.statusListeners.delete(listener);
+      },
+    };
+  }
+
+  public disconnect(): void {
+    this.listeners.clear();
+    this.statusListeners.clear();
+  }
+
+  public emitDirectory(directory: TrackerDirectory): void {
+    for (const listener of this.listeners) {
+      listener(directory);
+    }
+  }
+
+  public emitStatus(status: DirectoryConnectionStatus, detail?: string): void {
+    for (const listener of this.statusListeners) {
+      listener(status, detail);
+    }
+  }
+}
+
+interface FakeFollowLiveServiceOptions {
+  readonly directory?: TrackerDirectory;
+}
+
+export class FakeFollowLiveService implements FollowLiveService {
+  private readonly directory: TrackerDirectory;
+  public lastConnection: FakeDirectoryConnection | null = null;
+
+  public constructor(options?: FakeFollowLiveServiceOptions) {
+    this.directory = options?.directory ?? { trackers: [] };
+  }
+
+  public async getDirectory(): Promise<TrackerDirectory> {
+    await Promise.resolve();
+    return this.directory;
+  }
+
+  public connectDirectory(): DirectoryConnection {
+    const connection = new FakeDirectoryConnection();
+    this.lastConnection = connection;
+    return connection;
+  }
+
+  public async getTrackerView(): Promise<TrackerViewResponse> {
+    await Promise.resolve();
+    return { view: aFakeTrackerViewStateWith() };
+  }
+}
+
+export interface FakeFollowLiveServiceFactoryOpts {
+  readonly directory?: TrackerDirectory;
+}
+
+export function aFakeFollowLiveServiceWith(opts: FakeFollowLiveServiceFactoryOpts = {}): FakeFollowLiveService {
+  return new FakeFollowLiveService({
+    ...(opts.directory !== undefined ? { directory: opts.directory } : {}),
+  });
+}

--- a/pages/src/services/follow/follow-connection.ts
+++ b/pages/src/services/follow/follow-connection.ts
@@ -1,0 +1,79 @@
+import type { TrackerDirectoryMessage } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import { trackerDirectoryMessageContract } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import type {
+  DirectoryConnection,
+  DirectoryConnectionStatus,
+  DirectoryListener,
+  DirectoryStatusListener,
+  DirectorySubscription,
+} from "./follow-types";
+
+function tryParseDirectoryMessage(raw: string): TrackerDirectoryMessage | undefined {
+  try {
+    return trackerDirectoryMessageContract.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+export class RealDirectoryConnection implements DirectoryConnection {
+  private readonly listeners = new Set<DirectoryListener>();
+  private readonly statusListeners = new Set<DirectoryStatusListener>();
+  private ws: WebSocket | null;
+  private readonly onOffline: () => void;
+
+  public constructor(ws: WebSocket) {
+    this.ws = ws;
+    this.onOffline = (): void => {
+      this.ws?.close();
+    };
+    window.addEventListener("offline", this.onOffline);
+  }
+
+  public subscribe(listener: DirectoryListener): DirectorySubscription {
+    this.listeners.add(listener);
+    return {
+      unsubscribe: (): void => {
+        this.listeners.delete(listener);
+      },
+    };
+  }
+
+  public subscribeStatus(listener: DirectoryStatusListener): DirectorySubscription {
+    this.statusListeners.add(listener);
+    return {
+      unsubscribe: (): void => {
+        this.statusListeners.delete(listener);
+      },
+    };
+  }
+
+  public disconnect(): void {
+    window.removeEventListener("offline", this.onOffline);
+
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+
+    this.listeners.clear();
+    this.statusListeners.clear();
+  }
+
+  public handleStatus(status: DirectoryConnectionStatus, detail?: string): void {
+    for (const listener of this.statusListeners) {
+      listener(status, detail);
+    }
+  }
+
+  public handleRaw(raw: string): void {
+    const message = tryParseDirectoryMessage(raw);
+    if (message === undefined) {
+      return;
+    }
+
+    for (const listener of this.listeners) {
+      listener(message.directory);
+    }
+  }
+}

--- a/pages/src/services/follow/follow-types.ts
+++ b/pages/src/services/follow/follow-types.ts
@@ -1,0 +1,29 @@
+import type {
+  TrackerDirectory,
+  TrackerDirectoryMessage,
+} from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import type { TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
+
+export type { TrackerDirectory, TrackerDirectoryMessage };
+
+export type DirectoryListener = (directory: TrackerDirectory) => void;
+
+export type DirectoryConnectionStatus = "connecting" | "connected" | "error" | "disconnected";
+
+export type DirectoryStatusListener = (status: DirectoryConnectionStatus, detail?: string) => void;
+
+export interface DirectorySubscription {
+  unsubscribe(): void;
+}
+
+export interface DirectoryConnection {
+  subscribe(listener: DirectoryListener): DirectorySubscription;
+  subscribeStatus(listener: DirectoryStatusListener): DirectorySubscription;
+  disconnect(): void;
+}
+
+export interface FollowLiveService {
+  getDirectory(gamertag: string): Promise<TrackerDirectory>;
+  connectDirectory(gamertag: string): DirectoryConnection;
+  getTrackerView(trackerId: string): Promise<TrackerViewResponse>;
+}

--- a/pages/src/services/follow/follow.ts
+++ b/pages/src/services/follow/follow.ts
@@ -1,0 +1,105 @@
+import { errorContract } from "@guilty-spark/shared/contracts/error";
+import { trackerDirectoryContract } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import { trackerViewContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import type { TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import { RealDirectoryConnection } from "./follow-connection";
+import type { DirectoryConnection, FollowLiveService } from "./follow-types";
+
+interface FollowLiveServiceOpts {
+  readonly apiHost: string;
+}
+
+export class RealFollowLiveService implements FollowLiveService {
+  private readonly apiHost: string;
+
+  public constructor({ apiHost }: FollowLiveServiceOpts) {
+    this.apiHost = apiHost;
+  }
+
+  private buildUrl(path: string): string {
+    const baseUrl = this.apiHost.endsWith("/") ? this.apiHost.slice(0, -1) : this.apiHost;
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    return `${baseUrl}${normalizedPath}`;
+  }
+
+  private async readError(response: Response): Promise<Error> {
+    const body = await response.text();
+    if (body !== "") {
+      try {
+        const parsed = errorContract.safeParse(JSON.parse(body));
+        if (parsed.success && parsed.data.error !== "") {
+          return new Error(parsed.data.error);
+        }
+        return new Error(`Request failed (${String(response.status)})`);
+      } catch {
+        return new Error(body);
+      }
+    }
+
+    return new Error(`Request failed (${String(response.status)})`);
+  }
+
+  public async getDirectory(gamertag: string): Promise<TrackerDirectory> {
+    const response = await fetch(this.buildUrl(`/u/${encodeURIComponent(gamertag)}/view`), {
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    return trackerDirectoryContract.fromResponse(response);
+  }
+
+  public connectDirectory(gamertag: string): DirectoryConnection {
+    const apiUrl = new URL(this.apiHost);
+    const protocol = apiUrl.protocol === "https:" ? "wss:" : "ws:";
+    const wsUrl = `${protocol}//${apiUrl.host}/u/${encodeURIComponent(gamertag)}/ws`;
+
+    const ws = new WebSocket(wsUrl);
+    const connection = new RealDirectoryConnection(ws);
+
+    connection.handleStatus("connecting");
+
+    ws.onopen = (): void => {
+      connection.handleStatus("connected");
+    };
+
+    ws.onmessage = (event: MessageEvent): void => {
+      if (typeof event.data !== "string") {
+        return;
+      }
+
+      connection.handleRaw(event.data);
+    };
+
+    ws.onerror = (ev): void => {
+      console.error("WebSocket error", ev);
+      connection.handleStatus("error");
+    };
+
+    ws.onclose = (event: CloseEvent): void => {
+      if (event.code === 1000) {
+        connection.handleStatus("disconnected");
+        return;
+      }
+
+      connection.handleStatus("error", event.reason || undefined);
+    };
+
+    return connection;
+  }
+
+  public async getTrackerView(trackerId: string): Promise<TrackerViewResponse> {
+    const response = await fetch(this.buildUrl(`/api/individual-tracker/${encodeURIComponent(trackerId)}/view`), {
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    return trackerViewContract.fromResponse(response);
+  }
+}

--- a/pages/src/services/follow/install.ts
+++ b/pages/src/services/follow/install.ts
@@ -1,0 +1,11 @@
+import { getMode } from "../mode";
+import { RealFollowLiveService } from "./follow";
+import type { FollowLiveService } from "./follow-types";
+
+export async function installFollowLiveService(apiHost: string): Promise<FollowLiveService> {
+  if (getMode() === "FAKE") {
+    const { aFakeFollowLiveServiceWith } = await import("./fakes/follow.fake");
+    return aFakeFollowLiveServiceWith();
+  }
+  return new RealFollowLiveService({ apiHost });
+}

--- a/pages/src/services/follow/tests/follow.test.ts
+++ b/pages/src/services/follow/tests/follow.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import type { DirectoryListener, DirectoryStatusListener } from "../follow-types";
+import { RealFollowLiveService } from "../follow";
+
+class MockWebSocket {
+  public onopen: ((event: Event) => void) | null = null;
+  public onclose: ((event: CloseEvent) => void) | null = null;
+  public onerror: ((event: Event) => void) | null = null;
+  public onmessage: ((event: MessageEvent) => void) | null = null;
+  public readonly url: string;
+  public closed = false;
+
+  public constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  public close(): void {
+    this.closed = true;
+  }
+
+  public static instances: MockWebSocket[] = [];
+
+  public static reset(): void {
+    MockWebSocket.instances = [];
+  }
+}
+
+function aFakeDirectory(overrides: Partial<TrackerDirectory> = {}): TrackerDirectory {
+  return {
+    trackers: [],
+    ...overrides,
+  };
+}
+
+function directoryMessageData(directory: TrackerDirectory): string {
+  return JSON.stringify({ type: "directory", directory });
+}
+
+describe("RealFollowLiveService.getDirectory", () => {
+  it("fetches /u/<gamertag>/view with no credentials and returns the parsed directory", async () => {
+    const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
+    const directory = aFakeDirectory();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify(directory), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const result = await service.getDirectory("SomeTag");
+
+    expect(fetchSpy).toHaveBeenCalledWith("https://api.example.com/u/SomeTag/view", { method: "GET" });
+    expect(result).toEqual(directory);
+    fetchSpy.mockRestore();
+  });
+
+  it("throws on a non-ok response", async () => {
+    const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(service.getDirectory("SomeTag")).rejects.toThrow("not found");
+    fetchSpy.mockRestore();
+  });
+});
+
+describe("RealFollowLiveService.getTrackerView", () => {
+  it("fetches /api/individual-tracker/<id>/view with no credentials", async () => {
+    const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          view: {
+            trackerId: "t1",
+            gamertag: "Spartan",
+            status: "active",
+            matches: [],
+            series: [],
+            lastUpdateTime: "2100-01-01T00:00:00.000Z",
+            lastMatchDiscoveredAt: null,
+            isLive: true,
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await service.getTrackerView("t1");
+
+    expect(fetchSpy).toHaveBeenCalledWith("https://api.example.com/api/individual-tracker/t1/view", { method: "GET" });
+    fetchSpy.mockRestore();
+  });
+});
+
+describe("RealFollowLiveService.connectDirectory", () => {
+  let originalWebSocket: typeof WebSocket;
+
+  beforeEach(() => {
+    originalWebSocket = global.WebSocket;
+    global.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+    MockWebSocket.reset();
+  });
+
+  afterEach(() => {
+    global.WebSocket = originalWebSocket;
+  });
+
+  it("derives a wss URL from an https host", () => {
+    const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
+
+    service.connectDirectory("SomeTag");
+
+    expect(MockWebSocket.instances[0]?.url).toBe("wss://api.example.com/u/SomeTag/ws");
+  });
+
+  it("derives a ws URL from an http host", () => {
+    const service = new RealFollowLiveService({ apiHost: "http://localhost:8787" });
+
+    service.connectDirectory("SomeTag");
+
+    expect(MockWebSocket.instances[0]?.url).toBe("ws://localhost:8787/u/SomeTag/ws");
+  });
+
+  it("emits directory to listeners on a valid message", () => {
+    const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
+    const directory = aFakeDirectory({ trackers: [] });
+    const listener = vi.fn<DirectoryListener>();
+
+    const connection = service.connectDirectory("SomeTag");
+    connection.subscribe(listener);
+
+    const [ws] = MockWebSocket.instances;
+    ws.onmessage?.(new MessageEvent("message", { data: directoryMessageData(directory) }));
+
+    expect(listener).toHaveBeenCalledWith(directory);
+  });
+
+  it("ignores malformed messages", () => {
+    const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
+    const listener = vi.fn<DirectoryListener>();
+
+    const connection = service.connectDirectory("SomeTag");
+    connection.subscribe(listener);
+
+    const [ws] = MockWebSocket.instances;
+    ws.onmessage?.(
+      new MessageEvent("message", { data: JSON.stringify({ type: "directory", directory: { bogus: true } }) }),
+    );
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("disconnects and clears listeners on disconnect()", () => {
+    const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
+    const listener = vi.fn<DirectoryListener>();
+
+    const connection = service.connectDirectory("SomeTag");
+    connection.subscribe(listener);
+
+    const [ws] = MockWebSocket.instances;
+    connection.disconnect();
+
+    ws.onmessage?.(new MessageEvent("message", { data: directoryMessageData(aFakeDirectory()) }));
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(ws.closed).toBe(true);
+  });
+
+  it("closes the socket when the browser goes offline", () => {
+    const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
+
+    service.connectDirectory("SomeTag");
+    const [ws] = MockWebSocket.instances;
+
+    window.dispatchEvent(new Event("offline"));
+
+    expect(ws.closed).toBe(true);
+  });
+
+  it("emits connected when the socket opens", () => {
+    const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
+    const statusListener = vi.fn<DirectoryStatusListener>();
+
+    const connection = service.connectDirectory("SomeTag");
+    connection.subscribeStatus(statusListener);
+
+    expect(statusListener).not.toHaveBeenCalled();
+
+    const [ws] = MockWebSocket.instances;
+    ws.onopen?.(new Event("open"));
+
+    expect(statusListener).toHaveBeenCalledWith("connected", undefined);
+  });
+
+  it("emits error when the socket errors", () => {
+    const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
+    const statusListener = vi.fn<DirectoryStatusListener>();
+
+    const connection = service.connectDirectory("SomeTag");
+    connection.subscribeStatus(statusListener);
+
+    const [ws] = MockWebSocket.instances;
+    ws.onerror?.(new Event("error"));
+
+    expect(statusListener).toHaveBeenCalledWith("error", undefined);
+  });
+
+  it("emits disconnected when the socket closes normally", () => {
+    const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
+    const statusListener = vi.fn<DirectoryStatusListener>();
+
+    const connection = service.connectDirectory("SomeTag");
+    connection.subscribeStatus(statusListener);
+
+    const [ws] = MockWebSocket.instances;
+    ws.onclose?.(new CloseEvent("close", { code: 1000 }));
+
+    expect(statusListener).toHaveBeenCalledWith("disconnected", undefined);
+  });
+
+  it("emits error with reason when the socket closes abnormally", () => {
+    const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
+    const statusListener = vi.fn<DirectoryStatusListener>();
+
+    const connection = service.connectDirectory("SomeTag");
+    connection.subscribeStatus(statusListener);
+
+    const [ws] = MockWebSocket.instances;
+    ws.onclose?.(new CloseEvent("close", { code: 1006, reason: "Connection lost" }));
+
+    expect(statusListener).toHaveBeenCalledWith("error", "Connection lost");
+  });
+
+  it("stops closing the socket on offline once disconnected", () => {
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+    const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
+
+    const connection = service.connectDirectory("SomeTag");
+    connection.disconnect();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith("offline", expect.any(Function));
+    removeEventListenerSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Pages-layer data service for the public `/u/<gamertag>` follow-live API. Mirrors the `IndividualTrackerViewService` pattern (types → connection → service → fakes → install).

## What's here

**`RealFollowLiveService`**
- `getDirectory(gamertag)` — `GET /u/:gamertag/view`, no credentials (public)
- `connectDirectory(gamertag)` — WebSocket to `/u/:gamertag/ws`, returns `RealDirectoryConnection`
- `getTrackerView(trackerId)` — `GET /api/individual-tracker/:id/view`, no credentials (public after [#490](https://github.com/davidhouweling/guilty-spark/pull/490))

**`RealDirectoryConnection`** — parses `trackerDirectoryMessageContract`, emits `directory` to subscribers; no auto-disconnect on stopped (directory WS is always-open); offline auto-close + listener cleanup on `disconnect()`.

**Fake + install** — `FakeFollowLiveService` with driveable `emitDirectory`/`emitStatus`, `aFakeFollowLiveServiceWith` factory, `installFollowLiveService` (FAKE/REAL).

## Code review finding fixed
`"not_found"` removed from `DirectoryConnectionStatus` — no code path emits it (a 404 response to the WS upgrade arrives as an HTTP error, which maps to `"error"` via `onerror`/`onclose`). Leaving it in the union would mislead consumers.

2054 passing; `/code-review --fix` × 2 rounds until `[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)