### PR TITLE
feat(pages): G5 — wire topBarStats to overlay + slot picker in settings

### DIFF
--- a/pages/src/components/individual-tracker-manager/settings/streamer-settings.module.css
+++ b/pages/src/components/individual-tracker-manager/settings/streamer-settings.module.css
@@ -64,6 +64,35 @@
   gap: var(--space-2);
 }
 
+.slotList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.slotRow {
+  align-items: center;
+  display: flex;
+  gap: var(--space-3);
+}
+
+.slotLabel {
+  color: var(--halo-gray);
+  flex-shrink: 0;
+  font-size: var(--text-sm);
+  min-width: 3.5rem;
+}
+
+.slotSelect {
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--halo-white);
+  flex: 1;
+  font-size: var(--text-sm);
+  padding: var(--space-1) var(--space-2);
+}
+
 .actions {
   align-items: center;
   display: flex;

--- a/pages/src/components/individual-tracker-manager/settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/settings/streamer-settings.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback, useState } from "react";
-import type {
-  StreamerViewColorMode,
-  StreamerViewSettings,
+import {
+  INDIVIDUAL_TOP_BAR_SLOT_COUNT,
+  INDIVIDUAL_TOP_BAR_STAT_OPTION_DEFINITIONS,
+  type IndividualTopBarStatOption,
+  type StreamerViewColorMode,
+  type StreamerViewSettings,
 } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { Button } from "../../button/button";
 import { Checkbox } from "../../checkbox/checkbox";
@@ -28,11 +31,17 @@ interface FormState {
   readonly showTitle: boolean;
   readonly showSubtitle: boolean;
   readonly showScore: boolean;
+  readonly topBarStatSlots: readonly (IndividualTopBarStatOption | "")[];
 }
 
 function initialFormState(settings: StreamerViewSettings): FormState {
   const styleFlags = settings.styleFlags ?? {};
   const visibleSections = settings.visibleSections ?? {};
+  const savedSlots = (visibleSections.topBarStatSlots ?? []) as IndividualTopBarStatOption[];
+  const topBarStatSlots: (IndividualTopBarStatOption | "")[] = Array.from(
+    { length: INDIVIDUAL_TOP_BAR_SLOT_COUNT },
+    (_, i) => savedSlots[i] ?? "",
+  );
   return {
     colorMode: styleFlags.colorMode ?? "player",
     playerTeamColor: styleFlags.playerTeamColor ?? styleFlags.teamColor ?? getTeamColorOrDefault(undefined, 0).id,
@@ -46,6 +55,7 @@ function initialFormState(settings: StreamerViewSettings): FormState {
     showTitle: visibleSections.showTitle ?? true,
     showSubtitle: visibleSections.showSubtitle ?? true,
     showScore: visibleSections.showScore ?? true,
+    topBarStatSlots,
   };
 }
 
@@ -101,6 +111,14 @@ export function StreamerSettings({
     setForm((prev) => ({ ...prev, showScore: checked }));
   }, []);
 
+  const handleTopBarSlotChange = useCallback((slotIndex: number, value: IndividualTopBarStatOption | "") => {
+    setForm((prev) => {
+      const updated = [...prev.topBarStatSlots] as (IndividualTopBarStatOption | "")[];
+      updated[slotIndex] = value;
+      return { ...prev, topBarStatSlots: updated };
+    });
+  }, []);
+
   const handleSubmit = useCallback(
     (event: React.SyntheticEvent<HTMLFormElement>) => {
       event.preventDefault();
@@ -122,6 +140,7 @@ export function StreamerSettings({
           showTitle: form.showTitle,
           showSubtitle: form.showSubtitle,
           showScore: form.showScore,
+          topBarStatSlots: form.topBarStatSlots.filter((s) => s !== ""),
         },
       };
       onSave(newSettings);
@@ -221,6 +240,32 @@ export function StreamerSettings({
           <Checkbox label="Show title" checked={form.showTitle} onChange={handleShowTitleChange} />
           <Checkbox label="Show subtitle" checked={form.showSubtitle} onChange={handleShowSubtitleChange} />
           <Checkbox label="Show score" checked={form.showScore} onChange={handleShowScoreChange} />
+        </div>
+      </div>
+
+      <div className={styles.section}>
+        <h3 className={styles.sectionTitle}>Top Bar Stats</h3>
+        <div className={styles.slotList}>
+          {Array.from({ length: INDIVIDUAL_TOP_BAR_SLOT_COUNT }, (_, i) => (
+            <div key={i} className={styles.slotRow}>
+              <span className={styles.slotLabel}>Slot {i + 1}</span>
+              <select
+                className={styles.slotSelect}
+                aria-label={`Top bar stat slot ${String(i + 1)}`}
+                value={form.topBarStatSlots[i] ?? ""}
+                onChange={(e) => {
+                  handleTopBarSlotChange(i, e.target.value as IndividualTopBarStatOption | "");
+                }}
+              >
+                <option value="">— None —</option>
+                {INDIVIDUAL_TOP_BAR_STAT_OPTION_DEFINITIONS.map((def) => (
+                  <option key={def.value} value={def.value}>
+                    {def.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ))}
         </div>
       </div>
 

--- a/pages/src/components/individual-tracker-manager/settings/tests/streamer-settings.test.tsx
+++ b/pages/src/components/individual-tracker-manager/settings/tests/streamer-settings.test.tsx
@@ -175,4 +175,43 @@ describe("StreamerSettings", () => {
       expect(screen.getByRole("checkbox", { name: /show team details/i })).toBeChecked();
     });
   });
+
+  describe("top bar stat slots", () => {
+    it("renders 6 slot selects with None selected by default", () => {
+      renderSettings();
+
+      const slotSelects = screen.getAllByRole("combobox");
+      expect(slotSelects).toHaveLength(6);
+      for (const select of slotSelects) {
+        expect(select).toHaveValue("");
+      }
+    });
+
+    it("pre-populates slot selects from saved settings", () => {
+      renderSettings({ visibleSections: { topBarStatSlots: ["kills", "kda"] } });
+
+      expect(screen.getByRole("combobox", { name: /slot 1/i })).toHaveValue("kills");
+      expect(screen.getByRole("combobox", { name: /slot 2/i })).toHaveValue("kda");
+      expect(screen.getByRole("combobox", { name: /slot 3/i })).toHaveValue("");
+    });
+
+    it("saves selected slots (filtering empty) when form is submitted", async () => {
+      expect.assertions(2);
+      const user = userEvent.setup();
+      let savedSettings: StreamerViewSettings | undefined;
+      const onSave = (s: StreamerViewSettings): void => {
+        savedSettings = s;
+      };
+
+      renderSettings({ visibleSections: { topBarStatSlots: ["kills"] } }, false, null, onSave);
+
+      await user.selectOptions(screen.getByRole("combobox", { name: /slot 2/i }), "kda");
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      if (savedSettings !== undefined) {
+        expect(savedSettings.visibleSections?.topBarStatSlots).toEqual(["kills", "kda"]);
+      }
+      expect(savedSettings).toBeDefined();
+    });
+  });
 });

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -13,6 +13,7 @@ import {
   getShowTabs,
   isPanelOpen as computeIsPanelOpen,
 } from "./individual-tracker-overlay-presenter";
+import { OverlayTopBarStats } from "./overlay-top-bar-stats";
 import styles from "./individual-tracker-overlay.module.css";
 
 interface IndividualTrackerOverlayProps {
@@ -36,8 +37,8 @@ export function IndividualTrackerOverlay({
 
   const activeSeries = useMemo(() => getActiveSeries(renderModel.timeline), [renderModel.timeline]);
 
-  const topSection = useMemo(
-    () =>
+  const topSection = useMemo(() => {
+    const seriesSection =
       activeSeries != null ? (
         <TopSection
           title={activeSeries.title}
@@ -50,9 +51,21 @@ export function IndividualTrackerOverlay({
           teamLeft={null}
           teamRight={null}
         />
-      ) : null,
-    [activeSeries, teamColors],
-  );
+      ) : null;
+    const statsSection =
+      renderModel.topBarStats != null && renderModel.topBarStats.length > 0 ? (
+        <OverlayTopBarStats items={renderModel.topBarStats} />
+      ) : null;
+    if (seriesSection == null && statsSection == null) {
+      return null;
+    }
+    return (
+      <>
+        {seriesSection}
+        {statsSection}
+      </>
+    );
+  }, [activeSeries, teamColors, renderModel.topBarStats]);
 
   const tabs = useMemo(() => buildTabs(renderModel.timeline), [renderModel.timeline]);
 

--- a/pages/src/components/individual-tracker/overlay/overlay-top-bar-stats.module.css
+++ b/pages/src/components/individual-tracker/overlay/overlay-top-bar-stats.module.css
@@ -1,0 +1,31 @@
+.topBarStats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  justify-content: center;
+  padding: var(--space-2) var(--space-3);
+}
+
+.stat {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 4rem;
+}
+
+.statLabel {
+  color: var(--halo-light-grey);
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.statValue {
+  color: var(--halo-white);
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: bold;
+  text-align: center;
+}

--- a/pages/src/components/individual-tracker/overlay/overlay-top-bar-stats.tsx
+++ b/pages/src/components/individual-tracker/overlay/overlay-top-bar-stats.tsx
@@ -1,0 +1,25 @@
+import React, { memo } from "react";
+import type { TopBarStatItem } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import styles from "./overlay-top-bar-stats.module.css";
+
+interface OverlayTopBarStatsProps {
+  readonly items: readonly TopBarStatItem[];
+}
+
+function OverlayTopBarStatsComponent({ items }: OverlayTopBarStatsProps): React.ReactElement | null {
+  if (items.length === 0) {
+    return null;
+  }
+  return (
+    <div className={styles.topBarStats}>
+      {items.map((item, i) => (
+        <div key={i} className={styles.stat}>
+          <span className={styles.statLabel}>{item.label}</span>
+          <span className={styles.statValue}>{item.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export const OverlayTopBarStats = memo(OverlayTopBarStatsComponent);

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-top-bar-stats.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-top-bar-stats.test.tsx
@@ -1,0 +1,39 @@
+import "@testing-library/jest-dom/vitest";
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { OverlayTopBarStats } from "../overlay-top-bar-stats";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("OverlayTopBarStats", () => {
+  it("renders nothing when items array is empty", () => {
+    const { container } = render(<OverlayTopBarStats items={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders all provided stat items", () => {
+    render(
+      <OverlayTopBarStats
+        items={[
+          { label: "Won:Loss", value: "5:3" },
+          { label: "KDA", value: "3.2" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Won:Loss")).toBeInTheDocument();
+    expect(screen.getByText("5:3")).toBeInTheDocument();
+    expect(screen.getByText("KDA")).toBeInTheDocument();
+    expect(screen.getByText("3.2")).toBeInTheDocument();
+  });
+
+  it("renders N/A value for a slot with no data", () => {
+    render(<OverlayTopBarStats items={[{ label: "Kills", value: "N/A" }]} />);
+
+    expect(screen.getByText("Kills")).toBeInTheDocument();
+    expect(screen.getByText("N/A")).toBeInTheDocument();
+  });
+});

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
@@ -142,6 +142,24 @@ describe("buildViewerRenderModel", () => {
     ]);
   });
 
+  it("passes topBarStats from the view state through to the render model", () => {
+    const view = aFakeTrackerViewStateWith({
+      topBarStats: [{ label: "KDA", value: "3.2" }],
+    });
+
+    const model = buildViewerRenderModel({ view });
+
+    expect(model.topBarStats).toEqual([{ label: "KDA", value: "3.2" }]);
+  });
+
+  it("passes undefined topBarStats when absent from the view state", () => {
+    const view = aFakeTrackerViewStateWith();
+
+    const model = buildViewerRenderModel({ view });
+
+    expect(model.topBarStats).toBeUndefined();
+  });
+
   it("flows custom preferred colour ids into the hexes", () => {
     expect.assertions(2);
     const view = aFakeTrackerViewStateWith({

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -1,3 +1,4 @@
+import type { TopBarStatItem } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { TrackerStatus } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { TrackerViewConnectionStatus } from "../../../services/individual-tracker/view-types";
@@ -44,6 +45,7 @@ export interface IndividualTrackerViewerRenderModel {
   readonly lastUpdateTime: string;
   readonly timeline: readonly ViewerTimelineItem[];
   readonly accumulated: ViewerAccumulatedStats;
+  readonly topBarStats: readonly TopBarStatItem[] | undefined;
 }
 
 export interface IndividualTrackerViewerViewModel {

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -171,5 +171,6 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
     lastUpdateTime: view.lastUpdateTime,
     timeline,
     accumulated,
+    topBarStats: view.topBarStats,
   };
 }

--- a/pages/src/components/individual-tracker/viewer/viewer-store.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-store.ts
@@ -58,7 +58,8 @@ export class IndividualTrackerViewerStore {
   public setView(view: TrackerLiveView): void {
     const isLive = this.snapshot.view?.isLive ?? false;
     const streamerSettings = this.snapshot.view?.streamerSettings;
-    this.update({ status: ComponentLoaderStatus.LOADED, view: { ...view, isLive, streamerSettings } });
+    const topBarStats = this.snapshot.view?.topBarStats;
+    this.update({ status: ComponentLoaderStatus.LOADED, view: { ...view, isLive, streamerSettings, topBarStats } });
   }
 
   public setConnectionStatus(connectionStatus: TrackerViewConnectionStatus): void {

--- a/pages/src/services/individual-tracker/fakes/view.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/view.fake.ts
@@ -1,4 +1,5 @@
 import type {
+  TopBarStatItem,
   TrackerLiveView,
   TrackerMatchSummary,
   TrackerSeriesGroup,
@@ -84,12 +85,14 @@ export function aFakeTrackerLiveViewWith(overrides: FakeLiveViewOverrides = {}):
 
 interface FakeViewStateOverrides extends FakeLiveViewOverrides {
   readonly isLive?: boolean;
+  readonly topBarStats?: readonly TopBarStatItem[];
 }
 
 export function aFakeTrackerViewStateWith(overrides: FakeViewStateOverrides = {}): TrackerViewState {
   return {
     ...aFakeTrackerLiveViewWith(overrides),
     isLive: overrides.isLive ?? true,
+    ...(overrides.topBarStats !== undefined ? { topBarStats: [...overrides.topBarStats] } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

- **`viewer-store.setView`** now preserves `topBarStats` across WebSocket updates — previously the field was dropped on every WS message because `TrackerLiveView` doesn't carry it
- **`buildViewerRenderModel`** passes `topBarStats` from the view state through to `IndividualTrackerViewerRenderModel`
- **`OverlayTopBarStats`** new component renders `TopBarStatItem[]` in the overlay header
- **`StreamerSettings`** gains a 6-slot `IndividualTopBarStatOption` picker — reads from / saves to `visibleSections.topBarStatSlots`

## Code review fixes applied (round 1)

- React key uses slot index instead of `item.label` (avoids duplicate-key warning when same stat appears in two slots)
- `setView` preserves `topBarStats` from previous state (confirmed bug: field was lost on first WS push since `TrackerLiveView` does not include it)
- `aFakeTrackerViewStateWith` supports `topBarStats` override; viewer-render-model tests cover both present and absent paths

## Test plan

- [ ] `overlay-top-bar-stats.test.tsx` — renders items, handles empty array, handles N/A value
- [ ] `viewer-render-model.test.ts` — topBarStats passes through (present and absent paths)
- [ ] `streamer-settings.test.tsx` — 6 slot selects default to None, pre-populate from saved settings, save filters empty slots
- [ ] `npm run done` — 168 test files, 2108 tests passing, typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)