### PR TITLE
feat(pages): StreamerConnectionsSectionView — URL + settings panel (H2-3)

### DIFF
--- a/pages/src/components/individual-tracker-manager/create.tsx
+++ b/pages/src/components/individual-tracker-manager/create.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useSyncExternalStore } from "react";
-import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { IndividualTrackerSettingsService } from "../../services/individual-tracker/settings-types";
 import type { IndividualTrackerService } from "../../services/individual-tracker/types";
 import { ComponentLoader } from "../component-loader/component-loader";
@@ -65,9 +64,6 @@ export function IndividualTrackerManagerPage({
       onRowAction: (trackerId: string, action: TrackerRowAction): void => {
         presenter.runRowAction(trackerId, action);
       },
-      onUpdateSettings: (settings: StreamerViewSettings): void => {
-        presenter.updateSettings(settings);
-      },
     }),
     [presenter],
   );
@@ -85,7 +81,7 @@ export function IndividualTrackerManagerPage({
         />
       }
       loaded={
-        <IndividualTrackerManagerProvider model={model} actions={actions}>
+        <IndividualTrackerManagerProvider model={model} actions={actions} settingsService={settingsService}>
           <IndividualTrackerManagerView />
         </IndividualTrackerManagerProvider>
       }

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager-context.tsx
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager-context.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useMemo } from "react";
-import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import type { IndividualTrackerSettingsService } from "../../services/individual-tracker/settings-types";
 import type { TrackerRowAction } from "./manager-model";
 import type { IndividualTrackerManagerViewModel } from "./types";
 
@@ -11,12 +11,12 @@ interface IndividualTrackerManagerActions {
   readonly onIdleTimeoutHoursChange: (value: string) => void;
   readonly onAddTracker: () => void;
   readonly onRowAction: (trackerId: string, action: TrackerRowAction) => void;
-  readonly onUpdateSettings: (settings: StreamerViewSettings) => void;
 }
 
 interface IndividualTrackerManagerContextValue {
   readonly model: IndividualTrackerManagerViewModel;
   readonly actions: IndividualTrackerManagerActions;
+  readonly settingsService: IndividualTrackerSettingsService;
 }
 
 const IndividualTrackerManagerContext = createContext<IndividualTrackerManagerContextValue | null>(null);
@@ -24,15 +24,17 @@ const IndividualTrackerManagerContext = createContext<IndividualTrackerManagerCo
 interface IndividualTrackerManagerProviderProps {
   readonly model: IndividualTrackerManagerViewModel;
   readonly actions: IndividualTrackerManagerActions;
+  readonly settingsService: IndividualTrackerSettingsService;
   readonly children: React.ReactNode;
 }
 
 export function IndividualTrackerManagerProvider({
   model,
   actions,
+  settingsService,
   children,
 }: IndividualTrackerManagerProviderProps): React.ReactElement {
-  const value = useMemo(() => ({ model, actions }), [model, actions]);
+  const value = useMemo(() => ({ model, actions, settingsService }), [model, actions, settingsService]);
 
   return <IndividualTrackerManagerContext.Provider value={value}>{children}</IndividualTrackerManagerContext.Provider>;
 }
@@ -51,4 +53,8 @@ export function useManagerModel(): IndividualTrackerManagerViewModel {
 
 export function useManagerActions(): IndividualTrackerManagerActions {
   return useIndividualTrackerManagerContext().actions;
+}
+
+export function useManagerSettingsService(): IndividualTrackerSettingsService {
+  return useIndividualTrackerManagerContext().settingsService;
 }

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager-presenter.ts
@@ -51,7 +51,7 @@ export class IndividualTrackerManagerPresenter {
       pendingTrackerId: snapshot.pendingTrackerId,
       addDisabled,
       settings: snapshot.settings,
-      liveXuid: liveTracker?.xuid ?? null,
+      liveGamertag: liveTracker?.gamertag ?? null,
     };
   }
 

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager-presenter.ts
@@ -51,8 +51,6 @@ export class IndividualTrackerManagerPresenter {
       pendingTrackerId: snapshot.pendingTrackerId,
       addDisabled,
       settings: snapshot.settings,
-      settingsSaving: snapshot.settingsSaving,
-      settingsError: snapshot.settingsError,
       liveXuid: liveTracker?.xuid ?? null,
     };
   }
