### PR TITLE
feat(pages): TrackerList + TrackerSummary components (H2-2)

### DIFF
--- a/pages/src/components/individual-tracker-manager/tracker-list/tests/tracker-list.test.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-list/tests/tracker-list.test.tsx
@@ -1,0 +1,170 @@
+import "@testing-library/jest-dom/vitest";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { TrackerListItem, TrackerRowAction } from "../tracker-list";
+import { TrackerList } from "../tracker-list";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TrackerList", () => {
+  it("renders empty state when no items are present", () => {
+    render(<TrackerList items={[]} getActions={() => []} />);
+
+    expect(screen.getByText("No trackers yet. Start with your linked gamertag above.")).toBeInTheDocument();
+    expect(screen.getByText("How individual tracking works")).toBeInTheDocument();
+  });
+
+  it("renders tracker row with gamertag, status badge, and live badge", () => {
+    const item: TrackerListItem = {
+      trackerId: "tracker-1",
+      gamertag: "Chief",
+      status: "active",
+      isLive: true,
+      isPinned: false,
+    };
+
+    render(<TrackerList items={[item]} getActions={() => []} />);
+
+    expect(screen.getByText("Chief")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Live")).toBeInTheDocument();
+  });
+
+  it("renders paused status badge for a paused tracker", () => {
+    const item: TrackerListItem = {
+      trackerId: "tracker-2",
+      gamertag: "Arbiter",
+      status: "paused",
+      isLive: false,
+      isPinned: false,
+    };
+
+    render(<TrackerList items={[item]} getActions={() => []} />);
+
+    expect(screen.getByText("Paused")).toBeInTheDocument();
+    expect(screen.queryByText("Live")).not.toBeInTheDocument();
+  });
+
+  it("renders the pinned label when tracker is pinned", () => {
+    const item: TrackerListItem = {
+      trackerId: "tracker-3",
+      gamertag: "Noble Six",
+      status: "active",
+      isLive: false,
+      isPinned: true,
+    };
+
+    render(<TrackerList items={[item]} getActions={() => []} />);
+
+    expect(screen.getByText("(your account)")).toBeInTheDocument();
+  });
+
+  it("renders stopped status badge for a stopped tracker", () => {
+    const item: TrackerListItem = {
+      trackerId: "tracker-5",
+      gamertag: "Spartan",
+      status: "stopped",
+      isLive: false,
+      isPinned: false,
+    };
+
+    render(<TrackerList items={[item]} getActions={() => []} />);
+
+    expect(screen.getByText("Stopped")).toBeInTheDocument();
+  });
+
+  it("renders not-started status badge for a not-started tracker", () => {
+    const item: TrackerListItem = {
+      trackerId: "tracker-6",
+      gamertag: "Rookie",
+      status: "not-started",
+      isLive: false,
+      isPinned: false,
+    };
+
+    render(<TrackerList items={[item]} getActions={() => []} />);
+
+    expect(screen.getByText("Not started")).toBeInTheDocument();
+  });
+
+  it("does not render pinned label when tracker is not pinned", () => {
+    const item: TrackerListItem = {
+      trackerId: "tracker-4",
+      gamertag: "Buck",
+      status: "active",
+      isLive: false,
+      isPinned: false,
+    };
+
+    render(<TrackerList items={[item]} getActions={() => []} />);
+
+    expect(screen.queryByText("(your account)")).not.toBeInTheDocument();
+  });
+
+  it("renders a row per item", () => {
+    const items: readonly TrackerListItem[] = [
+      { trackerId: "t-1", gamertag: "Alpha", status: "active", isLive: true, isPinned: false },
+      { trackerId: "t-2", gamertag: "Bravo", status: "paused", isLive: false, isPinned: false },
+    ];
+
+    render(<TrackerList items={items} getActions={() => []} />);
+
+    const rows = screen.getAllByTestId("tracker-row");
+    expect(rows).toHaveLength(2);
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Bravo")).toBeInTheDocument();
+  });
+
+  it("calls getActions for each tracker item", () => {
+    const item: TrackerListItem = {
+      trackerId: "tracker-1",
+      gamertag: "Chief",
+      status: "active",
+      isLive: false,
+      isPinned: false,
+    };
+
+    const getActions = vi.fn<(item: TrackerListItem) => readonly TrackerRowAction[]>(() => []);
+
+    render(<TrackerList items={[item]} getActions={getActions} />);
+
+    expect(getActions).toHaveBeenCalledWith(item);
+    expect(getActions).toHaveBeenCalledOnce();
+  });
+
+  it("fires the action onClick when an action button is clicked", async () => {
+    const user = userEvent.setup();
+    const item: TrackerListItem = {
+      trackerId: "tracker-1",
+      gamertag: "Chief",
+      status: "active",
+      isLive: false,
+      isPinned: false,
+    };
+
+    const onClick = vi.fn<() => void>();
+    const getActions = (): readonly TrackerRowAction[] => [{ label: "Pause", onClick }];
+
+    render(<TrackerList items={[item]} getActions={getActions} />);
+
+    await user.click(screen.getByRole("button", { name: `Options for ${item.gamertag}` }));
+    await user.click(screen.getByRole("button", { name: "Pause" }));
+
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("calls onAddTracker when the add tracker button is clicked", async () => {
+    const user = userEvent.setup();
+    const onAddTracker = vi.fn<() => void>();
+
+    render(<TrackerList items={[]} onAddTracker={onAddTracker} getActions={() => []} />);
+
+    await user.click(screen.getByRole("button", { name: "Add tracker" }));
+
+    expect(onAddTracker).toHaveBeenCalledOnce();
+  });
+});

--- a/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.module.css
+++ b/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.module.css
@@ -1,0 +1,237 @@
+.listContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+/* ─── Header ─────────────────────────────────────────────────────────────── */
+
+.listHeader {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.listTitle {
+  color: var(--halo-white);
+  font-family: var(--font-heading);
+  font-size: var(--text-2xl);
+  margin: 0;
+}
+
+.addButton {
+  background: transparent;
+  border: 1px solid var(--halo-teal-primary);
+  border-radius: var(--radius-sm);
+  color: var(--halo-teal-primary);
+  cursor: pointer;
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  padding: var(--space-2) var(--space-3);
+  text-transform: uppercase;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.addButton:hover {
+  background: color-mix(in srgb, var(--halo-teal-primary) 14%, transparent);
+  color: var(--halo-white);
+}
+
+/* ─── List ───────────────────────────────────────────────────────────────── */
+
+.list {
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 25%, transparent);
+  border-radius: var(--radius-md);
+}
+
+.emptyList {
+  border: 1px dashed color-mix(in srgb, var(--halo-teal-primary) 30%, transparent);
+  border-radius: var(--radius-md);
+  padding: var(--space-5);
+  text-align: center;
+}
+
+/* ─── Row ────────────────────────────────────────────────────────────────── */
+
+.row {
+  align-items: center;
+  background: var(--halo-bg-secondary);
+  border-bottom: 1px solid color-mix(in srgb, var(--halo-teal-primary) 18%, transparent);
+  display: flex;
+  gap: var(--space-3);
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+}
+
+.row:last-child {
+  border-bottom: none;
+}
+
+.rowMain {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.rowGamertag {
+  color: var(--halo-white);
+  display: flex;
+  font-family: var(--font-heading);
+  font-size: var(--text-base);
+  gap: var(--space-2);
+}
+
+.pinnedLabel {
+  color: var(--halo-gray);
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: 400;
+}
+
+.rowBadges {
+  align-items: center;
+  display: flex;
+  gap: var(--space-2);
+}
+
+.rowActions {
+  flex-shrink: 0;
+}
+
+/* ─── Badges ─────────────────────────────────────────────────────────────── */
+
+.statusBadge {
+  border-radius: var(--radius-full);
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  padding: 2px var(--space-2);
+  text-transform: uppercase;
+}
+
+.statusActive {
+  background: color-mix(in srgb, var(--color-success) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-success) 50%, transparent);
+  color: var(--color-success);
+}
+
+.statusPaused {
+  background: color-mix(in srgb, var(--color-warning) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-warning) 50%, transparent);
+  color: var(--color-warning);
+}
+
+.statusStopped {
+  background: color-mix(in srgb, var(--halo-gray) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--halo-gray) 40%, transparent);
+  color: var(--halo-gray);
+}
+
+.liveBadge {
+  background: color-mix(in srgb, var(--halo-teal-primary) 20%, transparent);
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 60%, transparent);
+  border-radius: var(--radius-full);
+  color: var(--halo-teal-primary);
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  padding: 2px var(--space-2);
+  text-transform: uppercase;
+}
+
+/* ─── Ellipsis menu ──────────────────────────────────────────────────────── */
+
+.menuList {
+  display: flex;
+  flex-direction: column;
+}
+
+.menuItem {
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--halo-teal-primary) 18%, transparent);
+  color: var(--halo-teal-primary);
+  cursor: pointer;
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  min-height: 38px;
+  padding: var(--space-2) var(--space-4);
+  text-align: left;
+  text-transform: uppercase;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.menuItem:last-child {
+  border-bottom: 0;
+}
+
+.menuItem:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--halo-teal-primary) 14%, transparent);
+  color: var(--halo-white);
+}
+
+.menuItemDestructive {
+  color: var(--color-error);
+}
+
+.menuItemDestructive:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-error) 12%, transparent);
+  color: var(--halo-white);
+}
+
+.menuItemDisabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+/* ─── Info panel ─────────────────────────────────────────────────────────── */
+
+.emptyInfo {
+  background: color-mix(in srgb, var(--halo-teal-primary) 6%, transparent);
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 20%, transparent);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-5);
+}
+
+.emptyInfoTitle {
+  color: var(--halo-white);
+  font-family: var(--font-heading);
+  font-size: var(--text-lg);
+  margin: 0;
+}
+
+.emptyInfoText {
+  color: var(--halo-gray);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.emptyInfoList {
+  color: var(--halo-gray);
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  gap: var(--space-1);
+  line-height: 1.5;
+  margin: 0;
+  padding-left: var(--space-5);
+}

--- a/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.module.css
+++ b/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.module.css
@@ -4,8 +4,6 @@
   gap: var(--space-5);
 }
 
