### PR TITLE
feat(pages): individual-tracker utility functions (H2-1)

### DIFF
--- a/pages/src/components/individual-tracker/grouping-utils.ts
+++ b/pages/src/components/individual-tracker/grouping-utils.ts
@@ -1,0 +1,107 @@
+import type { TrackerMatchHistoryEntry } from "../../services/individual-tracker/types";
+
+function createEntryIndexMap(entries: readonly TrackerMatchHistoryEntry[]): Map<string, number> {
+  const entryIndexMap = new Map<string, number>();
+  for (const [index, entry] of entries.entries()) {
+    entryIndexMap.set(entry.matchId, index);
+  }
+  return entryIndexMap;
+}
+
+function orderMatchIdsByEntryIndex(matchIds: readonly string[], entryIndexMap: Map<string, number>): string[] {
+  return [...matchIds].sort((leftId, rightId) => {
+    const left = entryIndexMap.get(leftId) ?? Number.MAX_SAFE_INTEGER;
+    const right = entryIndexMap.get(rightId) ?? Number.MAX_SAFE_INTEGER;
+    return left - right;
+  });
+}
+
+function sortGroupsByTimeline(
+  groups: readonly (readonly string[])[],
+  entryIndexMap: Map<string, number>,
+): readonly (readonly string[])[] {
+  return [...groups].sort((leftGroup, rightGroup) => {
+    const leftMin = Math.min(...leftGroup.map((matchId) => entryIndexMap.get(matchId) ?? Number.MAX_SAFE_INTEGER));
+    const rightMin = Math.min(...rightGroup.map((matchId) => entryIndexMap.get(matchId) ?? Number.MAX_SAFE_INTEGER));
+    return leftMin - rightMin;
+  });
+}
+
+export function applyBreakFromGroup(
+  groupings: readonly (readonly string[])[],
+  entries: readonly TrackerMatchHistoryEntry[],
+  matchId: string,
+): readonly (readonly string[])[] {
+  const entryIndexMap = createEntryIndexMap(entries);
+
+  const nextGroupings: (readonly string[])[] = [];
+
+  for (const group of groupings) {
+    if (!group.includes(matchId)) {
+      nextGroupings.push(group);
+      continue;
+    }
+
+    const ordered = [...group].sort((leftId, rightId) => {
+      const left = entryIndexMap.get(leftId) ?? Number.MAX_SAFE_INTEGER;
+      const right = entryIndexMap.get(rightId) ?? Number.MAX_SAFE_INTEGER;
+      return left - right;
+    });
+
+    const breakIndex = ordered.indexOf(matchId);
+    if (breakIndex === -1) {
+      nextGroupings.push(group);
+      continue;
+    }
+
+    const before = ordered.slice(0, breakIndex);
+    const after = ordered.slice(breakIndex + 1);
+
+    if (before.length >= 2) {
+      nextGroupings.push(before);
+    }
+    if (after.length >= 2) {
+      nextGroupings.push(after);
+    }
+  }
+
+  return nextGroupings;
+}
+
+export function applyAddToAdjacentGroup(
+  groupings: readonly (readonly string[])[],
+  entries: readonly TrackerMatchHistoryEntry[],
+  matchId: string,
+  direction: "above" | "below",
+): readonly (readonly string[])[] {
+  const entryIndexMap = createEntryIndexMap(entries);
+  const entryIndex = entries.findIndex((e) => e.matchId === matchId);
+  if (entryIndex === -1) {
+    return groupings;
+  }
+
+  const adjacentIndex = direction === "above" ? entryIndex - 1 : entryIndex + 1;
+  if (adjacentIndex < 0 || adjacentIndex >= entries.length) {
+    return groupings;
+  }
+
+  const adjacentMatchId = entries[adjacentIndex].matchId;
+  const sourceGroupIndex = groupings.findIndex((group) => group.includes(matchId));
+  const targetGroupIndex = groupings.findIndex((group) => group.includes(adjacentMatchId));
+
+  if (sourceGroupIndex !== -1 && sourceGroupIndex === targetGroupIndex) {
+    return groupings;
+  }
+
+  const sourceGroup =
+    sourceGroupIndex !== -1 ? orderMatchIdsByEntryIndex(groupings[sourceGroupIndex], entryIndexMap) : [matchId];
+  const targetGroup =
+    targetGroupIndex !== -1 ? orderMatchIdsByEntryIndex(groupings[targetGroupIndex], entryIndexMap) : [adjacentMatchId];
+
+  const mergedGroup = direction === "above" ? [...targetGroup, ...sourceGroup] : [...sourceGroup, ...targetGroup];
+
+  const nextGroups = groupings.filter((_, index) => index !== sourceGroupIndex && index !== targetGroupIndex);
+  nextGroups.push(mergedGroup);
+
+  return sortGroupsByTimeline(nextGroups, entryIndexMap);
+}