@@ -178,32 +176,6 @@ export class IndividualTrackerManagerPresenter {
     this.config.store.setGamertagInput("");
     this.config.store.setSearchStartTime("");
     this.config.store.setIdleTimeoutHours("");
-  }
-
-  public updateSettings(settings: StreamerViewSettings): void {
-    if (this.isDisposed) {
-      return;
-    }
-    this.config.store.setSettingsSaving(true);
-    this.config.store.setSettingsError(null);
-    this.config.settingsService
-      .updateSettings(settings)
-      .then((saved) => {
-        if (!this.isDisposed) {
-          this.config.store.setSettings(saved);
-        }
-      })
-      .catch((err: unknown) => {
-        if (!this.isDisposed) {
-          this.config.store.setSettingsError(err instanceof Error ? err.message : "Failed to save settings");
-        }
-      })
-      .finally(() => {
-        if (this.isDisposed) {
-          return;
-        }
-        this.config.store.setSettingsSaving(false);
-      });
   }
 
   private async load(): Promise<void> {

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager-presenter.ts
@@ -39,6 +39,7 @@ export class IndividualTrackerManagerPresenter {
       !isValidGamertagInput(snapshot.gamertagInput) ||
       !isValidSearchStartTimeInput(snapshot.searchStartTime) ||
       !isValidIdleTimeoutHoursInput(snapshot.idleTimeoutHours);
+    const liveTracker = snapshot.trackers.find((tracker) => tracker.isLive);
     return {
       model,
       profileName: snapshot.profileName,
@@ -52,6 +53,7 @@ export class IndividualTrackerManagerPresenter {
       settings: snapshot.settings,
       settingsSaving: snapshot.settingsSaving,
       settingsError: snapshot.settingsError,
+      liveXuid: liveTracker?.xuid ?? null,
     };
   }
 

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager-store.ts
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager-store.ts
@@ -14,8 +14,6 @@ export interface IndividualTrackerManagerSnapshot {
   readonly addPending: boolean;
   readonly pendingTrackerId: string | null;
   readonly settings: StreamerViewSettings;
-  readonly settingsSaving: boolean;
-  readonly settingsError: string | null;
 }
 
 export class IndividualTrackerManagerStore {
@@ -35,8 +33,6 @@ export class IndividualTrackerManagerStore {
       addPending: false,
       pendingTrackerId: null,
       settings: {},
-      settingsSaving: false,
-      settingsError: null,
     };
   }
 
@@ -98,14 +94,6 @@ export class IndividualTrackerManagerStore {
 
   public setSettings(settings: StreamerViewSettings): void {
     this.update({ settings });
-  }
-
-  public setSettingsSaving(settingsSaving: boolean): void {
-    this.update({ settingsSaving });
-  }
-
-  public setSettingsError(settingsError: string | null): void {
-    this.update({ settingsError });
   }
 
   private update(partial: Partial<IndividualTrackerManagerSnapshot>): void {

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager.tsx
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager.tsx
@@ -5,8 +5,8 @@ import { Dialog } from "../dialog/dialog";
 import { Input } from "../input/input";
 import type { TrackerRowAction, TrackerRowModel } from "./manager-model";
 import { MAX_TRACKERS } from "./manager-model";
-import { useManagerActions, useManagerModel } from "./individual-tracker-manager-context";
-import { StreamerSettings } from "./settings/streamer-settings";
+import { useManagerActions, useManagerModel, useManagerSettingsService } from "./individual-tracker-manager-context";
+import { StreamerConnectionsSection } from "./streamer-connections/create";
 import styles from "./individual-tracker-manager.module.css";
 
 function StatusBadge({ row }: { readonly row: TrackerRowModel }): React.ReactElement {
@@ -106,8 +106,7 @@ export function IndividualTrackerManagerView(): React.ReactElement {
     pendingTrackerId,
     addDisabled,
     settings,
-    settingsSaving,
-    settingsError,
+    liveXuid,
   } = useManagerModel();
   const {
     onOpenAddDialog,
@@ -117,8 +116,8 @@ export function IndividualTrackerManagerView(): React.ReactElement {
     onIdleTimeoutHoursChange,
     onAddTracker,
     onRowAction,
-    onUpdateSettings,
   } = useManagerActions();
+  const settingsService = useManagerSettingsService();
 
   return (
     <div className={styles.container}>
@@ -184,13 +183,7 @@ export function IndividualTrackerManagerView(): React.ReactElement {
       </Dialog>
 
       <section className={styles.settingsSection}>
-        <h2 className={styles.settingsSectionTitle}>Streaming Settings</h2>
-        <StreamerSettings
-          settings={settings}
-          saving={settingsSaving}
-          errorMessage={settingsError}
-          onSave={onUpdateSettings}
-        />
+        <StreamerConnectionsSection settings={settings} settingsService={settingsService} xuid={liveXuid} />
       </section>
 
       {model.isAtLimit && (

--- a/pages/src/components/individual-tracker-manager/individual-tracker-manager.tsx
+++ b/pages/src/components/individual-tracker-manager/individual-tracker-manager.tsx
@@ -106,7 +106,7 @@ export function IndividualTrackerManagerView(): React.ReactElement {
     pendingTrackerId,
     addDisabled,
     settings,
-    liveXuid,
+    liveGamertag,
   } = useManagerModel();
   const {
     onOpenAddDialog,
@@ -183,7 +183,7 @@ export function IndividualTrackerManagerView(): React.ReactElement {
       </Dialog>
 
       <section className={styles.settingsSection}>
-        <StreamerConnectionsSection settings={settings} settingsService={settingsService} xuid={liveXuid} />
+        <StreamerConnectionsSection settings={settings} settingsService={settingsService} gamertag={liveGamertag} />
       </section>
 
       {model.isAtLimit && (

--- a/pages/src/components/individual-tracker-manager/streamer-connections/create.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/create.tsx
@@ -8,13 +8,13 @@ import { StreamerConnectionsSectionView } from "./streamer-connections";
 interface StreamerConnectionsSectionProps {
   readonly settings: StreamerViewSettings;
   readonly settingsService: IndividualTrackerSettingsService;
-  readonly xuid: string | null;
+  readonly gamertag: string | null;
 }
 
 export function StreamerConnectionsSection({
   settings,
   settingsService,
-  xuid,
+  gamertag,
 }: StreamerConnectionsSectionProps): React.ReactElement {
   const store = useMemo(() => new StreamerConnectionsStore(), []);
   const presenter = useMemo(
@@ -23,8 +23,8 @@ export function StreamerConnectionsSection({
   );
 
   useEffect(() => {
-    presenter.loadSettings(settings, xuid);
-  }, [presenter, settings, xuid]);
+    presenter.loadSettings(settings, gamertag);
+  }, [presenter, settings, gamertag]);
 
   useEffect(() => {
     return (): void => {
@@ -40,7 +40,7 @@ export function StreamerConnectionsSection({
 
   return (
     <StreamerConnectionsSectionView
-      xuid={snapshot.xuid}
+      gamertag={snapshot.gamertag}
       defaultColorMode={snapshot.defaultColorMode}
       playerTeamColor={snapshot.playerTeamColor}
       playerEnemyColor={snapshot.playerEnemyColor}

--- a/pages/src/components/individual-tracker-manager/streamer-connections/create.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/create.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useMemo, useSyncExternalStore } from "react";
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import type { IndividualTrackerSettingsService } from "../../../services/individual-tracker/settings-types";
+import { StreamerConnectionsPresenter } from "./streamer-connections-presenter";
+import { StreamerConnectionsStore } from "./streamer-connections-store";
+import { StreamerConnectionsSectionView } from "./streamer-connections";
+
+interface StreamerConnectionsSectionProps {
+  readonly settings: StreamerViewSettings;
+  readonly settingsService: IndividualTrackerSettingsService;
+  readonly xuid: string | null;
+}
+
+export function StreamerConnectionsSection({
+  settings,
+  settingsService,
+  xuid,
+}: StreamerConnectionsSectionProps): React.ReactElement {
+  const store = useMemo(() => new StreamerConnectionsStore(), []);
+  const presenter = useMemo(
+    () => new StreamerConnectionsPresenter({ settingsService, store }),
+    [settingsService, store],
+  );
+
+  useEffect(() => {
+    presenter.loadSettings(settings, xuid);
+  }, [presenter, settings, xuid]);
+
+  useEffect(() => {
+    return (): void => {
+      presenter.dispose();
+    };
+  }, [presenter]);
+
+  const snapshot = useSyncExternalStore(
+    (listener) => store.subscribe(listener),
+    () => store.getSnapshot(),
+    () => store.getSnapshot(),
+  );
+
+  return (
+    <StreamerConnectionsSectionView
+      xuid={snapshot.xuid}
+      defaultColorMode={snapshot.defaultColorMode}
+      playerTeamColor={snapshot.playerTeamColor}
+      playerEnemyColor={snapshot.playerEnemyColor}
+      observerTeamColor={snapshot.observerTeamColor}
+      observerEnemyColor={snapshot.observerEnemyColor}
+      displaySettings={snapshot.displaySettings}
+      tickerSettings={snapshot.tickerSettings}
+      fontSizeSettings={snapshot.fontSizeSettings}
+      saveStatus={snapshot.saveStatus}
+      saveErrorMessage={snapshot.saveErrorMessage}
+      onDefaultColorModeChange={(mode): void => {
+        presenter.setDefaultColorMode(mode);
+      }}
+      onPlayerColorsChange={(teamColor, enemyColor): void => {
+        presenter.setPlayerColors(teamColor, enemyColor);
+      }}
+      onObserverColorsChange={(teamColor, enemyColor): void => {
+        presenter.setObserverColors(teamColor, enemyColor);
+      }}
+      onDisplaySettingsChange={(updates): void => {
+        presenter.setDisplaySettings(updates);
+      }}
+      onTickerSettingsChange={(updates): void => {
+        presenter.setTickerSettings(updates);
+      }}
+      onFontSizesChange={(updates): void => {
+        presenter.setFontSizes(updates);
+      }}
+    />
+  );
+}

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-presenter.ts
@@ -51,6 +51,7 @@ function settingsToSnapshot(
       tabs: fontSizes.tabs ?? snapshot.fontSizeSettings.tabs,
       ticker: fontSizes.ticker ?? snapshot.fontSizeSettings.ticker,
     },
+    topBarStatSlots: visibleSections.topBarStatSlots ?? snapshot.topBarStatSlots,
   };
 }
 
@@ -59,13 +60,7 @@ function applyParsedSettingsToStore(
   parsed: Omit<StreamerConnectionsSnapshot, "saveStatus" | "saveErrorMessage" | "gamertag">,
   gamertag: string | null,
 ): void {
-  store.setXuid(gamertag);
-  store.setDefaultColorMode(parsed.defaultColorMode);
-  store.setPlayerColors(parsed.playerTeamColor, parsed.playerEnemyColor);
-  store.setObserverColors(parsed.observerTeamColor, parsed.observerEnemyColor);
-  store.setDisplaySettings(parsed.displaySettings);
-  store.setTickerSettings(parsed.tickerSettings);
-  store.setFontSizeSettings(parsed.fontSizeSettings);
+  store.batchUpdate({ gamertag, ...parsed });
 }
 
 function snapshotToSettings(snapshot: StreamerConnectionsSnapshot): StreamerViewSettings {
@@ -91,6 +86,7 @@ function snapshotToSettings(snapshot: StreamerConnectionsSnapshot): StreamerView
       showScore: snapshot.displaySettings.showScore,
       showTicker: snapshot.tickerSettings.showTicker,
       showTabs: snapshot.tickerSettings.showTabs,
+      topBarStatSlots: [...snapshot.topBarStatSlots],
     },
     layoutOptions: {
       fontSizes: {
@@ -124,6 +120,10 @@ export class StreamerConnectionsPresenter {
 
   public loadSettings(settings: StreamerViewSettings, gamertag: string | null): void {
     if (this.isDisposed) {
+      return;
+    }
+    if (this.debounceTimer !== null) {
+      this.config.store.setGamertag(gamertag);
       return;
     }
     const snapshot = this.config.store.getSnapshot();

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-presenter.ts
@@ -51,7 +51,7 @@ function settingsToSnapshot(
       tabs: fontSizes.tabs ?? snapshot.fontSizeSettings.tabs,
       ticker: fontSizes.ticker ?? snapshot.fontSizeSettings.ticker,
     },
-    topBarStatSlots: visibleSections.topBarStatSlots ?? snapshot.topBarStatSlots,
+    topBarStatSlots: [...(visibleSections.topBarStatSlots ?? snapshot.topBarStatSlots)],
   };
 }
 

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-presenter.ts
@@ -16,7 +16,7 @@ interface Config {
 function settingsToSnapshot(
   settings: StreamerViewSettings,
   snapshot: StreamerConnectionsSnapshot,
-): Omit<StreamerConnectionsSnapshot, "saveStatus" | "saveErrorMessage" | "xuid"> {
+): Omit<StreamerConnectionsSnapshot, "saveStatus" | "saveErrorMessage" | "gamertag"> {
   const styleFlags = settings.styleFlags ?? {};
   const visibleSections = settings.visibleSections ?? {};
   const fontSizes = settings.layoutOptions?.fontSizes ?? {};
@@ -56,10 +56,10 @@ function settingsToSnapshot(
 
 function applyParsedSettingsToStore(
   store: StreamerConnectionsStore,
-  parsed: Omit<StreamerConnectionsSnapshot, "saveStatus" | "saveErrorMessage" | "xuid">,
-  xuid: string | null,
+  parsed: Omit<StreamerConnectionsSnapshot, "saveStatus" | "saveErrorMessage" | "gamertag">,
+  gamertag: string | null,
 ): void {
-  store.setXuid(xuid);
+  store.setXuid(gamertag);
   store.setDefaultColorMode(parsed.defaultColorMode);
   store.setPlayerColors(parsed.playerTeamColor, parsed.playerEnemyColor);
   store.setObserverColors(parsed.observerTeamColor, parsed.observerEnemyColor);
@@ -122,13 +122,13 @@ export class StreamerConnectionsPresenter {
     }
   }
 
-  public loadSettings(settings: StreamerViewSettings, xuid: string | null): void {
+  public loadSettings(settings: StreamerViewSettings, gamertag: string | null): void {
     if (this.isDisposed) {
       return;
     }
     const snapshot = this.config.store.getSnapshot();
     const parsed = settingsToSnapshot(settings, snapshot);
-    applyParsedSettingsToStore(this.config.store, parsed, xuid);
+    applyParsedSettingsToStore(this.config.store, parsed, gamertag);
   }
 
   public setDefaultColorMode(mode: StreamerViewColorMode): void {
@@ -207,7 +207,7 @@ export class StreamerConnectionsPresenter {
         }
         const snapshot = this.config.store.getSnapshot();
         const parsed = settingsToSnapshot(saved, snapshot);
-        applyParsedSettingsToStore(this.config.store, parsed, snapshot.xuid);
+        applyParsedSettingsToStore(this.config.store, parsed, snapshot.gamertag);
         this.config.store.setSaved();
       })
       .catch((err: unknown) => {

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-presenter.ts
@@ -108,6 +108,7 @@ export class StreamerConnectionsPresenter {
   private readonly config: Config;
   private isDisposed = false;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private saveGeneration = 0;
 
   public constructor(config: Config) {
     this.config = config;
@@ -195,12 +196,13 @@ export class StreamerConnectionsPresenter {
     if (this.isDisposed) {
       return;
     }
+    const generation = ++this.saveGeneration;
     const settings = snapshotToSettings(this.config.store.getSnapshot());
     this.config.store.setSaving();
     this.config.settingsService
       .updateSettings(settings)
       .then((saved) => {
-        if (this.isDisposed) {
+        if (this.isDisposed || generation !== this.saveGeneration || this.debounceTimer !== null) {
           return;
         }
         const snapshot = this.config.store.getSnapshot();
@@ -209,7 +211,7 @@ export class StreamerConnectionsPresenter {
         this.config.store.setSaved();
       })
       .catch((err: unknown) => {
-        if (this.isDisposed) {
+        if (this.isDisposed || generation !== this.saveGeneration || this.debounceTimer !== null) {
           return;
         }
         const message = err instanceof Error ? err.message : "Failed to save settings";

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-presenter.ts
@@ -1,0 +1,219 @@
+import type {
+  StreamerViewColorMode,
+  StreamerViewSettings,
+} from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import type { IndividualTrackerSettingsService } from "../../../services/individual-tracker/settings-types";
+import type { DisplaySettings, FontSizeSettings, TickerSettings } from "../../live-tracker/settings/types";
+import type { StreamerConnectionsSnapshot, StreamerConnectionsStore } from "./streamer-connections-store";
+
+const DEBOUNCE_MS = 450;
+
+interface Config {
+  readonly settingsService: IndividualTrackerSettingsService;
+  readonly store: StreamerConnectionsStore;
+}
+
+function settingsToSnapshot(
+  settings: StreamerViewSettings,
+  snapshot: StreamerConnectionsSnapshot,
+): Omit<StreamerConnectionsSnapshot, "saveStatus" | "saveErrorMessage" | "xuid"> {
+  const styleFlags = settings.styleFlags ?? {};
+  const visibleSections = settings.visibleSections ?? {};
+  const fontSizes = settings.layoutOptions?.fontSizes ?? {};
+
+  return {
+    defaultColorMode: styleFlags.colorMode ?? snapshot.defaultColorMode,
+    playerTeamColor: styleFlags.playerTeamColor ?? snapshot.playerTeamColor,
+    playerEnemyColor: styleFlags.playerEnemyColor ?? snapshot.playerEnemyColor,
+    observerTeamColor: styleFlags.observerTeamColor ?? snapshot.observerTeamColor,
+    observerEnemyColor: styleFlags.observerEnemyColor ?? snapshot.observerEnemyColor,
+    displaySettings: {
+      showTeamDetails: visibleSections.showTeamDetails ?? snapshot.displaySettings.showTeamDetails,
+      showDiscordNames: visibleSections.showDiscordNames ?? snapshot.displaySettings.showDiscordNames,
+      showXboxNames: visibleSections.showXboxNames ?? snapshot.displaySettings.showXboxNames,
+      showServerIcon: visibleSections.showServerIcon ?? snapshot.displaySettings.showServerIcon,
+      showTitle: visibleSections.showTitle ?? snapshot.displaySettings.showTitle,
+      showSubtitle: visibleSections.showSubtitle ?? snapshot.displaySettings.showSubtitle,
+      showScore: visibleSections.showScore ?? snapshot.displaySettings.showScore,
+    },
+    tickerSettings: {
+      showTicker: visibleSections.showTicker ?? snapshot.tickerSettings.showTicker,
+      showTabs: visibleSections.showTabs ?? snapshot.tickerSettings.showTabs,
+      showPreSeriesInfo: styleFlags.showPreSeriesInfo ?? snapshot.tickerSettings.showPreSeriesInfo,
+      selectedSlayerStats: styleFlags.selectedSlayerStats ?? snapshot.tickerSettings.selectedSlayerStats,
+      showObjectiveStats: styleFlags.showObjectiveStats ?? snapshot.tickerSettings.showObjectiveStats,
+      medalRarityFilter: styleFlags.medalRarityFilter ?? snapshot.tickerSettings.medalRarityFilter,
+    },
+    fontSizeSettings: {
+      queueInfo: fontSizes.queueInfo ?? snapshot.fontSizeSettings.queueInfo,
+      score: fontSizes.score ?? snapshot.fontSizeSettings.score,
+      teams: fontSizes.teams ?? snapshot.fontSizeSettings.teams,
+      tabs: fontSizes.tabs ?? snapshot.fontSizeSettings.tabs,
+      ticker: fontSizes.ticker ?? snapshot.fontSizeSettings.ticker,
+    },
+  };
+}
+
+function applyParsedSettingsToStore(
+  store: StreamerConnectionsStore,
+  parsed: Omit<StreamerConnectionsSnapshot, "saveStatus" | "saveErrorMessage" | "xuid">,
+  xuid: string | null,
+): void {
+  store.setXuid(xuid);
+  store.setDefaultColorMode(parsed.defaultColorMode);
+  store.setPlayerColors(parsed.playerTeamColor, parsed.playerEnemyColor);
+  store.setObserverColors(parsed.observerTeamColor, parsed.observerEnemyColor);
+  store.setDisplaySettings(parsed.displaySettings);
+  store.setTickerSettings(parsed.tickerSettings);
+  store.setFontSizeSettings(parsed.fontSizeSettings);
+}
+
+function snapshotToSettings(snapshot: StreamerConnectionsSnapshot): StreamerViewSettings {
+  return {
+    styleFlags: {
+      colorMode: snapshot.defaultColorMode,
+      playerTeamColor: snapshot.playerTeamColor,
+      playerEnemyColor: snapshot.playerEnemyColor,
+      observerTeamColor: snapshot.observerTeamColor,
+      observerEnemyColor: snapshot.observerEnemyColor,
+      showPreSeriesInfo: snapshot.tickerSettings.showPreSeriesInfo,
+      selectedSlayerStats: [...snapshot.tickerSettings.selectedSlayerStats],
+      showObjectiveStats: snapshot.tickerSettings.showObjectiveStats,
+      medalRarityFilter: [...snapshot.tickerSettings.medalRarityFilter],
+    },
+    visibleSections: {
+      showTeamDetails: snapshot.displaySettings.showTeamDetails,
+      showDiscordNames: snapshot.displaySettings.showDiscordNames,
+      showXboxNames: snapshot.displaySettings.showXboxNames,
+      showServerIcon: snapshot.displaySettings.showServerIcon,
+      showTitle: snapshot.displaySettings.showTitle,
+      showSubtitle: snapshot.displaySettings.showSubtitle,
+      showScore: snapshot.displaySettings.showScore,
+      showTicker: snapshot.tickerSettings.showTicker,
+      showTabs: snapshot.tickerSettings.showTabs,
+    },
+    layoutOptions: {
+      fontSizes: {
+        queueInfo: snapshot.fontSizeSettings.queueInfo,
+        score: snapshot.fontSizeSettings.score,
+        teams: snapshot.fontSizeSettings.teams,
+        tabs: snapshot.fontSizeSettings.tabs,
+        ticker: snapshot.fontSizeSettings.ticker,
+      },
+    },
+  };
+}
+
+export class StreamerConnectionsPresenter {
+  private readonly config: Config;
+  private isDisposed = false;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  public constructor(config: Config) {
+    this.config = config;
+  }
+
+  public dispose(): void {
+    this.isDisposed = true;
+    if (this.debounceTimer !== null) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+  }
+
+  public loadSettings(settings: StreamerViewSettings, xuid: string | null): void {
+    if (this.isDisposed) {
+      return;
+    }
+    const snapshot = this.config.store.getSnapshot();
+    const parsed = settingsToSnapshot(settings, snapshot);
+    applyParsedSettingsToStore(this.config.store, parsed, xuid);
+  }
+
+  public setDefaultColorMode(mode: StreamerViewColorMode): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.config.store.setDefaultColorMode(mode);
+    this.scheduleSave();
+  }
+
+  public setPlayerColors(teamColor: string, enemyColor: string): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.config.store.setPlayerColors(teamColor, enemyColor);
+    this.scheduleSave();
+  }
+
+  public setObserverColors(teamColor: string, enemyColor: string): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.config.store.setObserverColors(teamColor, enemyColor);
+    this.scheduleSave();
+  }
+
+  public setDisplaySettings(updates: Partial<DisplaySettings>): void {
+    if (this.isDisposed) {
+      return;
+    }
+    const current = this.config.store.getSnapshot().displaySettings;
+    this.config.store.setDisplaySettings({ ...current, ...updates });
+    this.scheduleSave();
+  }
+
+  public setTickerSettings(updates: Partial<TickerSettings>): void {
+    if (this.isDisposed) {
+      return;
+    }
+    const current = this.config.store.getSnapshot().tickerSettings;
+    this.config.store.setTickerSettings({ ...current, ...updates });
+    this.scheduleSave();
+  }
+
+  public setFontSizes(updates: Partial<FontSizeSettings>): void {
+    if (this.isDisposed) {
+      return;
+    }
+    const current = this.config.store.getSnapshot().fontSizeSettings;
+    this.config.store.setFontSizeSettings({ ...current, ...updates });
+    this.scheduleSave();
+  }
+
+  private scheduleSave(): void {
+    if (this.debounceTimer !== null) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      this.save();
+    }, DEBOUNCE_MS);
+  }
+
+  private save(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    const settings = snapshotToSettings(this.config.store.getSnapshot());
+    this.config.store.setSaving();
+    this.config.settingsService
+      .updateSettings(settings)
+      .then((saved) => {
+        if (this.isDisposed) {
+          return;
+        }
+        const snapshot = this.config.store.getSnapshot();
+        const parsed = settingsToSnapshot(saved, snapshot);
+        applyParsedSettingsToStore(this.config.store, parsed, snapshot.xuid);
+        this.config.store.setSaved();
+      })
+      .catch((err: unknown) => {
+        if (this.isDisposed) {
+          return;
+        }
+        const message = err instanceof Error ? err.message : "Failed to save settings";
+        this.config.store.setSaveError(message);
+      });
+  }
+}

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-store.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-store.ts
@@ -115,10 +115,6 @@ export class StreamerConnectionsStore {
     this.update({ saveStatus: "error", saveErrorMessage: message });
   }
 
-  public setSaveIdle(): void {
-    this.update({ saveStatus: "idle" });
-  }
-
   private update(partial: Partial<StreamerConnectionsSnapshot>): void {
     this.snapshot = { ...this.snapshot, ...partial };
     for (const subscriber of this.subscribers) {

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-store.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-store.ts
@@ -4,7 +4,7 @@ import type { DisplaySettings, FontSizeSettings, TickerSettings } from "../../li
 export type SaveStatus = "idle" | "saving" | "saved" | "error";
 
 export interface StreamerConnectionsSnapshot {
-  readonly xuid: string | null;
+  readonly gamertag: string | null;
   readonly defaultColorMode: StreamerViewColorMode;
   readonly playerTeamColor: string;
   readonly playerEnemyColor: string;
@@ -50,7 +50,7 @@ export class StreamerConnectionsStore {
 
   public constructor() {
     this.snapshot = {
-      xuid: null,
+      gamertag: null,
       defaultColorMode: "player",
       playerTeamColor: "cerulean",
       playerEnemyColor: "salmon",
@@ -75,8 +75,8 @@ export class StreamerConnectionsStore {
     return this.snapshot;
   }
 
-  public setXuid(xuid: string | null): void {
-    this.update({ xuid });
+  public setXuid(gamertag: string | null): void {
+    this.update({ gamertag });
   }
 
   public setDefaultColorMode(defaultColorMode: StreamerViewColorMode): void {

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-store.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-store.ts
@@ -13,6 +13,7 @@ export interface StreamerConnectionsSnapshot {
   readonly displaySettings: DisplaySettings;
   readonly tickerSettings: TickerSettings;
   readonly fontSizeSettings: FontSizeSettings;
+  readonly topBarStatSlots: readonly string[];
   readonly saveStatus: SaveStatus;
   readonly saveErrorMessage: string | null;
 }
@@ -59,6 +60,7 @@ export class StreamerConnectionsStore {
       displaySettings: DEFAULT_DISPLAY_SETTINGS,
       tickerSettings: DEFAULT_TICKER_SETTINGS,
       fontSizeSettings: DEFAULT_FONT_SIZE_SETTINGS,
+      topBarStatSlots: [],
       saveStatus: "idle",
       saveErrorMessage: null,
     };
@@ -75,8 +77,12 @@ export class StreamerConnectionsStore {
     return this.snapshot;
   }
 
-  public setXuid(gamertag: string | null): void {
+  public setGamertag(gamertag: string | null): void {
     this.update({ gamertag });
+  }
+
+  public batchUpdate(partial: Partial<StreamerConnectionsSnapshot>): void {
+    this.update(partial);
   }
 
   public setDefaultColorMode(defaultColorMode: StreamerViewColorMode): void {

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-store.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-store.ts
@@ -1,0 +1,128 @@
+import type { StreamerViewColorMode } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import type { DisplaySettings, FontSizeSettings, TickerSettings } from "../../live-tracker/settings/types";
+
+export type SaveStatus = "idle" | "saving" | "saved" | "error";
+
+export interface StreamerConnectionsSnapshot {
+  readonly xuid: string | null;
+  readonly defaultColorMode: StreamerViewColorMode;
+  readonly playerTeamColor: string;
+  readonly playerEnemyColor: string;
+  readonly observerTeamColor: string;
+  readonly observerEnemyColor: string;
+  readonly displaySettings: DisplaySettings;
+  readonly tickerSettings: TickerSettings;
+  readonly fontSizeSettings: FontSizeSettings;
+  readonly saveStatus: SaveStatus;
+  readonly saveErrorMessage: string | null;
+}
+
+const DEFAULT_DISPLAY_SETTINGS: DisplaySettings = {
+  showTeamDetails: false,
+  showDiscordNames: true,
+  showXboxNames: true,
+  showServerIcon: true,
+  showTitle: true,
+  showSubtitle: true,
+  showScore: true,
+};
+
+const DEFAULT_TICKER_SETTINGS: TickerSettings = {
+  showTicker: true,
+  showTabs: true,
+  showPreSeriesInfo: true,
+  selectedSlayerStats: ["Score", "Kills", "Deaths", "Assists", "KDA", "Damage dealt", "Damage taken", "Damage ratio"],
+  showObjectiveStats: false,
+  medalRarityFilter: [2, 3],
+};
+
+const DEFAULT_FONT_SIZE_SETTINGS: FontSizeSettings = {
+  queueInfo: 100,
+  score: 100,
+  teams: 100,
+  tabs: 100,
+  ticker: 100,
+};
+
+export class StreamerConnectionsStore {
+  private snapshot: StreamerConnectionsSnapshot;
+  private readonly subscribers = new Set<() => void>();
+
+  public constructor() {
+    this.snapshot = {
+      xuid: null,
+      defaultColorMode: "player",
+      playerTeamColor: "cerulean",
+      playerEnemyColor: "salmon",
+      observerTeamColor: "salmon",
+      observerEnemyColor: "cerulean",
+      displaySettings: DEFAULT_DISPLAY_SETTINGS,
+      tickerSettings: DEFAULT_TICKER_SETTINGS,
+      fontSizeSettings: DEFAULT_FONT_SIZE_SETTINGS,
+      saveStatus: "idle",
+      saveErrorMessage: null,
+    };
+  }
+
+  public subscribe(listener: () => void): () => void {
+    this.subscribers.add(listener);
+    return (): void => {
+      this.subscribers.delete(listener);
+    };
+  }
+
+  public getSnapshot(): StreamerConnectionsSnapshot {
+    return this.snapshot;
+  }
+
+  public setXuid(xuid: string | null): void {
+    this.update({ xuid });
+  }
+
+  public setDefaultColorMode(defaultColorMode: StreamerViewColorMode): void {
+    this.update({ defaultColorMode });
+  }
+
+  public setPlayerColors(playerTeamColor: string, playerEnemyColor: string): void {
+    this.update({ playerTeamColor, playerEnemyColor });
+  }
+
+  public setObserverColors(observerTeamColor: string, observerEnemyColor: string): void {
+    this.update({ observerTeamColor, observerEnemyColor });
+  }
+
+  public setDisplaySettings(displaySettings: DisplaySettings): void {
+    this.update({ displaySettings });
+  }
+
+  public setTickerSettings(tickerSettings: TickerSettings): void {
+    this.update({ tickerSettings });
+  }
+
+  public setFontSizeSettings(fontSizeSettings: FontSizeSettings): void {
+    this.update({ fontSizeSettings });
+  }
+
+  public setSaving(): void {
+    this.update({ saveStatus: "saving", saveErrorMessage: null });
+  }
+
+  public setSaved(): void {
+    this.update({ saveStatus: "saved", saveErrorMessage: null });
+  }
+
+  public setSaveError(message: string): void {
+    this.update({ saveStatus: "error", saveErrorMessage: message });
+  }
+
+  public setSaveIdle(): void {
+    this.update({ saveStatus: "idle" });
+  }
+
+  private update(partial: Partial<StreamerConnectionsSnapshot>): void {
+    this.snapshot = { ...this.snapshot, ...partial };
+    for (const subscriber of this.subscribers) {
+      subscriber();
+    }
+  }
+}

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections.module.css
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections.module.css
@@ -1,0 +1,121 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.sectionTitle {
+  color: var(--halo-white);
+  font-family: var(--font-heading);
+  font-size: var(--text-2xl);
+  margin: 0;
+}
+
+.sectionDescription {
+  color: var(--halo-gray);
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: 1.7;
+  margin: 0;
+}
+
+.urlList {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.urlCard {
+  background: color-mix(in srgb, var(--halo-bg-elevated) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 20%, transparent);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-3);
+}
+
+.preferencesCard {
+  background: color-mix(in srgb, var(--halo-bg-elevated) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 20%, transparent);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-3);
+}
+
+.cardTitle {
+  color: var(--halo-white);
+  font-family: var(--font-heading);
+  font-size: var(--text-lg);
+  margin: 0;
+}
+
+.cardDescription {
+  color: var(--halo-gray);
+  font-size: var(--text-sm);
+  margin: 0;
+}
+
+.urlText {
+  background: color-mix(in srgb, var(--halo-bg) 90%, transparent);
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 30%, transparent);
+  border-radius: var(--radius-sm);
+  color: var(--halo-white);
+  margin: 0;
+  min-height: 2.5rem;
+  overflow-wrap: anywhere;
+  padding: var(--space-2);
+}
+
+.buttonRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.preferenceLabel {
+  color: var(--halo-white);
+  display: block;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  margin-bottom: var(--space-1);
+}
+
+.modeRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.pickerGrid {
+  display: grid;
+  gap: var(--space-3);
+}
+
+@media (--tablet-viewport) {
+  .pickerGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.fontSizeContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.floatingSaveToast {
+  bottom: var(--space-4);
+  max-width: min(26rem, calc(100vw - (var(--space-4) * 2)));
+  position: fixed;
+  right: var(--space-4);
+  z-index: 50;
+}
+
+@media (--tablet-viewport) {
+  .floatingSaveToast {
+    bottom: var(--space-6);
+    right: var(--space-6);
+  }
+}

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections.module.css
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections.module.css
@@ -24,17 +24,7 @@
   gap: var(--space-4);
 }
 
-.urlCard {
-  background: color-mix(in srgb, var(--halo-bg-elevated) 92%, transparent);
-  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 20%, transparent);
-  border-radius: var(--radius-md);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  padding: var(--space-3);
-}
-
-.preferencesCard {
+.card {
   background: color-mix(in srgb, var(--halo-bg-elevated) 92%, transparent);
   border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 20%, transparent);
   border-radius: var(--radius-md);

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections.tsx
@@ -88,6 +88,15 @@ export function StreamerConnectionsSectionView({
   const [copyTarget, setCopyTarget] = useState<CopyTarget>("idle");
   const [showSaveToast, setShowSaveToast] = useState(false);
   const prevSaveStatusRef = useRef<SaveStatus>("idle");
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return (): void => {
+      if (copyTimerRef.current !== null) {
+        clearTimeout(copyTimerRef.current);
+      }
+    };
+  }, []);
 
   const urls = gamertag !== null ? buildStreamerUrls(gamertag) : null;
   const selectedPlayerTeamColor = getTeamColorOrDefault(playerTeamColor, 0);
@@ -133,7 +142,11 @@ export function StreamerConnectionsSectionView({
         return;
       }
       setCopyTarget(target);
-      setTimeout(() => {
+      if (copyTimerRef.current !== null) {
+        clearTimeout(copyTimerRef.current);
+      }
+      copyTimerRef.current = setTimeout(() => {
+        copyTimerRef.current = null;
         setCopyTarget("idle");
       }, 1500);
     });
@@ -159,7 +172,7 @@ export function StreamerConnectionsSectionView({
         </Alert>
       ) : (
         <div className={styles.urlList}>
-          <div className={styles.urlCard}>
+          <div className={styles.card}>
             <h3 className={styles.cardTitle}>Viewer URL</h3>
             <p className={styles.cardDescription}>Share this with viewers to follow the active tracker.</p>
             <p className={styles.urlText}>{urls?.viewUrl}</p>
@@ -181,7 +194,7 @@ export function StreamerConnectionsSectionView({
             </div>
           </div>
 
-          <div className={styles.urlCard}>
+          <div className={styles.card}>
             <h3 className={styles.cardTitle}>Overlay URL</h3>
             <p className={styles.cardDescription}>Use this in OBS as a Browser Source.</p>
             <p className={styles.urlText}>{urls?.overlayUrl}</p>
@@ -212,7 +225,7 @@ export function StreamerConnectionsSectionView({
         </div>
       )}
 
-      <div className={styles.preferencesCard}>
+      <div className={styles.card}>
         <h3 className={styles.cardTitle}>Presentation defaults</h3>
         <p className={styles.cardDescription}>Configure the default color mode for the overlay.</p>
         <div className={styles.modeRow}>
@@ -237,7 +250,7 @@ export function StreamerConnectionsSectionView({
         </div>
       </div>
 
-      <div className={styles.preferencesCard}>
+      <div className={styles.card}>
         <h3 className={styles.cardTitle}>Player View Colors</h3>
         <p className={styles.cardDescription}>Used whenever color mode is set to player.</p>
         <div className={styles.pickerGrid}>
@@ -264,7 +277,7 @@ export function StreamerConnectionsSectionView({
         </div>
       </div>
 
-      <div className={styles.preferencesCard}>
+      <div className={styles.card}>
         <h3 className={styles.cardTitle}>Observer View Colors</h3>
         <p className={styles.cardDescription}>Global observer colors for fixed-team mode.</p>
         <div className={styles.pickerGrid}>
@@ -291,13 +304,13 @@ export function StreamerConnectionsSectionView({
         </div>
       </div>
 
-      <div className={styles.preferencesCard}>
+      <div className={styles.card}>
         <h3 className={styles.cardTitle}>Display Options</h3>
         <p className={styles.cardDescription}>Control what information is shown on the viewer and overlay.</p>
         <DisplaySettingsSection settings={displaySettings} onChange={onDisplaySettingsChange} />
       </div>
 
-      <div className={styles.preferencesCard}>
+      <div className={styles.card}>
         <h3 className={styles.cardTitle}>Information Ticker</h3>
         <p className={styles.cardDescription}>
           In the overlay at the bottom, the Information Ticker provides detailed insights at a glance.
@@ -305,7 +318,7 @@ export function StreamerConnectionsSectionView({
         <TickerSettingsSection settings={tickerSettings} onChange={onTickerSettingsChange} />
       </div>
 
-      <div className={styles.preferencesCard}>
+      <div className={styles.card}>
         <h3 className={styles.cardTitle}>Text Sizes</h3>
         <p className={styles.cardDescription}>Adjust the size of text for different sections.</p>
         <div className={styles.fontSizeContainer}>

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections.tsx
@@ -8,6 +8,10 @@ import { TickerSettingsSection } from "../../live-tracker/settings/ticker-settin
 import { FontSizeSlider } from "../../live-tracker/settings/font-size-slider";
 import type { DisplaySettings, FontSizeSettings, TickerSettings } from "../../live-tracker/settings/types";
 import { getTeamColorOrDefault } from "../../team-colors/team-colors";
+import {
+  buildIndividualTrackerPublicOverlayPath,
+  buildIndividualTrackerPublicViewPath,
+} from "../../individual-tracker/routes";
 import type { SaveStatus } from "./streamer-connections-store";
 import styles from "./streamer-connections.module.css";
 
@@ -18,11 +22,11 @@ interface StreamerUrls {
   readonly overlayUrl: string;
 }
 
-function buildStreamerUrls(xuid: string): StreamerUrls {
+function buildStreamerUrls(gamertag: string): StreamerUrls {
   const origin = typeof window === "undefined" ? "" : window.location.origin;
   return {
-    viewUrl: `${origin}/individual-tracker/${encodeURIComponent(xuid)}/view`,
-    overlayUrl: `${origin}/individual-tracker/${encodeURIComponent(xuid)}/overlay`,
+    viewUrl: `${origin}${buildIndividualTrackerPublicViewPath(gamertag)}`,
+    overlayUrl: `${origin}${buildIndividualTrackerPublicOverlayPath(gamertag)}`,
   };
 }
 
@@ -43,7 +47,7 @@ async function copyToClipboard(text: string): Promise<boolean> {
 }
 
 export interface StreamerConnectionsSectionViewProps {
-  readonly xuid: string | null;
+  readonly gamertag: string | null;
   readonly defaultColorMode: StreamerViewColorMode;
   readonly playerTeamColor: string;
   readonly playerEnemyColor: string;
@@ -63,7 +67,7 @@ export interface StreamerConnectionsSectionViewProps {
 }
 
 export function StreamerConnectionsSectionView({
-  xuid,
+  gamertag,
   defaultColorMode,
   playerTeamColor,
   playerEnemyColor,
@@ -85,7 +89,7 @@ export function StreamerConnectionsSectionView({
   const [showSaveToast, setShowSaveToast] = useState(false);
   const prevSaveStatusRef = useRef<SaveStatus>("idle");
 
-  const urls = xuid !== null ? buildStreamerUrls(xuid) : null;
+  const urls = gamertag !== null ? buildStreamerUrls(gamertag) : null;
   const selectedPlayerTeamColor = getTeamColorOrDefault(playerTeamColor, 0);
   const selectedPlayerEnemyColor = getTeamColorOrDefault(playerEnemyColor, 1);
   const selectedObserverTeamColor = getTeamColorOrDefault(observerTeamColor, 0);
@@ -149,7 +153,7 @@ export function StreamerConnectionsSectionView({
         tracker is currently marked live.
       </p>
 
-      {xuid === null ? (
+      {gamertag === null ? (
         <Alert variant="warning">
           No active Xbox identity is linked. Link an Xbox account to generate shareable URLs.
         </Alert>

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections.tsx
@@ -1,0 +1,361 @@
+import React, { useEffect, useRef, useState } from "react";
+import type { StreamerViewColorMode } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import { Alert } from "../../alert/alert";
+import { Button } from "../../button/button";
+import { TeamColorPicker } from "../../team-colors/team-color-picker";
+import { DisplaySettingsSection } from "../../live-tracker/settings/display-settings-section";
+import { TickerSettingsSection } from "../../live-tracker/settings/ticker-settings-section";
+import { FontSizeSlider } from "../../live-tracker/settings/font-size-slider";
+import type { DisplaySettings, FontSizeSettings, TickerSettings } from "../../live-tracker/settings/types";
+import { getTeamColorOrDefault } from "../../team-colors/team-colors";
+import type { SaveStatus } from "./streamer-connections-store";
+import styles from "./streamer-connections.module.css";
+
+type CopyTarget = "idle" | "view" | "overlay";
+
+interface StreamerUrls {
+  readonly viewUrl: string;
+  readonly overlayUrl: string;
+}
+
+function buildStreamerUrls(xuid: string): StreamerUrls {
+  const origin = typeof window === "undefined" ? "" : window.location.origin;
+  return {
+    viewUrl: `${origin}/individual-tracker/${encodeURIComponent(xuid)}/view`,
+    overlayUrl: `${origin}/individual-tracker/${encodeURIComponent(xuid)}/overlay`,
+  };
+}
+
+function buildOverlayPreviewUrl(overlayUrl: string, previewMode: StreamerViewColorMode): string {
+  const url = new URL(overlayUrl, typeof window === "undefined" ? "http://localhost" : window.location.origin);
+  url.searchParams.set("preview", "1");
+  url.searchParams.set("previewMode", previewMode);
+  return url.toString();
+}
+
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface StreamerConnectionsSectionViewProps {
+  readonly xuid: string | null;
+  readonly defaultColorMode: StreamerViewColorMode;
+  readonly playerTeamColor: string;
+  readonly playerEnemyColor: string;
+  readonly observerTeamColor: string;
+  readonly observerEnemyColor: string;
+  readonly displaySettings: DisplaySettings;
+  readonly tickerSettings: TickerSettings;
+  readonly fontSizeSettings: FontSizeSettings;
+  readonly saveStatus: SaveStatus;
+  readonly saveErrorMessage: string | null;
+  readonly onDefaultColorModeChange: (mode: StreamerViewColorMode) => void;
+  readonly onPlayerColorsChange: (teamColor: string, enemyColor: string) => void;
+  readonly onObserverColorsChange: (teamColor: string, enemyColor: string) => void;
+  readonly onDisplaySettingsChange: (updates: Partial<DisplaySettings>) => void;
+  readonly onTickerSettingsChange: (updates: Partial<TickerSettings>) => void;
+  readonly onFontSizesChange: (updates: Partial<FontSizeSettings>) => void;
+}
+
+export function StreamerConnectionsSectionView({
+  xuid,
+  defaultColorMode,
+  playerTeamColor,
+  playerEnemyColor,
+  observerTeamColor,
+  observerEnemyColor,
+  displaySettings,
+  tickerSettings,
+  fontSizeSettings,
+  saveStatus,
+  saveErrorMessage,
+  onDefaultColorModeChange,
+  onPlayerColorsChange,
+  onObserverColorsChange,
+  onDisplaySettingsChange,
+  onTickerSettingsChange,
+  onFontSizesChange,
+}: StreamerConnectionsSectionViewProps): React.ReactElement {
+  const [copyTarget, setCopyTarget] = useState<CopyTarget>("idle");
+  const [showSaveToast, setShowSaveToast] = useState(false);
+  const prevSaveStatusRef = useRef<SaveStatus>("idle");
+
+  const urls = xuid !== null ? buildStreamerUrls(xuid) : null;
+  const selectedPlayerTeamColor = getTeamColorOrDefault(playerTeamColor, 0);
+  const selectedPlayerEnemyColor = getTeamColorOrDefault(playerEnemyColor, 1);
+  const selectedObserverTeamColor = getTeamColorOrDefault(observerTeamColor, 0);
+  const selectedObserverEnemyColor = getTeamColorOrDefault(observerEnemyColor, 1);
+  const isSaving = saveStatus === "saving";
+
+  useEffect(() => {
+    const prev = prevSaveStatusRef.current;
+    prevSaveStatusRef.current = saveStatus;
+
+    if (saveStatus === "saving") {
+      setShowSaveToast(true);
+      return;
+    }
+
+    if (saveStatus === "error") {
+      setShowSaveToast(true);
+      return;
+    }
+
+    if (prev === "saving" && saveStatus === "saved") {
+      setShowSaveToast(true);
+    }
+  }, [saveStatus]);
+
+  useEffect(() => {
+    if (!showSaveToast || saveStatus === "saving") {
+      return;
+    }
+    const timeout = setTimeout(() => {
+      setShowSaveToast(false);
+    }, 2200);
+    return (): void => {
+      clearTimeout(timeout);
+    };
+  }, [showSaveToast, saveStatus]);
+
+  const handleCopy = (target: "view" | "overlay", url: string): void => {
+    void copyToClipboard(url).then((ok) => {
+      if (!ok) {
+        return;
+      }
+      setCopyTarget(target);
+      setTimeout(() => {
+        setCopyTarget("idle");
+      }, 1500);
+    });
+  };
+
+  const handleOpenUrl = (url: string): void => {
+    if (typeof window !== "undefined") {
+      window.open(url, "_blank");
+    }
+  };
+
+  return (
+    <div className={styles.panel}>
+      <h2 className={styles.sectionTitle}>Streamer Settings</h2>
+      <p className={styles.sectionDescription}>
+        Configure the stable public URLs for your active tracker viewer and OBS overlay. These routes follow whichever
+        tracker is currently marked live.
+      </p>
+
+      {xuid === null ? (
+        <Alert variant="warning">
+          No active Xbox identity is linked. Link an Xbox account to generate shareable URLs.
+        </Alert>
+      ) : (
+        <div className={styles.urlList}>
+          <div className={styles.urlCard}>
+            <h3 className={styles.cardTitle}>Viewer URL</h3>
+            <p className={styles.cardDescription}>Share this with viewers to follow the active tracker.</p>
+            <p className={styles.urlText}>{urls?.viewUrl}</p>
+            <div className={styles.buttonRow}>
+              <Button
+                onClick={(): void => {
+                  handleOpenUrl(urls?.viewUrl ?? "");
+                }}
+              >
+                Open viewer
+              </Button>
+              <Button
+                onClick={(): void => {
+                  handleCopy("view", urls?.viewUrl ?? "");
+                }}
+              >
+                {copyTarget === "view" ? "Copied!" : "Copy"}
+              </Button>
+            </div>
+          </div>
+
+          <div className={styles.urlCard}>
+            <h3 className={styles.cardTitle}>Overlay URL</h3>
+            <p className={styles.cardDescription}>Use this in OBS as a Browser Source.</p>
+            <p className={styles.urlText}>{urls?.overlayUrl}</p>
+            <div className={styles.buttonRow}>
+              <Button
+                onClick={(): void => {
+                  handleOpenUrl(urls?.overlayUrl ?? "");
+                }}
+              >
+                Open overlay
+              </Button>
+              <Button
+                onClick={(): void => {
+                  handleOpenUrl(buildOverlayPreviewUrl(urls?.overlayUrl ?? "", defaultColorMode));
+                }}
+              >
+                Open overlay with preview
+              </Button>
+              <Button
+                onClick={(): void => {
+                  handleCopy("overlay", urls?.overlayUrl ?? "");
+                }}
+              >
+                {copyTarget === "overlay" ? "Copied!" : "Copy"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className={styles.preferencesCard}>
+        <h3 className={styles.cardTitle}>Presentation defaults</h3>
+        <p className={styles.cardDescription}>Configure the default color mode for the overlay.</p>
+        <div className={styles.modeRow}>
+          <Button
+            variant={defaultColorMode === "player" ? "primary" : "secondary"}
+            disabled={isSaving}
+            onClick={(): void => {
+              onDefaultColorModeChange("player");
+            }}
+          >
+            Player Mode
+          </Button>
+          <Button
+            variant={defaultColorMode === "observer" ? "primary" : "secondary"}
+            disabled={isSaving}
+            onClick={(): void => {
+              onDefaultColorModeChange("observer");
+            }}
+          >
+            Observer Mode
+          </Button>
+        </div>
+      </div>
+
+      <div className={styles.preferencesCard}>
+        <h3 className={styles.cardTitle}>Player View Colors</h3>
+        <p className={styles.cardDescription}>Used whenever color mode is set to player.</p>
+        <div className={styles.pickerGrid}>
+          <div>
+            <label className={styles.preferenceLabel}>Player team color</label>
+            <TeamColorPicker
+              label="Player team color"
+              selectedColor={selectedPlayerTeamColor}
+              onColorSelect={(colorId): void => {
+                onPlayerColorsChange(colorId, playerEnemyColor);
+              }}
+            />
+          </div>
+          <div>
+            <label className={styles.preferenceLabel}>Player enemy color</label>
+            <TeamColorPicker
+              label="Player enemy color"
+              selectedColor={selectedPlayerEnemyColor}
+              onColorSelect={(colorId): void => {
+                onPlayerColorsChange(playerTeamColor, colorId);
+              }}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.preferencesCard}>
+        <h3 className={styles.cardTitle}>Observer View Colors</h3>
+        <p className={styles.cardDescription}>Global observer colors for fixed-team mode.</p>
+        <div className={styles.pickerGrid}>
+          <div>
+            <label className={styles.preferenceLabel}>Eagle</label>
+            <TeamColorPicker
+              label="Eagle"
+              selectedColor={selectedObserverTeamColor}
+              onColorSelect={(colorId): void => {
+                onObserverColorsChange(colorId, observerEnemyColor);
+              }}
+            />
+          </div>
+          <div>
+            <label className={styles.preferenceLabel}>Cobra</label>
+            <TeamColorPicker
+              label="Cobra"
+              selectedColor={selectedObserverEnemyColor}
+              onColorSelect={(colorId): void => {
+                onObserverColorsChange(observerTeamColor, colorId);
+              }}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.preferencesCard}>
+        <h3 className={styles.cardTitle}>Display Options</h3>
+        <p className={styles.cardDescription}>Control what information is shown on the viewer and overlay.</p>
+        <DisplaySettingsSection settings={displaySettings} onChange={onDisplaySettingsChange} />
+      </div>
+
+      <div className={styles.preferencesCard}>
+        <h3 className={styles.cardTitle}>Information Ticker</h3>
+        <p className={styles.cardDescription}>
+          In the overlay at the bottom, the Information Ticker provides detailed insights at a glance.
+        </p>
+        <TickerSettingsSection settings={tickerSettings} onChange={onTickerSettingsChange} />
+      </div>
+
+      <div className={styles.preferencesCard}>
+        <h3 className={styles.cardTitle}>Text Sizes</h3>
+        <p className={styles.cardDescription}>Adjust the size of text for different sections.</p>
+        <div className={styles.fontSizeContainer}>
+          <FontSizeSlider
+            label="Queue Info"
+            value={fontSizeSettings.queueInfo}
+            onChange={(value): void => {
+              onFontSizesChange({ queueInfo: value });
+            }}
+          />
+          <FontSizeSlider
+            label="Score"
+            value={fontSizeSettings.score}
+            onChange={(value): void => {
+              onFontSizesChange({ score: value });
+            }}
+          />
+          <FontSizeSlider
+            label="Teams"
+            value={fontSizeSettings.teams}
+            onChange={(value): void => {
+              onFontSizesChange({ teams: value });
+            }}
+          />
+          <FontSizeSlider
+            label="Tabs"
+            value={fontSizeSettings.tabs}
+            onChange={(value): void => {
+              onFontSizesChange({ tabs: value });
+            }}
+          />
+          <FontSizeSlider
+            label="Info Ticker"
+            value={fontSizeSettings.ticker}
+            onChange={(value): void => {
+              onFontSizesChange({ ticker: value });
+            }}
+          />
+        </div>
+      </div>
+
+      {showSaveToast ? (
+        <div className={styles.floatingSaveToast} role="status" aria-live="polite">
+          {saveStatus === "saving" ? (
+            <Alert variant="info">Saving streamer settings...</Alert>
+          ) : saveStatus === "error" ? (
+            <Alert variant="error">{saveErrorMessage ?? "Failed to save settings"}</Alert>
+          ) : (
+            <Alert variant="info">Streamer settings saved.</Alert>
+          )}
+        </div>
+      ) : null}
+
+      <Alert variant="info">Twitch automation and advanced overlay presets remain in the next Phase 4 slice.</Alert>
+    </div>
+  );
+}

--- a/pages/src/components/individual-tracker-manager/streamer-connections/tests/streamer-connections-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/tests/streamer-connections-presenter.test.ts
@@ -263,6 +263,17 @@ describe("StreamerConnectionsPresenter", () => {
       const [[saved]] = updateSpy.mock.calls;
       expect(saved.visibleSections?.topBarStatSlots).toEqual(["kills", "deaths"]);
     });
+
+    it("preserves topBarStatSlots in the store snapshot after save response is applied", async () => {
+      const { store, presenter } = aHarness();
+
+      presenter.loadSettings({ visibleSections: { topBarStatSlots: ["kills", "deaths"] } }, null);
+      presenter.setDefaultColorMode("observer");
+
+      await vi.runAllTimersAsync();
+
+      expect(store.getSnapshot().topBarStatSlots).toEqual(["kills", "deaths"]);
+    });
   });
 
   describe("debounced save", () => {

--- a/pages/src/components/individual-tracker-manager/streamer-connections/tests/streamer-connections-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/tests/streamer-connections-presenter.test.ts
@@ -97,6 +97,14 @@ describe("StreamerConnectionsPresenter", () => {
       expect(store.getSnapshot().gamertag).toBe("gamertag-123");
     });
 
+    it("applies topBarStatSlots from visible sections to the store", () => {
+      const { store, presenter } = aHarness();
+
+      presenter.loadSettings({ visibleSections: { topBarStatSlots: ["kills", "deaths"] } }, null);
+
+      expect(store.getSnapshot().topBarStatSlots).toEqual(["kills", "deaths"]);
+    });
+
     it("does nothing when disposed", () => {
       const { store, presenter } = aHarness();
 
@@ -105,6 +113,16 @@ describe("StreamerConnectionsPresenter", () => {
 
       expect(store.getSnapshot().defaultColorMode).toBe("player");
       expect(store.getSnapshot().gamertag).toBeNull();
+    });
+
+    it("skips settings reload but updates gamertag when a debounce is pending", () => {
+      const { store, presenter } = aHarness();
+
+      presenter.setDefaultColorMode("observer");
+      presenter.loadSettings({ styleFlags: { colorMode: "player" } }, "gamertag-456");
+
+      expect(store.getSnapshot().defaultColorMode).toBe("observer");
+      expect(store.getSnapshot().gamertag).toBe("gamertag-456");
     });
   });
 
@@ -220,6 +238,24 @@ describe("StreamerConnectionsPresenter", () => {
       const [[saved]] = updateSpy.mock.calls;
       expect(saved.layoutOptions?.fontSizes?.queueInfo).toBe(120);
       expect(saved.layoutOptions?.fontSizes?.score).toBe(100);
+    });
+  });
+
+  describe("snapshotToSettings round-trip", () => {
+    it("preserves topBarStatSlots in the save payload", async () => {
+      const { presenter, settingsService } = aHarness();
+      const updateSpy: MockInstance<typeof settingsService.updateSettings> = vi.spyOn(
+        settingsService,
+        "updateSettings",
+      );
+
+      presenter.loadSettings({ visibleSections: { topBarStatSlots: ["kills", "deaths"] } }, null);
+      presenter.setDefaultColorMode("observer");
+
+      await vi.runAllTimersAsync();
+
+      const [[saved]] = updateSpy.mock.calls;
+      expect(saved.visibleSections?.topBarStatSlots).toEqual(["kills", "deaths"]);
     });
   });
 

--- a/pages/src/components/individual-tracker-manager/streamer-connections/tests/streamer-connections-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/tests/streamer-connections-presenter.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { aFakeIndividualTrackerSettingsServiceWith } from "../../../../services/individual-tracker/fakes/settings.fake";
+import type { FakeIndividualTrackerSettingsService } from "../../../../services/individual-tracker/fakes/settings.fake";
+import { StreamerConnectionsPresenter } from "../streamer-connections-presenter";
+import { StreamerConnectionsStore } from "../streamer-connections-store";
+
+interface Harness {
+  readonly store: StreamerConnectionsStore;
+  readonly presenter: StreamerConnectionsPresenter;
+  readonly settingsService: FakeIndividualTrackerSettingsService;
+}
+
+function aHarness(settingsService?: FakeIndividualTrackerSettingsService): Harness {
+  const service = settingsService ?? aFakeIndividualTrackerSettingsServiceWith();
+  const store = new StreamerConnectionsStore();
+  const presenter = new StreamerConnectionsPresenter({ settingsService: service, store });
+  return { store, presenter, settingsService: service };
+}
+
+describe("StreamerConnectionsPresenter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("loadSettings", () => {
+    it("applies colorMode from streamer view settings to the store", () => {
+      const { store, presenter } = aHarness();
+
+      presenter.loadSettings({ styleFlags: { colorMode: "observer" } }, null);
+
+      expect(store.getSnapshot().defaultColorMode).toBe("observer");
+    });
+
+    it("applies player colors from style flags to the store", () => {
+      const { store, presenter } = aHarness();
+
+      presenter.loadSettings({ styleFlags: { playerTeamColor: "red", playerEnemyColor: "blue" } }, null);
+
+      expect(store.getSnapshot().playerTeamColor).toBe("red");
+      expect(store.getSnapshot().playerEnemyColor).toBe("blue");
+    });
+
+    it("applies observer colors from style flags to the store", () => {
+      const { store, presenter } = aHarness();
+
+      presenter.loadSettings({ styleFlags: { observerTeamColor: "green", observerEnemyColor: "orange" } }, null);
+
+      expect(store.getSnapshot().observerTeamColor).toBe("green");
+      expect(store.getSnapshot().observerEnemyColor).toBe("orange");
+    });
+
+    it("applies font sizes from layout options to the store", () => {
+      const { store, presenter } = aHarness();
+
+      presenter.loadSettings({ layoutOptions: { fontSizes: { queueInfo: 120, score: 80 } } }, null);
+
+      expect(store.getSnapshot().fontSizeSettings.queueInfo).toBe(120);
+      expect(store.getSnapshot().fontSizeSettings.score).toBe(80);
+    });
+
+    it("applies display settings from visible sections to the store", () => {
+      const { store, presenter } = aHarness();
+
+      presenter.loadSettings({ visibleSections: { showTeamDetails: true, showScore: false } }, null);
+
+      expect(store.getSnapshot().displaySettings.showTeamDetails).toBe(true);
+      expect(store.getSnapshot().displaySettings.showScore).toBe(false);
+    });
+
+    it("applies ticker settings from visible sections and style flags to the store", () => {
+      const { store, presenter } = aHarness();
+
+      presenter.loadSettings(
+        {
+          visibleSections: { showTicker: false, showTabs: false },
+          styleFlags: { showPreSeriesInfo: false },
+        },
+        null,
+      );
+
+      expect(store.getSnapshot().tickerSettings.showTicker).toBe(false);
+      expect(store.getSnapshot().tickerSettings.showTabs).toBe(false);
+      expect(store.getSnapshot().tickerSettings.showPreSeriesInfo).toBe(false);
+    });
+
+    it("sets the xuid on the store", () => {
+      const { store, presenter } = aHarness();
+
+      presenter.loadSettings({}, "xuid-123");
+
+      expect(store.getSnapshot().xuid).toBe("xuid-123");
+    });
+
+    it("does nothing when disposed", () => {
+      const { store, presenter } = aHarness();
+
+      presenter.dispose();
+      presenter.loadSettings({ styleFlags: { colorMode: "observer" } }, "xuid-123");
+
+      expect(store.getSnapshot().defaultColorMode).toBe("player");
+      expect(store.getSnapshot().xuid).toBeNull();
+    });
+  });
+
+  describe("setDefaultColorMode", () => {
+    it("updates the color mode in the store and schedules a debounced save", async () => {
+      const { store, presenter, settingsService } = aHarness();
+      const updateSpy: MockInstance<typeof settingsService.updateSettings> = vi.spyOn(
+        settingsService,
+        "updateSettings",
+      );
+
+      presenter.setDefaultColorMode("observer");
+
+      expect(store.getSnapshot().defaultColorMode).toBe("observer");
+      expect(updateSpy).not.toHaveBeenCalled();
+
+      await vi.runAllTimersAsync();
+
+      expect(updateSpy).toHaveBeenCalledOnce();
+      const [[saved]] = updateSpy.mock.calls;
+      expect(saved.styleFlags?.colorMode).toBe("observer");
+    });
+
+    it("does nothing when disposed", () => {
+      const { store, presenter } = aHarness();
+
+      presenter.dispose();
+      presenter.setDefaultColorMode("observer");
+
+      expect(store.getSnapshot().defaultColorMode).toBe("player");
+    });
+  });
+
+  describe("setPlayerColors", () => {
+    it("updates player colors in the store and schedules a debounced save", async () => {
+      const { store, presenter, settingsService } = aHarness();
+      const updateSpy: MockInstance<typeof settingsService.updateSettings> = vi.spyOn(
+        settingsService,
+        "updateSettings",
+      );
+
+      presenter.setPlayerColors("red", "blue");
+
+      expect(store.getSnapshot().playerTeamColor).toBe("red");
+      expect(store.getSnapshot().playerEnemyColor).toBe("blue");
+
+      await vi.runAllTimersAsync();
+
+      const [[saved]] = updateSpy.mock.calls;
+      expect(saved.styleFlags?.playerTeamColor).toBe("red");
+      expect(saved.styleFlags?.playerEnemyColor).toBe("blue");
+    });
+  });
+
+  describe("setObserverColors", () => {
+    it("updates observer colors in the store and schedules a debounced save", async () => {
+      const { store, presenter, settingsService } = aHarness();
+      const updateSpy: MockInstance<typeof settingsService.updateSettings> = vi.spyOn(
+        settingsService,
+        "updateSettings",
+      );
+
+      presenter.setObserverColors("green", "orange");
+
+      expect(store.getSnapshot().observerTeamColor).toBe("green");
+      expect(store.getSnapshot().observerEnemyColor).toBe("orange");
+
+      await vi.runAllTimersAsync();
+
+      const [[saved]] = updateSpy.mock.calls;
+      expect(saved.styleFlags?.observerTeamColor).toBe("green");
+      expect(saved.styleFlags?.observerEnemyColor).toBe("orange");
+    });
+  });
+
+  describe("setDisplaySettings", () => {
+    it("merges partial display settings and schedules a save", () => {
+      const { store, presenter } = aHarness();
+
+      presenter.setDisplaySettings({ showTeamDetails: true });
+
+      expect(store.getSnapshot().displaySettings.showTeamDetails).toBe(true);
+      expect(store.getSnapshot().displaySettings.showScore).toBe(true);
+    });
+  });
+
+  describe("setTickerSettings", () => {
+    it("merges partial ticker settings and schedules a save", () => {
+      const { store, presenter } = aHarness();
+
+      presenter.setTickerSettings({ showTicker: false });
+
+      expect(store.getSnapshot().tickerSettings.showTicker).toBe(false);
+      expect(store.getSnapshot().tickerSettings.showTabs).toBe(true);
+    });
+  });
+
+  describe("setFontSizes", () => {
+    it("merges partial font size settings and schedules a save", async () => {
+      const { store, presenter, settingsService } = aHarness();
+      const updateSpy: MockInstance<typeof settingsService.updateSettings> = vi.spyOn(
+        settingsService,
+        "updateSettings",
+      );
+
+      presenter.setFontSizes({ queueInfo: 120 });
+
+      expect(store.getSnapshot().fontSizeSettings.queueInfo).toBe(120);
+      expect(store.getSnapshot().fontSizeSettings.score).toBe(100);
+
+      await vi.runAllTimersAsync();
+
+      const [[saved]] = updateSpy.mock.calls;
+      expect(saved.layoutOptions?.fontSizes?.queueInfo).toBe(120);
+      expect(saved.layoutOptions?.fontSizes?.score).toBe(100);
+    });
+  });
+
+  describe("debounced save", () => {
+    it("coalesces multiple rapid changes into a single save call", async () => {
+      const { presenter, settingsService } = aHarness();
+      const updateSpy: MockInstance = vi.spyOn(settingsService, "updateSettings");
+
+      presenter.setDefaultColorMode("observer");
+      presenter.setPlayerColors("red", "blue");
+      presenter.setObserverColors("green", "orange");
+
+      await vi.runAllTimersAsync();
+
+      expect(updateSpy).toHaveBeenCalledOnce();
+    });
+
+    it("sets saveStatus to saving then saved on success", async () => {
+      const { store, presenter } = aHarness();
+
+      presenter.setDefaultColorMode("observer");
+
+      expect(store.getSnapshot().saveStatus).toBe("idle");
+
+      vi.advanceTimersByTime(450);
+      expect(store.getSnapshot().saveStatus).toBe("saving");
+
+      await vi.runAllTimersAsync();
+
+      expect(store.getSnapshot().saveStatus).toBe("saved");
+      expect(store.getSnapshot().saveErrorMessage).toBeNull();
+    });
+
+    it("sets saveStatus to error when the save fails", async () => {
+      const settingsService = aFakeIndividualTrackerSettingsServiceWith();
+      vi.spyOn(settingsService, "updateSettings").mockRejectedValue(new Error("Network error"));
+      const { store, presenter } = aHarness(settingsService);
+
+      presenter.setDefaultColorMode("observer");
+
+      await vi.runAllTimersAsync();
+
+      expect(store.getSnapshot().saveStatus).toBe("error");
+      expect(store.getSnapshot().saveErrorMessage).toBe("Network error");
+    });
+
+    it("does not call setSaved after dispose when a save is in flight", async () => {
+      const { store, presenter } = aHarness();
+
+      presenter.setDefaultColorMode("observer");
+      vi.advanceTimersByTime(450);
+      expect(store.getSnapshot().saveStatus).toBe("saving");
+
+      presenter.dispose();
+      await vi.runAllTimersAsync();
+
+      expect(store.getSnapshot().saveStatus).toBe("saving");
+    });
+
+    it("cancels the pending debounce timer on dispose", () => {
+      const { settingsService, presenter } = aHarness();
+      const updateSpy: MockInstance = vi.spyOn(settingsService, "updateSettings");
+
+      presenter.setDefaultColorMode("observer");
+      presenter.dispose();
+
+      vi.advanceTimersByTime(1000);
+
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/pages/src/components/individual-tracker-manager/streamer-connections/tests/streamer-connections-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/tests/streamer-connections-presenter.test.ts
@@ -119,9 +119,15 @@ describe("StreamerConnectionsPresenter", () => {
       const { store, presenter } = aHarness();
 
       presenter.setDefaultColorMode("observer");
-      presenter.loadSettings({ styleFlags: { colorMode: "player" } }, "gamertag-456");
+      presenter.setPlayerColors("red", "blue");
+      presenter.loadSettings(
+        { styleFlags: { colorMode: "player", playerTeamColor: "purple", playerEnemyColor: "yellow" } },
+        "gamertag-456",
+      );
 
       expect(store.getSnapshot().defaultColorMode).toBe("observer");
+      expect(store.getSnapshot().playerTeamColor).toBe("red");
+      expect(store.getSnapshot().playerEnemyColor).toBe("blue");
       expect(store.getSnapshot().gamertag).toBe("gamertag-456");
     });
   });

--- a/pages/src/components/individual-tracker-manager/streamer-connections/tests/streamer-connections-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/tests/streamer-connections-presenter.test.ts
@@ -89,22 +89,22 @@ describe("StreamerConnectionsPresenter", () => {
       expect(store.getSnapshot().tickerSettings.showPreSeriesInfo).toBe(false);
     });
 
-    it("sets the xuid on the store", () => {
+    it("sets the gamertag on the store", () => {
       const { store, presenter } = aHarness();
 
-      presenter.loadSettings({}, "xuid-123");
+      presenter.loadSettings({}, "gamertag-123");
 
-      expect(store.getSnapshot().xuid).toBe("xuid-123");
+      expect(store.getSnapshot().gamertag).toBe("gamertag-123");
     });
 
     it("does nothing when disposed", () => {
       const { store, presenter } = aHarness();
 
       presenter.dispose();
-      presenter.loadSettings({ styleFlags: { colorMode: "observer" } }, "xuid-123");
+      presenter.loadSettings({ styleFlags: { colorMode: "observer" } }, "gamertag-123");
 
       expect(store.getSnapshot().defaultColorMode).toBe("player");
-      expect(store.getSnapshot().xuid).toBeNull();
+      expect(store.getSnapshot().gamertag).toBeNull();
     });
   });
 

--- a/pages/src/components/individual-tracker-manager/streamer-connections/tests/streamer-connections.test.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/tests/streamer-connections.test.tsx
@@ -57,7 +57,7 @@ const DEFAULT_FONT_SIZE_SETTINGS: FontSizeSettings = {
 
 function aFakeProps(overrides?: Partial<StreamerConnectionsSectionViewProps>): StreamerConnectionsSectionViewProps {
   return {
-    xuid: "xuid-123",
+    gamertag: "gamertag-123",
     defaultColorMode: "player",
     playerTeamColor: "cerulean",
     playerEnemyColor: "salmon",
@@ -85,18 +85,18 @@ describe("StreamerConnectionsSectionView", () => {
   });
 
   describe("URL panel", () => {
-    it("renders the viewer and overlay URLs when xuid is provided", () => {
+    it("renders the viewer and overlay URLs when gamertag is provided", () => {
       vi.stubGlobal("location", { origin: "https://example.com" });
-      render(<StreamerConnectionsSectionView {...aFakeProps({ xuid: "xuid-abc" })} />);
+      render(<StreamerConnectionsSectionView {...aFakeProps({ gamertag: "gamertag-abc" })} />);
 
-      expect(screen.getByText(/xuid-abc\/view/)).toBeInTheDocument();
-      expect(screen.getByText(/xuid-abc\/overlay/)).toBeInTheDocument();
+      expect(screen.getByText(/\/u\/gamertag-abc\/view/)).toBeInTheDocument();
+      expect(screen.getByText(/\/u\/gamertag-abc\/overlay/)).toBeInTheDocument();
 
       vi.unstubAllGlobals();
     });
 
-    it("renders a warning alert when xuid is null", () => {
-      render(<StreamerConnectionsSectionView {...aFakeProps({ xuid: null })} />);
+    it("renders a warning alert when gamertag is null", () => {
+      render(<StreamerConnectionsSectionView {...aFakeProps({ gamertag: null })} />);
 
       expect(screen.getByText(/No active Xbox identity is linked/)).toBeInTheDocument();
     });
@@ -107,12 +107,12 @@ describe("StreamerConnectionsSectionView", () => {
       vi.stubGlobal("navigator", { clipboard: { writeText } });
       vi.stubGlobal("location", { origin: "https://example.com" });
 
-      render(<StreamerConnectionsSectionView {...aFakeProps({ xuid: "xuid-abc" })} />);
+      render(<StreamerConnectionsSectionView {...aFakeProps({ gamertag: "gamertag-abc" })} />);
 
       const copyButtons = screen.getAllByRole("button", { name: "Copy" });
       await user.click(copyButtons[0]);
 
-      expect(writeText).toHaveBeenCalledWith(expect.stringContaining("xuid-abc/view"));
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining("/u/gamertag-abc/view"));
 
       vi.unstubAllGlobals();
     });
@@ -125,7 +125,7 @@ describe("StreamerConnectionsSectionView", () => {
       });
       vi.stubGlobal("location", { origin: "https://example.com" });
 
-      render(<StreamerConnectionsSectionView {...aFakeProps({ xuid: "xuid-abc" })} />);
+      render(<StreamerConnectionsSectionView {...aFakeProps({ gamertag: "gamertag-abc" })} />);
 
       const copyButtons = screen.getAllByRole("button", { name: "Copy" });
       await user.click(copyButtons[0]);

--- a/pages/src/components/individual-tracker-manager/streamer-connections/tests/streamer-connections.test.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/tests/streamer-connections.test.tsx
@@ -1,0 +1,252 @@
+import "@testing-library/jest-dom/vitest";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import type { DisplaySettings, FontSizeSettings, TickerSettings } from "../../../live-tracker/settings/types";
+import type { StreamerConnectionsSectionViewProps } from "../streamer-connections";
+import { StreamerConnectionsSectionView } from "../streamer-connections";
+
+vi.mock("../../../team-colors/team-color-picker", () => ({
+  TeamColorPicker: ({ label }: { readonly label: string }): React.ReactElement => (
+    <div data-testid={`color-picker-${label}`} />
+  ),
+}));
+
+vi.mock("../../../live-tracker/settings/display-settings-section", () => ({
+  DisplaySettingsSection: (): React.ReactElement => <div data-testid="display-settings-section" />,
+}));
+
+vi.mock("../../../live-tracker/settings/ticker-settings-section", () => ({
+  TickerSettingsSection: (): React.ReactElement => <div data-testid="ticker-settings-section" />,
+}));
+
+vi.mock("../../../live-tracker/settings/font-size-slider", () => ({
+  FontSizeSlider: ({ label }: { readonly label: string }): React.ReactElement => (
+    <div data-testid={`font-size-slider-${label}`} />
+  ),
+}));
+
+const DEFAULT_DISPLAY_SETTINGS: DisplaySettings = {
+  showTeamDetails: false,
+  showDiscordNames: true,
+  showXboxNames: true,
+  showServerIcon: true,
+  showTitle: true,
+  showSubtitle: true,
+  showScore: true,
+};
+
+const DEFAULT_TICKER_SETTINGS: TickerSettings = {
+  showTicker: true,
+  showTabs: true,
+  showPreSeriesInfo: true,
+  selectedSlayerStats: [],
+  showObjectiveStats: false,
+  medalRarityFilter: [],
+};
+
+const DEFAULT_FONT_SIZE_SETTINGS: FontSizeSettings = {
+  queueInfo: 100,
+  score: 100,
+  teams: 100,
+  tabs: 100,
+  ticker: 100,
+};
+
+function aFakeProps(overrides?: Partial<StreamerConnectionsSectionViewProps>): StreamerConnectionsSectionViewProps {
+  return {
+    xuid: "xuid-123",
+    defaultColorMode: "player",
+    playerTeamColor: "cerulean",
+    playerEnemyColor: "salmon",
+    observerTeamColor: "salmon",
+    observerEnemyColor: "cerulean",
+    displaySettings: DEFAULT_DISPLAY_SETTINGS,
+    tickerSettings: DEFAULT_TICKER_SETTINGS,
+    fontSizeSettings: DEFAULT_FONT_SIZE_SETTINGS,
+    saveStatus: "idle",
+    saveErrorMessage: null,
+    onDefaultColorModeChange: (): void => undefined,
+    onPlayerColorsChange: (): void => undefined,
+    onObserverColorsChange: (): void => undefined,
+    onDisplaySettingsChange: (): void => undefined,
+    onTickerSettingsChange: (): void => undefined,
+    onFontSizesChange: (): void => undefined,
+    ...overrides,
+  };
+}
+
+describe("StreamerConnectionsSectionView", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("URL panel", () => {
+    it("renders the viewer and overlay URLs when xuid is provided", () => {
+      vi.stubGlobal("location", { origin: "https://example.com" });
+      render(<StreamerConnectionsSectionView {...aFakeProps({ xuid: "xuid-abc" })} />);
+
+      expect(screen.getByText(/xuid-abc\/view/)).toBeInTheDocument();
+      expect(screen.getByText(/xuid-abc\/overlay/)).toBeInTheDocument();
+
+      vi.unstubAllGlobals();
+    });
+
+    it("renders a warning alert when xuid is null", () => {
+      render(<StreamerConnectionsSectionView {...aFakeProps({ xuid: null })} />);
+
+      expect(screen.getByText(/No active Xbox identity is linked/)).toBeInTheDocument();
+    });
+
+    it("calls the clipboard API when the view copy button is clicked", async () => {
+      const user = userEvent.setup();
+      const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+      vi.stubGlobal("navigator", { clipboard: { writeText } });
+      vi.stubGlobal("location", { origin: "https://example.com" });
+
+      render(<StreamerConnectionsSectionView {...aFakeProps({ xuid: "xuid-abc" })} />);
+
+      const copyButtons = screen.getAllByRole("button", { name: "Copy" });
+      await user.click(copyButtons[0]);
+
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining("xuid-abc/view"));
+
+      vi.unstubAllGlobals();
+    });
+
+    it("shows Copied! on the view button after a successful copy", async () => {
+      const user = userEvent.setup({ delay: null });
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.stubGlobal("navigator", {
+        clipboard: { writeText: vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined) },
+      });
+      vi.stubGlobal("location", { origin: "https://example.com" });
+
+      render(<StreamerConnectionsSectionView {...aFakeProps({ xuid: "xuid-abc" })} />);
+
+      const copyButtons = screen.getAllByRole("button", { name: "Copy" });
+      await user.click(copyButtons[0]);
+
+      expect(screen.getByRole("button", { name: "Copied!" })).toBeInTheDocument();
+
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    });
+  });
+
+  describe("presentation defaults", () => {
+    it("highlights the active color mode button", () => {
+      render(<StreamerConnectionsSectionView {...aFakeProps({ defaultColorMode: "observer" })} />);
+
+      const observerBtn = screen.getByRole("button", { name: "Observer Mode" });
+      expect(observerBtn).toBeInTheDocument();
+    });
+
+    it("calls onDefaultColorModeChange when Player Mode is clicked", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn<(mode: "player" | "observer") => void>();
+
+      render(
+        <StreamerConnectionsSectionView
+          {...aFakeProps({ defaultColorMode: "observer", onDefaultColorModeChange: onChange })}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Player Mode" }));
+
+      expect(onChange).toHaveBeenCalledWith("player");
+    });
+
+    it("calls onDefaultColorModeChange when Observer Mode is clicked", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn<(mode: "player" | "observer") => void>();
+
+      render(
+        <StreamerConnectionsSectionView
+          {...aFakeProps({ defaultColorMode: "player", onDefaultColorModeChange: onChange })}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Observer Mode" }));
+
+      expect(onChange).toHaveBeenCalledWith("observer");
+    });
+
+    it("disables mode buttons while saving", () => {
+      render(<StreamerConnectionsSectionView {...aFakeProps({ saveStatus: "saving" })} />);
+
+      expect(screen.getByRole("button", { name: "Player Mode" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Observer Mode" })).toBeDisabled();
+    });
+  });
+
+  describe("save toast", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("shows a saving message when saveStatus is saving", () => {
+      render(<StreamerConnectionsSectionView {...aFakeProps({ saveStatus: "saving" })} />);
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.getByText("Saving streamer settings...")).toBeInTheDocument();
+    });
+
+    it("shows an error message when saveStatus is error", () => {
+      render(
+        <StreamerConnectionsSectionView
+          {...aFakeProps({ saveStatus: "error", saveErrorMessage: "Network failure" })}
+        />,
+      );
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.getByText("Network failure")).toBeInTheDocument();
+    });
+
+    it("does not show the toast when saveStatus is idle", () => {
+      render(<StreamerConnectionsSectionView {...aFakeProps({ saveStatus: "idle" })} />);
+
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+  });
+
+  describe("sub-sections", () => {
+    it("renders the display settings section", () => {
+      render(<StreamerConnectionsSectionView {...aFakeProps()} />);
+
+      expect(screen.getByTestId("display-settings-section")).toBeInTheDocument();
+    });
+
+    it("renders the ticker settings section", () => {
+      render(<StreamerConnectionsSectionView {...aFakeProps()} />);
+
+      expect(screen.getByTestId("ticker-settings-section")).toBeInTheDocument();
+    });
+
+    it("renders font size sliders for all sections", () => {
+      render(<StreamerConnectionsSectionView {...aFakeProps()} />);
+
+      expect(screen.getByTestId("font-size-slider-Queue Info")).toBeInTheDocument();
+      expect(screen.getByTestId("font-size-slider-Score")).toBeInTheDocument();
+      expect(screen.getByTestId("font-size-slider-Teams")).toBeInTheDocument();
+      expect(screen.getByTestId("font-size-slider-Tabs")).toBeInTheDocument();
+      expect(screen.getByTestId("font-size-slider-Info Ticker")).toBeInTheDocument();
+    });
+
+    it("renders color pickers for player and observer views", () => {
+      render(<StreamerConnectionsSectionView {...aFakeProps()} />);
+
+      expect(screen.getByTestId("color-picker-Player team color")).toBeInTheDocument();
+      expect(screen.getByTestId("color-picker-Player enemy color")).toBeInTheDocument();
+      expect(screen.getByTestId("color-picker-Eagle")).toBeInTheDocument();
+      expect(screen.getByTestId("color-picker-Cobra")).toBeInTheDocument();
+    });
+  });
+});

--- a/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-context.test.tsx
+++ b/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-context.test.tsx
@@ -25,7 +25,7 @@ function aFakeViewModelWith(overrides?: Partial<IndividualTrackerManagerViewMode
     pendingTrackerId: null,
     addDisabled: true,
     settings: {},
-    liveXuid: null,
+    liveGamertag: null,
     ...overrides,
   };
 }

--- a/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-context.test.tsx
+++ b/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-context.test.tsx
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { aFakeTrackerWith } from "../../../services/individual-tracker/fakes/individual-tracker.fake";
+import { aFakeIndividualTrackerSettingsServiceWith } from "../../../services/individual-tracker/fakes/settings.fake";
 import { toManagerModel } from "../manager-model";
 import type { IndividualTrackerManagerViewModel } from "../types";
 
@@ -26,6 +27,7 @@ function aFakeViewModelWith(overrides?: Partial<IndividualTrackerManagerViewMode
     settings: {},
     settingsSaving: false,
     settingsError: null,
+    liveXuid: null,
     ...overrides,
   };
 }
@@ -38,8 +40,9 @@ const noopActions = {
   onIdleTimeoutHoursChange: (): void => undefined,
   onAddTracker: (): void => undefined,
   onRowAction: (): void => undefined,
-  onUpdateSettings: (): void => undefined,
 };
+
+const fakeSettingsService = aFakeIndividualTrackerSettingsServiceWith();
 
 describe("IndividualTrackerManagerContext", () => {
   it("throws when the model hook is used outside the provider", () => {
@@ -53,7 +56,7 @@ describe("IndividualTrackerManagerContext", () => {
 
     const { result } = renderHook(() => useManagerModel(), {
       wrapper: ({ children }) => (
-        <IndividualTrackerManagerProvider model={model} actions={noopActions}>
+        <IndividualTrackerManagerProvider model={model} actions={noopActions} settingsService={fakeSettingsService}>
           {children}
         </IndividualTrackerManagerProvider>
       ),
@@ -73,6 +76,7 @@ describe("IndividualTrackerManagerContext", () => {
         <IndividualTrackerManagerProvider
           model={aFakeViewModelWith()}
           actions={{ ...noopActions, onAddTracker, onRowAction, onGamertagInputChange }}
+          settingsService={fakeSettingsService}
         >
           {children}
         </IndividualTrackerManagerProvider>

--- a/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-context.test.tsx
+++ b/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-context.test.tsx
@@ -25,8 +25,6 @@ function aFakeViewModelWith(overrides?: Partial<IndividualTrackerManagerViewMode
     pendingTrackerId: null,
     addDisabled: true,
     settings: {},
-    settingsSaving: false,
-    settingsError: null,
     liveXuid: null,
     ...overrides,
   };

--- a/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/tests/individual-tracker-manager-presenter.test.ts
@@ -393,68 +393,12 @@ describe("IndividualTrackerManagerPresenter.present", () => {
     expect(model.addDisabled).toBe(false);
   });
 
-  it("includes settings fields from the snapshot", () => {
+  it("includes settings from the snapshot", () => {
     const store = new IndividualTrackerManagerStore();
     store.setSettings({ styleFlags: { colorMode: "observer" } });
-    store.setSettingsSaving(true);
-    store.setSettingsError("Save failed");
 
     const model = IndividualTrackerManagerPresenter.present(store.getSnapshot());
 
     expect(model.settings).toStrictEqual({ styleFlags: { colorMode: "observer" } });
-    expect(model.settingsSaving).toBe(true);
-    expect(model.settingsError).toBe("Save failed");
-  });
-});
-
-describe("IndividualTrackerManagerPresenter updateSettings", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("sets settingsSaving to true, saves, then clears settingsSaving and updates settings", async () => {
-    const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
-    const { store, presenter } = aHarness(service);
-
-    presenter.updateSettings({ styleFlags: { colorMode: "observer" } });
-
-    expect(store.getSnapshot().settingsSaving).toBe(true);
-
-    await vi.waitFor(() => {
-      expect(store.getSnapshot().settingsSaving).toBe(false);
-    });
-
-    expect(store.getSnapshot().settings).toStrictEqual({ styleFlags: { colorMode: "observer" } });
-    expect(store.getSnapshot().settingsError).toBeNull();
-  });
-
-  it("sets settingsError when the save fails", async () => {
-    const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
-    const settingsService = aFakeIndividualTrackerSettingsServiceWith();
-    vi.spyOn(settingsService, "updateSettings").mockRejectedValue(new Error("Network error"));
-    const { store, presenter } = aHarness(service, settingsService);
-
-    presenter.updateSettings({ styleFlags: { colorMode: "player" } });
-
-    await vi.waitFor(() => {
-      expect(store.getSnapshot().settingsSaving).toBe(false);
-    });
-
-    expect(store.getSnapshot().settingsError).toBe("Network error");
-  });
-
-  it("ignores the result after dispose", async () => {
-    const service = aFakeIndividualTrackerServiceWith({ trackers: [] });
-    const { store, presenter } = aHarness(service);
-    const updateSpy = vi.spyOn(store, "setSettings");
-
-    presenter.updateSettings({ styleFlags: { colorMode: "observer" } });
-    presenter.dispose();
-
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(updateSpy).not.toHaveBeenCalled();
-    expect(store.getSnapshot().settings).toStrictEqual({});
   });
 });

--- a/pages/src/components/individual-tracker-manager/types.ts
+++ b/pages/src/components/individual-tracker-manager/types.ts
@@ -14,4 +14,5 @@ export interface IndividualTrackerManagerViewModel {
   readonly settings: StreamerViewSettings;
   readonly settingsSaving: boolean;
   readonly settingsError: string | null;
+  readonly liveXuid: string | null;
 }

--- a/pages/src/components/individual-tracker-manager/types.ts
+++ b/pages/src/components/individual-tracker-manager/types.ts
@@ -12,7 +12,5 @@ export interface IndividualTrackerManagerViewModel {
   readonly pendingTrackerId: string | null;
   readonly addDisabled: boolean;
   readonly settings: StreamerViewSettings;
-  readonly settingsSaving: boolean;
-  readonly settingsError: string | null;
   readonly liveXuid: string | null;
 }

--- a/pages/src/components/individual-tracker-manager/types.ts
+++ b/pages/src/components/individual-tracker-manager/types.ts
@@ -12,5 +12,5 @@ export interface IndividualTrackerManagerViewModel {
   readonly pendingTrackerId: string | null;
   readonly addDisabled: boolean;
   readonly settings: StreamerViewSettings;
-  readonly liveXuid: string | null;
+  readonly liveGamertag: string | null;
 }


### PR DESCRIPTION
## Summary

- Adds `StreamerConnectionsSectionView` — a new panel within the individual tracker manager that provides a **copy-to-clipboard overlay URL** and a full **colour + display settings editor** with debounced auto-save
- Integrates with the existing `IndividualTrackerSettingsService` via a dedicated `StreamerConnectionsPresenter` and `StreamerConnectionsStore`; the `StreamerConnectionsSection` component owns its own save lifecycle, so the manager presenter no longer duplicates it

## Code-review fixes (1 round, 3 issues)

1. **Save-clobbers-inflight-edits** — introduced a `saveGeneration` counter in the presenter; the save response is now ignored if a newer save has already been triggered or a debounce timer is pending, preventing stale server responses from overwriting in-flight user edits
2. **Dead `setSaveIdle()`** — removed from `StreamerConnectionsStore` (never called)
3. **Dead `updateSettings()` / `settingsSaving` / `settingsError`** in manager — removed the method, store fields, view-model fields, and corresponding tests from `IndividualTrackerManagerPresenter` / `IndividualTrackerManagerStore` / `types.ts` now that `StreamerConnectionsSection` owns saving

## Test plan

- [ ] All 2158 tests pass (`npm run done` clean)
- [ ] Manually open the individual tracker manager page and verify the URL copy button copies the correct overlay URL
- [ ] Change a colour setting and confirm it saves (status → saved) after the debounce fires
- [ ] Make two rapid changes and confirm only one network request is issued
- [ ] Disconnect / reconnect: verify the disconnected banner appears and disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)