-/* ─── Header ─────────────────────────────────────────────────────────────── */
-
 .listHeader {
   align-items: center;
   display: flex;
@@ -41,8 +39,6 @@
   color: var(--halo-white);
 }
 
-/* ─── List ───────────────────────────────────────────────────────────────── */
-
 .list {
   border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 25%, transparent);
   border-radius: var(--radius-md);
@@ -54,8 +50,6 @@
   padding: var(--space-5);
   text-align: center;
 }
-
-/* ─── Row ────────────────────────────────────────────────────────────────── */
 
 .row {
   align-items: center;
@@ -105,8 +99,6 @@
   flex-shrink: 0;
 }
 
-/* ─── Badges ─────────────────────────────────────────────────────────────── */
-
 .statusBadge {
   border-radius: var(--radius-full);
   font-family: var(--font-heading);
@@ -147,8 +139,6 @@
   padding: 2px var(--space-2);
   text-transform: uppercase;
 }
-
-/* ─── Ellipsis menu ──────────────────────────────────────────────────────── */
 
 .menuList {
   display: flex;
@@ -196,8 +186,6 @@
   cursor: not-allowed;
   opacity: 0.4;
 }
-
-/* ─── Info panel ─────────────────────────────────────────────────────────── */
 
 .emptyInfo {
   background: color-mix(in srgb, var(--halo-teal-primary) 6%, transparent);

--- a/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.tsx
@@ -1,0 +1,178 @@
+import React from "react";
+import classNames from "classnames";
+import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import { Alert } from "../../alert/alert";
+import { Dropdown } from "../../dropdown/dropdown";
+import styles from "./tracker-list.module.css";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type TrackerDisplayStatus = "active" | "paused" | "stopped" | "not-started";
+
+export interface TrackerListItem {
+  readonly trackerId: string | null;
+  readonly gamertag: string;
+  readonly status: TrackerDisplayStatus;
+  readonly isLive: boolean;
+  readonly isPinned: boolean;
+}
+
+export interface TrackerRowAction {
+  readonly label: string;
+  readonly destructive?: boolean;
+  readonly disabled?: boolean;
+  readonly onClick: () => void;
+}
+
+interface TrackerRowProps {
+  readonly item: TrackerListItem;
+  readonly actions: readonly TrackerRowAction[];
+}
+
+interface TrackerListProps {
+  readonly items: readonly TrackerListItem[];
+  readonly onAddTracker?: () => void;
+  readonly getActions: (item: TrackerListItem) => readonly TrackerRowAction[];
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function statusLabel(status: TrackerDisplayStatus): string {
+  switch (status) {
+    case "active": {
+      return "Active";
+    }
+    case "paused": {
+      return "Paused";
+    }
+    case "stopped": {
+      return "Stopped";
+    }
+    case "not-started": {
+      return "Not started";
+    }
+    default: {
+      throw new UnreachableError(status);
+    }
+  }
+}
+
+function StatusBadge({ status }: { status: TrackerDisplayStatus }): React.ReactElement {
+  return (
+    <span
+      className={classNames(styles.statusBadge, {
+        [styles.statusActive]: status === "active",
+        [styles.statusPaused]: status === "paused",
+        [styles.statusStopped]: status === "stopped" || status === "not-started",
+      })}
+    >
+      {statusLabel(status)}
+    </span>
+  );
+}
+
+function LiveBadge(): React.ReactElement {
+  return <span className={styles.liveBadge}>Live</span>;
+}
+
+const EllipsisIcon = (): React.ReactElement => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <circle cx="3" cy="8" r="1.5" />
+    <circle cx="8" cy="8" r="1.5" />
+    <circle cx="13" cy="8" r="1.5" />
+  </svg>
+);
+
+function TrackerRow({ item, actions }: TrackerRowProps): React.ReactElement {
+  return (
+    <div className={styles.row} data-testid="tracker-row">
+      <div className={styles.rowMain}>
+        <span className={styles.rowGamertag}>
+          {item.gamertag}
+          {item.isPinned && <span className={styles.pinnedLabel}>(your account)</span>}
+        </span>
+
+        <div className={styles.rowBadges}>
+          <StatusBadge status={item.status} />
+          {item.isLive && <LiveBadge />}
+        </div>
+      </div>
+
+      <div className={styles.rowActions}>
+        <Dropdown
+          trigger={<EllipsisIcon />}
+          ariaLabel={`Options for ${item.gamertag}`}
+          dropdownWidth={200}
+          dropdownHeight={220}
+        >
+          <div className={styles.menuList}>
+            {actions.map((action) => (
+              <button
+                key={action.label}
+                type="button"
+                disabled={action.disabled === true}
+                className={classNames(styles.menuItem, {
+                  [styles.menuItemDestructive]: action.destructive === true,
+                  [styles.menuItemDisabled]: action.disabled === true,
+                })}
+                onClick={action.onClick}
+              >
+                {action.label}
+              </button>
+            ))}
+          </div>
+        </Dropdown>
+      </div>
+    </div>
+  );
+}
+
+function EmptyInfoPanel(): React.ReactElement {
+  return (
+    <div className={styles.emptyInfo}>
+      <h3 className={styles.emptyInfoTitle}>How individual tracking works</h3>
+      <p className={styles.emptyInfoText}>
+        Your live tracker monitors your Halo Infinite match history in real time. Once started, it polls for new matches
+        and displays them on your streamer overlay — without requiring your browser to stay open.
+      </p>
+      <ul className={styles.emptyInfoList}>
+        <li>Start a tracker for your linked gamertag or any other player.</li>
+        <li>Optionally pre-load recent matches to include in the overlay.</li>
+        <li>Use the streamer overlay URL with your broadcasting software.</li>
+        <li>Control the tracker from this page — pause, resume, or stop at any time.</li>
+      </ul>
+    </div>
+  );
+}
+
+// ─── Main list ─────────────────────────────────────────────────────────────────
+
+export function TrackerList({ items, onAddTracker, getActions }: TrackerListProps): React.ReactElement {
+  const hasItems = items.length > 0;
+
+  return (
+    <div className={styles.listContainer}>
+      <div className={styles.listHeader}>
+        <h2 className={styles.listTitle}>Live Trackers</h2>
+        <button type="button" className={styles.addButton} onClick={onAddTracker} aria-label="Add tracker">
+          + Add tracker
+        </button>
+      </div>
+
+      {!hasItems ? (
+        <>
+          <div className={styles.emptyList}>
+            <Alert variant="info">No trackers yet. Start with your linked gamertag above.</Alert>
+          </div>
+          <EmptyInfoPanel />
+        </>
+      ) : (
+        <div className={styles.list}>
+          {items.map((item) => (
+            <TrackerRow key={item.trackerId ?? `pinned-${item.gamertag}`} item={item} actions={getActions(item)} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.tsx
@@ -5,8 +5,6 @@ import { Alert } from "../../alert/alert";
 import { Dropdown } from "../../dropdown/dropdown";
 import styles from "./tracker-list.module.css";
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-
 export type TrackerDisplayStatus = "active" | "paused" | "stopped" | "not-started";
 
 export interface TrackerListItem {
@@ -34,8 +32,6 @@ interface TrackerListProps {
   readonly onAddTracker?: () => void;
   readonly getActions: (item: TrackerListItem) => readonly TrackerRowAction[];
 }
-
-// ─── Sub-components ───────────────────────────────────────────────────────────
 
 function statusLabel(status: TrackerDisplayStatus): string {
   switch (status) {
@@ -144,8 +140,6 @@ function EmptyInfoPanel(): React.ReactElement {
     </div>
   );
 }
-
-// ─── Main list ─────────────────────────────────────────────────────────────────
 
 export function TrackerList({ items, onAddTracker, getActions }: TrackerListProps): React.ReactElement {
   const hasItems = items.length > 0;

--- a/pages/src/components/individual-tracker-manager/tracker-summary/tests/tracker-summary.test.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-summary/tests/tracker-summary.test.tsx
@@ -1,0 +1,94 @@
+import "@testing-library/jest-dom/vitest";
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { TrackerSearchResult } from "../tracker-summary";
+import { TrackerSummary } from "../tracker-summary";
+
+vi.mock("../../../icons/rank-icon", () => ({
+  RankIcon: (): React.ReactNode => <span data-testid="rank-icon" />,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+function aFakeTrackerSearchResult(overrides?: Partial<TrackerSearchResult>): TrackerSearchResult {
+  return {
+    gamertag: "Chief",
+    xuid: "xuid-001",
+    csrLabel: "1500",
+    currentRankTier: "Diamond",
+    currentRankSubTier: 3,
+    currentRankMeasurementMatchesRemaining: null,
+    currentRankInitialMeasurementMatches: null,
+    allTimePeakCsrLabel: "1800",
+    allTimePeakRankTier: "Onyx",
+    allTimePeakRankSubTier: null,
+    seasonPeakCsrLabel: "1600",
+    seasonPeakRankTier: "Diamond",
+    seasonPeakRankSubTier: 4,
+    matchmadeMatchCount: 200,
+    customMatchCount: 50,
+    ...overrides,
+  };
+}
+
+describe("TrackerSummary", () => {
+  it("renders rank stat labels", () => {
+    render(<TrackerSummary tracker={aFakeTrackerSearchResult()} />);
+
+    expect(screen.getByText("Current rank:")).toBeInTheDocument();
+    expect(screen.getByText("Season peak:")).toBeInTheDocument();
+    expect(screen.getByText("All time peak:")).toBeInTheDocument();
+  });
+
+  it("renders formatted CSR values", () => {
+    render(<TrackerSummary tracker={aFakeTrackerSearchResult({ csrLabel: "1500" })} />);
+
+    expect(screen.getByText("1,500")).toBeInTheDocument();
+  });
+
+  it("renders a dash when CSR value is null", () => {
+    render(
+      <TrackerSummary
+        tracker={aFakeTrackerSearchResult({ csrLabel: null, seasonPeakCsrLabel: null, allTimePeakCsrLabel: null })}
+      />,
+    );
+
+    const dashes = screen.getAllByText("-");
+    expect(dashes.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("renders match count labels and values", () => {
+    render(<TrackerSummary tracker={aFakeTrackerSearchResult({ matchmadeMatchCount: 200, customMatchCount: 50 })} />);
+
+    expect(screen.getByText("Matchmaking games:")).toBeInTheDocument();
+    expect(screen.getByText("Custom games:")).toBeInTheDocument();
+    expect(screen.getByText("200")).toBeInTheDocument();
+    expect(screen.getByText("50")).toBeInTheDocument();
+  });
+
+  it("renders dashes for null match counts", () => {
+    render(
+      <TrackerSummary tracker={aFakeTrackerSearchResult({ matchmadeMatchCount: null, customMatchCount: null })} />,
+    );
+
+    const dashes = screen.getAllByText("-");
+    expect(dashes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders rank icons for current rank, season peak, and all-time peak", () => {
+    render(<TrackerSummary tracker={aFakeTrackerSearchResult()} />);
+
+    const rankIcons = screen.getAllByTestId("rank-icon");
+    expect(rankIcons).toHaveLength(3);
+  });
+
+  it("applies the optional className to the card element", () => {
+    const { container } = render(<TrackerSummary tracker={aFakeTrackerSearchResult()} className="custom-class" />);
+
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+});

--- a/pages/src/components/individual-tracker-manager/tracker-summary/tracker-summary.module.css
+++ b/pages/src/components/individual-tracker-manager/tracker-summary/tracker-summary.module.css
@@ -1,0 +1,41 @@
+.summaryCard {
+  background: color-mix(in srgb, var(--halo-teal-primary) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 20%, transparent);
+  border-radius: var(--radius-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3);
+}
+
+.summaryMeta {
+  color: var(--halo-gray);
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  margin: 0;
+}
+
+.statLine {
+  align-items: center;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: var(--space-4);
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.statItem {
+  align-items: center;
+  display: inline-flex;
+  gap: var(--space-2);
+}
+
+.statLabel {
+  color: var(--halo-gray);
+  font-size: var(--text-xs);
+}
+
+.statValue {
+  color: var(--halo-white);
+  line-height: 1;
+}

--- a/pages/src/components/individual-tracker-manager/tracker-summary/tracker-summary.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-summary/tracker-summary.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import classNames from "classnames";
+import { RankIcon } from "../../icons/rank-icon";
+import styles from "./tracker-summary.module.css";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface TrackerSearchResult {
+  readonly gamertag: string;
+  readonly xuid: string;
+  readonly csrLabel: string | null;
+  readonly currentRankTier: string | null;
+  readonly currentRankSubTier: number | null;
+  readonly currentRankMeasurementMatchesRemaining: number | null;
+  readonly currentRankInitialMeasurementMatches: number | null;
+  readonly allTimePeakCsrLabel: string | null;
+  readonly allTimePeakRankTier: string | null;
+  readonly allTimePeakRankSubTier: number | null;
+  readonly seasonPeakCsrLabel: string | null;
+  readonly seasonPeakRankTier: string | null;
+  readonly seasonPeakRankSubTier: number | null;
+  readonly matchmadeMatchCount: number | null;
+  readonly customMatchCount: number | null;
+}
+
+interface TrackerSummaryProps {
+  readonly tracker: TrackerSearchResult;
+  readonly className?: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatCsr(value: string | null): string {
+  if (value === null || value === "-") {
+    return "-";
+  }
+
+  const numValue = Number.parseInt(value, 10);
+  if (Number.isNaN(numValue)) {
+    return value;
+  }
+
+  return new Intl.NumberFormat().format(numValue);
+}
+
+function formatMatchCount(value: number | null): string {
+  if (value === null) {
+    return "-";
+  }
+
+  return new Intl.NumberFormat().format(value);
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function TrackerSummary({ tracker, className }: TrackerSummaryProps): React.ReactElement {
+  const combinedClassName = classNames(styles.summaryCard, className);
+
+  return (
+    <div className={combinedClassName}>
+      <p className={styles.summaryMeta}>
+        <span className={styles.statLine}>
+          <span className={styles.statItem}>
+            <span className={styles.statLabel}>Current rank:</span>
+            <RankIcon
+              rankTier={tracker.currentRankTier}
+              subTier={tracker.currentRankSubTier}
+              measurementMatchesRemaining={tracker.currentRankMeasurementMatchesRemaining}
+              initialMeasurementMatches={tracker.currentRankInitialMeasurementMatches}
+              size="small"
+            />
+            <span className={styles.statValue}>{formatCsr(tracker.csrLabel)}</span>
+          </span>
+          <span className={styles.statItem}>
+            <span className={styles.statLabel}>Season peak:</span>
+            <RankIcon
+              rankTier={tracker.seasonPeakRankTier}
+              subTier={tracker.seasonPeakRankSubTier}
+              measurementMatchesRemaining={null}
+              initialMeasurementMatches={null}
+              size="small"
+            />
+            <span className={styles.statValue}>{formatCsr(tracker.seasonPeakCsrLabel)}</span>
+          </span>
+          <span className={styles.statItem}>
+            <span className={styles.statLabel}>All time peak:</span>
+            <RankIcon
+              rankTier={tracker.allTimePeakRankTier}
+              subTier={tracker.allTimePeakRankSubTier}
+              measurementMatchesRemaining={null}
+              initialMeasurementMatches={null}
+              size="small"
+            />
+            <span className={styles.statValue}>{formatCsr(tracker.allTimePeakCsrLabel)}</span>
+          </span>
+        </span>
+      </p>
+      <p className={styles.summaryMeta}>
+        <span className={styles.statLine}>
+          <span className={styles.statItem}>
+            <span className={styles.statLabel}>Matchmaking games:</span>
+            <span className={styles.statValue}>{formatMatchCount(tracker.matchmadeMatchCount)}</span>
+          </span>
+          <span className={styles.statItem}>
+            <span className={styles.statLabel}>Custom games:</span>
+            <span className={styles.statValue}>{formatMatchCount(tracker.customMatchCount)}</span>
+          </span>
+        </span>
+      </p>
+    </div>
+  );
+}

--- a/pages/src/components/individual-tracker-manager/tracker-summary/tracker-summary.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-summary/tracker-summary.tsx
@@ -28,8 +28,6 @@ interface TrackerSummaryProps {
   readonly className?: string;
 }
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
 function formatCsr(value: string | null): string {
   if (value === null || value === "-") {
     return "-";
@@ -50,8 +48,6 @@ function formatMatchCount(value: number | null): string {
 
   return new Intl.NumberFormat().format(value);
 }
-
-// ─── Component ────────────────────────────────────────────────────────────────
 
 export function TrackerSummary({ tracker, className }: TrackerSummaryProps): React.ReactElement {
   const combinedClassName = classNames(styles.summaryCard, className);

--- a/pages/src/components/individual-tracker-manager/tracker-summary/tracker-summary.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-summary/tracker-summary.tsx
@@ -3,8 +3,6 @@ import classNames from "classnames";
 import { RankIcon } from "../../icons/rank-icon";
 import styles from "./tracker-summary.module.css";
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-
 export interface TrackerSearchResult {
   readonly gamertag: string;
   readonly xuid: string;


### PR DESCRIPTION
## Summary

- **TrackerList** (`individual-tracker-manager/tracker-list/`): pure presentational component rendering a list of tracker rows with status badges (Active/Paused/Stopped/Not started), a Live badge, and a per-row `Dropdown` menu driven by a `getActions` callback. Includes an empty-state panel with a help section when no trackers exist. Adds `+ Add tracker` button calling an optional `onAddTracker` prop.
- **TrackerSummary** (`individual-tracker-manager/tracker-summary/`): player stats card showing current CSR rank, season peak, all-time peak (each with a `RankIcon`), and matchmaking/custom game counts. Accepts an optional `className` for layout composition.

## Types defined

- `TrackerDisplayStatus` (`"active" | "paused" | "stopped" | "not-started"`) with exhaustive `switch + UnreachableError` in `statusLabel()`
- `TrackerListItem`, `TrackerRowAction` — props interfaces for `TrackerList`
- `TrackerSearchResult` — local interface mirroring the rework branch's search result shape (not yet in shared)

## Test coverage

- `tracker-list`: 11 tests covering empty state, all 4 status badges, live badge, pinned label, multi-row rendering, `getActions` callback, action `onClick` firing, and `onAddTracker`
- `tracker-summary`: 7 tests covering rank labels, CSR formatting, null dash fallback, match counts, rank icon rendering count, and `className` prop

## Code-review loop

2 rounds until clean:
- Round 1: replaced chained ternary in `StatusBadge` with `switch + UnreachableError`; replaced `parseInt` with `Number.parseInt`; added tests for `stopped` and `not-started` status badges
- Round 2: no actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)