--- a/pages/src/components/individual-tracker/grouping-utils.ts
+++ b/pages/src/components/individual-tracker/grouping-utils.ts
@@ -42,17 +42,8 @@ export function applyBreakFromGroup(
       continue;
     }
 
-    const ordered = [...group].sort((leftId, rightId) => {
-      const left = entryIndexMap.get(leftId) ?? Number.MAX_SAFE_INTEGER;
-      const right = entryIndexMap.get(rightId) ?? Number.MAX_SAFE_INTEGER;
-      return left - right;
-    });
-
+    const ordered = orderMatchIdsByEntryIndex(group, entryIndexMap);
     const breakIndex = ordered.indexOf(matchId);
-    if (breakIndex === -1) {
-      nextGroupings.push(group);
-      continue;
-    }
 
     const before = ordered.slice(0, breakIndex);
     const after = ordered.slice(breakIndex + 1);

--- a/pages/src/components/individual-tracker/match-duration-filter.ts
+++ b/pages/src/components/individual-tracker/match-duration-filter.ts
@@ -1,0 +1,14 @@
+import { differenceInSeconds, parseISO } from "date-fns";
+import type { TrackerMatchHistoryEntry } from "../../services/individual-tracker/types";
+
+const MINIMUM_COMPLETE_GAME_DURATION_SECONDS = 2 * 60;
+
+function getMatchDurationSeconds(entry: TrackerMatchHistoryEntry): number {
+  const startTime = parseISO(entry.startTimeIso ?? entry.startTime);
+  const endTime = parseISO(entry.endTimeIso ?? entry.endTime);
+  return differenceInSeconds(endTime, startTime);
+}
+
+export function shouldHideShortDurationMatch(entry: TrackerMatchHistoryEntry): boolean {
+  return getMatchDurationSeconds(entry) < MINIMUM_COMPLETE_GAME_DURATION_SECONDS;
+}

--- a/pages/src/components/individual-tracker/match-duration-filter.ts
+++ b/pages/src/components/individual-tracker/match-duration-filter.ts
@@ -1,14 +1,23 @@
-import { differenceInSeconds, parseISO } from "date-fns";
+import { differenceInSeconds, isValid, parseISO } from "date-fns";
 import type { TrackerMatchHistoryEntry } from "../../services/individual-tracker/types";
 
 const MINIMUM_COMPLETE_GAME_DURATION_SECONDS = 2 * 60;
 
-function getMatchDurationSeconds(entry: TrackerMatchHistoryEntry): number {
-  const startTime = parseISO(entry.startTimeIso ?? entry.startTime);
-  const endTime = parseISO(entry.endTimeIso ?? entry.endTime);
+function getMatchDurationSeconds(entry: TrackerMatchHistoryEntry): number | undefined {
+  const startRaw = entry.startTimeIso ?? entry.startTime;
+  const endRaw = entry.endTimeIso ?? entry.endTime;
+  const startTime = parseISO(startRaw);
+  const endTime = parseISO(endRaw);
+  if (!isValid(startTime) || !isValid(endTime)) {
+    return undefined;
+  }
   return differenceInSeconds(endTime, startTime);
 }
 
 export function shouldHideShortDurationMatch(entry: TrackerMatchHistoryEntry): boolean {
-  return getMatchDurationSeconds(entry) < MINIMUM_COMPLETE_GAME_DURATION_SECONDS;
+  const duration = getMatchDurationSeconds(entry);
+  if (duration === undefined) {
+    return false;
+  }
+  return duration < MINIMUM_COMPLETE_GAME_DURATION_SECONDS;
 }

--- a/pages/src/components/individual-tracker/routes.ts
+++ b/pages/src/components/individual-tracker/routes.ts
@@ -22,10 +22,10 @@ export function buildIndividualTrackerTrackerViewPath(trackerId: string): string
   return `/tracker/${encodeURIComponent(trackerId)}`;
 }
 
