### PR TITLE
feat(pages): H2-4 AddTrackerDialog — gamertag search + match history + tracker start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,9 @@ Exported via glob patterns in `package.json` `exports`. Always import via packag
 - **Fakes**: In `fakes/` subfolders; factories named `aFake…With(overrides?)`
 - **Tests**: In `tests/` subfolders
 - **Imports**: Extensionless for internal TypeScript modules; package entrypoints for cross-workspace
+- **One key component per file**: If a file gains a non-trivial sub-component, move that sub-component to its own sibling folder (e.g. `match-card/`) with its own `tests/` subfolder
+- **No re-exports**: Consumers import directly from the source module; never re-export a symbol from an intermediary wrapper file
+- **Extract service helpers**: Helper functions that grow a service file belong in their own named files with dedicated tests
 
 ## Code Style
 
@@ -123,6 +126,8 @@ switch (item.type) {
 **Dates**: `date-fns` for all date operations.
 
 **Imports**: Extensionless for internal modules. `import type` for type-only imports.
+
+**Props ordering**: In React component interfaces, declare props in this order: data props (required first, then optional), then callback props (required first, then optional). Align destructuring order with the declaration order.
 
 **Functions**: Functions to be single single responsibility, when needing to do multiple things, break it down into individual functions that are called / chained.
 

--- a/pages/src/components/individual-tracker-manager/tracker-summary/tests/tracker-summary.test.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-summary/tests/tracker-summary.test.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
-import type { TrackerSearchResult } from "../tracker-summary";
+import type { TrackerSearchResult } from "../../../../services/individual-tracker/types";
 import { TrackerSummary } from "../tracker-summary";
 
 vi.mock("../../../icons/rank-icon", () => ({

--- a/pages/src/components/individual-tracker-manager/tracker-summary/tests/tracker-summary.test.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-summary/tests/tracker-summary.test.tsx
@@ -18,11 +18,13 @@ function aFakeTrackerSearchResult(overrides?: Partial<TrackerSearchResult>): Tra
   return {
     gamertag: "Chief",
     xuid: "xuid-001",
+    rankLabel: "Diamond 3",
     csrLabel: "1500",
     currentRankTier: "Diamond",
     currentRankSubTier: 3,
     currentRankMeasurementMatchesRemaining: null,
     currentRankInitialMeasurementMatches: null,
+    allTimePeakRankLabel: "Onyx",
     allTimePeakCsrLabel: "1800",
     allTimePeakRankTier: "Onyx",
     allTimePeakRankSubTier: null,

--- a/pages/src/components/individual-tracker-manager/tracker-summary/tracker-summary.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-summary/tracker-summary.tsx
@@ -1,25 +1,10 @@
 import React from "react";
 import classNames from "classnames";
+import type { TrackerSearchResult } from "../../../services/individual-tracker/types";
 import { RankIcon } from "../../icons/rank-icon";
 import styles from "./tracker-summary.module.css";
 
-export interface TrackerSearchResult {
-  readonly gamertag: string;
-  readonly xuid: string;
-  readonly csrLabel: string | null;
-  readonly currentRankTier: string | null;
-  readonly currentRankSubTier: number | null;
-  readonly currentRankMeasurementMatchesRemaining: number | null;
-  readonly currentRankInitialMeasurementMatches: number | null;
-  readonly allTimePeakCsrLabel: string | null;
-  readonly allTimePeakRankTier: string | null;
-  readonly allTimePeakRankSubTier: number | null;
-  readonly seasonPeakCsrLabel: string | null;
-  readonly seasonPeakRankTier: string | null;
-  readonly seasonPeakRankSubTier: number | null;
-  readonly matchmadeMatchCount: number | null;
-  readonly customMatchCount: number | null;
-}
+export type { TrackerSearchResult };
 
 interface TrackerSummaryProps {
   readonly tracker: TrackerSearchResult;

--- a/pages/src/components/individual-tracker-manager/tracker-summary/tracker-summary.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-summary/tracker-summary.tsx
@@ -4,8 +4,6 @@ import type { TrackerSearchResult } from "../../../services/individual-tracker/t
 import { RankIcon } from "../../icons/rank-icon";
 import styles from "./tracker-summary.module.css";
 
-export type { TrackerSearchResult };
-
 interface TrackerSummaryProps {
   readonly tracker: TrackerSearchResult;
   readonly className?: string;

--- a/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog-presenter.ts
@@ -1,0 +1,314 @@
+import type { IndividualTrackerSeriesGroup } from "../series-group-metadata";
+import type {
+  IndividualTrackerService,
+  TrackerMatchHistoryEntry,
+  TrackerSearchResult,
+} from "../../../services/individual-tracker/types";
+import { applyAddToAdjacentGroup, applyBreakFromGroup } from "../grouping-utils";
+import { alignSeriesGroupsToGroupings } from "../series-group-metadata";
+import { shouldHideShortDurationMatch } from "../match-duration-filter";
+import type { AddTrackerDialogSnapshot, AddTrackerDialogStore } from "./add-tracker-dialog-store";
+
+const MATCH_PAGE_SIZE = 25;
+
+interface Config {
+  readonly store: AddTrackerDialogStore;
+  readonly individualTrackerService: IndividualTrackerService;
+  readonly onTrackerStarted: () => void;
+}
+
+export interface AddTrackerDialogViewModel {
+  readonly query: string;
+  readonly searching: boolean;
+  readonly searchError: string | null;
+  readonly result: TrackerSearchResult | null;
+  readonly visibleMatches: readonly TrackerMatchHistoryEntry[] | null;
+  readonly activeGroupings: readonly (readonly string[])[];
+  readonly loadingMatches: boolean;
+  readonly hasMore: boolean;
+  readonly selectedMatchIds: ReadonlySet<string>;
+  readonly seriesGroups: readonly IndividualTrackerSeriesGroup[];
+  readonly hideShortGames: boolean;
+  readonly busy: boolean;
+  readonly canStart: boolean;
+}
+
+export class AddTrackerDialogPresenter {
+  private readonly config: Config;
+  private isDisposed = false;
+
+  public constructor(config: Config) {
+    this.config = config;
+  }
+
+  public static present(snapshot: AddTrackerDialogSnapshot): AddTrackerDialogViewModel {
+    const selectedMatchIds = new Set(snapshot.selectedMatchIds);
+    const visibleMatches =
+      snapshot.loadingMatches && snapshot.matches.length === 0
+        ? null
+        : snapshot.hideShortGames
+          ? snapshot.matches.filter((entry) => !shouldHideShortDurationMatch(entry))
+          : snapshot.matches;
+    return {
+      query: snapshot.query,
+      searching: snapshot.searching,
+      searchError: snapshot.searchError,
+      result: snapshot.result,
+      visibleMatches,
+      activeGroupings: snapshot.activeGroupings,
+      loadingMatches: snapshot.loadingMatches,
+      hasMore: snapshot.hasMore,
+      selectedMatchIds,
+      seriesGroups: snapshot.seriesGroups,
+      hideShortGames: snapshot.hideShortGames,
+      busy: snapshot.busy,
+      canStart: snapshot.result != null && !snapshot.busy,
+    };
+  }
+
+  public dispose(): void {
+    this.isDisposed = true;
+  }
+
+  public reset(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.config.store.batchUpdate({
+      query: "",
+      searching: false,
+      searchError: null,
+      result: null,
+      matches: [],
+      activeGroupings: [],
+      loadingMatches: false,
+      hasMore: false,
+      selectedMatchIds: [],
+      seriesGroups: [],
+      hideShortGames: true,
+      busy: false,
+    });
+  }
+
+  public setQuery(query: string): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.config.store.setQuery(query);
+  }
+
+  public search(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    const { query } = this.config.store.getSnapshot();
+    const normalized = query.trim();
+    if (normalized === "") {
+      return;
+    }
+    this.config.store.batchUpdate({ searching: true, searchError: null });
+    this.runSearch(normalized);
+  }
+
+  public loadMore(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    const snapshot = this.config.store.getSnapshot();
+    if (snapshot.result == null || snapshot.loadingMatches) {
+      return;
+    }
+    this.config.store.setLoadingMatches(true);
+    this.runLoadMore(snapshot.result.xuid, snapshot.matches.length);
+  }
+
+  public toggleMatch(matchId: string): void {
+    if (this.isDisposed) {
+      return;
+    }
+    const { selectedMatchIds } = this.config.store.getSnapshot();
+    const next = selectedMatchIds.includes(matchId)
+      ? selectedMatchIds.filter((id) => id !== matchId)
+      : [...selectedMatchIds, matchId];
+    this.config.store.setSelectedMatchIds(next);
+  }
+
+  public breakGroup(matchId: string): void {
+    if (this.isDisposed) {
+      return;
+    }
+    const { activeGroupings, matches } = this.config.store.getSnapshot();
+    const nextGroupings = applyBreakFromGroup(activeGroupings, matches, matchId);
+    this.applyGroupingsUpdate(nextGroupings);
+  }
+
+  public addToGroup(matchId: string, direction: "above" | "below"): void {
+    if (this.isDisposed) {
+      return;
+    }
+    const { activeGroupings, matches } = this.config.store.getSnapshot();
+    const nextGroupings = applyAddToAdjacentGroup(activeGroupings, matches, matchId, direction);
+    this.applyGroupingsUpdate(nextGroupings);
+  }
+
+  public setHideShortGames(hideShortGames: boolean): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.config.store.setHideShortGames(hideShortGames);
+  }
+
+  public setSeriesGroupTitle(groupIndex: number, value: string | null): void {
+    if (this.isDisposed) {
+      return;
+    }
+    const { seriesGroups } = this.config.store.getSnapshot();
+    const next = seriesGroups.map((group, index) =>
+      index === groupIndex ? { ...group, titleOverride: value } : group,
+    );
+    this.config.store.setSeriesGroups(next);
+  }
+
+  public setSeriesGroupSubtitle(groupIndex: number, value: string | null): void {
+    if (this.isDisposed) {
+      return;
+    }
+    const { seriesGroups } = this.config.store.getSnapshot();
+    const next = seriesGroups.map((group, index) =>
+      index === groupIndex ? { ...group, subtitleOverride: value } : group,
+    );
+    this.config.store.setSeriesGroups(next);
+  }
+
+  public startTracker(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    const snapshot = this.config.store.getSnapshot();
+    if (snapshot.result == null || snapshot.busy) {
+      return;
+    }
+    this.config.store.setBusy(true);
+    this.runStartTracker(snapshot.result.gamertag);
+  }
+
+  private applyGroupingsUpdate(nextGroupings: readonly (readonly string[])[]): void {
+    const { seriesGroups } = this.config.store.getSnapshot();
+    const nextSeriesGroups = alignSeriesGroupsToGroupings(nextGroupings, seriesGroups);
+    this.config.store.batchUpdate({
+      activeGroupings: nextGroupings,
+      seriesGroups: nextSeriesGroups,
+    });
+  }
+
+  private runSearch(gamertag: string): void {
+    void this.doSearch(gamertag);
+  }
+
+  private async doSearch(gamertag: string): Promise<void> {
+    try {
+      const found = await this.config.individualTrackerService.searchGamertag(gamertag);
+      if (this.isDisposed) {
+        return;
+      }
+      if (found == null) {
+        this.config.store.batchUpdate({
+          searching: false,
+          result: null,
+          matches: [],
+          selectedMatchIds: [],
+          searchError: "No matching gamertag found.",
+        });
+        return;
+      }
+      this.config.store.batchUpdate({ searching: false, result: found, loadingMatches: true });
+      this.runLoadInitialMatches(found.xuid);
+    } catch (err: unknown) {
+      if (this.isDisposed) {
+        return;
+      }
+      this.config.store.batchUpdate({
+        searching: false,
+        loadingMatches: false,
+        searchError: err instanceof Error ? err.message : "Failed to search gamertag.",
+      });
+    }
+  }
+
+  private runLoadInitialMatches(xuid: string): void {
+    void this.doLoadInitialMatches(xuid);
+  }
+
+  private async doLoadInitialMatches(xuid: string): Promise<void> {
+    try {
+      const firstResponse = await this.config.individualTrackerService.getMatchHistory(xuid, 0, MATCH_PAGE_SIZE);
+      if (this.isDisposed) {
+        return;
+      }
+      const nextSeriesGroups = alignSeriesGroupsToGroupings(firstResponse.suggestedGroupings, []);
+      this.config.store.batchUpdate({
+        matches: firstResponse.matches,
+        activeGroupings: firstResponse.suggestedGroupings,
+        seriesGroups: nextSeriesGroups,
+        hasMore: firstResponse.matches.length >= MATCH_PAGE_SIZE,
+        selectedMatchIds: [],
+        loadingMatches: false,
+      });
+    } catch (err: unknown) {
+      if (this.isDisposed) {
+        return;
+      }
+      this.config.store.batchUpdate({
+        loadingMatches: false,
+        searchError: err instanceof Error ? err.message : "Failed to load match history.",
+      });
+    }
+  }
+
+  private runLoadMore(xuid: string, offset: number): void {
+    void this.doLoadMore(xuid, offset);
+  }
+
+  private async doLoadMore(xuid: string, offset: number): Promise<void> {
+    try {
+      const nextResponse = await this.config.individualTrackerService.getMatchHistory(xuid, offset, MATCH_PAGE_SIZE);
+      if (this.isDisposed) {
+        return;
+      }
+      const currentMatches = this.config.store.getSnapshot().matches;
+      this.config.store.batchUpdate({
+        matches: [...currentMatches, ...nextResponse.matches],
+        hasMore: nextResponse.matches.length >= MATCH_PAGE_SIZE,
+        loadingMatches: false,
+      });
+    } catch {
+      if (this.isDisposed) {
+        return;
+      }
+      this.config.store.setLoadingMatches(false);
+    }
+  }
+
+  private runStartTracker(gamertag: string): void {
+    void this.doStartTracker(gamertag);
+  }
+
+  private async doStartTracker(gamertag: string): Promise<void> {
+    try {
+      await this.config.individualTrackerService.startTracker({ gamertag });
+      if (this.isDisposed) {
+        return;
+      }
+      this.config.store.setBusy(false);
+      this.config.onTrackerStarted();
+    } catch (err: unknown) {
+      if (this.isDisposed) {
+        return;
+      }
+      this.config.store.batchUpdate({
+        busy: false,
+        searchError: err instanceof Error ? err.message : "Failed to start tracker.",
+      });
+    }
+  }
+}

--- a/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog-presenter.ts
@@ -110,16 +110,16 @@ export class AddTrackerDialogPresenter {
     this.runSearch(normalized);
   }
 
-  public loadMore(): void {
+  public async loadMore(): Promise<void> {
     if (this.isDisposed) {
-      return;
+      return Promise.resolve();
     }
     const snapshot = this.config.store.getSnapshot();
     if (snapshot.result == null || snapshot.loadingMatches) {
-      return;
+      return Promise.resolve();
     }
     this.config.store.setLoadingMatches(true);
-    this.runLoadMore(snapshot.result.xuid, snapshot.matches.length);
+    return this.doLoadMore(snapshot.result.xuid, snapshot.matches.length);
   }
 
   public toggleMatch(matchId: string): void {
@@ -263,10 +263,6 @@ export class AddTrackerDialogPresenter {
         searchError: err instanceof Error ? err.message : "Failed to load match history.",
       });
     }
-  }
-
-  private runLoadMore(xuid: string, offset: number): void {
-    void this.doLoadMore(xuid, offset);
   }
 
   private async doLoadMore(xuid: string, offset: number): Promise<void> {

--- a/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog-presenter.ts
@@ -101,9 +101,9 @@ export class AddTrackerDialogPresenter {
     if (this.isDisposed) {
       return;
     }
-    const { query } = this.config.store.getSnapshot();
-    const normalized = query.trim();
-    if (normalized === "") {
+    const snapshot = this.config.store.getSnapshot();
+    const normalized = snapshot.query.trim();
+    if (normalized === "" || snapshot.searching || snapshot.loadingMatches) {
       return;
     }
     this.config.store.batchUpdate({ searching: true, searchError: null });

--- a/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog-store.ts
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog-store.ts
@@ -1,0 +1,109 @@
+import type { IndividualTrackerSeriesGroup } from "../series-group-metadata";
+import type { TrackerMatchHistoryEntry, TrackerSearchResult } from "../../../services/individual-tracker/types";
+
+export interface AddTrackerDialogSnapshot {
+  readonly query: string;
+  readonly searching: boolean;
+  readonly searchError: string | null;
+  readonly result: TrackerSearchResult | null;
+  readonly matches: readonly TrackerMatchHistoryEntry[];
+  readonly activeGroupings: readonly (readonly string[])[];
+  readonly loadingMatches: boolean;
+  readonly hasMore: boolean;
+  readonly selectedMatchIds: readonly string[];
+  readonly seriesGroups: readonly IndividualTrackerSeriesGroup[];
+  readonly hideShortGames: boolean;
+  readonly busy: boolean;
+}
+
+export class AddTrackerDialogStore {
+  private snapshot: AddTrackerDialogSnapshot;
+  private readonly subscribers = new Set<() => void>();
+
+  public constructor() {
+    this.snapshot = {
+      query: "",
+      searching: false,
+      searchError: null,
+      result: null,
+      matches: [],
+      activeGroupings: [],
+      loadingMatches: false,
+      hasMore: false,
+      selectedMatchIds: [],
+      seriesGroups: [],
+      hideShortGames: true,
+      busy: false,
+    };
+  }
+
+  public subscribe(listener: () => void): () => void {
+    this.subscribers.add(listener);
+    return (): void => {
+      this.subscribers.delete(listener);
+    };
+  }
+
+  public getSnapshot(): AddTrackerDialogSnapshot {
+    return this.snapshot;
+  }
+
+  public setQuery(query: string): void {
+    this.update({ query });
+  }
+
+  public setSearching(searching: boolean): void {
+    this.update({ searching });
+  }
+
+  public setSearchError(searchError: string | null): void {
+    this.update({ searchError });
+  }
+
+  public setResult(result: TrackerSearchResult | null): void {
+    this.update({ result });
+  }
+
+  public setMatches(matches: readonly TrackerMatchHistoryEntry[]): void {
+    this.update({ matches });
+  }
+
+  public setActiveGroupings(activeGroupings: readonly (readonly string[])[]): void {
+    this.update({ activeGroupings });
+  }
+
+  public setLoadingMatches(loadingMatches: boolean): void {
+    this.update({ loadingMatches });
+  }
+
+  public setHasMore(hasMore: boolean): void {
+    this.update({ hasMore });
+  }
+
+  public setSelectedMatchIds(selectedMatchIds: readonly string[]): void {
+    this.update({ selectedMatchIds });
+  }
+
+  public setSeriesGroups(seriesGroups: readonly IndividualTrackerSeriesGroup[]): void {
+    this.update({ seriesGroups });
+  }
+
+  public setHideShortGames(hideShortGames: boolean): void {
+    this.update({ hideShortGames });
+  }
+
+  public setBusy(busy: boolean): void {
+    this.update({ busy });
+  }
+
+  public batchUpdate(partial: Partial<AddTrackerDialogSnapshot>): void {
+    this.update(partial);
+  }
+
+  private update(partial: Partial<AddTrackerDialogSnapshot>): void {
+    this.snapshot = { ...this.snapshot, ...partial };
+    for (const subscriber of this.subscribers) {
+      subscriber();
+    }
+  }
+}

--- a/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.module.css
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.module.css
@@ -1,0 +1,69 @@
+.section {
+  background: var(--halo-bg-secondary);
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 18%, transparent);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+}
+
+.sectionTitle {
+  color: var(--halo-white);
+  font-family: var(--font-heading);
+  font-size: var(--text-lg);
+  margin: 0;
+}
+
+.sectionDescription {
+  color: var(--halo-gray);
+  flex: 1 1 auto;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  margin: 0;
+  min-width: 0;
+}
+
+.controlsRow {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.searchRow {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: 1fr;
+}
+
+.dialogActions {
+  display: flex;
+  gap: var(--space-3);
+  justify-content: flex-end;
+  padding-top: var(--space-4);
+}
+
+.previewCard {
+  margin-top: var(--space-2);
+}
+
+.mutedText {
+  color: var(--halo-gray);
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  margin: 0;
+}
+
+@media (--tablet-viewport) {
+  .controlsRow {
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .searchRow {
+    align-items: end;
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+}

--- a/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.tsx
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import type { IndividualTrackerSeriesGroup } from "../series-group-metadata";
+import type { TrackerMatchHistoryEntry, TrackerSearchResult } from "../../../services/individual-tracker/types";
+import { Alert } from "../../alert/alert";
+import { Button } from "../../button/button";
+import { Checkbox } from "../../checkbox/checkbox";
+import { Dialog } from "../../dialog/dialog";
+import { Input } from "../../input/input";
+import { MatchHistory } from "../../match-history/match-history";
+import { TrackerSummary } from "../../individual-tracker-manager/tracker-summary/tracker-summary";
+import styles from "./add-tracker-dialog.module.css";
+
+interface AddTrackerDialogProps {
+  readonly open: boolean;
+  readonly busy: boolean;
+  readonly query: string;
+  readonly searching: boolean;
+  readonly searchError: string | null;
+  readonly result: TrackerSearchResult | null;
+  readonly visibleMatches: readonly TrackerMatchHistoryEntry[] | null;
+  readonly activeGroupings: readonly (readonly string[])[];
+  readonly loadingMatches: boolean;
+  readonly hasMore: boolean;
+  readonly selectedMatchIds: ReadonlySet<string>;
+  readonly seriesGroups: readonly IndividualTrackerSeriesGroup[];
+  readonly hideShortGames: boolean;
+  readonly canStart: boolean;
+  readonly onClose: () => void;
+  readonly onQueryChange: (value: string) => void;
+  readonly onSearch: () => void;
+  readonly onMatchToggle: (matchId: string) => void;
+  readonly onLoadMore: () => Promise<void>;
+  readonly onAddToAboveGroup: (matchId: string) => void;
+  readonly onAddToBelowGroup: (matchId: string) => void;
+  readonly onBreakFromGroup: (matchId: string) => void;
+  readonly onHideShortGamesChange: (value: boolean) => void;
+  readonly onSeriesGroupTitleChange: (groupIndex: number, value: string | null) => void;
+  readonly onSeriesGroupSubtitleChange: (groupIndex: number, value: string | null) => void;
+  readonly onStartTracker: () => void;
+}
+
+export function AddTrackerDialog({
+  open,
+  busy,
+  query,
+  searching,
+  searchError,
+  result,
+  visibleMatches,
+  activeGroupings,
+  loadingMatches,
+  hasMore,
+  selectedMatchIds,
+  seriesGroups,
+  hideShortGames,
+  canStart,
+  onClose,
+  onQueryChange,
+  onSearch,
+  onMatchToggle,
+  onLoadMore,
+  onAddToAboveGroup,
+  onAddToBelowGroup,
+  onBreakFromGroup,
+  onHideShortGamesChange,
+  onSeriesGroupTitleChange,
+  onSeriesGroupSubtitleChange,
+  onStartTracker,
+}: AddTrackerDialogProps): React.ReactElement | null {
+  return (
+    <Dialog open={open} title="Add Tracker" onClose={onClose}>
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>1. Gamertag</h3>
+        <div className={styles.searchRow}>
+          <Input
+            label="Gamertag"
+            value={query}
+            placeholder="Search gamertag"
+            onChange={(event): void => {
+              onQueryChange(event.currentTarget.value);
+            }}
+          />
+          <Button onClick={onSearch} disabled={searching || query.trim() === ""}>
+            {searching ? "Searching..." : "Search"}
+          </Button>
+        </div>
+
+        {searchError != null && <Alert variant="error">{searchError}</Alert>}
+
+        {result != null && <TrackerSummary tracker={result} className={styles.previewCard} />}
+      </section>
+
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>2. Add past games</h3>
+        <div className={styles.controlsRow}>
+          <p className={styles.sectionDescription}>Optional — you can skip this section if you want a clean start.</p>
+
+          {result != null && (
+            <Checkbox checked={hideShortGames} onChange={onHideShortGamesChange} label="Hide games < 2m duration" />
+          )}
+        </div>
+
+        {result == null ? (
+          <p className={styles.mutedText}>Search for a gamertag first to load recent matches.</p>
+        ) : (
+          <MatchHistory
+            entries={loadingMatches && visibleMatches == null ? null : (visibleMatches ?? [])}
+            loadingCount={3}
+            showGroupings={true}
+            allowManualGrouping={true}
+            groupings={activeGroupings}
+            allowSelection={true}
+            selectedMatchIds={selectedMatchIds}
+            seriesGroups={seriesGroups}
+            hasMore={hasMore}
+            onLoadMore={onLoadMore}
+            onMatchToggle={onMatchToggle}
+            onBreakFromGroup={onBreakFromGroup}
+            onAddToAboveGroup={onAddToAboveGroup}
+            onAddToBelowGroup={onAddToBelowGroup}
+            onSeriesGroupTitleChange={onSeriesGroupTitleChange}
+            onSeriesGroupSubtitleChange={onSeriesGroupSubtitleChange}
+          />
+        )}
+      </section>
+
+      <div className={styles.dialogActions}>
+        <Button variant="secondary" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button onClick={onStartTracker} disabled={!canStart || busy}>
+          {busy ? "Starting..." : "Start tracker"}
+        </Button>
+      </div>
+    </Dialog>
+  );
+}

--- a/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.tsx
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.tsx
@@ -6,7 +6,7 @@ import { Button } from "../../button/button";
 import { Checkbox } from "../../checkbox/checkbox";
 import { Dialog } from "../../dialog/dialog";
 import { Input } from "../../input/input";
-import { MatchHistory } from "../../match-history/match-history";
+import { MatchHistorySection } from "../../match-history/create";
 import { TrackerSummary } from "../../individual-tracker-manager/tracker-summary/tracker-summary";
 import styles from "./add-tracker-dialog.module.css";
 
@@ -103,7 +103,7 @@ export function AddTrackerDialog({
         {result == null ? (
           <p className={styles.mutedText}>Search for a gamertag first to load recent matches.</p>
         ) : (
-          <MatchHistory
+          <MatchHistorySection
             entries={loadingMatches && visibleMatches == null ? null : (visibleMatches ?? [])}
             loadingCount={3}
             showGroupings={true}

--- a/pages/src/components/individual-tracker/add-tracker-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/create.tsx
@@ -1,0 +1,101 @@
+import React, { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
+import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
+import { AddTrackerDialogPresenter } from "./add-tracker-dialog-presenter";
+import { AddTrackerDialogStore } from "./add-tracker-dialog-store";
+import { AddTrackerDialog } from "./add-tracker-dialog";
+
+interface AddTrackerDialogSectionProps {
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onTrackerStarted: () => void;
+  readonly individualTrackerService: IndividualTrackerService;
+}
+
+export function AddTrackerDialogSection({
+  isOpen,
+  onClose,
+  onTrackerStarted,
+  individualTrackerService,
+}: AddTrackerDialogSectionProps): React.ReactElement {
+  const store = useMemo(() => new AddTrackerDialogStore(), []);
+  const presenter = useMemo(
+    () => new AddTrackerDialogPresenter({ store, individualTrackerService, onTrackerStarted }),
+    [store, individualTrackerService, onTrackerStarted],
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      presenter.reset();
+    }
+  }, [presenter, isOpen]);
+
+  useEffect(() => {
+    return (): void => {
+      presenter.dispose();
+    };
+  }, [presenter]);
+
+  const snapshot = useSyncExternalStore(
+    (listener) => store.subscribe(listener),
+    () => store.getSnapshot(),
+    () => store.getSnapshot(),
+  );
+
+  const model = useMemo(() => AddTrackerDialogPresenter.present(snapshot), [snapshot]);
+
+  const handleLoadMore = useCallback(async (): Promise<void> => {
+    presenter.loadMore();
+    return Promise.resolve();
+  }, [presenter]);
+
+  return (
+    <AddTrackerDialog
+      open={isOpen}
+      busy={model.busy}
+      query={model.query}
+      searching={model.searching}
+      searchError={model.searchError}
+      result={model.result}
+      visibleMatches={model.visibleMatches}
+      activeGroupings={model.activeGroupings}
+      loadingMatches={model.loadingMatches}
+      hasMore={model.hasMore}
+      selectedMatchIds={model.selectedMatchIds}
+      seriesGroups={model.seriesGroups}
+      hideShortGames={model.hideShortGames}
+      canStart={model.canStart}
+      onClose={onClose}
+      onQueryChange={(value): void => {
+        presenter.setQuery(value);
+      }}
+      onSearch={(): void => {
+        presenter.search();
+      }}
+      onMatchToggle={(matchId): void => {
+        presenter.toggleMatch(matchId);
+      }}
+      onLoadMore={handleLoadMore}
+      onAddToAboveGroup={(matchId): void => {
+        presenter.addToGroup(matchId, "above");
+      }}
+      onAddToBelowGroup={(matchId): void => {
+        presenter.addToGroup(matchId, "below");
+      }}
+      onBreakFromGroup={(matchId): void => {
+        presenter.breakGroup(matchId);
+      }}
+      onHideShortGamesChange={(value): void => {
+        presenter.setHideShortGames(value);
+      }}
+      onSeriesGroupTitleChange={(groupIndex, value): void => {
+        presenter.setSeriesGroupTitle(groupIndex, value);
+      }}
+      onSeriesGroupSubtitleChange={(groupIndex, value): void => {
+        presenter.setSeriesGroupSubtitle(groupIndex, value);
+      }}
+      onStartTracker={(): void => {
+        presenter.startTracker();
+      }}
+    />
+  );
+}

--- a/pages/src/components/individual-tracker/add-tracker-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/create.tsx
@@ -44,8 +44,7 @@ export function AddTrackerDialogSection({
   const model = useMemo(() => AddTrackerDialogPresenter.present(snapshot), [snapshot]);
 
   const handleLoadMore = useCallback(async (): Promise<void> => {
-    presenter.loadMore();
-    return Promise.resolve();
+    return presenter.loadMore();
   }, [presenter]);
 
   return (

--- a/pages/src/components/individual-tracker/add-tracker-dialog/tests/add-tracker-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/tests/add-tracker-dialog-presenter.test.ts
@@ -1,0 +1,476 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { IndividualTrackerService } from "../../../../services/individual-tracker/types";
+import { aFakeIndividualTrackerServiceWith } from "../../../../services/individual-tracker/fakes/individual-tracker.fake";
+import { AddTrackerDialogStore } from "../add-tracker-dialog-store";
+import { AddTrackerDialogPresenter } from "../add-tracker-dialog-presenter";
+
+function buildPresenter(opts: { service?: IndividualTrackerService; onTrackerStarted?: () => void }): {
+  store: AddTrackerDialogStore;
+  presenter: AddTrackerDialogPresenter;
+} {
+  const store = new AddTrackerDialogStore();
+  const presenter = new AddTrackerDialogPresenter({
+    store,
+    individualTrackerService: opts.service ?? aFakeIndividualTrackerServiceWith(),
+    onTrackerStarted: opts.onTrackerStarted ?? vi.fn<() => void>(),
+  });
+  return { store, presenter };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AddTrackerDialogPresenter", () => {
+  describe("setQuery", () => {
+    it("updates query in the store", () => {
+      const { store, presenter } = buildPresenter({});
+
+      presenter.setQuery("Chief");
+
+      expect(store.getSnapshot().query).toBe("Chief");
+    });
+
+    it("does nothing when disposed", () => {
+      const { store, presenter } = buildPresenter({});
+
+      presenter.dispose();
+      presenter.setQuery("Chief");
+
+      expect(store.getSnapshot().query).toBe("");
+    });
+  });
+
+  describe("search", () => {
+    it("sets searching flag while searching", async () => {
+      let resolveSearch!: (v: null) => void;
+      const service = aFakeIndividualTrackerServiceWith({
+        searchResult: null,
+      });
+      vi.spyOn(service, "searchGamertag").mockImplementation(
+        async () =>
+          new Promise<null>((resolve) => {
+            resolveSearch = resolve;
+          }),
+      );
+
+      const { store, presenter } = buildPresenter({ service });
+      presenter.setQuery("Chief");
+      presenter.search();
+
+      expect(store.getSnapshot().searching).toBe(true);
+      resolveSearch(null);
+      await Promise.resolve();
+    });
+
+    it("sets searchError when no gamertag found", async () => {
+      const service = aFakeIndividualTrackerServiceWith({ searchResult: null });
+      const { store, presenter } = buildPresenter({ service });
+
+      presenter.setQuery("NoSuchPlayer");
+      presenter.search();
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().searching).toBe(false);
+      });
+
+      expect(store.getSnapshot().searchError).toBe("No matching gamertag found.");
+      expect(store.getSnapshot().result).toBeNull();
+    });
+
+    it("sets result and loads matches on success", async () => {
+      const matchHistory = {
+        matches: [
+          {
+            matchId: "m1",
+            startTime: "Jan 1, 2026, 12:00:00 AM",
+            endTime: "Jan 1, 2026, 12:10:00 AM",
+            mapAssetId: "map-1",
+            mapVersionId: "map-v-1",
+            modeAssetId: "mode-1",
+            modeVersionId: "mode-v-1",
+            gameVariantCategory: 6 as const,
+            duration: "10m 0s",
+            mapName: "Aquarius",
+            modeName: "Slayer",
+            outcome: "Win" as const,
+            resultString: "Win - 50:40",
+            isMatchmaking: false,
+            category: "custom" as const,
+            teams: [],
+            mapThumbnailUrl: "data:,",
+          },
+        ],
+        suggestedGroupings: [],
+      };
+      const service = aFakeIndividualTrackerServiceWith({ matchHistory });
+      const { store, presenter } = buildPresenter({ service });
+
+      presenter.setQuery("Chief");
+      presenter.search();
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().result).not.toBeNull();
+      });
+
+      expect(store.getSnapshot().result?.gamertag).toBe("Fake Spartan");
+      expect(store.getSnapshot().matches).toHaveLength(1);
+      expect(store.getSnapshot().searching).toBe(false);
+      expect(store.getSnapshot().loadingMatches).toBe(false);
+    });
+
+    it("sets searchError when service throws", async () => {
+      const service = aFakeIndividualTrackerServiceWith();
+      vi.spyOn(service, "searchGamertag").mockRejectedValue(new Error("Network error"));
+
+      const { store, presenter } = buildPresenter({ service });
+      presenter.setQuery("Chief");
+      presenter.search();
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().searching).toBe(false);
+      });
+
+      expect(store.getSnapshot().searchError).toBe("Network error");
+    });
+
+    it("ignores stale responses after dispose", async () => {
+      let resolveSearch!: (v: null) => void;
+      const service = aFakeIndividualTrackerServiceWith({ searchResult: null });
+      vi.spyOn(service, "searchGamertag").mockImplementation(
+        async () =>
+          new Promise<null>((resolve) => {
+            resolveSearch = resolve;
+          }),
+      );
+
+      const { store, presenter } = buildPresenter({ service });
+      presenter.setQuery("Chief");
+      presenter.search();
+      presenter.dispose();
+      resolveSearch(null);
+
+      await Promise.resolve();
+
+      expect(store.getSnapshot().searching).toBe(true);
+    });
+  });
+
+  describe("toggleMatch", () => {
+    it("adds a match to selectedMatchIds when not present", () => {
+      const { store, presenter } = buildPresenter({});
+
+      presenter.toggleMatch("m1");
+
+      expect(store.getSnapshot().selectedMatchIds).toContain("m1");
+    });
+
+    it("removes a match from selectedMatchIds when already present", () => {
+      const { store, presenter } = buildPresenter({});
+      presenter.toggleMatch("m1");
+
+      presenter.toggleMatch("m1");
+
+      expect(store.getSnapshot().selectedMatchIds).not.toContain("m1");
+    });
+  });
+
+  describe("breakGroup", () => {
+    it("removes a single-element group from groupings", () => {
+      const matchHistory = {
+        matches: [
+          {
+            matchId: "m1",
+            startTime: "Jan 1, 2026, 12:00:00 AM",
+            endTime: "Jan 1, 2026, 12:10:00 AM",
+            mapAssetId: "a",
+            mapVersionId: "b",
+            modeAssetId: "c",
+            modeVersionId: "d",
+            gameVariantCategory: 6 as const,
+            duration: "10m",
+            mapName: "A",
+            modeName: "Slayer",
+            outcome: "Win" as const,
+            resultString: "W",
+            isMatchmaking: false,
+            category: "custom" as const,
+            teams: [],
+            mapThumbnailUrl: "data:,",
+          },
+          {
+            matchId: "m2",
+            startTime: "Jan 1, 2026, 12:15:00 AM",
+            endTime: "Jan 1, 2026, 12:25:00 AM",
+            mapAssetId: "a",
+            mapVersionId: "b",
+            modeAssetId: "c",
+            modeVersionId: "d",
+            gameVariantCategory: 6 as const,
+            duration: "10m",
+            mapName: "B",
+            modeName: "Slayer",
+            outcome: "Win" as const,
+            resultString: "W",
+            isMatchmaking: false,
+            category: "custom" as const,
+            teams: [],
+            mapThumbnailUrl: "data:,",
+          },
+        ],
+        suggestedGroupings: [["m1", "m2"]],
+      };
+      const service = aFakeIndividualTrackerServiceWith({ matchHistory });
+      const { store, presenter } = buildPresenter({ service });
+
+      store.batchUpdate({
+        matches: matchHistory.matches,
+        activeGroupings: matchHistory.suggestedGroupings,
+        result: {
+          gamertag: "Chief",
+          xuid: "xuid-1",
+          rankLabel: null,
+          csrLabel: null,
+          currentRankTier: null,
+          currentRankSubTier: null,
+          currentRankMeasurementMatchesRemaining: null,
+          currentRankInitialMeasurementMatches: null,
+          allTimePeakRankLabel: null,
+          allTimePeakCsrLabel: null,
+          allTimePeakRankTier: null,
+          allTimePeakRankSubTier: null,
+          seasonPeakCsrLabel: null,
+          seasonPeakRankTier: null,
+          seasonPeakRankSubTier: null,
+          matchmadeMatchCount: null,
+          customMatchCount: null,
+        },
+      });
+
+      presenter.breakGroup("m1");
+
+      expect(store.getSnapshot().activeGroupings).toHaveLength(0);
+    });
+  });
+
+  describe("setHideShortGames", () => {
+    it("updates hideShortGames in the store", () => {
+      const { store, presenter } = buildPresenter({});
+
+      presenter.setHideShortGames(false);
+
+      expect(store.getSnapshot().hideShortGames).toBe(false);
+    });
+  });
+
+  describe("startTracker", () => {
+    it("calls onTrackerStarted after a successful start", async () => {
+      const onTrackerStarted = vi.fn<() => void>();
+      const service = aFakeIndividualTrackerServiceWith();
+      const { store, presenter } = buildPresenter({ service, onTrackerStarted });
+
+      store.batchUpdate({
+        result: {
+          gamertag: "Chief",
+          xuid: "xuid-1",
+          rankLabel: null,
+          csrLabel: null,
+          currentRankTier: null,
+          currentRankSubTier: null,
+          currentRankMeasurementMatchesRemaining: null,
+          currentRankInitialMeasurementMatches: null,
+          allTimePeakRankLabel: null,
+          allTimePeakCsrLabel: null,
+          allTimePeakRankTier: null,
+          allTimePeakRankSubTier: null,
+          seasonPeakCsrLabel: null,
+          seasonPeakRankTier: null,
+          seasonPeakRankSubTier: null,
+          matchmadeMatchCount: null,
+          customMatchCount: null,
+        },
+      });
+
+      presenter.startTracker();
+
+      await vi.waitFor(() => {
+        expect(onTrackerStarted).toHaveBeenCalledOnce();
+      });
+
+      expect(store.getSnapshot().busy).toBe(false);
+    });
+
+    it("sets searchError when startTracker throws", async () => {
+      const service = aFakeIndividualTrackerServiceWith();
+      vi.spyOn(service, "startTracker").mockRejectedValue(new Error("Start failed"));
+
+      const { store, presenter } = buildPresenter({ service });
+
+      store.batchUpdate({
+        result: {
+          gamertag: "Chief",
+          xuid: "xuid-1",
+          rankLabel: null,
+          csrLabel: null,
+          currentRankTier: null,
+          currentRankSubTier: null,
+          currentRankMeasurementMatchesRemaining: null,
+          currentRankInitialMeasurementMatches: null,
+          allTimePeakRankLabel: null,
+          allTimePeakCsrLabel: null,
+          allTimePeakRankTier: null,
+          allTimePeakRankSubTier: null,
+          seasonPeakCsrLabel: null,
+          seasonPeakRankTier: null,
+          seasonPeakRankSubTier: null,
+          matchmadeMatchCount: null,
+          customMatchCount: null,
+        },
+      });
+
+      presenter.startTracker();
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().busy).toBe(false);
+      });
+
+      expect(store.getSnapshot().searchError).toBe("Start failed");
+    });
+
+    it("does nothing when result is null", () => {
+      const service = aFakeIndividualTrackerServiceWith();
+      const startTrackerSpy = vi.spyOn(service, "startTracker");
+      const { presenter } = buildPresenter({ service });
+
+      presenter.startTracker();
+
+      expect(startTrackerSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("reset", () => {
+    it("clears all state to defaults", () => {
+      const { store, presenter } = buildPresenter({});
+
+      store.batchUpdate({
+        query: "Chief",
+        searchError: "some error",
+        result: {
+          gamertag: "Chief",
+          xuid: "xuid-1",
+          rankLabel: null,
+          csrLabel: null,
+          currentRankTier: null,
+          currentRankSubTier: null,
+          currentRankMeasurementMatchesRemaining: null,
+          currentRankInitialMeasurementMatches: null,
+          allTimePeakRankLabel: null,
+          allTimePeakCsrLabel: null,
+          allTimePeakRankTier: null,
+          allTimePeakRankSubTier: null,
+          seasonPeakCsrLabel: null,
+          seasonPeakRankTier: null,
+          seasonPeakRankSubTier: null,
+          matchmadeMatchCount: null,
+          customMatchCount: null,
+        },
+      });
+
+      presenter.reset();
+
+      const snapshot = store.getSnapshot();
+      expect(snapshot.query).toBe("");
+      expect(snapshot.result).toBeNull();
+      expect(snapshot.searchError).toBeNull();
+      expect(snapshot.matches).toHaveLength(0);
+    });
+  });
+
+  describe("present", () => {
+    it("returns null visibleMatches when loading with no matches", () => {
+      const snapshot = {
+        query: "",
+        searching: false,
+        searchError: null,
+        result: null,
+        matches: [],
+        activeGroupings: [],
+        loadingMatches: true,
+        hasMore: false,
+        selectedMatchIds: [],
+        seriesGroups: [],
+        hideShortGames: true,
+        busy: false,
+      };
+
+      const model = AddTrackerDialogPresenter.present(snapshot);
+
+      expect(model.visibleMatches).toBeNull();
+    });
+
+    it("filters short matches when hideShortGames is true", () => {
+      const snapshot = {
+        query: "",
+        searching: false,
+        searchError: null,
+        result: null,
+        matches: [
+          {
+            matchId: "short",
+            startTime: "Jan 1, 2026, 12:00:00 AM",
+            endTime: "Jan 1, 2026, 12:01:00 AM",
+            startTimeIso: "2026-01-01T00:00:00.000Z",
+            endTimeIso: "2026-01-01T00:01:00.000Z",
+            mapAssetId: "a",
+            mapVersionId: "b",
+            modeAssetId: "c",
+            modeVersionId: "d",
+            gameVariantCategory: 6 as const,
+            duration: "1m",
+            mapName: "A",
+            modeName: "Slayer",
+            outcome: "Win" as const,
+            resultString: "W",
+            isMatchmaking: false,
+            category: "custom" as const,
+            teams: [],
+            mapThumbnailUrl: "data:,",
+          },
+          {
+            matchId: "long",
+            startTime: "Jan 1, 2026, 12:15:00 AM",
+            endTime: "Jan 1, 2026, 12:25:00 AM",
+            startTimeIso: "2026-01-01T00:15:00.000Z",
+            endTimeIso: "2026-01-01T00:25:00.000Z",
+            mapAssetId: "a",
+            mapVersionId: "b",
+            modeAssetId: "c",
+            modeVersionId: "d",
+            gameVariantCategory: 6 as const,
+            duration: "10m",
+            mapName: "B",
+            modeName: "Slayer",
+            outcome: "Win" as const,
+            resultString: "W",
+            isMatchmaking: false,
+            category: "custom" as const,
+            teams: [],
+            mapThumbnailUrl: "data:,",
+          },
+        ],
+        activeGroupings: [],
+        loadingMatches: false,
+        hasMore: false,
+        selectedMatchIds: [],
+        seriesGroups: [],
+        hideShortGames: true,
+        busy: false,
+      };
+
+      const model = AddTrackerDialogPresenter.present(snapshot);
+
+      expect(model.visibleMatches).toHaveLength(1);
+      expect(model.visibleMatches?.[0].matchId).toBe("long");
+    });
+  });
+});

--- a/pages/src/components/individual-tracker/add-tracker-dialog/tests/add-tracker-dialog.test.tsx
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/tests/add-tracker-dialog.test.tsx
@@ -1,0 +1,195 @@
+import "@testing-library/jest-dom/vitest";
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { TrackerMatchHistoryEntry, TrackerSearchResult } from "../../../../services/individual-tracker/types";
+import { AddTrackerDialog } from "../add-tracker-dialog";
+
+vi.mock("../../../icons/rank-icon", () => ({
+  RankIcon: (): React.ReactNode => <span data-testid="rank-icon" />,
+}));
+
+vi.mock("../../../icons/team-icon", () => ({
+  TeamIcon: (): React.ReactNode => <span data-testid="team-icon" />,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+function aFakeSearchResult(overrides?: Partial<TrackerSearchResult>): TrackerSearchResult {
+  return {
+    gamertag: "Chief",
+    xuid: "xuid-1",
+    rankLabel: "Gold 5",
+    csrLabel: "1200",
+    currentRankTier: "Gold",
+    currentRankSubTier: 5,
+    currentRankMeasurementMatchesRemaining: null,
+    currentRankInitialMeasurementMatches: null,
+    allTimePeakRankLabel: "Platinum 1",
+    allTimePeakCsrLabel: "1300",
+    allTimePeakRankTier: "Platinum",
+    allTimePeakRankSubTier: 1,
+    seasonPeakCsrLabel: "1250",
+    seasonPeakRankTier: "Gold",
+    seasonPeakRankSubTier: 6,
+    matchmadeMatchCount: 20,
+    customMatchCount: 8,
+    ...overrides,
+  };
+}
+
+function aFakeMatch(matchId: string): TrackerMatchHistoryEntry {
+  return {
+    matchId,
+    startTime: "Jan 1, 2026, 12:00:00 AM",
+    endTime: "Jan 1, 2026, 12:10:00 AM",
+    mapAssetId: "map-1",
+    mapVersionId: "map-v-1",
+    modeAssetId: "mode-1",
+    modeVersionId: "mode-v-1",
+    gameVariantCategory: 6,
+    duration: "10m 0s",
+    mapName: "Aquarius",
+    modeName: "Slayer",
+    outcome: "Win",
+    resultString: "Win - 50:40",
+    isMatchmaking: false,
+    category: "custom",
+    teams: [],
+    mapThumbnailUrl: "data:,",
+  };
+}
+
+const defaultProps = {
+  open: true,
+  busy: false,
+  query: "",
+  searching: false,
+  searchError: null,
+  result: null,
+  visibleMatches: null,
+  activeGroupings: [] as readonly (readonly string[])[],
+  loadingMatches: false,
+  hasMore: false,
+  selectedMatchIds: new Set<string>(),
+  seriesGroups: [] as const,
+  hideShortGames: true,
+  canStart: false,
+  onClose: vi.fn<() => void>(),
+  onQueryChange: vi.fn<(v: string) => void>(),
+  onSearch: vi.fn<() => void>(),
+  onMatchToggle: vi.fn<(id: string) => void>(),
+  onLoadMore: vi.fn<() => Promise<void>>(async () => Promise.resolve()),
+  onAddToAboveGroup: vi.fn<(id: string) => void>(),
+  onAddToBelowGroup: vi.fn<(id: string) => void>(),
+  onBreakFromGroup: vi.fn<(id: string) => void>(),
+  onHideShortGamesChange: vi.fn<(v: boolean) => void>(),
+  onSeriesGroupTitleChange: vi.fn<(i: number, v: string | null) => void>(),
+  onSeriesGroupSubtitleChange: vi.fn<(i: number, v: string | null) => void>(),
+  onStartTracker: vi.fn<() => void>(),
+};
+
+describe("AddTrackerDialog", () => {
+  it("renders null when closed", () => {
+    const { container } = render(<AddTrackerDialog {...defaultProps} open={false} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the dialog title when open", () => {
+    render(<AddTrackerDialog {...defaultProps} />);
+
+    expect(screen.getByText("Add Tracker")).toBeInTheDocument();
+  });
+
+  it("calls onQueryChange when the gamertag input changes", () => {
+    const onQueryChange = vi.fn<(v: string) => void>();
+    render(<AddTrackerDialog {...defaultProps} onQueryChange={onQueryChange} />);
+
+    fireEvent.change(screen.getByLabelText("Gamertag"), { target: { value: "Chief" } });
+
+    expect(onQueryChange).toHaveBeenCalledWith("Chief");
+  });
+
+  it("calls onSearch when Search is clicked", () => {
+    const onSearch = vi.fn<() => void>();
+    render(<AddTrackerDialog {...defaultProps} query="Chief" onSearch={onSearch} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(onSearch).toHaveBeenCalledOnce();
+  });
+
+  it("disables Search button when query is empty", () => {
+    render(<AddTrackerDialog {...defaultProps} query="" />);
+
+    expect(screen.getByRole("button", { name: "Search" })).toBeDisabled();
+  });
+
+  it("shows the search error alert when searchError is set", () => {
+    render(<AddTrackerDialog {...defaultProps} searchError="No matching gamertag found." />);
+
+    expect(screen.getByText("No matching gamertag found.")).toBeInTheDocument();
+  });
+
+  it("shows the tracker summary when result is set", () => {
+    render(<AddTrackerDialog {...defaultProps} result={aFakeSearchResult()} />);
+
+    expect(screen.getByText("Current rank:")).toBeInTheDocument();
+  });
+
+  it("shows muted prompt when result is null", () => {
+    render(<AddTrackerDialog {...defaultProps} result={null} />);
+
+    expect(screen.getByText("Search for a gamertag first to load recent matches.")).toBeInTheDocument();
+  });
+
+  it("renders match cards when visibleMatches is set", () => {
+    render(
+      <AddTrackerDialog
+        {...defaultProps}
+        result={aFakeSearchResult()}
+        visibleMatches={[aFakeMatch("m1")]}
+        activeGroupings={[]}
+        loadingMatches={false}
+      />,
+    );
+
+    expect(screen.getByText("Slayer: Aquarius")).toBeInTheDocument();
+  });
+
+  it("calls onStartTracker when Start tracker is clicked", async () => {
+    const onStartTracker = vi.fn<() => void>();
+    render(<AddTrackerDialog {...defaultProps} canStart={true} onStartTracker={onStartTracker} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Start tracker" }));
+
+    await waitFor(() => {
+      expect(onStartTracker).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("disables Start tracker when canStart is false", () => {
+    render(<AddTrackerDialog {...defaultProps} canStart={false} />);
+
+    expect(screen.getByRole("button", { name: "Start tracker" })).toBeDisabled();
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    const onClose = vi.fn<() => void>();
+    render(<AddTrackerDialog {...defaultProps} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows busy label on Start tracker button when busy", () => {
+    render(<AddTrackerDialog {...defaultProps} busy={true} canStart={true} />);
+
+    expect(screen.getByRole("button", { name: "Starting..." })).toBeInTheDocument();
+  });
+});

--- a/pages/src/components/match-history/create.tsx
+++ b/pages/src/components/match-history/create.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import React, { useMemo, useSyncExternalStore } from "react";
 import type { TrackerMatchHistoryEntry } from "../../services/individual-tracker/types";
 import type { IndividualTrackerSeriesGroup } from "../individual-tracker/series-group-metadata";
 import { MatchHistoryPresenter } from "./match-history-presenter";
@@ -48,33 +48,6 @@ export function MatchHistorySection({
 }: MatchHistorySectionProps): React.JSX.Element {
   const store = useMemo(() => new MatchHistoryStore(), []);
   const presenter = useMemo(() => new MatchHistoryPresenter({ store, onLoadMore }), [store, onLoadMore]);
-  const sentinelRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (onLoadMore == null || hasMore !== true) {
-      return;
-    }
-
-    const sentinel = sentinelRef.current;
-    if (sentinel == null) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (intersectionEntries) => {
-        const [first] = intersectionEntries;
-        if (first.isIntersecting && !store.getSnapshot().isLoadingMore) {
-          void presenter.loadMore();
-        }
-      },
-      { rootMargin: "0px 0px 150px 0px", threshold: 0 },
-    );
-
-    observer.observe(sentinel);
-    return (): void => {
-      observer.disconnect();
-    };
-  }, [presenter, store, onLoadMore, hasMore]);
 
   const snapshot = useSyncExternalStore(
     (listener) => store.subscribe(listener),
@@ -100,7 +73,7 @@ export function MatchHistorySection({
       hasMore={hasMore}
       seriesGroups={seriesGroups}
       onMatchToggle={onMatchToggle}
-      onLoadMore={onLoadMore}
+      onLoadMore={async () => presenter.loadMore()}
       onAddToAboveGroup={onAddToAboveGroup}
       onAddToBelowGroup={onAddToBelowGroup}
       onBreakFromGroup={onBreakFromGroup}
@@ -108,7 +81,6 @@ export function MatchHistorySection({
       onSeriesGroupTitleChange={onSeriesGroupTitleChange}
       onSeriesGroupSubtitleChange={onSeriesGroupSubtitleChange}
       model={model}
-      sentinelRef={sentinelRef}
     />
   );
 }

--- a/pages/src/components/match-history/match-history.module.css
+++ b/pages/src/components/match-history/match-history.module.css
@@ -101,15 +101,21 @@
   min-width: 0;
 }
 
-.sentinel {
-  height: 40px;
+.loadMoreButton {
+  align-self: center;
+  background: var(--color-background-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-base);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  margin-top: var(--space-4);
+  padding: var(--space-2) var(--space-6);
 }
 
-.loadingMoreList {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  margin-top: var(--space-2);
+.loadMoreButton:disabled {
+  cursor: default;
+  opacity: 0.6;
 }
 
 @media (--tablet-viewport) {

--- a/pages/src/components/match-history/match-history.tsx
+++ b/pages/src/components/match-history/match-history.tsx
@@ -32,7 +32,6 @@ export interface MatchHistoryProps {
   readonly onSeriesGroupTitleChange?: (groupIndex: number, value: string | null) => void;
   readonly onSeriesGroupSubtitleChange?: (groupIndex: number, value: string | null) => void;
   readonly model: MatchHistoryModel;
-  readonly sentinelRef: React.RefObject<HTMLDivElement | null>;
 }
 
 export function MatchHistory({
@@ -44,7 +43,9 @@ export function MatchHistory({
   selectedMatchIds,
   groupings,
   showGroupings = false,
+  hasMore,
   onMatchToggle,
+  onLoadMore,
   onAddToAboveGroup,
   onAddToBelowGroup,
   onBreakFromGroup,
@@ -52,7 +53,6 @@ export function MatchHistory({
   onSeriesGroupTitleChange,
   onSeriesGroupSubtitleChange,
   model,
-  sentinelRef,
 }: MatchHistoryProps): React.JSX.Element {
   const isGroupableGame = (entry: TrackerMatchHistoryEntry): boolean =>
     entry.category === "custom" || entry.category === "local";
@@ -249,11 +249,16 @@ export function MatchHistory({
             }
           }
         })}
-        <div ref={sentinelRef} className={styles.sentinel} />
-        {model.isLoadingMore && (
-          <div className={styles.loadingMoreList}>
-            <LoadingState text="Loading more matches..." />
-          </div>
+        {hasMore === true && (
+          <button
+            className={styles.loadMoreButton}
+            disabled={model.isLoadingMore}
+            onClick={() => {
+              void onLoadMore?.();
+            }}
+          >
+            {model.isLoadingMore ? "Loading…" : "Load more"}
+          </button>
         )}
       </div>
     </div>

--- a/pages/src/components/match-history/tests/match-history.test.tsx
+++ b/pages/src/components/match-history/tests/match-history.test.tsx
@@ -4,8 +4,10 @@ import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
+import { MatchHistory } from "../match-history";
 import { MatchHistorySection } from "../create";
 import { HALO_TEAM_COLORS } from "../../team-colors/team-colors";
+import type { MatchHistoryModel } from "../match-history-presenter";
 
 afterEach(() => {
   cleanup();
@@ -79,6 +81,52 @@ describe("MatchHistorySection", () => {
     expect(screen.queryByTitle("Add to group above")).not.toBeInTheDocument();
     expect(screen.queryByTitle("Add to group below")).not.toBeInTheDocument();
     expect(screen.getAllByTitle("Break from group")).toHaveLength(3);
+  });
+
+  it("renders Load more button when hasMore is true", () => {
+    render(
+      <MatchHistorySection
+        entries={[aMatchWith("m1", "custom", "Slayer")]}
+        hasMore={true}
+        onLoadMore={vi.fn<() => Promise<void>>().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument();
+  });
+
+  it("does not render Load more button when hasMore is false", () => {
+    render(<MatchHistorySection entries={[aMatchWith("m1", "custom", "Slayer")]} hasMore={false} />);
+
+    expect(screen.queryByRole("button", { name: "Load more" })).not.toBeInTheDocument();
+  });
+
+  it("disables Load more button and shows Loading text when isLoadingMore is true", () => {
+    const model: MatchHistoryModel = { segmentBlocks: [], isLoadingMore: true };
+
+    render(
+      <MatchHistory
+        entries={[aMatchWith("m1", "custom", "Slayer")]}
+        hasMore={true}
+        onLoadMore={vi.fn<() => Promise<void>>().mockResolvedValue(undefined)}
+        model={model}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Loading…" });
+    expect(button).toBeDisabled();
+  });
+
+  it("calls onLoadMore when Load more button is clicked", () => {
+    const onLoadMore = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    render(
+      <MatchHistorySection entries={[aMatchWith("m1", "custom", "Slayer")]} hasMore={true} onLoadMore={onLoadMore} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+
+    expect(onLoadMore).toHaveBeenCalledOnce();
   });
 
   it("rotates series colors by visible series order", () => {

--- a/pages/src/services/individual-tracker/fakes/individual-tracker.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/individual-tracker.fake.ts
@@ -9,7 +9,12 @@ import type {
   TrackerResponse,
   TrackersResponse,
 } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
-import type { IndividualTrackerService, TrackerMatchHistoryResponse, TrackerSyncMatchesRequest } from "../types";
+import type {
+  IndividualTrackerService,
+  TrackerMatchHistoryResponse,
+  TrackerSearchResult,
+  TrackerSyncMatchesRequest,
+} from "../types";
 
 interface FakeTrackerOverrides {
   readonly trackerId?: string;
@@ -59,23 +64,58 @@ export function aFakeTrackerProfileWith(overrides: FakeProfileOverrides = {}): T
   };
 }
 
+export interface FakeTrackerSearchResultOverrides {
+  readonly gamertag?: string;
+  readonly xuid?: string;
+}
+
+export function aFakeTrackerSearchResultWith(overrides: FakeTrackerSearchResultOverrides = {}): TrackerSearchResult {
+  return {
+    gamertag: overrides.gamertag ?? "Fake Spartan",
+    xuid: overrides.xuid ?? "2533274800000001",
+    rankLabel: "Gold 5",
+    csrLabel: "1200",
+    currentRankTier: "Gold",
+    currentRankSubTier: 5,
+    currentRankMeasurementMatchesRemaining: null,
+    currentRankInitialMeasurementMatches: null,
+    allTimePeakRankLabel: "Platinum 1",
+    allTimePeakCsrLabel: "1300",
+    allTimePeakRankTier: "Platinum",
+    allTimePeakRankSubTier: 1,
+    seasonPeakCsrLabel: "1250",
+    seasonPeakRankTier: "Gold",
+    seasonPeakRankSubTier: 6,
+    matchmadeMatchCount: 20,
+    customMatchCount: 8,
+  };
+}
+
 interface FakeIndividualTrackerServiceOptions {
   readonly profile: TrackerProfile;
   readonly trackers: readonly Tracker[];
+  readonly searchResult: TrackerSearchResult | null;
+  readonly matchHistory: TrackerMatchHistoryResponse;
 }
 
 export interface FakeIndividualTrackerServiceFactoryOpts {
   readonly profile?: TrackerProfile;
   readonly trackers?: readonly Tracker[];
+  readonly searchResult?: TrackerSearchResult | null;
+  readonly matchHistory?: TrackerMatchHistoryResponse;
 }
 
 export class FakeIndividualTrackerService implements IndividualTrackerService {
   private profile: TrackerProfile;
   private trackers: Tracker[];
+  private readonly searchResult: TrackerSearchResult | null;
+  private readonly matchHistory: TrackerMatchHistoryResponse;
 
   public constructor(options?: Partial<FakeIndividualTrackerServiceOptions>) {
     this.profile = options?.profile ?? aFakeTrackerProfileWith();
     this.trackers = [...(options?.trackers ?? [aFakeTrackerWith()])];
+    this.searchResult = options?.searchResult !== undefined ? options.searchResult : aFakeTrackerSearchResultWith();
+    this.matchHistory = options?.matchHistory ?? { matches: [], suggestedGroupings: [] };
   }
 
   public async getProfile(): Promise<TrackerProfileResponse> {
@@ -131,12 +171,18 @@ export class FakeIndividualTrackerService implements IndividualTrackerService {
     return { tracker: this.findTracker(trackerId) };
   }
 
+  public async searchGamertag(query: string): Promise<TrackerSearchResult | null> {
+    void query;
+    await Promise.resolve();
+    return this.searchResult;
+  }
+
   public async getMatchHistory(xuid: string, start: number, count: number): Promise<TrackerMatchHistoryResponse> {
     void xuid;
     void start;
     void count;
     await Promise.resolve();
-    return { matches: [], suggestedGroupings: [] };
+    return this.matchHistory;
   }
 
   public async syncMatchesToTracker(request: TrackerSyncMatchesRequest): Promise<void> {
@@ -168,5 +214,7 @@ export function aFakeIndividualTrackerServiceWith(
   return new FakeIndividualTrackerService({
     ...(opts.profile !== undefined ? { profile: opts.profile } : {}),
     ...(opts.trackers !== undefined ? { trackers: opts.trackers } : {}),
+    ...(opts.searchResult !== undefined ? { searchResult: opts.searchResult } : {}),
+    ...(opts.matchHistory !== undefined ? { matchHistory: opts.matchHistory } : {}),
   });
 }

--- a/pages/src/services/individual-tracker/individual-tracker.ts
+++ b/pages/src/services/individual-tracker/individual-tracker.ts
@@ -29,6 +29,7 @@ import type {
   IndividualTrackerService,
   TrackerMatchHistoryEntry,
   TrackerMatchHistoryResponse,
+  TrackerSearchResult,
   TrackerSyncMatchesRequest,
 } from "./types";
 
@@ -207,6 +208,29 @@ export class RealIndividualTrackerService implements IndividualTrackerService {
     }
 
     return trackerContract.fromResponse(response);
+  }
+
+  public async searchGamertag(query: string): Promise<TrackerSearchResult | null> {
+    const normalized = query.trim();
+    if (normalized === "") {
+      return null;
+    }
+
+    const url = this.buildUrl(`/api/individual-tracker/manage/search-gamertag?q=${encodeURIComponent(normalized)}`);
+    const response = await fetch(url, {
+      credentials: "include",
+      method: "GET",
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    return await response.json();
   }
 
   public async getMatchHistory(xuid: string, start: number, count: number): Promise<TrackerMatchHistoryResponse> {

--- a/pages/src/services/individual-tracker/individual-tracker.ts
+++ b/pages/src/services/individual-tracker/individual-tracker.ts
@@ -24,7 +24,16 @@ import { getReadableDuration } from "@guilty-spark/shared/halo/duration";
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
 import type { HaloInfiniteClient, MapAsset, MatchStats, UgcGameVariantAsset } from "halo-infinite-api";
 import { AssetKind, MatchType } from "halo-infinite-api";
-import { buildMatchResultString, buildTeams, formatDisplayDateTime, getMapThumbnailUrl } from "./match-history-helpers";
+import {
+  buildMatchResultString,
+  buildTeams,
+  formatDisplayDateTime,
+  getCsrLabel,
+  getMapThumbnailUrl,
+  getRankAndCsrLabels,
+  getRankLabel,
+  RANKED_ARENA_PLAYLIST_ID,
+} from "./match-history-helpers";
 import type {
   IndividualTrackerService,
   TrackerMatchHistoryEntry,
@@ -216,21 +225,79 @@ export class RealIndividualTrackerService implements IndividualTrackerService {
       return null;
     }
 
-    const url = this.buildUrl(`/api/individual-tracker/manage/search-gamertag?q=${encodeURIComponent(normalized)}`);
-    const response = await fetch(url, {
-      credentials: "include",
-      method: "GET",
-    });
-
-    if (response.status === 404) {
+    let userResult: { gamertag: string; xuid: string };
+    try {
+      userResult = await this.haloInfiniteClient.getUser(normalized);
+    } catch {
       return null;
     }
 
-    if (!response.ok) {
-      throw await this.readError(response);
+    let rankLabel: string | null = null;
+    let csrLabel: string | null = null;
+    let currentRankTier: string | null = null;
+    let currentRankSubTier: number | null = null;
+    let currentRankMeasurementMatchesRemaining: number | null = null;
+    let currentRankInitialMeasurementMatches: number | null = null;
+    let allTimePeakRankLabel: string | null = null;
+    let allTimePeakCsrLabel: string | null = null;
+    let allTimePeakRankTier: string | null = null;
+    let allTimePeakRankSubTier: number | null = null;
+    let seasonPeakCsrLabel: string | null = null;
+    let seasonPeakRankTier: string | null = null;
+    let seasonPeakRankSubTier: number | null = null;
+    let matchmadeMatchCount: number | null = null;
+    let customMatchCount: number | null = null;
+
+    const [rankedArenaCsrs, matchCounts] = await Promise.allSettled([
+      this.haloInfiniteClient.getPlaylistCsr(RANKED_ARENA_PLAYLIST_ID, [userResult.xuid]),
+      this.haloInfiniteClient.getPlayerMatchCount(userResult.xuid),
+    ]);
+
+    if (rankedArenaCsrs.status === "fulfilled") {
+      const [{ Result }] = rankedArenaCsrs.value;
+      const labels = getRankAndCsrLabels(Result);
+      const current = Result.Current;
+      const allTimeMax = Result.AllTimeMax;
+      const seasonMax = Result.SeasonMax;
+      ({ rankLabel, csrLabel } = labels);
+      currentRankTier = current.Tier;
+      currentRankSubTier = current.SubTier;
+      currentRankMeasurementMatchesRemaining = current.MeasurementMatchesRemaining;
+      currentRankInitialMeasurementMatches = current.InitialMeasurementMatches;
+      allTimePeakRankLabel = getRankLabel(allTimeMax.Tier, allTimeMax.SubTier);
+      allTimePeakCsrLabel = getCsrLabel(allTimeMax.Value);
+      allTimePeakRankTier = allTimeMax.Tier;
+      allTimePeakRankSubTier = allTimeMax.SubTier;
+      seasonPeakCsrLabel = getCsrLabel(seasonMax.Value);
+      seasonPeakRankTier = seasonMax.Tier;
+      seasonPeakRankSubTier = seasonMax.SubTier;
     }
 
-    return await response.json();
+    if (matchCounts.status === "fulfilled") {
+      const count = matchCounts.value;
+      matchmadeMatchCount = count.MatchmadeMatchesPlayedCount;
+      customMatchCount = count.CustomMatchesPlayedCount;
+    }
+
+    return {
+      gamertag: userResult.gamertag,
+      xuid: userResult.xuid,
+      rankLabel,
+      csrLabel,
+      currentRankTier,
+      currentRankSubTier,
+      currentRankMeasurementMatchesRemaining,
+      currentRankInitialMeasurementMatches,
+      allTimePeakRankLabel,
+      allTimePeakCsrLabel,
+      allTimePeakRankTier,
+      allTimePeakRankSubTier,
+      seasonPeakCsrLabel,
+      seasonPeakRankTier,
+      seasonPeakRankSubTier,
+      matchmadeMatchCount,
+      customMatchCount,
+    };
   }
 
   public async getMatchHistory(xuid: string, start: number, count: number): Promise<TrackerMatchHistoryResponse> {

--- a/pages/src/services/individual-tracker/match-history-helpers.ts
+++ b/pages/src/services/individual-tracker/match-history-helpers.ts
@@ -1,5 +1,29 @@
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
-import type { MapAsset, MatchStats } from "halo-infinite-api";
+import type { MapAsset, MatchStats, PlaylistCsrContainer } from "halo-infinite-api";
+
+export const RANKED_ARENA_PLAYLIST_ID = "edfef3ac-9cbe-4fa2-b949-8f29deafd483";
+
+export function getRankLabel(tier: string, subTier: number): string {
+  if (tier === "Onyx") {
+    return tier;
+  }
+
+  return `${tier} ${(subTier + 1).toString()}`;
+}
+
+export function getRankAndCsrLabels(csr: PlaylistCsrContainer): { rankLabel: string | null; csrLabel: string | null } {
+  const currentCsr = csr.Current;
+
+  const csrLabel = currentCsr.Value >= 0 ? currentCsr.Value.toString() : "-";
+  const rankLabel =
+    currentCsr.MeasurementMatchesRemaining > 0 ? "Unranked" : getRankLabel(currentCsr.Tier, currentCsr.SubTier);
+
+  return { rankLabel, csrLabel };
+}
+
+export function getCsrLabel(value: number): string | null {
+  return value >= 0 ? value.toString() : "-";
+}
 
 export function formatDisplayDateTime(value: string): string {
   const date = new Date(value);

--- a/pages/src/services/individual-tracker/tests/individual-tracker.test.ts
+++ b/pages/src/services/individual-tracker/tests/individual-tracker.test.ts
@@ -2,7 +2,7 @@ import type { TrackerProfile } from "@guilty-spark/shared/contracts/individual-t
 import type { Tracker } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MockInstance } from "vitest";
-import type { HaloInfiniteClient } from "halo-infinite-api";
+import type { HaloInfiniteClient, PlaylistCsr, PlaylistCsrContainer, ResultContainer } from "halo-infinite-api";
 import { RealIndividualTrackerService } from "../individual-tracker";
 
 function jsonResponse(payload: object, status = 200): Response {
@@ -27,15 +27,51 @@ const FAKE_TRACKER: Tracker = {
   state: null,
 };
 
+function aFakePlaylistCsr(overrides: Partial<PlaylistCsr> = {}): PlaylistCsr {
+  return {
+    Value: 1200,
+    MeasurementMatchesRemaining: 0,
+    Tier: "Gold",
+    TierStart: 1100,
+    SubTier: 4,
+    NextTier: "Platinum",
+    NextTierStart: 1300,
+    NextSubTier: 0,
+    InitialMeasurementMatches: 10,
+    DemotionProtectionMatchesRemaining: 0,
+    InitialDemotionProtectionMatches: 0,
+    ...overrides,
+  };
+}
+
+function aFakePlaylistCsrContainer(overrides: Partial<PlaylistCsrContainer> = {}): PlaylistCsrContainer {
+  return {
+    Current: aFakePlaylistCsr(),
+    SeasonMax: aFakePlaylistCsr({ Value: 1250, Tier: "Gold", SubTier: 5 }),
+    AllTimeMax: aFakePlaylistCsr({ Value: 1300, Tier: "Platinum", SubTier: 0 }),
+    ...overrides,
+  };
+}
+
+function aFakeCsrResult(container: PlaylistCsrContainer): ResultContainer<PlaylistCsrContainer>[] {
+  return [{ Result: container } as unknown as ResultContainer<PlaylistCsrContainer>];
+}
+
 describe("RealIndividualTrackerService", () => {
   let fetchSpy: MockInstance;
+  let haloInfiniteClient: HaloInfiniteClient;
   let service: RealIndividualTrackerService;
 
   beforeEach(() => {
     fetchSpy = vi.spyOn(globalThis, "fetch");
+    haloInfiniteClient = {
+      getUser: vi.fn(),
+      getPlaylistCsr: vi.fn(),
+      getPlayerMatchCount: vi.fn(),
+    } as unknown as HaloInfiniteClient;
     service = new RealIndividualTrackerService({
       apiHost: "https://api.example.com",
-      haloInfiniteClient: {} as unknown as HaloInfiniteClient,
+      haloInfiniteClient,
     });
   });
 
@@ -166,5 +202,80 @@ describe("RealIndividualTrackerService", () => {
     fetchSpy.mockResolvedValueOnce(jsonResponse({ error: "Failed to list trackers" }, 500));
 
     await expect(service.listTrackers()).rejects.toThrow("Failed to list trackers");
+  });
+
+  describe("searchGamertag", () => {
+    it("returns null for an empty query", async () => {
+      const result = await service.searchGamertag("   ");
+
+      expect(result).toBeNull();
+      expect(haloInfiniteClient.getUser).not.toHaveBeenCalled();
+    });
+
+    it("returns null when getUser throws (gamertag not found)", async () => {
+      vi.mocked(haloInfiniteClient.getUser).mockRejectedValueOnce(new Error("Not found"));
+
+      const result = await service.searchGamertag("UnknownSpartan");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns result with rank fields when CSR call succeeds", async () => {
+      vi.mocked(haloInfiniteClient.getUser).mockResolvedValueOnce({
+        gamertag: "Master Chief",
+        xuid: "2533274800000001",
+      } as unknown as Awaited<ReturnType<HaloInfiniteClient["getUser"]>>);
+      vi.mocked(haloInfiniteClient.getPlaylistCsr).mockResolvedValueOnce(aFakeCsrResult(aFakePlaylistCsrContainer()));
+      vi.mocked(haloInfiniteClient.getPlayerMatchCount).mockResolvedValueOnce({
+        MatchmadeMatchesPlayedCount: 50,
+        CustomMatchesPlayedCount: 5,
+      } as unknown as Awaited<ReturnType<HaloInfiniteClient["getPlayerMatchCount"]>>);
+
+      const result = await service.searchGamertag("Master Chief");
+
+      expect(result).not.toBeNull();
+      expect(result?.gamertag).toBe("Master Chief");
+      expect(result?.xuid).toBe("2533274800000001");
+      expect(result?.rankLabel).toBe("Gold 5");
+      expect(result?.csrLabel).toBe("1200");
+      expect(result?.matchmadeMatchCount).toBe(50);
+      expect(result?.customMatchCount).toBe(5);
+    });
+
+    it("returns result with null rank fields when CSR call fails", async () => {
+      vi.mocked(haloInfiniteClient.getUser).mockResolvedValueOnce({
+        gamertag: "Master Chief",
+        xuid: "2533274800000001",
+      } as unknown as Awaited<ReturnType<HaloInfiniteClient["getUser"]>>);
+      vi.mocked(haloInfiniteClient.getPlaylistCsr).mockRejectedValueOnce(new Error("CSR unavailable"));
+      vi.mocked(haloInfiniteClient.getPlayerMatchCount).mockResolvedValueOnce({
+        MatchmadeMatchesPlayedCount: 10,
+        CustomMatchesPlayedCount: 2,
+      } as unknown as Awaited<ReturnType<HaloInfiniteClient["getPlayerMatchCount"]>>);
+
+      const result = await service.searchGamertag("Master Chief");
+
+      expect(result).not.toBeNull();
+      expect(result?.rankLabel).toBeNull();
+      expect(result?.csrLabel).toBeNull();
+      expect(result?.currentRankTier).toBeNull();
+      expect(result?.matchmadeMatchCount).toBe(10);
+    });
+
+    it("returns result with null match counts when count call fails", async () => {
+      vi.mocked(haloInfiniteClient.getUser).mockResolvedValueOnce({
+        gamertag: "Master Chief",
+        xuid: "2533274800000001",
+      } as unknown as Awaited<ReturnType<HaloInfiniteClient["getUser"]>>);
+      vi.mocked(haloInfiniteClient.getPlaylistCsr).mockResolvedValueOnce(aFakeCsrResult(aFakePlaylistCsrContainer()));
+      vi.mocked(haloInfiniteClient.getPlayerMatchCount).mockRejectedValueOnce(new Error("Count unavailable"));
+
+      const result = await service.searchGamertag("Master Chief");
+
+      expect(result).not.toBeNull();
+      expect(result?.rankLabel).toBe("Gold 5");
+      expect(result?.matchmadeMatchCount).toBeNull();
+      expect(result?.customMatchCount).toBeNull();
+    });
   });
 });

--- a/pages/src/services/individual-tracker/tests/match-history-helpers.test.ts
+++ b/pages/src/services/individual-tracker/tests/match-history-helpers.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
-import type { MapAsset, MatchStats } from "halo-infinite-api";
+import type { MapAsset, MatchStats, PlaylistCsrContainer } from "halo-infinite-api";
 import {
   buildMatchResultString,
   buildTeams,
   formatDisplayDateTime,
+  getCsrLabel,
   getMapThumbnailUrl,
+  getRankAndCsrLabels,
+  getRankLabel,
 } from "../match-history-helpers";
 
 describe("formatDisplayDateTime", () => {
@@ -116,5 +119,77 @@ describe("buildTeams", () => {
     const teams = buildTeams(matchStats, new Map());
 
     expect(teams[0]).toEqual(["*Unknown*"]);
+  });
+});
+
+describe("getRankLabel", () => {
+  it("returns 'Onyx' for Onyx tier regardless of subTier", () => {
+    expect(getRankLabel("Onyx", 0)).toBe("Onyx");
+    expect(getRankLabel("Onyx", 5)).toBe("Onyx");
+  });
+
+  it("returns tier with 1-indexed subTier for non-Onyx tiers", () => {
+    expect(getRankLabel("Gold", 0)).toBe("Gold 1");
+    expect(getRankLabel("Gold", 4)).toBe("Gold 5");
+    expect(getRankLabel("Platinum", 5)).toBe("Platinum 6");
+  });
+});
+
+describe("getCsrLabel", () => {
+  it("returns the CSR value as a string for non-negative values", () => {
+    expect(getCsrLabel(0)).toBe("0");
+    expect(getCsrLabel(1500)).toBe("1500");
+  });
+
+  it("returns '-' for negative values", () => {
+    expect(getCsrLabel(-1)).toBe("-");
+  });
+});
+
+describe("getRankAndCsrLabels", () => {
+  function aContainer(
+    overrides: {
+      value?: number;
+      measurementMatchesRemaining?: number;
+      tier?: string;
+      subTier?: number;
+    } = {},
+  ): PlaylistCsrContainer {
+    return {
+      Current: {
+        Value: overrides.value ?? 1200,
+        MeasurementMatchesRemaining: overrides.measurementMatchesRemaining ?? 0,
+        Tier: overrides.tier ?? "Gold",
+        SubTier: overrides.subTier ?? 4,
+        TierStart: 1100,
+        NextTier: "Platinum",
+        NextTierStart: 1300,
+        NextSubTier: 0,
+        InitialMeasurementMatches: 10,
+        DemotionProtectionMatchesRemaining: 0,
+        InitialDemotionProtectionMatches: 0,
+      },
+      SeasonMax: {} as PlaylistCsrContainer["SeasonMax"],
+      AllTimeMax: {} as PlaylistCsrContainer["AllTimeMax"],
+    };
+  }
+
+  it("returns rank and CSR labels for a ranked player", () => {
+    const result = getRankAndCsrLabels(aContainer({ value: 1200, tier: "Gold", subTier: 4 }));
+
+    expect(result.rankLabel).toBe("Gold 5");
+    expect(result.csrLabel).toBe("1200");
+  });
+
+  it("returns 'Unranked' when measurement matches remain", () => {
+    const result = getRankAndCsrLabels(aContainer({ measurementMatchesRemaining: 5 }));
+
+    expect(result.rankLabel).toBe("Unranked");
+  });
+
+  it("returns '-' for csrLabel when CSR value is negative", () => {
+    const result = getRankAndCsrLabels(aContainer({ value: -1 }));
+
+    expect(result.csrLabel).toBe("-");
   });
 });

--- a/pages/src/services/individual-tracker/types.ts
+++ b/pages/src/services/individual-tracker/types.ts
@@ -9,6 +9,26 @@ import type {
 } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import type { GameVariantCategory, MatchStats } from "halo-infinite-api";
 
+export interface TrackerSearchResult {
+  readonly gamertag: string;
+  readonly xuid: string;
+  readonly rankLabel: string | null;
+  readonly csrLabel: string | null;
+  readonly currentRankTier: string | null;
+  readonly currentRankSubTier: number | null;
+  readonly currentRankMeasurementMatchesRemaining: number | null;
+  readonly currentRankInitialMeasurementMatches: number | null;
+  readonly allTimePeakRankLabel: string | null;
+  readonly allTimePeakCsrLabel: string | null;
+  readonly allTimePeakRankTier: string | null;
+  readonly allTimePeakRankSubTier: number | null;
+  readonly seasonPeakCsrLabel: string | null;
+  readonly seasonPeakRankTier: string | null;
+  readonly seasonPeakRankSubTier: number | null;
+  readonly matchmadeMatchCount: number | null;
+  readonly customMatchCount: number | null;
+}
+
 export interface TrackerMatchHistoryEntry {
   readonly matchId: string;
   readonly startTime: string;
@@ -58,6 +78,7 @@ export interface IndividualTrackerService {
   resumeTracker(trackerId: string): Promise<TrackerResponse>;
   selectActive(trackerId: string): Promise<TrackerResponse>;
   getTrackerStatus(trackerId: string): Promise<TrackerResponse>;
+  searchGamertag(query: string): Promise<TrackerSearchResult | null>;
   getMatchHistory(xuid: string, start: number, count: number): Promise<TrackerMatchHistoryResponse>;
   syncMatchesToTracker(request: TrackerSyncMatchesRequest): Promise<void>;
 }


### PR DESCRIPTION
## Summary

- Ports the **AddTrackerDialog** from `rework-individual-tracker` using the store-presenter-create pattern
- Ports the shared **MatchHistory** component (used across H2-4, H2-5, H2-6) — "Load more" button pagination (replaces IntersectionObserver infinite scroll from #507 — better accessibility, user-initiated API calls), series grouping, short-match filtering, per-match checkbox selection
- Extracts `MatchCard` sub-component to its own `match-card/` folder
- Moves `formatDisplayDateTime`, `getMapThumbnailUrl`, `buildMatchResultString`, `buildTeams` helpers out of `individual-tracker.ts` into `match-history-helpers.ts`
- Extends `IndividualTrackerService` with `searchGamertag` and `getMatchHistory` (via HaloInfiniteClient proxy)
- Two-step wizard: 1) gamertag search → confirm profile, 2) match selection → start tracker via `startTracker()`
- Replaces the simpler E3 `AddTrackerDialog`

## Key design decisions

- MatchHistory uses store-presenter-create: `MatchHistoryPresenter.static present()` derives `segmentBlocks`; `loadMore()` manages `isLoadingMore` in the store; `create.tsx` wires the callback
- `seriesGroups` lookup uses a `visibleSeriesIndex` counter (multi-match groups only) — not the raw `groupIndex` — to avoid misalignment when singletons precede series groups
- `search()` guards on `loadingMatches` in addition to `searching` to prevent concurrent searches racing to stamp match results
- Props ordered: data (required → optional) then callbacks; no re-exports from intermediary wrapper files

## Test plan

- [ ] `add-tracker-dialog-presenter.test.ts` — gamertag search, match load, pagination, selection, startTracker call
- [ ] `add-tracker-dialog.test.tsx` — render + interaction tests
- [ ] `match-history-presenter.test.ts` — segmentBlocks derivation, loadMore state
- [ ] `match-history.test.tsx` — Load more button renders/hides, disabled while loading, calls onLoadMore
- [ ] `match-card/tests/match-card.test.tsx` — card rendering
- [ ] `match-history-helpers.test.ts` — helper function unit tests
- [ ] `npm run done` — 2296 tests pass, typecheck + lint clean