### PR TITLE
feat(individual-tracker): G4 — rank + ESRA top-bar slots via haloService

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -483,8 +483,14 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   private async handleViewState(request: Request): Promise<Response> {
     const url = new URL(request.url);
     const slotsParam = url.searchParams.get("topBarStatSlots");
-    const topBarStatSlots: readonly IndividualTopBarStatOption[] =
-      slotsParam != null ? (JSON.parse(slotsParam) as IndividualTopBarStatOption[]) : [];
+    let topBarStatSlots: readonly IndividualTopBarStatOption[] = [];
+    if (slotsParam != null) {
+      try {
+        topBarStatSlots = JSON.parse(slotsParam) as IndividualTopBarStatOption[];
+      } catch {
+        // malformed JSON — treat as empty slots
+      }
+    }
 
     const trackerState = await this.getState();
     const topBarStats =
@@ -517,7 +523,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     if (!hasRankSlot && !hasEsraSlot) {
       const latestMatchId = state.matchIds.at(-1) ?? "";
       const accumulatedCount = state.accumulatedMatchIds?.length ?? 0;
-      this.cachedResolvedRosterCount ??= Object.values(state.discoveredMatches).filter((s) => s.teamRosterSignature != null).length;
+      this.cachedResolvedRosterCount ??= Object.values(state.discoveredMatches).filter(
+        (s) => s.teamRosterSignature != null,
+      ).length;
       const cacheKey = `${latestMatchId}:${accumulatedCount.toString()}:${this.cachedResolvedRosterCount.toString()}:${JSON.stringify(topBarStatSlots)}`;
 
       if (this.topBarStatsCacheKey === cacheKey && this.cachedTopBarStats != null) {

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -489,7 +489,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     const trackerState = await this.getState();
     const topBarStats =
       trackerState != null && topBarStatSlots.length > 0
-        ? this.buildTopBarStats(trackerState, topBarStatSlots)
+        ? await this.buildTopBarStats(trackerState, topBarStatSlots)
         : undefined;
 
     const response: IndividualTrackerViewStateResponse = {
@@ -504,25 +504,51 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     return Response.json(response);
   }
 
-  private buildTopBarStats(
+  private async buildTopBarStats(
     state: IndividualTrackerInternalState,
     topBarStatSlots: readonly IndividualTopBarStatOption[],
-  ): readonly TopBarStatItem[] {
-    const latestMatchId = state.matchIds.at(-1) ?? "";
-    const accumulatedCount = state.accumulatedMatchIds?.length ?? 0;
-    this.cachedResolvedRosterCount ??= Object.values(state.discoveredMatches).filter(
-      (s) => s.teamRosterSignature != null,
-    ).length;
-    const cacheKey = `${latestMatchId}:${accumulatedCount.toString()}:${this.cachedResolvedRosterCount.toString()}:${JSON.stringify(topBarStatSlots)}`;
+  ): Promise<readonly TopBarStatItem[]> {
+    const hasRankSlot =
+      topBarStatSlots.includes("current-rank") ||
+      topBarStatSlots.includes("season-peak") ||
+      topBarStatSlots.includes("all-time-peak");
+    const hasEsraSlot = topBarStatSlots.includes("esra");
 
-    if (this.topBarStatsCacheKey === cacheKey && this.cachedTopBarStats != null) {
-      return this.cachedTopBarStats;
+    if (!hasRankSlot && !hasEsraSlot) {
+      const latestMatchId = state.matchIds.at(-1) ?? "";
+      const accumulatedCount = state.accumulatedMatchIds?.length ?? 0;
+      this.cachedResolvedRosterCount ??= Object.values(state.discoveredMatches).filter((s) => s.teamRosterSignature != null).length;
+      const cacheKey = `${latestMatchId}:${accumulatedCount.toString()}:${this.cachedResolvedRosterCount.toString()}:${JSON.stringify(topBarStatSlots)}`;
+
+      if (this.topBarStatsCacheKey === cacheKey && this.cachedTopBarStats != null) {
+        return this.cachedTopBarStats;
+      }
+
+      const stats = computeTopBarStats(state, topBarStatSlots, undefined, undefined);
+      this.topBarStatsCacheKey = cacheKey;
+      this.cachedTopBarStats = stats;
+      return stats;
     }
 
-    const stats = computeTopBarStats(state, topBarStatSlots);
-    this.topBarStatsCacheKey = cacheKey;
-    this.cachedTopBarStats = stats;
-    return stats;
+    const [csrContainer, esraData] = await Promise.all([
+      hasRankSlot
+        ? this.services.haloService
+            .getRankedArenaCsrs([state.xuid])
+            .then((m) => m.get(state.xuid) ?? null)
+            .catch(() => {
+              this.logService.warn("IndividualTracker: getRankedArenaCsrs failed", new Map([["xuid", state.xuid]]));
+              return null;
+            })
+        : Promise.resolve(null),
+      hasEsraSlot
+        ? this.services.haloService.getPlayerEsra(state.xuid).catch(() => {
+            this.logService.warn("IndividualTracker: getPlayerEsra failed", new Map([["xuid", state.xuid]]));
+            return null;
+          })
+        : Promise.resolve(null),
+    ]);
+
+    return computeTopBarStats(state, topBarStatSlots, csrContainer, esraData);
   }
 
   private async getState(): Promise<IndividualTrackerInternalState | null> {

--- a/api/durable-objects/individual-tracker/tests/top-bar-stats.test.ts
+++ b/api/durable-objects/individual-tracker/tests/top-bar-stats.test.ts
@@ -1,7 +1,12 @@
 import { describe, beforeEach, it, expect, vi, afterEach } from "vitest";
 import type { MockInstance } from "vitest";
 import { aFakeCoreStatsWith, aFakeMatchStatsWith, aFakePlayerWith } from "@guilty-spark/shared/halo/fakes/data";
-import { type HaloInfiniteClient, type PlayerMatchHistory, type PlaylistCsrContainer, type Stats } from "halo-infinite-api";
+import {
+  type HaloInfiniteClient,
+  type PlayerMatchHistory,
+  type PlaylistCsrContainer,
+  type Stats,
+} from "halo-infinite-api";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 import { IndividualTrackerDO } from "../individual-tracker-do";
@@ -183,6 +188,29 @@ describe("topBarStats", () => {
     const persisted = lastPersistedState(storagePutSpy);
     expect(persisted.accumulatedPlayerTotals?.kills).toBe(25);
     expect(persisted.accumulatedPlayerTotals?.deaths).toBe(12);
+  });
+
+  it("keeps totalSpawns but skips totalLifeSpawns for a match with malformed AverageLifeDuration", async () => {
+    ownerClient.getPlayerMatches.mockResolvedValueOnce([
+      aFakePlayerMatch("m1", "2024-11-26T11:00:00.000Z"),
+      aFakePlayerMatch("m2", "2024-11-26T11:30:00.000Z"),
+    ]);
+    ownerClient.getMatchStats
+      .mockResolvedValueOnce(aMatchStatsForTrackedPlayer("m1", { Spawns: 5, AverageLifeDuration: "NOT_VALID" }))
+      .mockResolvedValueOnce(aMatchStatsForTrackedPlayer("m2", { Spawns: 3, AverageLifeDuration: "PT30S" }));
+    storageGetSpy.mockResolvedValue(
+      aFakeIndividualTrackerInternalStateWith({
+        xuid: trackedXuid,
+        startTime: "2024-11-26T12:00:00.000Z",
+        searchStartTime: "2024-11-26T11:00:00.000Z",
+      }),
+    );
+
+    await individualTrackerDO.alarm();
+
+    const persisted = lastPersistedState(storagePutSpy);
+    expect(persisted.accumulatedPlayerTotals?.totalSpawns).toBe(8);
+    expect(persisted.accumulatedPlayerTotals?.totalLifeSpawns).toBe(3);
   });
 
   it("returns topBarStats in handleViewState when topBarStatSlots provided", async () => {

--- a/api/durable-objects/individual-tracker/tests/top-bar-stats.test.ts
+++ b/api/durable-objects/individual-tracker/tests/top-bar-stats.test.ts
@@ -481,6 +481,22 @@ describe("topBarStats", () => {
       expect(body.state?.topBarStats?.[0]).toEqual({ label: "Current Rank", value: "–" });
     });
 
+    it("returns – for CSR slots when Value is 0 (placement/unranked sentinel)", async () => {
+      const unrankedCsr = { ...fakeCsr, Value: 0, Tier: "", MeasurementMatchesRemaining: 3 };
+      vi.spyOn(services.haloService, "getRankedArenaCsrs").mockResolvedValue(
+        new Map([[trackedXuid, { Current: unrankedCsr, SeasonMax: unrankedCsr, AllTimeMax: unrankedCsr }]]),
+      );
+
+      const url = new URL("http://do/view-state");
+      url.searchParams.set("topBarStatSlots", JSON.stringify(["current-rank", "season-peak", "all-time-peak"]));
+      const response = await individualTrackerDO.fetch(new Request(url.toString(), { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect(body.state?.topBarStats?.[0]).toEqual({ label: "Current Rank", value: "–" });
+      expect(body.state?.topBarStats?.[1]).toEqual({ label: "Season Peak", value: "–" });
+      expect(body.state?.topBarStats?.[2]).toEqual({ label: "All Time Peak", value: "–" });
+    });
+
     it("does not call getRankedArenaCsrs or getPlayerEsra when those slots are not requested", async () => {
       const csrSpy = vi.spyOn(services.haloService, "getRankedArenaCsrs");
       const esraSpy = vi.spyOn(services.haloService, "getPlayerEsra");

--- a/api/durable-objects/individual-tracker/tests/top-bar-stats.test.ts
+++ b/api/durable-objects/individual-tracker/tests/top-bar-stats.test.ts
@@ -1,7 +1,7 @@
 import { describe, beforeEach, it, expect, vi, afterEach } from "vitest";
 import type { MockInstance } from "vitest";
 import { aFakeCoreStatsWith, aFakeMatchStatsWith, aFakePlayerWith } from "@guilty-spark/shared/halo/fakes/data";
-import { type HaloInfiniteClient, type PlayerMatchHistory, type Stats } from "halo-infinite-api";
+import { type HaloInfiniteClient, type PlayerMatchHistory, type PlaylistCsrContainer, type Stats } from "halo-infinite-api";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 import { IndividualTrackerDO } from "../individual-tracker-do";
@@ -204,6 +204,7 @@ describe("topBarStats", () => {
           damageTaken: 6000,
           totalLifeSeconds: 300,
           totalSpawns: 10,
+          totalLifeSpawns: 10,
         },
         accumulatedMatchIds: ["m1"],
       }),
@@ -253,6 +254,7 @@ describe("topBarStats", () => {
         damageTaken: 1000,
         totalLifeSeconds: 60,
         totalSpawns: 2,
+        totalLifeSpawns: 2,
       },
       accumulatedMatchIds: ["m1"],
     });
@@ -289,6 +291,7 @@ describe("topBarStats", () => {
         damageTaken: 1000,
         totalLifeSeconds: 60,
         totalSpawns: 2,
+        totalLifeSpawns: 2,
       },
       accumulatedMatchIds: ["m2"],
     });
@@ -314,6 +317,7 @@ describe("topBarStats", () => {
         damageTaken: 2000,
         totalLifeSeconds: 120,
         totalSpawns: 4,
+        totalLifeSpawns: 4,
       },
       accumulatedMatchIds: ["m2", "m1"],
     });
@@ -356,20 +360,109 @@ describe("topBarStats", () => {
     expect(body.state?.topBarStats?.[0]).toEqual({ label: "Series Won:Loss", value: "1:0" });
   });
 
-  it("returns N/A for rank/esra slots (deferred to G4)", async () => {
-    storageGetSpy.mockResolvedValue(
-      aFakeIndividualTrackerInternalStateWith({
-        matchIds: ["m1"],
-        discoveredMatches: { m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }) },
-      }),
-    );
+  describe("rank/ESRA slots", () => {
+    const fakeCsr = {
+      Value: 1567,
+      Tier: "Onyx",
+      SubTier: 0,
+      MeasurementMatchesRemaining: 0,
+      TierStart: 1500,
+      NextTier: "Onyx",
+      NextTierStart: 1600,
+      InitialMeasurementMatches: 10,
+      DemotionProtectionMatchesRemaining: 0,
+      InitialDemotionProtectionMatches: 5,
+      NextSubTier: 0,
+    };
+    const fakeCsrContainer: PlaylistCsrContainer = {
+      Current: { ...fakeCsr, Value: 1567 },
+      SeasonMax: { ...fakeCsr, Value: 1450 },
+      AllTimeMax: { ...fakeCsr, Value: 1600 },
+    };
 
-    const url = new URL("http://do/view-state");
-    url.searchParams.set("topBarStatSlots", JSON.stringify(["current-rank", "esra"]));
-    const response = await individualTrackerDO.fetch(new Request(url.toString(), { method: "GET" }));
-    const body: IndividualTrackerViewStateResponse = await response.json();
+    beforeEach(() => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          xuid: trackedXuid,
+          matchIds: ["m1"],
+          discoveredMatches: { m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }) },
+        }),
+      );
+    });
 
-    expect(body.state?.topBarStats?.[0]).toEqual({ label: "Current Rank", value: "N/A" });
-    expect(body.state?.topBarStats?.[1]).toEqual({ label: "ESRA", value: "N/A" });
+    it("returns formatted CSR for current-rank, season-peak, all-time-peak slots", async () => {
+      vi.spyOn(services.haloService, "getRankedArenaCsrs").mockResolvedValue(
+        new Map([[trackedXuid, fakeCsrContainer]]),
+      );
+
+      const url = new URL("http://do/view-state");
+      url.searchParams.set("topBarStatSlots", JSON.stringify(["current-rank", "season-peak", "all-time-peak"]));
+      const response = await individualTrackerDO.fetch(new Request(url.toString(), { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect(body.state?.topBarStats?.[0]).toEqual({ label: "Current Rank", value: "1,567" });
+      expect(body.state?.topBarStats?.[1]).toEqual({ label: "Season Peak", value: "1,450" });
+      expect(body.state?.topBarStats?.[2]).toEqual({ label: "All Time Peak", value: "1,600" });
+    });
+
+    it("returns formatted ESRA for esra slot", async () => {
+      vi.spyOn(services.haloService, "getPlayerEsra").mockResolvedValue({
+        esra: 1234.7,
+        lastRankedGamePlayed: null,
+      });
+
+      const url = new URL("http://do/view-state");
+      url.searchParams.set("topBarStatSlots", JSON.stringify(["esra"]));
+      const response = await individualTrackerDO.fetch(new Request(url.toString(), { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect(body.state?.topBarStats?.[0]).toEqual({ label: "ESRA", value: "1,235" });
+    });
+
+    it("returns – when getRankedArenaCsrs throws (graceful degradation)", async () => {
+      vi.spyOn(services.haloService, "getRankedArenaCsrs").mockRejectedValue(new Error("CSR fetch failed"));
+
+      const url = new URL("http://do/view-state");
+      url.searchParams.set("topBarStatSlots", JSON.stringify(["current-rank", "season-peak"]));
+      const response = await individualTrackerDO.fetch(new Request(url.toString(), { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect(body.state?.topBarStats?.[0]).toEqual({ label: "Current Rank", value: "–" });
+      expect(body.state?.topBarStats?.[1]).toEqual({ label: "Season Peak", value: "–" });
+    });
+
+    it("returns – when getPlayerEsra throws (graceful degradation)", async () => {
+      vi.spyOn(services.haloService, "getPlayerEsra").mockRejectedValue(new Error("ESRA fetch failed"));
+
+      const url = new URL("http://do/view-state");
+      url.searchParams.set("topBarStatSlots", JSON.stringify(["esra"]));
+      const response = await individualTrackerDO.fetch(new Request(url.toString(), { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect(body.state?.topBarStats?.[0]).toEqual({ label: "ESRA", value: "–" });
+    });
+
+    it("returns – when no CSR found for xuid (player not ranked)", async () => {
+      vi.spyOn(services.haloService, "getRankedArenaCsrs").mockResolvedValue(new Map());
+
+      const url = new URL("http://do/view-state");
+      url.searchParams.set("topBarStatSlots", JSON.stringify(["current-rank"]));
+      const response = await individualTrackerDO.fetch(new Request(url.toString(), { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect(body.state?.topBarStats?.[0]).toEqual({ label: "Current Rank", value: "–" });
+    });
+
+    it("does not call getRankedArenaCsrs or getPlayerEsra when those slots are not requested", async () => {
+      const csrSpy = vi.spyOn(services.haloService, "getRankedArenaCsrs");
+      const esraSpy = vi.spyOn(services.haloService, "getPlayerEsra");
+
+      const url = new URL("http://do/view-state");
+      url.searchParams.set("topBarStatSlots", JSON.stringify(["kills", "deaths"]));
+      await individualTrackerDO.fetch(new Request(url.toString(), { method: "GET" }));
+
+      expect(csrSpy).not.toHaveBeenCalled();
+      expect(esraSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/api/durable-objects/individual-tracker/top-bar-stats.ts
+++ b/api/durable-objects/individual-tracker/top-bar-stats.ts
@@ -1,6 +1,5 @@
 import { compareAsc } from "date-fns";
 import { type MatchStats, type PlaylistCsrContainer } from "halo-infinite-api";
-import type { PlayerEsraData } from "../../services/halo/types";
 import { getDurationInIsoString, getDurationInSeconds, getReadableDuration } from "@guilty-spark/shared/halo/duration";
 import { analyzeMatchGroupings } from "@guilty-spark/shared/halo/match-enrichment";
 import { formatDamageRatio, formatStatValue } from "@guilty-spark/shared/halo/stat-formatting";
@@ -9,6 +8,7 @@ import {
   type IndividualTopBarStatOption,
 } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
+import type { PlayerEsraData } from "../../services/halo/types";
 import type {
   AccumulatedPlayerTotals,
   IndividualTrackerInternalState,
@@ -41,6 +41,8 @@ export function accumulatePlayerStats(state: IndividualTrackerInternalState, mat
     totalSpawns: 0,
     totalLifeSpawns: 0,
   };
+
+  totals.totalLifeSpawns ??= 0;
 
   totals.kills += playerStats.Kills;
   totals.deaths += playerStats.Deaths;
@@ -250,7 +252,7 @@ function formatTopBarStatOption(option: IndividualTopBarStatOption, ctx: TopBarS
       }
       const avgSeconds = totals.totalLifeSeconds / totals.totalLifeSpawns;
       const lifeDisplay = getReadableDuration(getDurationInIsoString(avgSeconds));
-      const dmgPerLife = formatDamageRatio(totals.damageDealt, totals.totalSpawns);
+      const dmgPerLife = formatDamageRatio(totals.damageDealt, totals.totalLifeSpawns);
       return `${lifeDisplay} (${dmgPerLife})`;
     }
     default: {
@@ -277,7 +279,17 @@ export function computeTopBarStats(
 
   return topBarStatSlots.map((option): TopBarStatItem => {
     const label = getTopBarStatLabel(option);
-    const value = formatTopBarStatOption(option, { totals, total, wins, losses, matchmaking, customOrLocal, state, csrContainer, esraData });
+    const value = formatTopBarStatOption(option, {
+      totals,
+      total,
+      wins,
+      losses,
+      matchmaking,
+      customOrLocal,
+      state,
+      csrContainer,
+      esraData,
+    });
     return { label, value: value ?? "N/A" };
   });
 }

--- a/api/durable-objects/individual-tracker/top-bar-stats.ts
+++ b/api/durable-objects/individual-tracker/top-bar-stats.ts
@@ -1,5 +1,6 @@
 import { compareAsc } from "date-fns";
-import { type MatchStats } from "halo-infinite-api";
+import { type MatchStats, type PlaylistCsrContainer } from "halo-infinite-api";
+import type { PlayerEsraData } from "../../services/halo/types";
 import { getDurationInIsoString, getDurationInSeconds, getReadableDuration } from "@guilty-spark/shared/halo/duration";
 import { analyzeMatchGroupings } from "@guilty-spark/shared/halo/match-enrichment";
 import { formatDamageRatio, formatStatValue } from "@guilty-spark/shared/halo/stat-formatting";
@@ -38,6 +39,7 @@ export function accumulatePlayerStats(state: IndividualTrackerInternalState, mat
     damageTaken: 0,
     totalLifeSeconds: 0,
     totalSpawns: 0,
+    totalLifeSpawns: 0,
   };
 
   totals.kills += playerStats.Kills;
@@ -51,6 +53,7 @@ export function accumulatePlayerStats(state: IndividualTrackerInternalState, mat
   totals.totalSpawns += playerStats.Spawns;
   try {
     totals.totalLifeSeconds += getDurationInSeconds(playerStats.AverageLifeDuration) * playerStats.Spawns;
+    totals.totalLifeSpawns += playerStats.Spawns;
   } catch {
     // malformed AverageLifeDuration — skip life-seconds for this match
   }
@@ -123,10 +126,12 @@ interface TopBarStatContext {
   matchmaking: number;
   customOrLocal: number;
   state: IndividualTrackerInternalState;
+  csrContainer: PlaylistCsrContainer | null | undefined;
+  esraData: PlayerEsraData | null | undefined;
 }
 
 function formatTopBarStatOption(option: IndividualTopBarStatOption, ctx: TopBarStatContext): string | null {
-  const { totals, total, wins, losses, matchmaking, customOrLocal, state } = ctx;
+  const { totals, total, wins, losses, matchmaking, customOrLocal, state, csrContainer, esraData } = ctx;
 
   switch (option) {
     case "matches-win-loss": {
@@ -145,11 +150,21 @@ function formatTopBarStatOption(option: IndividualTopBarStatOption, ctx: TopBarS
     case "custom-local-games": {
       return customOrLocal.toString();
     }
-    case "current-rank":
-    case "season-peak":
-    case "all-time-peak":
+    case "current-rank": {
+      const value = csrContainer?.Current.Value;
+      return value != null && value >= 0 ? formatStatValue(value) : "–";
+    }
+    case "season-peak": {
+      const value = csrContainer?.SeasonMax.Value;
+      return value != null && value >= 0 ? formatStatValue(value) : "–";
+    }
+    case "all-time-peak": {
+      const value = csrContainer?.AllTimeMax.Value;
+      return value != null && value >= 0 ? formatStatValue(value) : "–";
+    }
     case "esra": {
-      return null;
+      const esra = esraData?.esra;
+      return esra != null && esra > 0 ? formatStatValue(Math.round(esra)) : "–";
     }
     case "kills": {
       return totals != null ? formatStatValue(totals.kills) : null;
@@ -191,10 +206,10 @@ function formatTopBarStatOption(option: IndividualTopBarStatOption, ctx: TopBarS
       return totals != null ? formatDamageRatio(totals.damageDealt, totals.damageTaken) : null;
     }
     case "avg-life-time": {
-      if (totals == null || totals.totalSpawns === 0) {
+      if (totals == null || totals.totalLifeSpawns === 0) {
         return null;
       }
-      const avgSeconds = totals.totalLifeSeconds / totals.totalSpawns;
+      const avgSeconds = totals.totalLifeSeconds / totals.totalLifeSpawns;
       return getReadableDuration(getDurationInIsoString(avgSeconds));
     }
     case "avg-damage-per-life": {
@@ -230,10 +245,10 @@ function formatTopBarStatOption(option: IndividualTopBarStatOption, ctx: TopBarS
       return `${formatStatValue(totals.damageDealt)}:${formatStatValue(totals.damageTaken)} (${formatDamageRatio(totals.damageDealt, totals.damageTaken)})`;
     }
     case "avg-life-damage-per-life": {
-      if (totals == null || totals.totalSpawns === 0) {
+      if (totals == null || totals.totalLifeSpawns === 0) {
         return null;
       }
-      const avgSeconds = totals.totalLifeSeconds / totals.totalSpawns;
+      const avgSeconds = totals.totalLifeSeconds / totals.totalLifeSpawns;
       const lifeDisplay = getReadableDuration(getDurationInIsoString(avgSeconds));
       const dmgPerLife = formatDamageRatio(totals.damageDealt, totals.totalSpawns);
       return `${lifeDisplay} (${dmgPerLife})`;
@@ -247,6 +262,8 @@ function formatTopBarStatOption(option: IndividualTopBarStatOption, ctx: TopBarS
 export function computeTopBarStats(
   state: IndividualTrackerInternalState,
   topBarStatSlots: readonly IndividualTopBarStatOption[],
+  csrContainer?: PlaylistCsrContainer | null,
+  esraData?: PlayerEsraData | null,
 ): readonly TopBarStatItem[] {
   const totals = state.accumulatedPlayerTotals;
   const matches = state.matchIds
@@ -260,7 +277,7 @@ export function computeTopBarStats(
 
   return topBarStatSlots.map((option): TopBarStatItem => {
     const label = getTopBarStatLabel(option);
-    const value = formatTopBarStatOption(option, { totals, total, wins, losses, matchmaking, customOrLocal, state });
+    const value = formatTopBarStatOption(option, { totals, total, wins, losses, matchmaking, customOrLocal, state, csrContainer, esraData });
     return { label, value: value ?? "N/A" };
   });
 }

--- a/api/durable-objects/individual-tracker/top-bar-stats.ts
+++ b/api/durable-objects/individual-tracker/top-bar-stats.ts
@@ -153,19 +153,19 @@ function formatTopBarStatOption(option: IndividualTopBarStatOption, ctx: TopBarS
     }
     case "current-rank": {
       const value = csrContainer?.Current.Value;
-      return value != null && value >= 0 ? formatStatValue(value) : "–";
+      return value != null && value > 0 ? formatStatValue(value) : "–";
     }
     case "season-peak": {
       const value = csrContainer?.SeasonMax.Value;
-      return value != null && value >= 0 ? formatStatValue(value) : "–";
+      return value != null && value > 0 ? formatStatValue(value) : "–";
     }
     case "all-time-peak": {
       const value = csrContainer?.AllTimeMax.Value;
-      return value != null && value >= 0 ? formatStatValue(value) : "–";
+      return value != null && value > 0 ? formatStatValue(value) : "–";
     }
     case "esra": {
       const esra = esraData?.esra;
-      return esra != null && esra > 0 ? formatStatValue(Math.round(esra)) : "–";
+      return esra != null && esra >= 0 ? formatStatValue(Math.round(esra)) : "–";
     }
     case "kills": {
       return totals != null ? formatStatValue(totals.kills) : null;

--- a/api/durable-objects/individual-tracker/top-bar-stats.ts
+++ b/api/durable-objects/individual-tracker/top-bar-stats.ts
@@ -28,7 +28,7 @@ export function accumulatePlayerStats(state: IndividualTrackerInternalState, mat
     return false;
   }
 
-  const totals = state.accumulatedPlayerTotals ?? {
+  const totals = {
     kills: 0,
     deaths: 0,
     assists: 0,
@@ -40,9 +40,8 @@ export function accumulatePlayerStats(state: IndividualTrackerInternalState, mat
     totalLifeSeconds: 0,
     totalSpawns: 0,
     totalLifeSpawns: 0,
+    ...state.accumulatedPlayerTotals,
   };
-
-  totals.totalLifeSpawns ??= 0;
 
   totals.kills += playerStats.Kills;
   totals.deaths += playerStats.Deaths;
@@ -208,17 +207,19 @@ function formatTopBarStatOption(option: IndividualTopBarStatOption, ctx: TopBarS
       return totals != null ? formatDamageRatio(totals.damageDealt, totals.damageTaken) : null;
     }
     case "avg-life-time": {
-      if (totals == null || totals.totalLifeSpawns === 0) {
+      const lifeSpawns = totals?.totalLifeSpawns ?? 0;
+      if (totals == null || lifeSpawns === 0) {
         return null;
       }
-      const avgSeconds = totals.totalLifeSeconds / totals.totalLifeSpawns;
+      const avgSeconds = totals.totalLifeSeconds / lifeSpawns;
       return getReadableDuration(getDurationInIsoString(avgSeconds));
     }
     case "avg-damage-per-life": {
-      if (totals == null || totals.totalSpawns === 0) {
+      const lifeSpawns = totals?.totalLifeSpawns ?? 0;
+      if (totals == null || lifeSpawns === 0) {
         return null;
       }
-      return formatDamageRatio(totals.damageDealt, totals.totalSpawns);
+      return formatDamageRatio(totals.damageDealt, lifeSpawns);
     }
     case "kills-deaths-kd": {
       if (totals == null) {
@@ -247,12 +248,13 @@ function formatTopBarStatOption(option: IndividualTopBarStatOption, ctx: TopBarS
       return `${formatStatValue(totals.damageDealt)}:${formatStatValue(totals.damageTaken)} (${formatDamageRatio(totals.damageDealt, totals.damageTaken)})`;
     }
     case "avg-life-damage-per-life": {
-      if (totals == null || totals.totalLifeSpawns === 0) {
+      const lifeSpawns = totals?.totalLifeSpawns ?? 0;
+      if (totals == null || lifeSpawns === 0) {
         return null;
       }
-      const avgSeconds = totals.totalLifeSeconds / totals.totalLifeSpawns;
+      const avgSeconds = totals.totalLifeSeconds / lifeSpawns;
       const lifeDisplay = getReadableDuration(getDurationInIsoString(avgSeconds));
-      const dmgPerLife = formatDamageRatio(totals.damageDealt, totals.totalLifeSpawns);
+      const dmgPerLife = formatDamageRatio(totals.damageDealt, lifeSpawns);
       return `${lifeDisplay} (${dmgPerLife})`;
     }
     default: {

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -69,7 +69,7 @@ export interface AccumulatedPlayerTotals {
   damageTaken: number;
   totalLifeSeconds: number;
   totalSpawns: number;
-  totalLifeSpawns: number;
+  totalLifeSpawns?: number;
 }
 
 export interface TopBarStatItem {

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -69,6 +69,7 @@ export interface AccumulatedPlayerTotals {
   damageTaken: number;
   totalLifeSeconds: number;
   totalSpawns: number;
+  totalLifeSpawns: number;
 }
 
 export interface TopBarStatItem {


### PR DESCRIPTION
## Summary

- Extends `buildTopBarStats` (now async) to fetch CSR and ESRA data from `haloService` when `current-rank`, `season-peak`, `all-time-peak`, or `esra` slots are configured
- Adds `csrContainer` and `esraData` to `TopBarStatContext`; formats CSR values via `formatStatValue`, ESRA via `Math.round` + `formatStatValue`; graceful degradation to `"–"` on fetch failure or when player is unranked
- Preserves the synchronous DO-level cache path for all non-rank/ESRA slots (service-level caches make a separate DO cache unnecessary for rank slots)
- Parallelises `getRankedArenaCsrs` + `getPlayerEsra` with `Promise.all` when both slot types are present
- Adds `totalLifeSpawns` to `AccumulatedPlayerTotals` to separate the avg-life-time denominator from `totalSpawns`, preventing avg-damage-per-life from inflating when a match has a malformed `AverageLifeDuration`

## Test plan

- [x] 6 new tests in `describe("rank/ESRA slots (G4)")`: CSR happy path, ESRA happy path, CSR degradation, ESRA degradation, player not ranked, no calls when slots not requested
- [x] `npm run typecheck` — 0 errors
- [x] `npx vitest run api/durable-objects/individual-tracker` — 72 tests pass
- [x] `npm run lint` — 0 errors
- [x] Code-review loop: 3 rounds until clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)