-export function buildIndividualTrackerPublicViewPath(xuid: string): string {
-  return `/${encodeURIComponent(xuid)}/view`;
+export function buildIndividualTrackerPublicViewPath(gamertag: string): string {
+  return `/u/${encodeURIComponent(gamertag)}/view`;
 }
 
-export function buildIndividualTrackerPublicOverlayPath(xuid: string): string {
-  return `/${encodeURIComponent(xuid)}/overlay`;
+export function buildIndividualTrackerPublicOverlayPath(gamertag: string): string {
+  return `/u/${encodeURIComponent(gamertag)}/overlay`;
 }

--- a/pages/src/components/individual-tracker/routes.ts
+++ b/pages/src/components/individual-tracker/routes.ts
@@ -1,0 +1,31 @@
+export type IndividualTrackerAppRoute =
+  | {
+      readonly kind: "manage";
+    }
+  | {
+      readonly kind: "view-active";
+    }
+  | {
+      readonly kind: "view-tracker";
+      readonly trackerId: string;
+    };
+
+export function buildIndividualTrackerManagePath(): string {
+  return "/";
+}
+
+export function buildIndividualTrackerActiveViewPath(): string {
+  return "/active";
+}
+
+export function buildIndividualTrackerTrackerViewPath(trackerId: string): string {
+  return `/tracker/${encodeURIComponent(trackerId)}`;
+}
+
+export function buildIndividualTrackerPublicViewPath(xuid: string): string {
+  return `/${encodeURIComponent(xuid)}/view`;
+}
+
+export function buildIndividualTrackerPublicOverlayPath(xuid: string): string {
+  return `/${encodeURIComponent(xuid)}/overlay`;
+}

--- a/pages/src/components/individual-tracker/series-group-metadata.ts
+++ b/pages/src/components/individual-tracker/series-group-metadata.ts
@@ -1,0 +1,51 @@
+import {
+  buildSeriesGroupKey,
+  normalizeSeriesGroupMatchIds,
+  getDefaultSeriesGroupSubtitle as sharedGetDefaultSeriesGroupSubtitle,
+} from "@guilty-spark/shared/individual-tracker/series-grouping";
+import type { TrackerMatchHistoryEntry } from "../../services/individual-tracker/types";
+
+export interface IndividualTrackerSeriesGroup {
+  readonly matchIds: readonly string[];
+  readonly titleOverride: string | null;
+  readonly subtitleOverride: string | null;
+}
+
+export { buildSeriesGroupKey };
+
+export function getDefaultSeriesGroupSubtitle(
+  entries: readonly Pick<
+    TrackerMatchHistoryEntry,
+    "startTimeIso" | "startTime" | "mapAssetId" | "mapVersionId" | "gameVariantCategory" | "outcome"
+  >[],
+): string {
+  return sharedGetDefaultSeriesGroupSubtitle(
+    entries.map((entry) => ({
+      startTime: entry.startTimeIso ?? entry.startTime,
+      mapAssetId: entry.mapAssetId,
+      mapVersionId: entry.mapVersionId,
+      gameVariantCategory: entry.gameVariantCategory,
+      outcome: entry.outcome,
+    })),
+  );
+}
+
+export function alignSeriesGroupsToGroupings(
+  groupings: readonly (readonly string[])[],
+  seriesGroups: readonly IndividualTrackerSeriesGroup[],
+): IndividualTrackerSeriesGroup[] {
+  const existingGroupsByKey = new Map(seriesGroups.map((group) => [buildSeriesGroupKey(group.matchIds), group]));
+
+  return groupings
+    .filter((group) => group.length >= 2)
+    .map((group) => {
+      const normalizedMatchIds = normalizeSeriesGroupMatchIds(group);
+      const existingGroup = existingGroupsByKey.get(buildSeriesGroupKey(normalizedMatchIds));
+
+      return {
+        matchIds: normalizedMatchIds,
+        titleOverride: existingGroup?.titleOverride ?? null,
+        subtitleOverride: existingGroup?.subtitleOverride ?? null,
+      } satisfies IndividualTrackerSeriesGroup;
+    });
+}

--- a/pages/src/components/individual-tracker/tests/grouping-utils.test.ts
+++ b/pages/src/components/individual-tracker/tests/grouping-utils.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import type { TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
+import { applyAddToAdjacentGroup, applyBreakFromGroup } from "../grouping-utils";
+
+function aMatchWith(matchId: string, category: TrackerMatchHistoryEntry["category"]): TrackerMatchHistoryEntry {
+  return {
+    matchId,
+    startTime: "Jan 1, 2026, 12:00:00 AM",
+    endTime: "Jan 1, 2026, 12:10:00 AM",
+    mapAssetId: `map-${matchId}`,
+    mapVersionId: `map-version-${matchId}`,
+    modeAssetId: `mode-${matchId}`,
+    modeVersionId: `mode-version-${matchId}`,
+    gameVariantCategory: 6,
+    duration: "10m 0s",
+    mapName: "Aquarius",
+    modeName: "Slayer",
+    outcome: "Win",
+    resultString: "Win - 50:40",
+    isMatchmaking: category === "matchmaking",
+    category,
+    teams: [],
+    mapThumbnailUrl: "data:,",
+  };
+}
+
+describe("applyAddToAdjacentGroup", () => {
+  it("merges the full source series into the above series", () => {
+    const entries: readonly TrackerMatchHistoryEntry[] = [
+      aMatchWith("m1", "custom"),
+      aMatchWith("m2", "custom"),
+      aMatchWith("m3", "custom"),
+      aMatchWith("m4", "custom"),
+      aMatchWith("m5", "custom"),
+    ];
+
+    const groupings: readonly (readonly string[])[] = [
+      ["m1", "m2"],
+      ["m3", "m4"],
+    ];
+
+    const result = applyAddToAdjacentGroup(groupings, entries, "m3", "above");
+
+    expect(result).toEqual([["m1", "m2", "m3", "m4"]]);
+  });
+
+  it("adds an individual game to the below series", () => {
+    const entries: readonly TrackerMatchHistoryEntry[] = [
+      aMatchWith("m1", "custom"),
+      aMatchWith("m2", "custom"),
+      aMatchWith("m3", "custom"),
+      aMatchWith("m4", "custom"),
+    ];
+
+    const groupings: readonly (readonly string[])[] = [["m3", "m4"]];
+
+    const result = applyAddToAdjacentGroup(groupings, entries, "m2", "below");
+
+    expect(result).toEqual([["m2", "m3", "m4"]]);
+  });
+
+  it("creates a new series when two individual games are joined", () => {
+    const entries: readonly TrackerMatchHistoryEntry[] = [aMatchWith("m1", "custom"), aMatchWith("m2", "custom")];
+
+    const result = applyAddToAdjacentGroup([], entries, "m2", "above");
+
+    expect(result).toEqual([["m1", "m2"]]);
+  });
+
+  it("returns unchanged groupings when matchId is not found in entries", () => {
+    const entries: readonly TrackerMatchHistoryEntry[] = [aMatchWith("m1", "custom")];
+    const groupings: readonly (readonly string[])[] = [["m1"]];
+
+    const result = applyAddToAdjacentGroup(groupings, entries, "unknown", "above");
+
+    expect(result).toEqual([["m1"]]);
+  });
+
+  it("returns unchanged groupings when match is already in the same group as adjacent", () => {
+    const entries: readonly TrackerMatchHistoryEntry[] = [aMatchWith("m1", "custom"), aMatchWith("m2", "custom")];
+
+    const groupings: readonly (readonly string[])[] = [["m1", "m2"]];
+
+    const result = applyAddToAdjacentGroup(groupings, entries, "m2", "above");
+
+    expect(result).toEqual([["m1", "m2"]]);
+  });
+
+  it("returns unchanged groupings when there is no adjacent entry in the direction", () => {
+    const entries: readonly TrackerMatchHistoryEntry[] = [aMatchWith("m1", "custom")];
+
+    const result = applyAddToAdjacentGroup([], entries, "m1", "above");
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("applyBreakFromGroup", () => {
+  it("splits a grouped series around the selected match", () => {
+    const entries: readonly TrackerMatchHistoryEntry[] = [
+      aMatchWith("m1", "custom"),
+      aMatchWith("m2", "custom"),
+      aMatchWith("m3", "custom"),
+      aMatchWith("m4", "custom"),
+      aMatchWith("m5", "custom"),
+      aMatchWith("m6", "custom"),
+      aMatchWith("m7", "custom"),
+    ];
+
+    const groupings: readonly (readonly string[])[] = [["m1", "m2", "m3", "m4", "m5", "m6", "m7"]];
+
+    const result = applyBreakFromGroup(groupings, entries, "m3");
+
+    expect(result).toEqual([
+      ["m1", "m2"],
+      ["m4", "m5", "m6", "m7"],
+    ]);
+  });
+
+  it("removes a group entirely when breaking from a two-match group", () => {
+    const entries: readonly TrackerMatchHistoryEntry[] = [aMatchWith("m1", "custom"), aMatchWith("m2", "custom")];
+
+    const groupings: readonly (readonly string[])[] = [["m1", "m2"]];
+
+    const result = applyBreakFromGroup(groupings, entries, "m1");
+
+    expect(result).toEqual([]);
+  });
+
+  it("leaves other groups untouched and discards sub-two-match fragments", () => {
+    const entries: readonly TrackerMatchHistoryEntry[] = [
+      aMatchWith("m1", "custom"),
+      aMatchWith("m2", "custom"),
+      aMatchWith("m3", "custom"),
+      aMatchWith("m4", "custom"),
+      aMatchWith("m5", "custom"),
+    ];
+
+    const groupings: readonly (readonly string[])[] = [
+      ["m1", "m2", "m3"],
+      ["m4", "m5"],
+    ];
+
+    const result = applyBreakFromGroup(groupings, entries, "m2");
+
+    expect(result).toEqual([["m4", "m5"]]);
+  });
+
+  it("returns groupings unchanged when matchId is not in any group", () => {
+    const entries: readonly TrackerMatchHistoryEntry[] = [aMatchWith("m1", "custom"), aMatchWith("m2", "custom")];
+
+    const groupings: readonly (readonly string[])[] = [["m1", "m2"]];
+
+    const result = applyBreakFromGroup(groupings, entries, "unknown");
+
+    expect(result).toEqual([["m1", "m2"]]);
+  });
+});

--- a/pages/src/components/individual-tracker/tests/match-duration-filter.test.ts
+++ b/pages/src/components/individual-tracker/tests/match-duration-filter.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
+import { shouldHideShortDurationMatch } from "../match-duration-filter";
+
+function aMatchWith(
+  overrides: Partial<Pick<TrackerMatchHistoryEntry, "startTime" | "endTime" | "startTimeIso" | "endTimeIso">>,
+): TrackerMatchHistoryEntry {
+  return {
+    matchId: "match-1",
+    startTime: overrides.startTime ?? "Jan 1, 2026, 12:00:00 AM",
+    endTime: overrides.endTime ?? "Jan 1, 2026, 12:10:00 AM",
+    startTimeIso: overrides.startTimeIso,
+    endTimeIso: overrides.endTimeIso,
+    mapAssetId: "map-1",
+    mapVersionId: "map-version-1",
+    modeAssetId: "mode-1",
+    modeVersionId: "mode-version-1",
+    gameVariantCategory: 6,
+    duration: "10m 0s",
+    mapName: "Aquarius",
+    modeName: "Slayer",
+    outcome: "Win",
+    resultString: "Win - 50:40",
+    isMatchmaking: false,
+    category: "custom",
+    teams: [],
+    mapThumbnailUrl: "data:,",
+  };
+}
+
+describe("shouldHideShortDurationMatch", () => {
+  it("returns true for a match shorter than 2 minutes using ISO timestamps", () => {
+    const entry = aMatchWith({
+      startTimeIso: "2026-01-01T12:00:00.000Z",
+      endTimeIso: "2026-01-01T12:01:30.000Z",
+    });
+
+    expect(shouldHideShortDurationMatch(entry)).toBe(true);
+  });
+
+  it("returns false for a match exactly 2 minutes using ISO timestamps", () => {
+    const entry = aMatchWith({
+      startTimeIso: "2026-01-01T12:00:00.000Z",
+      endTimeIso: "2026-01-01T12:02:00.000Z",
+    });
+
+    expect(shouldHideShortDurationMatch(entry)).toBe(false);
+  });
+
+  it("returns false for a match longer than 2 minutes using ISO timestamps", () => {
+    const entry = aMatchWith({
+      startTimeIso: "2026-01-01T12:00:00.000Z",
+      endTimeIso: "2026-01-01T12:15:00.000Z",
+    });
+
+    expect(shouldHideShortDurationMatch(entry)).toBe(false);
+  });
+
+  it("falls back to startTime and endTime when ISO fields are absent", () => {
+    const entry = aMatchWith({
+      startTime: "2026-01-01T12:00:00.000Z",
+      endTime: "2026-01-01T12:01:00.000Z",
+    });
+
+    expect(shouldHideShortDurationMatch(entry)).toBe(true);
+  });
+
+  it("prefers ISO timestamps over legacy time fields when both are present", () => {
+    const entry = aMatchWith({
+      startTime: "2026-01-01T12:00:00.000Z",
+      endTime: "2026-01-01T12:01:00.000Z",
+      startTimeIso: "2026-01-01T12:00:00.000Z",
+      endTimeIso: "2026-01-01T12:15:00.000Z",
+    });
+
+    expect(shouldHideShortDurationMatch(entry)).toBe(false);
+  });
+});

--- a/pages/src/components/individual-tracker/tests/routes.test.ts
+++ b/pages/src/components/individual-tracker/tests/routes.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildIndividualTrackerActiveViewPath,
+  buildIndividualTrackerManagePath,
+  buildIndividualTrackerPublicOverlayPath,
+  buildIndividualTrackerPublicViewPath,
+  buildIndividualTrackerTrackerViewPath,
+} from "../routes";
+
+describe("buildIndividualTrackerManagePath", () => {
+  it("returns the root path", () => {
+    expect(buildIndividualTrackerManagePath()).toBe("/");
+  });
+});
+
+describe("buildIndividualTrackerActiveViewPath", () => {
+  it("returns the active view path", () => {
+    expect(buildIndividualTrackerActiveViewPath()).toBe("/active");
+  });
+});
+
+describe("buildIndividualTrackerTrackerViewPath", () => {
+  it("encodes the tracker id into the path", () => {
+    expect(buildIndividualTrackerTrackerViewPath("abc-123")).toBe("/tracker/abc-123");
+  });
+
+  it("percent-encodes special characters in the tracker id", () => {
+    expect(buildIndividualTrackerTrackerViewPath("id with spaces")).toBe("/tracker/id%20with%20spaces");
+  });
+});
+
+describe("buildIndividualTrackerPublicViewPath", () => {
+  it("encodes the xuid into the view path", () => {
+    expect(buildIndividualTrackerPublicViewPath("xuid(123456)")).toBe("/xuid(123456)/view");
+  });
+});
+
+describe("buildIndividualTrackerPublicOverlayPath", () => {
+  it("encodes the xuid into the overlay path", () => {
+    expect(buildIndividualTrackerPublicOverlayPath("xuid(123456)")).toBe("/xuid(123456)/overlay");
+  });
+});

--- a/pages/src/components/individual-tracker/tests/routes.test.ts
+++ b/pages/src/components/individual-tracker/tests/routes.test.ts
@@ -30,13 +30,21 @@ describe("buildIndividualTrackerTrackerViewPath", () => {
 });
 
 describe("buildIndividualTrackerPublicViewPath", () => {
-  it("encodes the xuid into the view path", () => {
-    expect(buildIndividualTrackerPublicViewPath("xuid(123456)")).toBe("/xuid(123456)/view");
+  it("returns the /u/<gamertag>/view path", () => {
+    expect(buildIndividualTrackerPublicViewPath("SpartanOne")).toBe("/u/SpartanOne/view");
+  });
+
+  it("percent-encodes special characters in the gamertag", () => {
+    expect(buildIndividualTrackerPublicViewPath("Spartan One")).toBe("/u/Spartan%20One/view");
   });
 });
 
 describe("buildIndividualTrackerPublicOverlayPath", () => {
-  it("encodes the xuid into the overlay path", () => {
-    expect(buildIndividualTrackerPublicOverlayPath("xuid(123456)")).toBe("/xuid(123456)/overlay");
+  it("returns the /u/<gamertag>/overlay path", () => {
+    expect(buildIndividualTrackerPublicOverlayPath("SpartanOne")).toBe("/u/SpartanOne/overlay");
+  });
+
+  it("percent-encodes special characters in the gamertag", () => {
+    expect(buildIndividualTrackerPublicOverlayPath("Spartan One")).toBe("/u/Spartan%20One/overlay");
   });
 });

--- a/pages/src/components/individual-tracker/tests/series-group-metadata.test.ts
+++ b/pages/src/components/individual-tracker/tests/series-group-metadata.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import type { TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
+import {
+  alignSeriesGroupsToGroupings,
+  buildSeriesGroupKey,
+  getDefaultSeriesGroupSubtitle,
+  type IndividualTrackerSeriesGroup,
+} from "../series-group-metadata";
+
+function aMatchEntryWith(
+  overrides: Partial<
+    Pick<
+      TrackerMatchHistoryEntry,
+      "startTimeIso" | "startTime" | "mapAssetId" | "mapVersionId" | "gameVariantCategory" | "outcome"
+    >
+  >,
+): Pick<
+  TrackerMatchHistoryEntry,
+  "startTimeIso" | "startTime" | "mapAssetId" | "mapVersionId" | "gameVariantCategory" | "outcome"
+> {
+  return {
+    startTime: overrides.startTime ?? "2026-01-01T12:00:00.000Z",
+    startTimeIso: overrides.startTimeIso,
+    mapAssetId: overrides.mapAssetId ?? "map-1",
+    mapVersionId: overrides.mapVersionId ?? "map-version-1",
+    gameVariantCategory: overrides.gameVariantCategory ?? 6,
+    outcome: overrides.outcome ?? "Win",
+  };
+}
+
+describe("buildSeriesGroupKey", () => {
+  it("produces a stable key regardless of input order or duplicates", () => {
+    expect(buildSeriesGroupKey(["match-2", "match-1"])).toBe("match-1:match-2");
+    expect(buildSeriesGroupKey(["match-1", "match-2", "match-1"])).toBe("match-1:match-2");
+  });
+});
+
+describe("getDefaultSeriesGroupSubtitle", () => {
+  it("infers Best of 3 from two wins and one loss over three logical games", () => {
+    const subtitle = getDefaultSeriesGroupSubtitle([
+      aMatchEntryWith({
+        startTimeIso: "2026-01-01T12:00:00.000Z",
+        mapAssetId: "m1",
+        mapVersionId: "v1",
+        outcome: "Win",
+      }),
+      aMatchEntryWith({
+        startTimeIso: "2026-01-01T12:10:00.000Z",
+        mapAssetId: "m2",
+        mapVersionId: "v2",
+        outcome: "Loss",
+      }),
+      aMatchEntryWith({
+        startTimeIso: "2026-01-01T12:20:00.000Z",
+        mapAssetId: "m3",
+        mapVersionId: "v3",
+        outcome: "Win",
+      }),
+    ]);
+
+    expect(subtitle).toBe("Best of 3");
+  });
+
+  it("uses startTime when startTimeIso is absent and infers Best of 3 from one win and one loss", () => {
+    const subtitle = getDefaultSeriesGroupSubtitle([
+      aMatchEntryWith({ startTime: "2026-01-01T12:00:00.000Z", mapAssetId: "m1", mapVersionId: "v1", outcome: "Win" }),
+      aMatchEntryWith({ startTime: "2026-01-01T12:10:00.000Z", mapAssetId: "m2", mapVersionId: "v2", outcome: "Loss" }),
+    ]);
+
+    expect(subtitle).toBe("Best of 3");
+  });
+});
+
+describe("alignSeriesGroupsToGroupings", () => {
+  it("creates new series groups from groupings that have no existing match", () => {
+    const groupings: readonly (readonly string[])[] = [["match-1", "match-2"]];
+    const seriesGroups: readonly IndividualTrackerSeriesGroup[] = [];
+
+    const result = alignSeriesGroupsToGroupings(groupings, seriesGroups);
+
+    expect(result).toEqual([
+      {
+        matchIds: ["match-1", "match-2"],
+        titleOverride: null,
+        subtitleOverride: null,
+      },
+    ]);
+  });
+
+  it("preserves title and subtitle overrides from an existing matching series group", () => {
+    const groupings: readonly (readonly string[])[] = [["match-2", "match-1"]];
+    const seriesGroups: readonly IndividualTrackerSeriesGroup[] = [
+      {
+        matchIds: ["match-1", "match-2"],
+        titleOverride: "Eagle vs Cobra",
+        subtitleOverride: "Best of 3",
+      },
+    ];
+
+    const result = alignSeriesGroupsToGroupings(groupings, seriesGroups);
+
+    expect(result).toEqual([
+      {
+        matchIds: ["match-1", "match-2"],
+        titleOverride: "Eagle vs Cobra",
+        subtitleOverride: "Best of 3",
+      },
+    ]);
+  });
+
+  it("filters out groupings with fewer than two match ids", () => {
+    const groupings: readonly (readonly string[])[] = [["match-1"], ["match-2", "match-3"]];
+    const seriesGroups: readonly IndividualTrackerSeriesGroup[] = [];
+
+    const result = alignSeriesGroupsToGroupings(groupings, seriesGroups);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].matchIds).toEqual(["match-2", "match-3"]);
+  });
+
+  it("normalizes match id order in the output regardless of input order", () => {
+    const groupings: readonly (readonly string[])[] = [["z-match", "a-match"]];
+    const seriesGroups: readonly IndividualTrackerSeriesGroup[] = [];
+
+    const result = alignSeriesGroupsToGroupings(groupings, seriesGroups);
+
+    expect(result[0].matchIds).toEqual(["a-match", "z-match"]);
+  });
+
+  it("returns an empty array when all groupings are singletons", () => {
+    const groupings: readonly (readonly string[])[] = [["match-1"], ["match-2"]];
+    const seriesGroups: readonly IndividualTrackerSeriesGroup[] = [];
+
+    const result = alignSeriesGroupsToGroupings(groupings, seriesGroups);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/pages/src/services/individual-tracker/types.ts
+++ b/pages/src/services/individual-tracker/types.ts
@@ -7,6 +7,34 @@ import type {
   TrackerResponse,
   TrackersResponse,
 } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import type { GameVariantCategory, MatchStats } from "halo-infinite-api";
+
+export interface TrackerMatchHistoryEntry {
+  readonly matchId: string;
+  readonly startTime: string;
+  readonly endTime: string;
+  readonly mapAssetId: string;
+  readonly mapVersionId: string;
+  readonly modeAssetId: string;
+  readonly modeVersionId: string;
+  readonly gameVariantCategory: GameVariantCategory;
+  readonly startTimeIso?: string | undefined;
+  readonly endTimeIso?: string | undefined;
+  readonly duration: string;
+  readonly mapName: string;
+  readonly modeName: string;
+  readonly gameType?: string | undefined;
+  readonly gameMap?: string | undefined;
+  readonly gameTypeAndMap?: string | undefined;
+  readonly outcome: "Win" | "Loss" | "Tie" | "DNF" | "Unknown";
+  readonly resultString: string;
+  readonly isMatchmaking: boolean;
+  readonly category: "matchmaking" | "custom" | "local" | "unknown";
+  readonly teams: readonly (readonly string[])[];
+  readonly rawMatchStats?: MatchStats | null | undefined;
+  readonly playerXuidToGametag?: Readonly<Record<string, string>> | undefined;
+  readonly mapThumbnailUrl: string;
+}
 
 export interface IndividualTrackerService {
   getProfile(): Promise<TrackerProfileResponse>;


### PR DESCRIPTION
## Summary

Ports four individual-tracker utility modules from the rework branch:

- **`match-duration-filter`** — `shouldHideShortDurationMatch` returns `true` for matches shorter than 2 minutes. Uses `startTimeIso`/`endTimeIso` when available and falls back to `startTime`/`endTime`; returns `false` (don't hide) when timestamps cannot be parsed as ISO.
- **`grouping-utils`** — `applyBreakFromGroup` splits a series group around a selected match; `applyAddToAdjacentGroup` merges a match or group into an adjacent group. Both operate on an entry-index map for stable ordering.
- **`series-group-metadata`** — `alignSeriesGroupsToGroupings` reconciles persisted `IndividualTrackerSeriesGroup` overrides to a new set of groupings; `getDefaultSeriesGroupSubtitle` wraps the shared helper with the `startTimeIso` → `startTime` fallback.
- **`routes`** — typed `IndividualTrackerAppRoute` union and path-builder helpers for the manage, active-view, tracker-view, public-view, and overlay routes.

## Code-review fixes (2 rounds until clean)

**Round 1 (3 issues fixed):**
- `match-duration-filter`: `parseISO` on non-ISO `startTime` produced Invalid Date; added `isValid()` guard — returns `false` (don't hide) when timestamps can't be parsed.
- `grouping-utils` line 407: inline sort comparator was a duplicate of `orderMatchIdsByEntryIndex`; replaced with a call to that helper.
- `grouping-utils` line 413: `breakIndex === -1` guard was dead code (unreachable since `group.includes(matchId)` was already true); removed.

**Round 2:** No actionable findings.

## Test plan

- [ ] `npm run test` passes (172 test files, 2155 tests)
- [ ] `npm run typecheck` passes
- [ ] `npm run lint:fix` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)