### PR TITLE
feat(pages): follow-live viewer + overlay pages (F-3/F-4)

### DIFF
--- a/api/routes/individual-tracker/tests/follow.test.ts
+++ b/api/routes/individual-tracker/tests/follow.test.ts
@@ -327,9 +327,8 @@ describe("/u/:gamertag follow routes", () => {
       const serverMocks = capturedServer as unknown as Record<string, ReturnType<typeof vi.fn>> | undefined;
       const sendMock = serverMocks?.["send"];
       expect(sendMock).toHaveBeenCalledOnce();
-      const [[sentArg]] = sendMock?.mock.calls ?? [];
-      expect(typeof sentArg).toBe("string");
-      const msg = trackerDirectoryMessageContract.parse(sentArg as string);
+      expect(sendMock).toHaveBeenCalledWith(expect.any(String));
+      const msg = trackerDirectoryMessageContract.parse(sendMock?.mock.calls[0]?.[0] as string);
       expect(msg.directory.trackers).toEqual([]);
     });
 

--- a/pages/src/apps/follow-live/create.tsx
+++ b/pages/src/apps/follow-live/create.tsx
@@ -59,11 +59,11 @@ export function FollowLiveApp({ apiHost, gamertag, variant = "viewer" }: FollowL
       loading={<LoadingState text={isOverlay ? "Loading overlay..." : "Loading..."} />}
       error={<ErrorState message={isOverlay ? "Failed to load overlay" : "Failed to load viewer"} />}
       loaded={
-        services ? (
-          // TODO (F-4 polish): when variant === "overlay", render a StreamerOverlay
-          // layout (transparent, OBS-sized) instead of FollowLiveViewer. The overlay
-          // should show only the live tracker and use the StreamerOverlay components
-          // ported from the rework branch (BottomSection, TopSection, ticker).
+        // TODO (F-4 polish): when variant === "overlay", render a StreamerOverlay
+        // layout (transparent, OBS-sized) instead of FollowLiveViewer. The overlay
+        // should show only the live tracker and use the StreamerOverlay components
+        // ported from the rework branch (BottomSection, TopSection, ticker).
+        services != null ? (
           <FollowLiveViewer
             gamertag={gamertag}
             followLiveService={services.followLiveService}

--- a/pages/src/apps/follow-live/create.tsx
+++ b/pages/src/apps/follow-live/create.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+import type { ReactElement } from "react";
+import { ComponentLoader, ComponentLoaderStatus } from "../../components/component-loader/component-loader";
+import { ErrorState } from "../../components/error-state/error-state";
+import { LoadingState } from "../../components/loading-state/loading-state";
+import { FollowLiveViewer } from "../../components/follow/follow-live-viewer";
+import type { Services } from "./services";
+import { installServices } from "./services";
+
+interface FollowLiveAppProps {
+  readonly apiHost: string;
+  readonly gamertag: string;
+  readonly variant?: "viewer" | "overlay";
+}
+
+export function FollowLiveApp({ apiHost, gamertag, variant = "viewer" }: FollowLiveAppProps): ReactElement {
+  const [state, setState] = useState(ComponentLoaderStatus.PENDING);
+  const [services, setServices] = useState<Services | null>(null);
+
+  useEffect(() => {
+    if (gamertag === "") {
+      return;
+    }
+
+    let isCancelled = false;
+
+    setServices(null);
+    setState(ComponentLoaderStatus.PENDING);
+
+    installServices(apiHost)
+      .then((installedServices) => {
+        if (isCancelled) {
+          return;
+        }
+        setServices(installedServices);
+        setState(ComponentLoaderStatus.LOADED);
+      })
+      .catch(() => {
+        if (isCancelled) {
+          return;
+        }
+        setState(ComponentLoaderStatus.ERROR);
+      });
+
+    return (): void => {
+      isCancelled = true;
+    };
+  }, [apiHost, gamertag]);
+
+  if (gamertag === "") {
+    return <ErrorState message="No gamertag provided" />;
+  }
+
+  const isOverlay = variant === "overlay";
+
+  return (
+    <ComponentLoader
+      status={state}
+      loading={<LoadingState text={isOverlay ? "Loading overlay..." : "Loading..."} />}
+      error={<ErrorState message={isOverlay ? "Failed to load overlay" : "Failed to load viewer"} />}
+      loaded={
+        services ? (
+          // TODO (F-4 polish): when variant === "overlay", render a StreamerOverlay
+          // layout (transparent, OBS-sized) instead of FollowLiveViewer. The overlay
+          // should show only the live tracker and use the StreamerOverlay components
+          // ported from the rework branch (BottomSection, TopSection, ticker).
+          <FollowLiveViewer
+            gamertag={gamertag}
+            followLiveService={services.followLiveService}
+            individualTrackerViewService={services.individualTrackerViewService}
+            haloClient={services.haloClient}
+          />
+        ) : (
+          <ErrorState message="Services failed to load" />
+        )
+      }
+    />
+  );
+}
+
+// Re-export a named alias for the overlay route so the Astro page import stays
+// explicit about what it's rendering.
+export { FollowLiveApp as FollowLiveOverlayApp };

--- a/pages/src/apps/follow-live/services.ts
+++ b/pages/src/apps/follow-live/services.ts
@@ -1,0 +1,21 @@
+import type { HaloInfiniteClient } from "halo-infinite-api";
+import { createHaloInfiniteClientProxy } from "@guilty-spark/shared/halo/halo-infinite-client-proxy";
+import { installFollowLiveService } from "../../services/follow/install";
+import type { FollowLiveService } from "../../services/follow/follow-types";
+import { installIndividualTrackerViewService } from "../../services/individual-tracker/install";
+import type { IndividualTrackerViewService } from "../../services/individual-tracker/view-types";
+
+export interface Services {
+  readonly followLiveService: FollowLiveService;
+  readonly individualTrackerViewService: IndividualTrackerViewService;
+  readonly haloClient: HaloInfiniteClient;
+}
+
+export async function installServices(apiHost: string): Promise<Services> {
+  const [followLiveService, individualTrackerViewService] = await Promise.all([
+    installFollowLiveService(apiHost),
+    installIndividualTrackerViewService(apiHost),
+  ]);
+  const haloClient = createHaloInfiniteClientProxy({ proxyBaseUrl: apiHost });
+  return { followLiveService, individualTrackerViewService, haloClient };
+}

--- a/pages/src/apps/follow-live/services.ts
+++ b/pages/src/apps/follow-live/services.ts
@@ -4,6 +4,7 @@ import { installFollowLiveService } from "../../services/follow/install";
 import type { FollowLiveService } from "../../services/follow/follow-types";
 import { installIndividualTrackerViewService } from "../../services/individual-tracker/install";
 import type { IndividualTrackerViewService } from "../../services/individual-tracker/view-types";
+import { getMode } from "../../services/mode";
 
 export interface Services {
   readonly followLiveService: FollowLiveService;
@@ -12,6 +13,20 @@ export interface Services {
 }
 
 export async function installServices(apiHost: string): Promise<Services> {
+  if (getMode() === "FAKE") {
+    const [{ aFakeFollowLiveServiceWith }, { aFakeIndividualTrackerViewServiceWith }, { aFakeHaloClientWith }] =
+      await Promise.all([
+        import("../../services/follow/fakes/follow.fake"),
+        import("../../services/individual-tracker/fakes/view.fake"),
+        import("../../services/fakes/halo-client.fake"),
+      ]);
+    return {
+      followLiveService: aFakeFollowLiveServiceWith(),
+      individualTrackerViewService: aFakeIndividualTrackerViewServiceWith(),
+      haloClient: aFakeHaloClientWith(),
+    };
+  }
+
   const [followLiveService, individualTrackerViewService] = await Promise.all([
     installFollowLiveService(apiHost),
     installIndividualTrackerViewService(apiHost),

--- a/pages/src/components/follow/follow-live-viewer.module.css
+++ b/pages/src/components/follow/follow-live-viewer.module.css
@@ -1,0 +1,26 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-4);
+}
+
+.connectionBanner {
+  background: rgb(244 67 54 / 10%);
+  border: 1px solid var(--color-error, #e53935);
+  color: var(--color-error, #e53935);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-4);
+  text-align: center;
+}
+
+.connectionBanner.disconnected {
+  background: rgb(255 152 0 / 10%);
+  border-color: var(--color-warning, #ff9800);
+  color: var(--color-warning, #ff9800);
+}
+
+.trackerContent {
+  flex: 1;
+}

--- a/pages/src/components/follow/follow-live-viewer.module.css
+++ b/pages/src/components/follow/follow-live-viewer.module.css
@@ -5,21 +5,6 @@
   padding: var(--space-4);
 }
 
-.connectionBanner {
-  background: rgb(244 67 54 / 10%);
-  border: 1px solid var(--color-error, #e53935);
-  color: var(--color-error, #e53935);
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  padding: var(--space-2) var(--space-4);
-  text-align: center;
-}
-
-.connectionBanner.disconnected {
-  background: rgb(255 152 0 / 10%);
-  border-color: var(--color-warning, #ff9800);
-  color: var(--color-warning, #ff9800);
-}
 
 .trackerContent {
   flex: 1;

--- a/pages/src/components/follow/follow-live-viewer.module.css
+++ b/pages/src/components/follow/follow-live-viewer.module.css
@@ -5,7 +5,6 @@
   padding: var(--space-4);
 }
 
-
 .trackerContent {
   flex: 1;
 }

--- a/pages/src/components/follow/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer.tsx
@@ -34,7 +34,7 @@ export function FollowLiveViewer({
           className={cn(styles.connectionBanner, { [styles.disconnected]: directoryStatus === "disconnected" })}
           data-testid="connection-banner"
         >
-          {directoryStatus === "error" ? "Connection error — data may be stale" : "Reconnecting..."}
+          {directoryStatus === "error" ? "Connection error — data may be stale" : "Disconnected — reload to refresh"}
         </div>
       )}
       {directory !== null && directory.trackers.length > 0 && (

--- a/pages/src/components/follow/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer.tsx
@@ -34,7 +34,11 @@ export function FollowLiveViewer({
           className={cn(styles.connectionBanner, { [styles.disconnected]: directoryStatus === "disconnected" })}
           data-testid="connection-banner"
         >
-          {directoryStatus === "error" ? "Connection error — data may be stale" : "Disconnected — reload to refresh"}
+          {directoryStatus === "error"
+            ? directory !== null
+              ? "Connection error — data may be stale"
+              : "Failed to load tracker directory"
+            : "Disconnected — reload to refresh"}
         </div>
       )}
       {directory !== null && directory.trackers.length > 0 && (
@@ -54,8 +58,10 @@ export function FollowLiveViewer({
             haloClient={haloClient}
             trackerId={selectedTrackerId}
           />
-        ) : (
+        ) : directoryStatus === "error" && directory === null ? null : directory === null ? (
           <LoadingState text="Loading tracker directory..." />
+        ) : (
+          <LoadingState text="No active tracker — waiting for a live game" />
         )}
       </div>
     </div>

--- a/pages/src/components/follow/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import cn from "classnames";
 import type { HaloInfiniteClient } from "halo-infinite-api";
+import { Alert } from "../alert/alert";
 import { LoadingState } from "../loading-state/loading-state";
 import { IndividualTrackerViewerPage } from "../individual-tracker/viewer/create";
 import type { FollowLiveService } from "../../services/follow/follow-types";
@@ -30,16 +30,13 @@ export function FollowLiveViewer({
   return (
     <div className={styles.container}>
       {showBanner && (
-        <div
-          className={cn(styles.connectionBanner, { [styles.disconnected]: directoryStatus === "disconnected" })}
-          data-testid="connection-banner"
-        >
+        <Alert variant={directoryStatus === "disconnected" ? "warning" : "error"}>
           {directoryStatus === "error"
             ? directory !== null
               ? "Connection error — data may be stale"
               : "Failed to load tracker directory"
             : "Disconnected — reload to refresh"}
-        </div>
+        </Alert>
       )}
       {directory !== null && directory.trackers.length > 0 && (
         <FollowTrackerTabs

--- a/pages/src/components/follow/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import cn from "classnames";
+import type { HaloInfiniteClient } from "halo-infinite-api";
+import { LoadingState } from "../loading-state/loading-state";
+import { IndividualTrackerViewerPage } from "../individual-tracker/viewer/create";
+import type { FollowLiveService } from "../../services/follow/follow-types";
+import type { IndividualTrackerViewService } from "../../services/individual-tracker/view-types";
+import { FollowTrackerTabs } from "./follow-tracker-tabs";
+import { useFollowLiveDirectory } from "./use-follow-live-directory";
+import styles from "./follow-live-viewer.module.css";
+
+export interface FollowLiveViewerProps {
+  readonly gamertag: string;
+  readonly followLiveService: FollowLiveService;
+  readonly individualTrackerViewService: IndividualTrackerViewService;
+  readonly haloClient: HaloInfiniteClient;
+}
+
+export function FollowLiveViewer({
+  gamertag,
+  followLiveService,
+  individualTrackerViewService,
+  haloClient,
+}: FollowLiveViewerProps): React.ReactElement {
+  const { directory, directoryStatus, selectedTrackerId, isFollowingLive, onSelectTracker, onFollowLive } =
+    useFollowLiveDirectory({ followLiveService, gamertag });
+
+  const showBanner = directoryStatus === "error" || directoryStatus === "disconnected";
+
+  return (
+    <div className={styles.container}>
+      {showBanner && (
+        <div
+          className={cn(styles.connectionBanner, { [styles.disconnected]: directoryStatus === "disconnected" })}
+          data-testid="connection-banner"
+        >
+          {directoryStatus === "error" ? "Connection error — data may be stale" : "Reconnecting..."}
+        </div>
+      )}
+      {directory !== null && directory.trackers.length > 0 && (
+        <FollowTrackerTabs
+          directory={directory}
+          selectedTrackerId={selectedTrackerId}
+          isFollowingLive={isFollowingLive}
+          onSelectTracker={onSelectTracker}
+          onFollowLive={onFollowLive}
+        />
+      )}
+      <div className={styles.trackerContent}>
+        {selectedTrackerId !== null ? (
+          <IndividualTrackerViewerPage
+            key={selectedTrackerId}
+            individualTrackerViewService={individualTrackerViewService}
+            haloClient={haloClient}
+            trackerId={selectedTrackerId}
+          />
+        ) : (
+          <LoadingState text="Loading tracker directory..." />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/pages/src/components/follow/follow-tracker-tabs.module.css
+++ b/pages/src/components/follow/follow-tracker-tabs.module.css
@@ -1,0 +1,96 @@
+.tabBar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.tab {
+  align-items: center;
+  background: transparent;
+  border: 1px solid var(--halo-gray-dark, #444);
+  color: var(--halo-gray, #aaa);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  gap: var(--space-1);
+  min-width: 120px;
+  padding: var(--space-2) var(--space-4);
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.tab:hover {
+  background: rgb(255 255 255 / 5%);
+  border-color: var(--halo-teal-primary);
+  color: var(--halo-white);
+}
+
+.tab.selected {
+  background: rgb(93 212 216 / 10%);
+  border-color: var(--halo-teal-primary);
+  color: var(--halo-white);
+}
+
+.tabGamertag {
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.tabRecord {
+  color: var(--halo-gray);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.tab.selected .tabRecord {
+  color: var(--halo-gray-light, #ccc);
+}
+
+.liveBadge {
+  background: var(--color-live, #e53935);
+  border-radius: 2px;
+  color: #fff;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 1px 4px;
+  text-transform: uppercase;
+}
+
+.followLiveButton {
+  align-self: flex-start;
+  background: transparent;
+  border: 1px solid var(--halo-teal-primary);
+  color: var(--halo-teal-primary);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  padding: var(--space-1) var(--space-3);
+  text-transform: uppercase;
+  transition:
+    background 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.followLiveButton:hover {
+  background: rgb(93 212 216 / 10%);
+  box-shadow: 0 0 12px rgb(93 212 216 / 25%);
+}
+
+.followLiveButton:focus-visible {
+  outline: 2px solid var(--halo-teal-primary);
+  outline-offset: 2px;
+}

--- a/pages/src/components/follow/follow-tracker-tabs.tsx
+++ b/pages/src/components/follow/follow-tracker-tabs.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import cn from "classnames";
+import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import styles from "./follow-tracker-tabs.module.css";
+
+export interface FollowTrackerTabsProps {
+  readonly directory: TrackerDirectory;
+  readonly selectedTrackerId: string | null;
+  readonly isFollowingLive: boolean;
+  readonly onSelectTracker: (trackerId: string) => void;
+  readonly onFollowLive: () => void;
+}
+
+function hasLiveTracker(directory: TrackerDirectory): boolean {
+  for (const entry of directory.trackers) {
+    if (entry.isLive) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function FollowTrackerTabs({
+  directory,
+  selectedTrackerId,
+  isFollowingLive,
+  onSelectTracker,
+  onFollowLive,
+}: FollowTrackerTabsProps): React.ReactElement {
+  const showFollowLive = !isFollowingLive && hasLiveTracker(directory);
+
+  return (
+    <div className={styles.tabBar}>
+      <div className={styles.tabs} role="tablist">
+        {directory.trackers.map((entry) => (
+          <button
+            key={entry.trackerId}
+            type="button"
+            role="tab"
+            aria-selected={entry.trackerId === selectedTrackerId}
+            className={cn(styles.tab, { [styles.selected]: entry.trackerId === selectedTrackerId })}
+            onClick={(): void => {
+              onSelectTracker(entry.trackerId);
+            }}
+          >
+            <span className={styles.tabGamertag}>{entry.gamertag}</span>
+            <span className={styles.tabRecord} data-testid="tab-record">
+              {entry.accumulated.wins}:{entry.accumulated.losses}
+            </span>
+            {entry.isLive && (
+              <span className={styles.liveBadge} data-testid="live-badge">
+                Live
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+      {showFollowLive && (
+        <button type="button" className={styles.followLiveButton} onClick={onFollowLive} data-testid="follow-live-btn">
+          Follow live
+        </button>
+      )}
+    </div>
+  );
+}

--- a/pages/src/components/follow/tests/follow-tracker-tabs.test.tsx
+++ b/pages/src/components/follow/tests/follow-tracker-tabs.test.tsx
@@ -1,0 +1,201 @@
+import "@testing-library/jest-dom/vitest";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import { FollowTrackerTabs } from "../follow-tracker-tabs";
+
+function aDirectory(): TrackerDirectory {
+  return {
+    trackers: [
+      {
+        trackerId: "tracker-1",
+        gamertag: "Spartan One",
+        status: "active",
+        isLive: true,
+        accumulated: { total: 5, wins: 3, losses: 2, ties: 0 },
+      },
+      {
+        trackerId: "tracker-2",
+        gamertag: "Spartan Two",
+        status: "active",
+        isLive: false,
+        accumulated: { total: 4, wins: 1, losses: 3, ties: 0 },
+      },
+    ],
+  };
+}
+
+describe("FollowTrackerTabs", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders one button per tracker", () => {
+    render(
+      <FollowTrackerTabs
+        directory={aDirectory()}
+        selectedTrackerId="tracker-1"
+        isFollowingLive={true}
+        onSelectTracker={vi.fn<(trackerId: string) => void>()}
+        onFollowLive={vi.fn<() => void>()}
+      />,
+    );
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0]).toHaveTextContent("Spartan One");
+    expect(tabs[1]).toHaveTextContent("Spartan Two");
+  });
+
+  it("shows the record for each tracker", () => {
+    render(
+      <FollowTrackerTabs
+        directory={aDirectory()}
+        selectedTrackerId="tracker-1"
+        isFollowingLive={true}
+        onSelectTracker={vi.fn<(trackerId: string) => void>()}
+        onFollowLive={vi.fn<() => void>()}
+      />,
+    );
+
+    const records = screen.getAllByTestId("tab-record");
+    expect(records[0]).toHaveTextContent("3:2");
+    expect(records[1]).toHaveTextContent("1:3");
+  });
+
+  it("shows Live badge on the live tracker", () => {
+    render(
+      <FollowTrackerTabs
+        directory={aDirectory()}
+        selectedTrackerId="tracker-1"
+        isFollowingLive={true}
+        onSelectTracker={vi.fn<(trackerId: string) => void>()}
+        onFollowLive={vi.fn<() => void>()}
+      />,
+    );
+
+    const badges = screen.getAllByTestId("live-badge");
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toHaveTextContent("Live");
+  });
+
+  it("does not show a Live badge when no tracker is live", () => {
+    const dir: TrackerDirectory = {
+      trackers: [
+        {
+          trackerId: "tracker-1",
+          gamertag: "Spartan One",
+          status: "active",
+          isLive: false,
+          accumulated: { total: 0, wins: 0, losses: 0, ties: 0 },
+        },
+      ],
+    };
+
+    render(
+      <FollowTrackerTabs
+        directory={dir}
+        selectedTrackerId="tracker-1"
+        isFollowingLive={true}
+        onSelectTracker={vi.fn<(trackerId: string) => void>()}
+        onFollowLive={vi.fn<() => void>()}
+      />,
+    );
+
+    expect(screen.queryByTestId("live-badge")).toBeNull();
+  });
+
+  it("calls onSelectTracker with the correct trackerId when a tab is clicked", async () => {
+    const onSelectTracker = vi.fn<(trackerId: string) => void>();
+
+    render(
+      <FollowTrackerTabs
+        directory={aDirectory()}
+        selectedTrackerId="tracker-1"
+        isFollowingLive={true}
+        onSelectTracker={onSelectTracker}
+        onFollowLive={vi.fn<() => void>()}
+      />,
+    );
+
+    const tabs = screen.getAllByRole("tab");
+    await userEvent.click(tabs[1]);
+
+    expect(onSelectTracker).toHaveBeenCalledOnce();
+    expect(onSelectTracker).toHaveBeenCalledWith("tracker-2");
+  });
+
+  it("shows Follow live button when isFollowingLive is false and there is a live tracker", () => {
+    render(
+      <FollowTrackerTabs
+        directory={aDirectory()}
+        selectedTrackerId="tracker-2"
+        isFollowingLive={false}
+        onSelectTracker={vi.fn<(trackerId: string) => void>()}
+        onFollowLive={vi.fn<() => void>()}
+      />,
+    );
+
+    expect(screen.getByTestId("follow-live-btn")).toBeInTheDocument();
+  });
+
+  it("does not show Follow live button when isFollowingLive is true", () => {
+    render(
+      <FollowTrackerTabs
+        directory={aDirectory()}
+        selectedTrackerId="tracker-1"
+        isFollowingLive={true}
+        onSelectTracker={vi.fn<(trackerId: string) => void>()}
+        onFollowLive={vi.fn<() => void>()}
+      />,
+    );
+
+    expect(screen.queryByTestId("follow-live-btn")).toBeNull();
+  });
+
+  it("does not show Follow live button when no tracker is live", () => {
+    const dir: TrackerDirectory = {
+      trackers: [
+        {
+          trackerId: "tracker-1",
+          gamertag: "Spartan One",
+          status: "active",
+          isLive: false,
+          accumulated: { total: 0, wins: 0, losses: 0, ties: 0 },
+        },
+      ],
+    };
+
+    render(
+      <FollowTrackerTabs
+        directory={dir}
+        selectedTrackerId="tracker-1"
+        isFollowingLive={false}
+        onSelectTracker={vi.fn<(trackerId: string) => void>()}
+        onFollowLive={vi.fn<() => void>()}
+      />,
+    );
+
+    expect(screen.queryByTestId("follow-live-btn")).toBeNull();
+  });
+
+  it("calls onFollowLive when the Follow live button is clicked", async () => {
+    const onFollowLive = vi.fn<() => void>();
+
+    render(
+      <FollowTrackerTabs
+        directory={aDirectory()}
+        selectedTrackerId="tracker-2"
+        isFollowingLive={false}
+        onSelectTracker={vi.fn<(trackerId: string) => void>()}
+        onFollowLive={onFollowLive}
+      />,
+    );
+
+    await userEvent.click(screen.getByTestId("follow-live-btn"));
+
+    expect(onFollowLive).toHaveBeenCalledOnce();
+  });
+});

--- a/pages/src/components/follow/tests/use-follow-live-directory.test.ts
+++ b/pages/src/components/follow/tests/use-follow-live-directory.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import { aFakeFollowLiveServiceWith } from "../../../services/follow/fakes/follow.fake";
+import { useFollowLiveDirectory } from "../use-follow-live-directory";
+
+function aDirectory(overrides: Partial<TrackerDirectory> = {}): TrackerDirectory {
+  return {
+    trackers: [
+      {
+        trackerId: "tracker-1",
+        gamertag: "Spartan One",
+        status: "active",
+        isLive: true,
+        accumulated: { total: 5, wins: 3, losses: 2, ties: 0 },
+      },
+      {
+        trackerId: "tracker-2",
+        gamertag: "Spartan Two",
+        status: "active",
+        isLive: false,
+        accumulated: { total: 2, wins: 1, losses: 1, ties: 0 },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("useFollowLiveDirectory", () => {
+  it("loads directory on mount and sets selectedTrackerId to the live tracker", async () => {
+    const service = aFakeFollowLiveServiceWith({ directory: aDirectory() });
+    const { result } = renderHook(() =>
+      useFollowLiveDirectory({ followLiveService: service, gamertag: "Spartan One" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.directory).not.toBeNull();
+    });
+
+    expect(result.current.selectedTrackerId).toBe("tracker-1");
+    expect(result.current.isFollowingLive).toBe(true);
+    expect(result.current.directoryStatus).toBe("connected");
+  });
+
+  it("sets selectedTrackerId to null when no tracker is live", async () => {
+    const dir: TrackerDirectory = {
+      trackers: [
+        {
+          trackerId: "tracker-1",
+          gamertag: "Spartan One",
+          status: "active",
+          isLive: false,
+          accumulated: { total: 0, wins: 0, losses: 0, ties: 0 },
+        },
+      ],
+    };
+    const service = aFakeFollowLiveServiceWith({ directory: dir });
+    const { result } = renderHook(() =>
+      useFollowLiveDirectory({ followLiveService: service, gamertag: "Spartan One" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.directory).not.toBeNull();
+    });
+
+    expect(result.current.selectedTrackerId).toBeNull();
+  });
+
+  it("propagates directory WS updates to directory state", async () => {
+    const service = aFakeFollowLiveServiceWith({ directory: aDirectory() });
+    const { result } = renderHook(() =>
+      useFollowLiveDirectory({ followLiveService: service, gamertag: "Spartan One" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.directory).not.toBeNull();
+    });
+
+    const updatedDir: TrackerDirectory = {
+      trackers: [
+        {
+          trackerId: "tracker-1",
+          gamertag: "Spartan One",
+          status: "active",
+          isLive: true,
+          accumulated: { total: 6, wins: 4, losses: 2, ties: 0 },
+        },
+        {
+          trackerId: "tracker-2",
+          gamertag: "Spartan Two",
+          status: "active",
+          isLive: false,
+          accumulated: { total: 3, wins: 1, losses: 2, ties: 0 },
+        },
+      ],
+    };
+
+    act(() => {
+      service.lastConnection?.emitDirectory(updatedDir);
+    });
+
+    expect(result.current.directory?.trackers[0].accumulated.wins).toBe(4);
+  });
+
+  it("auto-switches selectedTrackerId when isFollowingLive is true and live tracker changes", async () => {
+    const service = aFakeFollowLiveServiceWith({ directory: aDirectory() });
+    const { result } = renderHook(() =>
+      useFollowLiveDirectory({ followLiveService: service, gamertag: "Spartan One" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedTrackerId).toBe("tracker-1");
+    });
+
+    const updatedDir: TrackerDirectory = {
+      trackers: [
+        {
+          trackerId: "tracker-1",
+          gamertag: "Spartan One",
+          status: "active",
+          isLive: false,
+          accumulated: { total: 5, wins: 3, losses: 2, ties: 0 },
+        },
+        {
+          trackerId: "tracker-2",
+          gamertag: "Spartan Two",
+          status: "active",
+          isLive: true,
+          accumulated: { total: 2, wins: 1, losses: 1, ties: 0 },
+        },
+      ],
+    };
+
+    act(() => {
+      service.lastConnection?.emitDirectory(updatedDir);
+    });
+
+    expect(result.current.selectedTrackerId).toBe("tracker-2");
+  });
+
+  it("does not auto-switch when isFollowingLive is false", async () => {
+    const service = aFakeFollowLiveServiceWith({ directory: aDirectory() });
+    const { result } = renderHook(() =>
+      useFollowLiveDirectory({ followLiveService: service, gamertag: "Spartan One" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedTrackerId).toBe("tracker-1");
+    });
+
+    // User manually selects tracker-2 (non-live) → isFollowingLive becomes false
+    act(() => {
+      result.current.onSelectTracker("tracker-2");
+    });
+
+    expect(result.current.isFollowingLive).toBe(false);
+
+    // Live tracker changes to tracker-3 (different from the selected tracker-2)
+    const updatedDir: TrackerDirectory = {
+      trackers: [
+        {
+          trackerId: "tracker-1",
+          gamertag: "Spartan One",
+          status: "active",
+          isLive: false,
+          accumulated: { total: 5, wins: 3, losses: 2, ties: 0 },
+        },
+        {
+          trackerId: "tracker-2",
+          gamertag: "Spartan Two",
+          status: "active",
+          isLive: false,
+          accumulated: { total: 3, wins: 2, losses: 1, ties: 0 },
+        },
+        {
+          trackerId: "tracker-3",
+          gamertag: "Spartan Three",
+          status: "active",
+          isLive: true,
+          accumulated: { total: 1, wins: 1, losses: 0, ties: 0 },
+        },
+      ],
+    };
+
+    act(() => {
+      service.lastConnection?.emitDirectory(updatedDir);
+    });
+
+    // Should stay on tracker-2 despite tracker-3 becoming live
+    expect(result.current.selectedTrackerId).toBe("tracker-2");
+  });
+
+  it("onSelectTracker sets isFollowingLive to false when selecting a non-live tracker", async () => {
+    const service = aFakeFollowLiveServiceWith({ directory: aDirectory() });
+    const { result } = renderHook(() =>
+      useFollowLiveDirectory({ followLiveService: service, gamertag: "Spartan One" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.directory).not.toBeNull();
+    });
+
+    act(() => {
+      result.current.onSelectTracker("tracker-2");
+    });
+
+    expect(result.current.selectedTrackerId).toBe("tracker-2");
+    expect(result.current.isFollowingLive).toBe(false);
+  });
+
+  it("onSelectTracker sets isFollowingLive to true when selecting the live tracker", async () => {
+    const service = aFakeFollowLiveServiceWith({ directory: aDirectory() });
+    const { result } = renderHook(() =>
+      useFollowLiveDirectory({ followLiveService: service, gamertag: "Spartan One" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.directory).not.toBeNull();
+    });
+
+    act(() => {
+      result.current.onSelectTracker("tracker-2");
+    });
+
+    expect(result.current.isFollowingLive).toBe(false);
+
+    act(() => {
+      result.current.onSelectTracker("tracker-1");
+    });
+
+    expect(result.current.selectedTrackerId).toBe("tracker-1");
+    expect(result.current.isFollowingLive).toBe(true);
+  });
+
+  it("onFollowLive sets isFollowingLive to true and selects the live tracker", async () => {
+    const service = aFakeFollowLiveServiceWith({ directory: aDirectory() });
+    const { result } = renderHook(() =>
+      useFollowLiveDirectory({ followLiveService: service, gamertag: "Spartan One" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.directory).not.toBeNull();
+    });
+
+    act(() => {
+      result.current.onSelectTracker("tracker-2");
+    });
+
+    expect(result.current.isFollowingLive).toBe(false);
+
+    act(() => {
+      result.current.onFollowLive();
+    });
+
+    expect(result.current.isFollowingLive).toBe(true);
+    expect(result.current.selectedTrackerId).toBe("tracker-1");
+  });
+});

--- a/pages/src/components/follow/use-follow-live-directory.ts
+++ b/pages/src/components/follow/use-follow-live-directory.ts
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import type { DirectoryConnectionStatus, FollowLiveService } from "../../services/follow/follow-types";
+
+export interface UseFollowLiveDirectoryOpts {
+  readonly followLiveService: FollowLiveService;
+  readonly gamertag: string;
+}
+
+export interface FollowLiveDirectoryResult {
+  readonly directory: TrackerDirectory | null;
+  readonly directoryStatus: DirectoryConnectionStatus;
+  readonly selectedTrackerId: string | null;
+  readonly isFollowingLive: boolean;
+  readonly onSelectTracker: (trackerId: string) => void;
+  readonly onFollowLive: () => void;
+}
+
+function findLiveTrackerId(directory: TrackerDirectory): string | null {
+  for (const entry of directory.trackers) {
+    if (entry.isLive) {
+      return entry.trackerId;
+    }
+  }
+  return null;
+}
+
+export function useFollowLiveDirectory({
+  followLiveService,
+  gamertag,
+}: UseFollowLiveDirectoryOpts): FollowLiveDirectoryResult {
+  const [directory, setDirectory] = useState<TrackerDirectory | null>(null);
+  const [directoryStatus, setDirectoryStatus] = useState<DirectoryConnectionStatus>("connecting");
+  const [selectedTrackerId, setSelectedTrackerId] = useState<string | null>(null);
+  const [isFollowingLive, setIsFollowingLive] = useState(true);
+
+  // Refs let WS callbacks and action handlers read current values without
+  // stale closures and without calling state setters inside updater functions.
+  const isFollowingLiveRef = useRef(isFollowingLive);
+  isFollowingLiveRef.current = isFollowingLive;
+  const directoryRef = useRef(directory);
+  directoryRef.current = directory;
+
+  const prevLiveTrackerIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    const connection = followLiveService.connectDirectory(gamertag);
+
+    followLiveService
+      .getDirectory(gamertag)
+      .then((dir) => {
+        if (isCancelled) {
+          return;
+        }
+        setDirectory(dir);
+        const liveId = findLiveTrackerId(dir);
+        prevLiveTrackerIdRef.current = liveId;
+        setSelectedTrackerId(liveId);
+        setDirectoryStatus("connected");
+      })
+      .catch(() => {
+        if (isCancelled) {
+          return;
+        }
+        setDirectoryStatus("error");
+      });
+
+    const dirSubscription = connection.subscribe((updatedDirectory) => {
+      if (isCancelled) {
+        return;
+      }
+      setDirectory(updatedDirectory);
+
+      const newLiveId = findLiveTrackerId(updatedDirectory);
+      const prevLiveId = prevLiveTrackerIdRef.current;
+
+      if (isFollowingLiveRef.current && newLiveId !== prevLiveId) {
+        setSelectedTrackerId(newLiveId);
+      }
+      prevLiveTrackerIdRef.current = newLiveId;
+    });
+
+    const statusSubscription = connection.subscribeStatus((status) => {
+      if (isCancelled) {
+        return;
+      }
+      setDirectoryStatus(status);
+    });
+
+    return (): void => {
+      isCancelled = true;
+      dirSubscription.unsubscribe();
+      statusSubscription.unsubscribe();
+      connection.disconnect();
+    };
+  }, [followLiveService, gamertag]);
+
+  const onSelectTracker = useCallback((trackerId: string): void => {
+    const dir = directoryRef.current;
+    const entry = dir?.trackers.find((t) => t.trackerId === trackerId);
+    const entryIsLive = entry?.isLive === true;
+    setSelectedTrackerId(trackerId);
+    setIsFollowingLive(entryIsLive);
+  }, []);
+
+  const onFollowLive = useCallback((): void => {
+    const dir = directoryRef.current;
+    const liveId = dir != null ? findLiveTrackerId(dir) : null;
+    setIsFollowingLive(true);
+    if (liveId != null) {
+      setSelectedTrackerId(liveId);
+    }
+  }, []);
+
+  return {
+    directory,
+    directoryStatus,
+    selectedTrackerId,
+    isFollowingLive,
+    onSelectTracker,
+    onFollowLive,
+  };
+}

--- a/pages/src/components/follow/use-follow-live-directory.ts
+++ b/pages/src/components/follow/use-follow-live-directory.ts
@@ -47,6 +47,11 @@ export function useFollowLiveDirectory({
   useEffect(() => {
     let isCancelled = false;
     initialLoadDoneRef.current = false;
+    prevLiveTrackerIdRef.current = null;
+    setDirectory(null);
+    setSelectedTrackerId(null);
+    setIsFollowingLive(true);
+    setDirectoryStatus("connecting");
 
     const connection = followLiveService.connectDirectory(gamertag);
 

--- a/pages/src/components/follow/use-follow-live-directory.ts
+++ b/pages/src/components/follow/use-follow-live-directory.ts
@@ -42,9 +42,11 @@ export function useFollowLiveDirectory({
   directoryRef.current = directory;
 
   const prevLiveTrackerIdRef = useRef<string | null>(null);
+  const initialLoadDoneRef = useRef(false);
 
   useEffect(() => {
     let isCancelled = false;
+    initialLoadDoneRef.current = false;
 
     const connection = followLiveService.connectDirectory(gamertag);
 
@@ -59,16 +61,18 @@ export function useFollowLiveDirectory({
         prevLiveTrackerIdRef.current = liveId;
         setSelectedTrackerId(liveId);
         setDirectoryStatus("connected");
+        initialLoadDoneRef.current = true;
       })
       .catch(() => {
         if (isCancelled) {
           return;
         }
         setDirectoryStatus("error");
+        initialLoadDoneRef.current = true;
       });
 
     const dirSubscription = connection.subscribe((updatedDirectory) => {
-      if (isCancelled) {
+      if (isCancelled || !initialLoadDoneRef.current) {
         return;
       }
       setDirectory(updatedDirectory);

--- a/pages/src/layouts/overlay-layout.astro
+++ b/pages/src/layouts/overlay-layout.astro
@@ -1,0 +1,35 @@
+---
+interface Props {
+  title?: string;
+}
+
+const { title = "Guilty Spark Overlay" } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="generator" content={Astro.generator} />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;500;600;700&family=Saira+Condensed:wght@600;700;800&family=Orbitron:wght@600;700;800;900&display=swap"
+      rel="stylesheet"
+    />
+    <title>{title}</title>
+  </head>
+  <body data-view-mode="streamer">
+    <slot />
+  </body>
+</html>
+<style is:global>
+  @import url("../styles/base.css");
+
+  body {
+    background: transparent;
+    margin: 0;
+    padding: 0;
+  }
+</style>

--- a/pages/src/pages/u/[gamertag]/overlay.astro
+++ b/pages/src/pages/u/[gamertag]/overlay.astro
@@ -1,0 +1,11 @@
+---
+export const prerender = false;
+import OverlayLayout from "../../../layouts/overlay-layout.astro";
+import { API_HOST } from "../../../constants";
+import { FollowLiveOverlayApp } from "../../../apps/follow-live/create";
+const { gamertag } = Astro.params;
+---
+
+<OverlayLayout title={`${gamertag ?? ""} Overlay — Guilty Spark`}>
+  <FollowLiveOverlayApp client:only="react" apiHost={API_HOST} gamertag={gamertag ?? ""} variant="overlay" />
+</OverlayLayout>

--- a/pages/src/pages/u/[gamertag]/view.astro
+++ b/pages/src/pages/u/[gamertag]/view.astro
@@ -1,0 +1,11 @@
+---
+export const prerender = false;
+import Layout from "../../../layouts/layout.astro";
+import { API_HOST } from "../../../constants";
+import { FollowLiveApp } from "../../../apps/follow-live/create";
+const { gamertag } = Astro.params;
+---
+
+<Layout title={`${gamertag ?? ""} — Guilty Spark`} description="Follow this player live">
+  <FollowLiveApp client:only="react" apiHost={API_HOST} gamertag={gamertag ?? ""} />
+</Layout>

--- a/pages/src/services/follow/fakes/follow.fake.ts
+++ b/pages/src/services/follow/fakes/follow.fake.ts
@@ -1,6 +1,4 @@
 import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
-import type { TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
-import { aFakeTrackerViewStateWith } from "../../individual-tracker/fakes/view.fake";
 import type {
   DirectoryConnection,
   DirectoryConnectionStatus,
@@ -50,21 +48,16 @@ class FakeDirectoryConnection implements DirectoryConnection {
   }
 }
 
-interface FakeFollowLiveServiceOptions {
-  readonly directory?: TrackerDirectory;
-}
-
 export class FakeFollowLiveService implements FollowLiveService {
   private readonly directory: TrackerDirectory;
   public lastConnection: FakeDirectoryConnection | null = null;
 
-  public constructor(options?: FakeFollowLiveServiceOptions) {
+  public constructor(options?: { readonly directory?: TrackerDirectory }) {
     this.directory = options?.directory ?? { trackers: [] };
   }
 
   public async getDirectory(): Promise<TrackerDirectory> {
-    await Promise.resolve();
-    return this.directory;
+    return Promise.resolve(this.directory);
   }
 
   public connectDirectory(): DirectoryConnection {
@@ -72,19 +65,8 @@ export class FakeFollowLiveService implements FollowLiveService {
     this.lastConnection = connection;
     return connection;
   }
-
-  public async getTrackerView(): Promise<TrackerViewResponse> {
-    await Promise.resolve();
-    return { view: aFakeTrackerViewStateWith() };
-  }
 }
 
-export interface FakeFollowLiveServiceFactoryOpts {
-  readonly directory?: TrackerDirectory;
-}
-
-export function aFakeFollowLiveServiceWith(opts: FakeFollowLiveServiceFactoryOpts = {}): FakeFollowLiveService {
-  return new FakeFollowLiveService({
-    ...(opts.directory !== undefined ? { directory: opts.directory } : {}),
-  });
+export function aFakeFollowLiveServiceWith(opts: { directory?: TrackerDirectory } = {}): FakeFollowLiveService {
+  return new FakeFollowLiveService(opts);
 }

--- a/pages/src/services/follow/follow-types.ts
+++ b/pages/src/services/follow/follow-types.ts
@@ -2,7 +2,6 @@ import type {
   TrackerDirectory,
   TrackerDirectoryMessage,
 } from "@guilty-spark/shared/contracts/individual-tracker/follow";
-import type { TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
 
 export type { TrackerDirectory, TrackerDirectoryMessage };
 
@@ -25,5 +24,4 @@ export interface DirectoryConnection {
 export interface FollowLiveService {
   getDirectory(gamertag: string): Promise<TrackerDirectory>;
   connectDirectory(gamertag: string): DirectoryConnection;
-  getTrackerView(trackerId: string): Promise<TrackerViewResponse>;
 }

--- a/pages/src/services/follow/follow.ts
+++ b/pages/src/services/follow/follow.ts
@@ -1,8 +1,6 @@
 import { errorContract } from "@guilty-spark/shared/contracts/error";
 import { trackerDirectoryContract } from "@guilty-spark/shared/contracts/individual-tracker/follow";
 import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
-import { trackerViewContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
-import type { TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import { RealDirectoryConnection } from "./follow-connection";
 import type { DirectoryConnection, FollowLiveService } from "./follow-types";
 
@@ -89,17 +87,5 @@ export class RealFollowLiveService implements FollowLiveService {
     };
 
     return connection;
-  }
-
-  public async getTrackerView(trackerId: string): Promise<TrackerViewResponse> {
-    const response = await fetch(this.buildUrl(`/api/individual-tracker/${encodeURIComponent(trackerId)}/view`), {
-      method: "GET",
-    });
-
-    if (!response.ok) {
-      throw await this.readError(response);
-    }
-
-    return trackerViewContract.fromResponse(response);
   }
 }

--- a/pages/src/services/follow/tests/follow.test.ts
+++ b/pages/src/services/follow/tests/follow.test.ts
@@ -70,37 +70,6 @@ describe("RealFollowLiveService.getDirectory", () => {
   });
 });
 
-describe("RealFollowLiveService.getTrackerView", () => {
-  it("fetches /api/individual-tracker/<id>/view with no credentials", async () => {
-    const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          view: {
-            trackerId: "t1",
-            gamertag: "Spartan",
-            status: "active",
-            matches: [],
-            series: [],
-            lastUpdateTime: "2100-01-01T00:00:00.000Z",
-            lastMatchDiscoveredAt: null,
-            isLive: true,
-          },
-        }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        },
-      ),
-    );
-
-    await service.getTrackerView("t1");
-
-    expect(fetchSpy).toHaveBeenCalledWith("https://api.example.com/api/individual-tracker/t1/view", { method: "GET" });
-    fetchSpy.mockRestore();
-  });
-});
-
 describe("RealFollowLiveService.connectDirectory", () => {
   let originalWebSocket: typeof WebSocket;
 


### PR DESCRIPTION
**Stacked on [#492](https://github.com/davidhouweling/guilty-spark/pull/492)** (F-2 — follow-live service layer). Merge F-2 first.

Adds the public `/u/<gamertag>/view` and `/u/<gamertag>/overlay` pages.

## What's here

### `/u/<gamertag>/view` — follow-live viewer

**`useFollowLiveDirectory` hook** — manages:
- Directory REST load → directory WS subscription for live updates
- `selectedTrackerId` — which tracker tab is open
- `isFollowingLive` — whether the viewer auto-follows the live tracker
- Auto-switch: when directory WS signals live tracker change AND `isFollowingLive` is true → automatically switch `selectedTrackerId`

**`FollowTrackerTabs`** — tab bar with gamertag, W:L record, live badge, and "Follow live" button when `isFollowingLive` is false.

**`FollowLiveViewer`** — renders the tab bar + `IndividualTrackerViewerPage` for the selected tracker. `key={selectedTrackerId}` triggers a full remount (clean state, new WS) on tab switch.

### `/u/<gamertag>/overlay` — OBS overlay (placeholder)

Uses `FollowLiveViewer` as a placeholder. A TODO comment in the code notes that the overlay should eventually render a `StreamerOverlay` layout. The route and layout (`overlay-layout.astro` — transparent, Halo fonts) are in place for when that work lands.

## Key design decisions

**React 18 concurrent safety** — `onSelectTracker` and `onFollowLive` read from refs (`directoryRef`, `isFollowingLiveRef`) instead of calling `setState` inside another `setState` updater — a pattern that React may invoke multiple times speculatively in concurrent mode.

**Tab switch via `key` prop** — switching tabs remounts `IndividualTrackerViewerPage` with a new key, giving it a clean presenter/store/WS without manual cleanup logic.

**`FollowLiveApp` unified** — viewer and overlay use the same component with a `variant` prop; `overlay-create.tsx` deleted.

## Code-review fixes (3 rounds until `[]`)
- `setState`-inside-updater replaced with ref reads
- "does not auto-switch" test made unambiguous (new live tracker is different from selected)
- `getTrackerView` removed from `FollowLiveService` (dead method — callers use `IndividualTrackerViewService` directly)
- `FakeFollowLiveServiceFactoryOpts` collapsed to an inline type

2070 passing; build completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)