### PR TITLE
fix(individual-tracker): recompute player totals per selection (E4b)

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -340,6 +340,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       try {
         matchStats = await haloClient.getMatchStats(matchId);
       } catch (error) {
+        if (this.isAuthError(error)) {
+          this.ownerClient = null;
+          throw error;
+        }
         this.logService.warn(
           "IndividualTracker: recomputeAccumulatedTotals getMatchStats failed",
           new Map([
@@ -523,13 +527,22 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return new Response("Bad Request", { status: 400 });
     }
     const known = new Set(trackerState.matchIds);
-    trackerState.selectedMatchIds = body.matchIds.filter((id) => known.has(id)).sort();
-    delete trackerState.accumulatedPlayerTotals;
-    trackerState.accumulatedMatchIds = [];
+    const incoming = body.matchIds.filter((id) => known.has(id)).sort();
+    const unchanged = incoming.join(",") === trackerState.selectedMatchIds.join(",");
+
+    if (!unchanged) {
+      trackerState.selectedMatchIds = incoming;
+      if (!trackerState.isPaused) {
+        delete trackerState.accumulatedPlayerTotals;
+        trackerState.accumulatedMatchIds = [];
+      }
+    }
 
     await this.setState(trackerState);
     this.broadcastViewState(trackerState);
-    await this.state.storage.setAlarm(Date.now());
+    if (!unchanged && !trackerState.isPaused) {
+      await this.state.storage.setAlarm(Date.now());
+    }
 
     const response: IndividualTrackerSelectMatchesResponse = { success: true };
     return Response.json(response);

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -288,10 +288,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     return discoveredNewMatch;
   }
 
-  private async enrichScore(
-    haloClient: HaloInfiniteClient,
-    summary: IndividualTrackerMatchSummary,
-  ): Promise<boolean> {
+  private async enrichScore(haloClient: HaloInfiniteClient, summary: IndividualTrackerMatchSummary): Promise<boolean> {
     let matchStats: MatchStats;
     try {
       matchStats = await haloClient.getMatchStats(summary.matchId);

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -230,7 +230,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         teamRosterSignature: null,
         teamOutcomes: null,
       };
-      await this.enrichScore(haloClient, summary, trackerState);
+      await this.enrichScore(haloClient, summary);
       trackerState.discoveredMatches[matchId] = summary;
       trackerState.matchIds.push(matchId);
       if (trackerState.selectedMatchIds.length > 0) {
@@ -253,7 +253,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       }
 
       if (summary.teamOutcomes === null) {
-        const enriched = await this.enrichScore(haloClient, summary, trackerState);
+        const enriched = await this.enrichScore(haloClient, summary);
         if (enriched) {
           viewChanged = true;
         }
@@ -276,6 +276,8 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       discoveredNewMatch = true;
     }
 
+    await this.recomputeAccumulatedTotals(haloClient, trackerState);
+
     trackerState.checkCount += 1;
     trackerState.lastUpdateTime = now;
     trackerState.errorState.consecutiveErrors = 0;
@@ -289,7 +291,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   private async enrichScore(
     haloClient: HaloInfiniteClient,
     summary: IndividualTrackerMatchSummary,
-    trackerState: IndividualTrackerInternalState,
   ): Promise<boolean> {
     let matchStats: MatchStats;
     try {
@@ -318,14 +319,40 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     summary.teamRosterSignature = newRosterSignature;
     summary.teamOutcomes = matchStats.Teams.map((team) => team.Outcome);
 
-    const accumulatedIds = trackerState.accumulatedMatchIds ?? [];
-    if (!accumulatedIds.includes(summary.matchId)) {
-      if (accumulatePlayerStats(trackerState, matchStats)) {
-        trackerState.accumulatedMatchIds = [...accumulatedIds, summary.matchId];
-      }
+    return true;
+  }
+
+  private async recomputeAccumulatedTotals(
+    haloClient: HaloInfiniteClient,
+    trackerState: IndividualTrackerInternalState,
+  ): Promise<void> {
+    const needsRecompute =
+      trackerState.selectedMatchIds.join(",") !== (trackerState.accumulatedMatchIds ?? []).join(",");
+    if (!needsRecompute) {
+      return;
     }
 
-    return true;
+    delete trackerState.accumulatedPlayerTotals;
+    trackerState.accumulatedMatchIds = [];
+
+    for (const matchId of trackerState.selectedMatchIds) {
+      let matchStats: MatchStats;
+      try {
+        matchStats = await haloClient.getMatchStats(matchId);
+      } catch (error) {
+        this.logService.warn(
+          "IndividualTracker: recomputeAccumulatedTotals getMatchStats failed",
+          new Map([
+            ["matchId", matchId],
+            ["error", String(error)],
+          ]),
+        );
+        continue;
+      }
+      if (accumulatePlayerStats(trackerState, matchStats)) {
+        trackerState.accumulatedMatchIds.push(matchId);
+      }
+    }
   }
 
   private async resolveMapName(assetId: string, versionId: string): Promise<string> {
@@ -497,9 +524,12 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
     const known = new Set(trackerState.matchIds);
     trackerState.selectedMatchIds = body.matchIds.filter((id) => known.has(id)).sort();
+    delete trackerState.accumulatedPlayerTotals;
+    trackerState.accumulatedMatchIds = [];
 
     await this.setState(trackerState);
     this.broadcastViewState(trackerState);
+    await this.state.storage.setAlarm(Date.now());
 
     const response: IndividualTrackerSelectMatchesResponse = { success: true };
     return Response.json(response);

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -322,13 +322,15 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     return true;
   }
 
+  private hasPendingRecompute(trackerState: IndividualTrackerInternalState): boolean {
+    return trackerState.selectedMatchIds.join(",") !== (trackerState.accumulatedMatchIds ?? []).join(",");
+  }
+
   private async recomputeAccumulatedTotals(
     haloClient: HaloInfiniteClient,
     trackerState: IndividualTrackerInternalState,
   ): Promise<void> {
-    const needsRecompute =
-      trackerState.selectedMatchIds.join(",") !== (trackerState.accumulatedMatchIds ?? []).join(",");
-    if (!needsRecompute) {
+    if (!this.hasPendingRecompute(trackerState)) {
       return;
     }
 
@@ -492,9 +494,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.status = "active";
     trackerState.lastUpdateTime = new Date().toISOString();
     await this.setState(trackerState);
-    const pendingRecompute =
-      trackerState.selectedMatchIds.join(",") !== (trackerState.accumulatedMatchIds ?? []).join(",");
-    const resumeAlarmDelay = pendingRecompute ? 0 : ALARM_INTERVAL_MS;
+    const resumeAlarmDelay = this.hasPendingRecompute(trackerState) ? 0 : ALARM_INTERVAL_MS;
     await this.state.storage.setAlarm(addMilliseconds(new Date(), resumeAlarmDelay).getTime());
     this.broadcastViewState(trackerState);
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -492,7 +492,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.status = "active";
     trackerState.lastUpdateTime = new Date().toISOString();
     await this.setState(trackerState);
-    await this.state.storage.setAlarm(addMilliseconds(new Date(), ALARM_INTERVAL_MS).getTime());
+    const pendingRecompute =
+      trackerState.selectedMatchIds.join(",") !== (trackerState.accumulatedMatchIds ?? []).join(",");
+    const resumeAlarmDelay = pendingRecompute ? 0 : ALARM_INTERVAL_MS;
+    await this.state.storage.setAlarm(addMilliseconds(new Date(), resumeAlarmDelay).getTime());
     this.broadcastViewState(trackerState);
 
     const response: IndividualTrackerResumeResponse = { success: true, state: this.sanitizeState(trackerState) };
@@ -530,17 +533,19 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     const incoming = body.matchIds.filter((id) => known.has(id)).sort();
     const unchanged = incoming.join(",") === trackerState.selectedMatchIds.join(",");
 
-    if (!unchanged) {
-      trackerState.selectedMatchIds = incoming;
-      if (!trackerState.isPaused) {
-        delete trackerState.accumulatedPlayerTotals;
-        trackerState.accumulatedMatchIds = [];
-      }
+    if (unchanged) {
+      return Response.json({ success: true } satisfies IndividualTrackerSelectMatchesResponse);
+    }
+
+    trackerState.selectedMatchIds = incoming;
+    if (!trackerState.isPaused) {
+      delete trackerState.accumulatedPlayerTotals;
+      trackerState.accumulatedMatchIds = [];
     }
 
     await this.setState(trackerState);
     this.broadcastViewState(trackerState);
-    if (!unchanged && !trackerState.isPaused) {
+    if (!trackerState.isPaused) {
       await this.state.storage.setAlarm(Date.now());
     }
 

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -663,9 +663,7 @@ describe("IndividualTrackerDO", () => {
     });
 
     it("schedules an immediate alarm after selection changes", async () => {
-      storageGetSpy.mockResolvedValue(
-        aFakeIndividualTrackerInternalStateWith({ matchIds: ["m1", "m2"] }),
-      );
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ matchIds: ["m1", "m2"] }));
 
       await individualTrackerDO.fetch(selectRequest(["m1"]));
 

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -626,6 +626,51 @@ describe("IndividualTrackerDO", () => {
         expect.objectContaining({ selectedMatchIds: ["m1"] }),
       );
     });
+
+    it("clears accumulatedPlayerTotals and accumulatedMatchIds after selection changes", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2"],
+          selectedMatchIds: ["m1"],
+          accumulatedMatchIds: ["m1"],
+          accumulatedPlayerTotals: {
+            kills: 5,
+            deaths: 2,
+            assists: 1,
+            headshotKills: 1,
+            shotsFired: 50,
+            shotsHit: 25,
+            damageDealt: 2000,
+            damageTaken: 1000,
+            totalLifeSeconds: 60,
+            totalSpawns: 2,
+            totalLifeSpawns: 2,
+          },
+        }),
+      );
+
+      await individualTrackerDO.fetch(selectRequest(["m1", "m2"]));
+
+      expect(storagePutSpy).toHaveBeenCalledWith(
+        "individualTrackerState",
+        expect.objectContaining({
+          selectedMatchIds: ["m1", "m2"],
+          accumulatedMatchIds: [],
+        }),
+      );
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted).not.toHaveProperty("accumulatedPlayerTotals");
+    });
+
+    it("schedules an immediate alarm after selection changes", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({ matchIds: ["m1", "m2"] }),
+      );
+
+      await individualTrackerDO.fetch(selectRequest(["m1"]));
+
+      expect(storageSetAlarmSpy).toHaveBeenCalledWith(Date.now());
+    });
   });
 
   describe("toViewState() selection filtering", () => {

--- a/api/durable-objects/individual-tracker/tests/top-bar-stats.test.ts
+++ b/api/durable-objects/individual-tracker/tests/top-bar-stats.test.ts
@@ -1,11 +1,7 @@
 import { describe, beforeEach, it, expect, vi, afterEach } from "vitest";
 import type { MockInstance } from "vitest";
 import { aFakeCoreStatsWith, aFakeMatchStatsWith, aFakePlayerWith } from "@guilty-spark/shared/halo/fakes/data";
-import {
-  type HaloInfiniteClient,
-  type PlaylistCsrContainer,
-  type Stats,
-} from "halo-infinite-api";
+import { type HaloInfiniteClient, type PlaylistCsrContainer, type Stats } from "halo-infinite-api";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 import { IndividualTrackerDO } from "../individual-tracker-do";

--- a/api/durable-objects/individual-tracker/tests/top-bar-stats.test.ts
+++ b/api/durable-objects/individual-tracker/tests/top-bar-stats.test.ts
@@ -3,7 +3,6 @@ import type { MockInstance } from "vitest";
 import { aFakeCoreStatsWith, aFakeMatchStatsWith, aFakePlayerWith } from "@guilty-spark/shared/halo/fakes/data";
 import {
   type HaloInfiniteClient,
-  type PlayerMatchHistory,
   type PlaylistCsrContainer,
   type Stats,
 } from "halo-infinite-api";
@@ -20,19 +19,6 @@ import {
   aFakeIndividualTrackerInternalStateWith,
   aFakeIndividualTrackerMatchSummaryWith,
 } from "../fakes/individual-tracker-do.fake";
-
-const aFakePlayerMatch = (matchId: string, startTime: string, outcome = 2): PlayerMatchHistory =>
-  ({
-    MatchId: matchId,
-    Outcome: outcome,
-    MatchInfo: {
-      StartTime: startTime,
-      EndTime: startTime,
-      GameVariantCategory: 6,
-      MapVariant: { AssetId: "map-asset", VersionId: "v1" },
-      UgcGameVariant: { AssetId: "mode-asset", VersionId: "v1" },
-    },
-  }) as unknown as PlayerMatchHistory;
 
 const lastPersistedState = (
   spy: MockInstance<(key: string, value: IndividualTrackerInternalState) => Promise<void>>,
@@ -121,14 +107,20 @@ describe("topBarStats", () => {
     vi.useRealTimers();
   });
 
-  it("accumulates player stats from getMatchStats on alarm", async () => {
-    ownerClient.getPlayerMatches.mockResolvedValue([aFakePlayerMatch("m1", "2024-11-26T11:30:00.000Z")]);
+  it("recomputes accumulated totals from selectedMatchIds when they differ from accumulatedMatchIds", async () => {
+    ownerClient.getPlayerMatches.mockResolvedValue([]);
     ownerClient.getMatchStats.mockResolvedValue(aMatchStatsForTrackedPlayer("m1"));
     storageGetSpy.mockResolvedValue(
       aFakeIndividualTrackerInternalStateWith({
         xuid: trackedXuid,
         startTime: "2024-11-26T12:00:00.000Z",
         searchStartTime: "2024-11-26T11:00:00.000Z",
+        matchIds: ["m1"],
+        selectedMatchIds: ["m1"],
+        discoveredMatches: {
+          m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1", teamOutcomes: [2, 3] }),
+        },
+        accumulatedMatchIds: [],
       }),
     );
 
@@ -139,39 +131,46 @@ describe("topBarStats", () => {
     expect(persisted.accumulatedPlayerTotals?.kills).toBe(10);
     expect(persisted.accumulatedPlayerTotals?.deaths).toBe(5);
     expect(persisted.accumulatedPlayerTotals?.assists).toBe(3);
-    expect(persisted.accumulatedMatchIds).toContain("m1");
+    expect(persisted.accumulatedMatchIds).toEqual(["m1"]);
   });
 
-  it("does not double-accumulate if a match is re-enriched on a later poll", async () => {
-    ownerClient.getPlayerMatches.mockResolvedValue([aFakePlayerMatch("m1", "2024-11-26T11:30:00.000Z")]);
-    ownerClient.getMatchStats
-      .mockRejectedValueOnce(new Error("stats not ready"))
-      .mockResolvedValue(aMatchStatsForTrackedPlayer("m1"));
+  it("skips recompute when selectedMatchIds equals accumulatedMatchIds", async () => {
+    ownerClient.getPlayerMatches.mockResolvedValue([]);
     storageGetSpy.mockResolvedValue(
       aFakeIndividualTrackerInternalStateWith({
         xuid: trackedXuid,
         startTime: "2024-11-26T12:00:00.000Z",
-        searchStartTime: "2024-11-26T11:00:00.000Z",
+        matchIds: ["m1"],
+        selectedMatchIds: ["m1"],
+        discoveredMatches: {
+          m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1", teamOutcomes: [2, 3] }),
+        },
+        accumulatedMatchIds: ["m1"],
+        accumulatedPlayerTotals: {
+          kills: 10,
+          deaths: 5,
+          assists: 3,
+          headshotKills: 4,
+          shotsFired: 100,
+          shotsHit: 52,
+          damageDealt: 5000,
+          damageTaken: 3000,
+          totalLifeSeconds: 150,
+          totalSpawns: 5,
+          totalLifeSpawns: 5,
+        },
       }),
     );
 
     await individualTrackerDO.alarm();
-    const afterFirst = lastPersistedState(storagePutSpy);
-    expect(afterFirst.accumulatedPlayerTotals).toBeUndefined();
 
-    storageGetSpy.mockResolvedValue(afterFirst);
-    await individualTrackerDO.alarm();
-
-    const afterSecond = lastPersistedState(storagePutSpy);
-    expect(afterSecond.accumulatedPlayerTotals?.kills).toBe(10);
-    expect(afterSecond.accumulatedMatchIds).toHaveLength(1);
+    expect(ownerClient.getMatchStats).not.toHaveBeenCalled();
+    const persisted = lastPersistedState(storagePutSpy);
+    expect(persisted.accumulatedPlayerTotals?.kills).toBe(10);
   });
 
-  it("accumulates totals across multiple matches", async () => {
-    ownerClient.getPlayerMatches.mockResolvedValueOnce([
-      aFakePlayerMatch("m1", "2024-11-26T11:00:00.000Z"),
-      aFakePlayerMatch("m2", "2024-11-26T11:30:00.000Z"),
-    ]);
+  it("recomputes accumulated totals across multiple selected matches", async () => {
+    ownerClient.getPlayerMatches.mockResolvedValue([]);
     ownerClient.getMatchStats
       .mockResolvedValueOnce(aMatchStatsForTrackedPlayer("m1", { Kills: 10, Deaths: 5 }))
       .mockResolvedValueOnce(aMatchStatsForTrackedPlayer("m2", { Kills: 15, Deaths: 7 }));
@@ -179,7 +178,13 @@ describe("topBarStats", () => {
       aFakeIndividualTrackerInternalStateWith({
         xuid: trackedXuid,
         startTime: "2024-11-26T12:00:00.000Z",
-        searchStartTime: "2024-11-26T11:00:00.000Z",
+        matchIds: ["m1", "m2"],
+        selectedMatchIds: ["m1", "m2"],
+        discoveredMatches: {
+          m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1", teamOutcomes: [2, 3] }),
+          m2: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m2", teamOutcomes: [2, 3] }),
+        },
+        accumulatedMatchIds: [],
       }),
     );
 
@@ -191,10 +196,7 @@ describe("topBarStats", () => {
   });
 
   it("keeps totalSpawns but skips totalLifeSpawns for a match with malformed AverageLifeDuration", async () => {
-    ownerClient.getPlayerMatches.mockResolvedValueOnce([
-      aFakePlayerMatch("m1", "2024-11-26T11:00:00.000Z"),
-      aFakePlayerMatch("m2", "2024-11-26T11:30:00.000Z"),
-    ]);
+    ownerClient.getPlayerMatches.mockResolvedValue([]);
     ownerClient.getMatchStats
       .mockResolvedValueOnce(aMatchStatsForTrackedPlayer("m1", { Spawns: 5, AverageLifeDuration: "NOT_VALID" }))
       .mockResolvedValueOnce(aMatchStatsForTrackedPlayer("m2", { Spawns: 3, AverageLifeDuration: "PT30S" }));
@@ -202,7 +204,13 @@ describe("topBarStats", () => {
       aFakeIndividualTrackerInternalStateWith({
         xuid: trackedXuid,
         startTime: "2024-11-26T12:00:00.000Z",
-        searchStartTime: "2024-11-26T11:00:00.000Z",
+        matchIds: ["m1", "m2"],
+        selectedMatchIds: ["m1", "m2"],
+        discoveredMatches: {
+          m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1", teamOutcomes: [2, 3] }),
+          m2: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m2", teamOutcomes: [2, 3] }),
+        },
+        accumulatedMatchIds: [],
       }),
     );
 


### PR DESCRIPTION
## Summary

- `accumulatedPlayerTotals` previously accumulated across all discovered matches; now recomputes from scratch for `selectedMatchIds` only on each alarm cycle and on explicit selection changes
- `hasPendingRecompute()` helper guards idempotent writes — skips the alarm recompute when `selectedMatchIds` hasn't changed since last accumulation
- `handleSelectMatches` clears totals immediately and schedules an instant alarm when not paused; leaves totals intact when paused (deferred to `handleResume`)
- `handleResume` checks `hasPendingRecompute()` and schedules an immediate alarm if a selection is pending
- Auth error propagation from `recomputeAccumulatedTotals` fixed — was silently swallowed

## Test plan

- [ ] `npx vitest run api/durable-objects/individual-tracker` — all DO tests green
- [ ] `npm run typecheck` — 0 errors
- [ ] `npm run lint` — 0 warnings
- [ ] `npm test` — 2126 tests, 168 files pass

Code-review loop ran 4 rounds until clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)