### PR TITLE
feat(pages): H2-6 ManualSeriesDialog — team builder + custom series start

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -571,6 +571,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       subtitleOverride: body.subtitleOverride,
       teams: body.teams,
       startedAt: new Date().toISOString(),
+      ...(body.matchIds != null && body.matchIds.length > 0 ? { backfillMatchIds: body.matchIds } : {}),
     };
     trackerState.lastUpdateTime = new Date().toISOString();
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -703,7 +703,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     const summariesById = new Map(summaries.map((summary) => [summary.matchId, summary]));
 
-    const groupings = analyzeMatchGroupings(
+    const autoGroupings = analyzeMatchGroupings(
       summaries.map((summary) => ({
         matchId: summary.matchId,
         isMatchmaking: summary.isMatchmaking,
@@ -711,7 +711,12 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       })),
     );
 
-    const series = groupings.map((matchIds, groupIndex): IndividualTrackerSeriesGroup => {
+    const backfillMatchIds = state.manualSeries?.backfillMatchIds;
+    const groupings =
+      backfillMatchIds != null && backfillMatchIds.length >= 2 ? [backfillMatchIds, ...autoGroupings] : autoGroupings;
+
+    let visibleSeriesIndex = 0;
+    const series = groupings.map((matchIds): IndividualTrackerSeriesGroup => {
       const groupSummaries = matchIds
         .map((matchId) => summariesById.get(matchId))
         .filter((summary): summary is IndividualTrackerMatchSummary => summary != null);
@@ -737,9 +742,14 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         })),
       );
 
-      const manualSeries = groupIndex === 0 ? state.manualSeries : undefined;
+      const isMultiMatch = matchIds.length >= 2;
+      const manualSeries = isMultiMatch && visibleSeriesIndex === 0 ? state.manualSeries : undefined;
       const title = manualSeries?.titleOverride ?? defaultTitle;
       const subtitle = manualSeries?.subtitleOverride ?? defaultSubtitle;
+
+      if (isMultiMatch) {
+        visibleSeriesIndex += 1;
+      }
 
       return {
         id: `series:${buildSeriesGroupKey(matchIds)}`,

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -562,9 +562,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
 
     const body = await request.json<IndividualTrackerStartSeriesRequest>();
-    if (trackerState.userId !== body.userId) {
-      return new Response("Forbidden", { status: 403 });
-    }
 
     trackerState.manualSeries = {
       titleOverride: body.titleOverride,

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -37,6 +37,8 @@ import type {
   IndividualTrackerViewStateResponse,
   IndividualTrackerSelectMatchesRequest,
   IndividualTrackerSelectMatchesResponse,
+  IndividualTrackerStartSeriesRequest,
+  IndividualTrackerStartSeriesResponse,
   TopBarStatItem,
 } from "./types";
 import { accumulatePlayerStats, computeTopBarStats, getActiveMatchIds } from "./top-bar-stats";
@@ -111,6 +113,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           }
           case "select-matches": {
             return await this.handleSelectMatches(request);
+          }
+          case "start-series": {
+            return await this.handleStartSeries(request);
           }
           case "websocket": {
             return await this.handleWebSocket(request);
@@ -547,6 +552,32 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
 
     const response: IndividualTrackerSelectMatchesResponse = { success: true };
+    return Response.json(response);
+  }
+
+  private async handleStartSeries(request: Request): Promise<Response> {
+    const trackerState = await this.getState();
+    if (trackerState == null) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const body = await request.json<IndividualTrackerStartSeriesRequest>();
+    if (trackerState.userId !== body.userId) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    trackerState.manualSeries = {
+      titleOverride: body.titleOverride,
+      subtitleOverride: body.subtitleOverride,
+      teams: body.teams,
+      startedAt: new Date().toISOString(),
+    };
+    trackerState.lastUpdateTime = new Date().toISOString();
+
+    await this.setState(trackerState);
+    this.broadcastViewState(trackerState);
+
+    const response: IndividualTrackerStartSeriesResponse = { success: true };
     return Response.json(response);
   }
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -710,7 +710,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       })),
     );
 
-    const series = groupings.map((matchIds): IndividualTrackerSeriesGroup => {
+    const series = groupings.map((matchIds, groupIndex): IndividualTrackerSeriesGroup => {
       const groupSummaries = matchIds
         .map((matchId) => summariesById.get(matchId))
         .filter((summary): summary is IndividualTrackerMatchSummary => summary != null);
@@ -725,20 +725,27 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         })),
       );
 
+      const defaultTitle = getDefaultSeriesGroupTitle();
+      const defaultSubtitle = getDefaultSeriesGroupSubtitle(
+        groupSummaries.map((summary) => ({
+          startTime: summary.startTime,
+          mapAssetId: summary.mapAssetId,
+          mapVersionId: summary.mapVersionId,
+          gameVariantCategory: summary.gameVariantCategory,
+          outcome: summary.outcome,
+        })),
+      );
+
+      const manualSeries = groupIndex === 0 ? state.manualSeries : undefined;
+      const title = manualSeries?.titleOverride ?? defaultTitle;
+      const subtitle = manualSeries?.subtitleOverride ?? defaultSubtitle;
+
       return {
         id: `series:${buildSeriesGroupKey(matchIds)}`,
         matchIds,
         score: teamWins.length === 0 ? "0:0" : teamWins.join(":"),
-        title: getDefaultSeriesGroupTitle(),
-        subtitle: getDefaultSeriesGroupSubtitle(
-          groupSummaries.map((summary) => ({
-            startTime: summary.startTime,
-            mapAssetId: summary.mapAssetId,
-            mapVersionId: summary.mapVersionId,
-            gameVariantCategory: summary.gameVariantCategory,
-            outcome: summary.outcome,
-          })),
-        ),
+        title,
+        subtitle,
       };
     });
 

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -25,6 +25,7 @@ import type {
   IndividualTrackerStatusResponse,
   IndividualTrackerViewStateResponse,
   IndividualTrackerSelectMatchesResponse,
+  IndividualTrackerStartSeriesRequest,
 } from "../types";
 import {
   aFakeIndividualTrackerInternalStateWith,
@@ -1349,6 +1350,66 @@ describe("IndividualTrackerDO", () => {
         individualTrackerDO.webSocketClose(ws, 1000, "bye", true);
         individualTrackerDO.webSocketError(ws, new Error("boom"));
       }).not.toThrow();
+    });
+  });
+
+  describe("handleStartSeries()", () => {
+    const startSeriesRequest = (body: IndividualTrackerStartSeriesRequest): Request =>
+      new Request("http://do/start-series", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+    it("returns 404 when no state exists", async () => {
+      storageGetSpy.mockResolvedValue(null);
+
+      const response = await individualTrackerDO.fetch(
+        startSeriesRequest({ userId: "user-1", titleOverride: null, subtitleOverride: null, teams: [] }),
+      );
+
+      expect(response.status).toBe(404);
+    });
+
+    it("returns 403 when userId does not match", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ userId: "owner" }));
+
+      const response = await individualTrackerDO.fetch(
+        startSeriesRequest({ userId: "other-user", titleOverride: null, subtitleOverride: null, teams: [] }),
+      );
+
+      expect(response.status).toBe(403);
+    });
+
+    it("persists manualSeries to state and broadcasts view", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ userId: "user-1" }));
+
+      const webSocketAdapter = aFakeWebSocketHibernationAdapter();
+      const do2 = new IndividualTrackerDO(mockState, env, () => services, webSocketAdapter);
+
+      const body: IndividualTrackerStartSeriesRequest = {
+        userId: "user-1",
+        titleOverride: "Eagle vs Cobra",
+        subtitleOverride: "Bo5",
+        teams: [
+          { name: "Eagle", members: ["Alpha", "Bravo"] },
+          { name: "Cobra", members: ["Charlie"] },
+        ],
+      };
+
+      const response = await do2.fetch(startSeriesRequest(body));
+
+      expect(response.status).toBe(200);
+      const result = await response.json<{ success: boolean }>();
+      expect(result.success).toBe(true);
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.manualSeries).toMatchObject({
+        titleOverride: "Eagle vs Cobra",
+        subtitleOverride: "Bo5",
+        teams: body.teams,
+      });
+      expect(webSocketAdapter.broadcasts).toHaveLength(1);
     });
   });
 });

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1365,20 +1365,10 @@ describe("IndividualTrackerDO", () => {
       storageGetSpy.mockResolvedValue(null);
 
       const response = await individualTrackerDO.fetch(
-        startSeriesRequest({ userId: "user-1", titleOverride: null, subtitleOverride: null, teams: [] }),
+        startSeriesRequest({ titleOverride: null, subtitleOverride: null, teams: [] }),
       );
 
       expect(response.status).toBe(404);
-    });
-
-    it("returns 403 when userId does not match", async () => {
-      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ userId: "owner" }));
-
-      const response = await individualTrackerDO.fetch(
-        startSeriesRequest({ userId: "other-user", titleOverride: null, subtitleOverride: null, teams: [] }),
-      );
-
-      expect(response.status).toBe(403);
     });
 
     it("persists manualSeries to state and broadcasts view", async () => {
@@ -1388,7 +1378,6 @@ describe("IndividualTrackerDO", () => {
       const do2 = new IndividualTrackerDO(mockState, env, () => services, webSocketAdapter);
 
       const body: IndividualTrackerStartSeriesRequest = {
-        userId: "user-1",
         titleOverride: "Eagle vs Cobra",
         subtitleOverride: "Bo5",
         teams: [

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -77,6 +77,13 @@ export interface TopBarStatItem {
   value: string;
 }
 
+export interface IndividualTrackerManualSeries {
+  titleOverride: string | null;
+  subtitleOverride: string | null;
+  teams: IndividualTrackerSeriesTeam[];
+  startedAt: string;
+}
+
 export interface IndividualTrackerInternalState extends IndividualTrackerState {
   searchStartTime: string;
   lastMatchDiscoveredAt: string | undefined;
@@ -86,12 +93,29 @@ export interface IndividualTrackerInternalState extends IndividualTrackerState {
   selectedMatchIds: string[];
   accumulatedPlayerTotals?: AccumulatedPlayerTotals;
   accumulatedMatchIds?: string[];
+  manualSeries?: IndividualTrackerManualSeries;
   errorState: {
     consecutiveErrors: number;
     backoffMinutes: number;
     lastSuccessTime: string;
     lastErrorMessage?: string | undefined;
   };
+}
+
+export interface IndividualTrackerSeriesTeam {
+  name: string;
+  members: string[];
+}
+
+export interface IndividualTrackerStartSeriesRequest {
+  userId: string;
+  titleOverride: string | null;
+  subtitleOverride: string | null;
+  teams: IndividualTrackerSeriesTeam[];
+}
+
+export interface IndividualTrackerStartSeriesResponse {
+  success: true;
 }
 
 export interface IndividualTrackerSelectMatchesRequest {

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -109,7 +109,6 @@ export interface IndividualTrackerSeriesTeam {
 }
 
 export interface IndividualTrackerStartSeriesRequest {
-  userId: string;
   titleOverride: string | null;
   subtitleOverride: string | null;
   teams: IndividualTrackerSeriesTeam[];

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -82,6 +82,7 @@ export interface IndividualTrackerManualSeries {
   subtitleOverride: string | null;
   teams: IndividualTrackerSeriesTeam[];
   startedAt: string;
+  backfillMatchIds?: string[];
 }
 
 export interface IndividualTrackerInternalState extends IndividualTrackerState {
@@ -112,6 +113,7 @@ export interface IndividualTrackerStartSeriesRequest {
   titleOverride: string | null;
   subtitleOverride: string | null;
   teams: IndividualTrackerSeriesTeam[];
+  matchIds?: string[];
 }
 
 export interface IndividualTrackerStartSeriesResponse {

--- a/api/routes/individual-tracker/manage.ts
+++ b/api/routes/individual-tracker/manage.ts
@@ -463,7 +463,6 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
       }
 
       await startSeriesDo(env, auth.session.userId, tracker.TrackerId, {
-        userId: auth.session.userId,
         titleOverride: parsed.data.titleOverride,
         subtitleOverride: parsed.data.subtitleOverride,
         teams: parsed.data.teams.map((team) => ({ name: team.name, members: Array.from(team.members) })),

--- a/api/routes/individual-tracker/manage.ts
+++ b/api/routes/individual-tracker/manage.ts
@@ -1,9 +1,9 @@
-import { z } from "zod";
 import { errorContract } from "@guilty-spark/shared/contracts/error";
 import {
   selectMatchesContract,
   selectMatchesRequestSchema,
   selectActiveTrackerRequestSchema,
+  startSeriesRequestSchema,
   startTrackerRequestSchema,
   stopTrackerContract,
   trackerContract,
@@ -11,12 +11,6 @@ import {
   trackersContract,
 } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import { parseJsonBody, parsePathParams } from "@guilty-spark/shared/base/request-parsing";
-
-const startSeriesRequestSchema = z.object({
-  titleOverride: z.string().nullable(),
-  subtitleOverride: z.string().nullable(),
-  teams: z.array(z.object({ name: z.string(), members: z.array(z.string()) })),
-});
 import type {
   IndividualTrackerPauseResponse,
   IndividualTrackerResumeResponse,
@@ -473,6 +467,9 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
         titleOverride: parsed.data.titleOverride,
         subtitleOverride: parsed.data.subtitleOverride,
         teams: parsed.data.teams.map((team) => ({ name: team.name, members: Array.from(team.members) })),
+        ...(parsed.data.matchIds != null && parsed.data.matchIds.length > 0
+          ? { matchIds: [...parsed.data.matchIds] }
+          : {}),
       });
 
       return Response.json({ success: true }, { headers: { "Cache-Control": "no-store" } });

--- a/api/routes/individual-tracker/manage.ts
+++ b/api/routes/individual-tracker/manage.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { errorContract } from "@guilty-spark/shared/contracts/error";
 import {
   selectMatchesContract,
@@ -10,6 +11,12 @@ import {
   trackersContract,
 } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import { parseJsonBody, parsePathParams } from "@guilty-spark/shared/base/request-parsing";
+
+const startSeriesRequestSchema = z.object({
+  titleOverride: z.string().nullable(),
+  subtitleOverride: z.string().nullable(),
+  teams: z.array(z.object({ name: z.string(), members: z.array(z.string()) })),
+});
 import type {
   IndividualTrackerPauseResponse,
   IndividualTrackerResumeResponse,
@@ -19,6 +26,7 @@ import type {
   IndividualTrackerStatusResponse,
   IndividualTrackerStopResponse,
   IndividualTrackerSelectMatchesResponse,
+  IndividualTrackerStartSeriesRequest,
 } from "../../durable-objects/individual-tracker/types";
 import type { IndividualTrackersRow } from "../../services/database/types/individual_trackers";
 import { TrackerLimitReachedError, TrackerNotFoundError } from "../../services/individual-tracker/errors";
@@ -99,6 +107,22 @@ async function syncMatchesDo(env: Env, userId: string, trackerId: string, matchI
   });
   assertDoOkWith404(response);
   await response.json<IndividualTrackerSelectMatchesResponse>();
+}
+
+async function startSeriesDo(
+  env: Env,
+  userId: string,
+  trackerId: string,
+  body: IndividualTrackerStartSeriesRequest,
+): Promise<void> {
+  const stub = trackerDoStub(env, userId, trackerId);
+  const response = await stub.fetch("http://do/start-series", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  assertDoOkWith404(response);
+  await response.json<{ success: true }>();
 }
 
 export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
@@ -410,6 +434,51 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
     } catch (error) {
       logService.error(error as Error, new Map([["message", "Individual tracker select matches error"]]));
       return errorContract.toResponse({ error: "Failed to update match selection" }, { status: 500, noStore: true });
+    }
+  });
+
+  router.post("/api/individual-tracker/:trackerId/start-series", async (request, env: Env) => {
+    const services = installServices({ env });
+    const { authService, individualTrackerService, logService } = services;
+
+    try {
+      const auth = await requireSession(request, authService);
+      if (!auth.ok) {
+        return auth.response;
+      }
+
+      const parsedParams = parsePathParams(request.params, trackerParamsSchema, "Invalid tracker id");
+      if (!parsedParams.success) {
+        return parsedParams.response;
+      }
+      const { trackerId } = parsedParams.data;
+
+      const parsed = await parseJsonBody(request, startSeriesRequestSchema, "Invalid start series request");
+      if (!parsed.success) {
+        return parsed.response;
+      }
+
+      let tracker: IndividualTrackersRow;
+      try {
+        tracker = await individualTrackerService.getOwnedTracker(auth.session.userId, trackerId);
+      } catch (error) {
+        if (error instanceof TrackerNotFoundError) {
+          return errorContract.toResponse({ error: "Tracker not found" }, { status: 404, noStore: true });
+        }
+        throw error;
+      }
+
+      await startSeriesDo(env, auth.session.userId, tracker.TrackerId, {
+        userId: auth.session.userId,
+        titleOverride: parsed.data.titleOverride,
+        subtitleOverride: parsed.data.subtitleOverride,
+        teams: parsed.data.teams.map((team) => ({ name: team.name, members: Array.from(team.members) })),
+      });
+
+      return Response.json({ success: true }, { headers: { "Cache-Control": "no-store" } });
+    } catch (error) {
+      logService.error(error as Error, new Map([["message", "Individual tracker start series error"]]));
+      return errorContract.toResponse({ error: "Failed to start series" }, { status: 500, noStore: true });
     }
   });
 };

--- a/pages/src/components/individual-tracker/manual-series-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/create.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
+import { ManualSeriesDialogPresenter } from "./manual-series-dialog-presenter";
+import { ManualSeriesDialogStore } from "./manual-series-dialog-store";
+import { ManualSeriesDialog } from "./manual-series-dialog";
+
+interface ManualSeriesDialogSectionProps {
+  readonly trackerId: string;
+  readonly trackerLabel: string;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onSeriesStarted: () => void;
+  readonly individualTrackerService: IndividualTrackerService;
+}
+
+export function ManualSeriesDialogSection({
+  trackerId,
+  trackerLabel,
+  isOpen,
+  onClose,
+  onSeriesStarted,
+  individualTrackerService,
+}: ManualSeriesDialogSectionProps): React.ReactElement | null {
+  const onSeriesStartedRef = useRef(onSeriesStarted);
+  onSeriesStartedRef.current = onSeriesStarted;
+
+  const store = useMemo(() => new ManualSeriesDialogStore(), []);
+  const presenter = useMemo(
+    () =>
+      new ManualSeriesDialogPresenter({
+        trackerId,
+        store,
+        individualTrackerService,
+        onSeriesStarted: (): void => {
+          onSeriesStartedRef.current();
+        },
+      }),
+    [trackerId, store, individualTrackerService],
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      store.reset();
+    }
+  }, [isOpen, store]);
+
+  useEffect(() => {
+    return (): void => {
+      presenter.dispose();
+    };
+  }, [presenter]);
+
+  const snapshot = useSyncExternalStore(
+    (listener) => store.subscribe(listener),
+    () => store.getSnapshot(),
+    () => store.getSnapshot(),
+  );
+
+  return (
+    <ManualSeriesDialog
+      isOpen={isOpen}
+      trackerLabel={trackerLabel}
+      snapshot={snapshot}
+      onClose={onClose}
+      onTitleChange={(value): void => {
+        presenter.setTitleOverride(value);
+      }}
+      onSubtitleChange={(value): void => {
+        presenter.setSubtitleOverride(value);
+      }}
+      onTeamNameChange={(teamIndex, value): void => {
+        presenter.setTeamName(teamIndex, value);
+      }}
+      onTeamMemberChange={(teamIndex, memberIndex, value): void => {
+        presenter.setTeamMember(teamIndex, memberIndex, value);
+      }}
+      onAddTeamMember={(teamIndex): void => {
+        presenter.addTeamMember(teamIndex);
+      }}
+      onRemoveTeamMember={(teamIndex, memberIndex): void => {
+        presenter.removeTeamMember(teamIndex, memberIndex);
+      }}
+      onDiscoverBackfill={(): void => {
+        presenter.discoverBackfillMatches();
+      }}
+      onBackfillMatchToggle={(matchId): void => {
+        presenter.toggleBackfillMatch(matchId);
+      }}
+      onStartSeries={(): void => {
+        presenter.startSeries();
+      }}
+    />
+  );
+}

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -265,6 +265,7 @@ export class ManualSeriesDialogPresenter {
         titleOverride,
         subtitleOverride,
         teams,
+        matchIds: [...snapshot.selectedBackfillMatchIds],
       });
 
       if (this.checkDisposed()) {

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -1,0 +1,287 @@
+import type {
+  IndividualTrackerService,
+  TrackerMatchHistoryEntry,
+  TrackerSearchResult,
+} from "../../../services/individual-tracker/types";
+import type {
+  ManualSeriesDialogSnapshot,
+  ManualSeriesDialogStore,
+  ManualSeriesTeamSnapshot,
+} from "./manual-series-dialog-store";
+
+interface Config {
+  readonly trackerId: string;
+  readonly store: ManualSeriesDialogStore;
+  readonly individualTrackerService: IndividualTrackerService;
+  readonly onSeriesStarted: () => void;
+}
+
+function collectUniqueTeamMembers(teams: readonly ManualSeriesTeamSnapshot[]): readonly string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const team of teams) {
+    for (const member of team.members) {
+      const normalized = member.trim();
+      if (normalized !== "" && !seen.has(normalized)) {
+        seen.add(normalized);
+        result.push(normalized);
+      }
+    }
+  }
+  return result;
+}
+
+function computeMatchIntersection(histories: readonly { readonly matches: readonly TrackerMatchHistoryEntry[] }[]): {
+  readonly intersection: ReadonlySet<string>;
+  readonly matchById: ReadonlyMap<string, TrackerMatchHistoryEntry>;
+} {
+  const historiesWithData = histories.filter((h) => h.matches.length > 0);
+
+  const matchById = new Map<string, TrackerMatchHistoryEntry>();
+  for (const entry of historiesWithData) {
+    for (const match of entry.matches) {
+      if (!matchById.has(match.matchId)) {
+        matchById.set(match.matchId, match);
+      }
+    }
+  }
+
+  if (historiesWithData.length === 0) {
+    return { intersection: new Set(), matchById };
+  }
+
+  const intersection = new Set(historiesWithData[0].matches.map((m) => m.matchId));
+  for (const entry of historiesWithData.slice(1)) {
+    const entryIds = new Set(entry.matches.map((m) => m.matchId));
+    for (const matchId of intersection) {
+      if (!entryIds.has(matchId)) {
+        intersection.delete(matchId);
+      }
+    }
+  }
+
+  return { intersection, matchById };
+}
+
+function sortCandidateMatches(
+  intersection: ReadonlySet<string>,
+  matchById: ReadonlyMap<string, TrackerMatchHistoryEntry>,
+): readonly TrackerMatchHistoryEntry[] {
+  return Array.from(intersection)
+    .map((matchId) => matchById.get(matchId))
+    .filter((match): match is TrackerMatchHistoryEntry => match != null)
+    .sort((left, right) => {
+      const leftTime = new Date(left.startTimeIso ?? left.startTime).getTime();
+      const rightTime = new Date(right.startTimeIso ?? right.startTime).getTime();
+      return rightTime - leftTime;
+    });
+}
+
+export class ManualSeriesDialogPresenter {
+  private readonly config: Config;
+  private disposed = false;
+
+  public constructor(config: Config) {
+    this.config = config;
+  }
+
+  public dispose(): void {
+    this.disposed = true;
+  }
+
+  private checkDisposed(): boolean {
+    return this.disposed;
+  }
+
+  public static present(snapshot: ManualSeriesDialogSnapshot): ManualSeriesDialogSnapshot {
+    return snapshot;
+  }
+
+  public setTitleOverride(value: string): void {
+    if (this.checkDisposed()) {
+      return;
+    }
+    this.config.store.setTitleOverride(value);
+  }
+
+  public setSubtitleOverride(value: string): void {
+    if (this.checkDisposed()) {
+      return;
+    }
+    this.config.store.setSubtitleOverride(value);
+  }
+
+  public setTeamName(teamIndex: number, name: string): void {
+    if (this.checkDisposed()) {
+      return;
+    }
+    const { teams } = this.config.store.getSnapshot();
+    const updated = teams.map((team, index) => (index === teamIndex ? { ...team, name } : team));
+    this.config.store.setTeams(updated);
+  }
+
+  public setTeamMember(teamIndex: number, memberIndex: number, value: string): void {
+    if (this.checkDisposed()) {
+      return;
+    }
+    const { teams } = this.config.store.getSnapshot();
+    const updated = teams.map((team, tIdx) => {
+      if (tIdx !== teamIndex) {
+        return team;
+      }
+      const members = team.members.map((m, mIdx) => (mIdx === memberIndex ? value : m));
+      return { ...team, members };
+    });
+    this.config.store.setTeams(updated);
+  }
+
+  public addTeamMember(teamIndex: number): void {
+    if (this.checkDisposed()) {
+      return;
+    }
+    const { teams } = this.config.store.getSnapshot();
+    const updated = teams.map((team, index) =>
+      index === teamIndex ? { ...team, members: [...team.members, ""] } : team,
+    );
+    this.config.store.setTeams(updated);
+  }
+
+  public removeTeamMember(teamIndex: number, memberIndex: number): void {
+    if (this.checkDisposed()) {
+      return;
+    }
+    const { teams } = this.config.store.getSnapshot();
+    const updated = teams.map((team, tIdx) => {
+      if (tIdx !== teamIndex) {
+        return team;
+      }
+      const nextMembers = team.members.filter((_, mIdx) => mIdx !== memberIndex);
+      return { ...team, members: nextMembers.length > 0 ? nextMembers : [""] };
+    });
+    this.config.store.setTeams(updated);
+  }
+
+  public toggleBackfillMatch(matchId: string): void {
+    if (this.checkDisposed()) {
+      return;
+    }
+    this.config.store.toggleBackfillMatch(matchId);
+  }
+
+  public discoverBackfillMatches(): void {
+    if (this.checkDisposed()) {
+      return;
+    }
+    void this.runBackfillDiscovery();
+  }
+
+  private async runBackfillDiscovery(): Promise<void> {
+    const { teams } = this.config.store.getSnapshot();
+    const memberNames = collectUniqueTeamMembers(teams);
+
+    if (memberNames.length === 0) {
+      this.config.store.setBackfillError("Add at least one player name before searching for shared custom games.");
+      return;
+    }
+
+    this.config.store.setBackfillLoading();
+
+    try {
+      const resolvedPlayers = await Promise.all(
+        memberNames.map(
+          async (member): Promise<{ member: string; result: TrackerSearchResult | null }> => ({
+            member,
+            result: await this.config.individualTrackerService.searchGamertag(member),
+          }),
+        ),
+      );
+
+      if (this.checkDisposed()) {
+        return;
+      }
+
+      const playersWithIdentity = resolvedPlayers.filter(
+        (entry): entry is { member: string; result: TrackerSearchResult } => entry.result != null,
+      );
+
+      if (playersWithIdentity.length === 0) {
+        this.config.store.setBackfillDone([], null, "No player identities were resolved. Check names and try again.");
+        return;
+      }
+
+      const histories = await Promise.all(
+        playersWithIdentity.map(async ({ member, result }) => ({
+          member,
+          matches: (
+            await this.config.individualTrackerService.getMatchHistory(result.xuid, 0, 25, "custom")
+          ).matches.filter((match) => match.category === "custom"),
+        })),
+      );
+
+      if (this.checkDisposed()) {
+        return;
+      }
+
+      const playersWithoutHistory = histories.filter((h) => h.matches.length === 0).map((h) => h.member);
+      const { intersection, matchById } = computeMatchIntersection(histories);
+      const candidates = sortCandidateMatches(intersection, matchById);
+
+      const warning =
+        playersWithoutHistory.length > 0
+          ? `History unavailable for ${playersWithoutHistory.join(", ")}. Shared matches are based on players with available history.`
+          : null;
+
+      const error = candidates.length === 0 ? "No shared custom matches were found across the selected players." : null;
+
+      this.config.store.setBackfillDone(candidates, warning, error);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to discover custom-game matches.";
+      this.config.store.setBackfillError(message);
+    }
+  }
+
+  public startSeries(): void {
+    if (this.checkDisposed()) {
+      return;
+    }
+    void this.runStartSeries();
+  }
+
+  private async runStartSeries(): Promise<void> {
+    const snapshot = this.config.store.getSnapshot();
+    this.config.store.setBusy(true);
+    this.config.store.setSubmitError(null);
+
+    try {
+      const titleOverride = snapshot.titleOverride.trim() || null;
+      const subtitleOverride = snapshot.subtitleOverride.trim() || null;
+      const teams = snapshot.teams.map((team) => ({
+        name: team.name.trim(),
+        members: team.members.map((m) => m.trim()).filter((m) => m !== ""),
+      }));
+
+      await this.config.individualTrackerService.startSeries({
+        trackerId: this.config.trackerId,
+        titleOverride,
+        subtitleOverride,
+        teams,
+      });
+
+      if (this.checkDisposed()) {
+        return;
+      }
+
+      this.config.onSeriesStarted();
+    } catch (err) {
+      if (this.checkDisposed()) {
+        return;
+      }
+      const message = err instanceof Error ? err.message : "Failed to start series.";
+      this.config.store.setSubmitError(message);
+    } finally {
+      if (!this.checkDisposed()) {
+        this.config.store.setBusy(false);
+      }
+    }
+  }
+}

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-store.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-store.ts
@@ -1,0 +1,142 @@
+import type { TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
+
+export interface ManualSeriesTeamSnapshot {
+  readonly name: string;
+  readonly members: readonly string[];
+}
+
+export type BackfillState = "idle" | "loading" | "done" | "error";
+
+export interface ManualSeriesDialogSnapshot {
+  readonly titleOverride: string;
+  readonly subtitleOverride: string;
+  readonly teams: readonly ManualSeriesTeamSnapshot[];
+  readonly backfillState: BackfillState;
+  readonly backfillError: string | null;
+  readonly backfillWarning: string | null;
+  readonly backfillMatches: readonly TrackerMatchHistoryEntry[];
+  readonly selectedBackfillMatchIds: readonly string[];
+  readonly busy: boolean;
+  readonly submitError: string | null;
+}
+
+const INITIAL_TEAM_MEMBERS: readonly string[] = ["", "", "", ""];
+
+function buildDefaultTeams(): readonly ManualSeriesTeamSnapshot[] {
+  return [
+    { name: "", members: INITIAL_TEAM_MEMBERS },
+    { name: "", members: INITIAL_TEAM_MEMBERS },
+  ];
+}
+
+export class ManualSeriesDialogStore {
+  private snapshot: ManualSeriesDialogSnapshot;
+  private readonly subscribers = new Set<() => void>();
+
+  public constructor() {
+    this.snapshot = {
+      titleOverride: "",
+      subtitleOverride: "",
+      teams: buildDefaultTeams(),
+      backfillState: "idle",
+      backfillError: null,
+      backfillWarning: null,
+      backfillMatches: [],
+      selectedBackfillMatchIds: [],
+      busy: false,
+      submitError: null,
+    };
+  }
+
+  public subscribe(listener: () => void): () => void {
+    this.subscribers.add(listener);
+    return (): void => {
+      this.subscribers.delete(listener);
+    };
+  }
+
+  public getSnapshot(): ManualSeriesDialogSnapshot {
+    return this.snapshot;
+  }
+
+  public reset(): void {
+    this.update({
+      titleOverride: "",
+      subtitleOverride: "",
+      teams: buildDefaultTeams(),
+      backfillState: "idle",
+      backfillError: null,
+      backfillWarning: null,
+      backfillMatches: [],
+      selectedBackfillMatchIds: [],
+      busy: false,
+      submitError: null,
+    });
+  }
+
+  public setTitleOverride(titleOverride: string): void {
+    this.update({ titleOverride });
+  }
+
+  public setSubtitleOverride(subtitleOverride: string): void {
+    this.update({ subtitleOverride });
+  }
+
+  public setTeams(teams: readonly ManualSeriesTeamSnapshot[]): void {
+    this.update({ teams });
+  }
+
+  public setBackfillLoading(): void {
+    this.update({
+      backfillState: "loading",
+      backfillError: null,
+      backfillWarning: null,
+      backfillMatches: [],
+      selectedBackfillMatchIds: [],
+    });
+  }
+
+  public setBackfillDone(
+    matches: readonly TrackerMatchHistoryEntry[],
+    warning: string | null,
+    error: string | null,
+  ): void {
+    this.update({
+      backfillState: "done",
+      backfillMatches: matches,
+      backfillWarning: warning,
+      backfillError: error,
+      selectedBackfillMatchIds: [],
+    });
+  }
+
+  public setBackfillError(error: string): void {
+    this.update({
+      backfillState: "error",
+      backfillError: error,
+      backfillMatches: [],
+      selectedBackfillMatchIds: [],
+    });
+  }
+
+  public toggleBackfillMatch(matchId: string): void {
+    const current = this.snapshot.selectedBackfillMatchIds;
+    const updated = current.includes(matchId) ? current.filter((id) => id !== matchId) : [...current, matchId];
+    this.update({ selectedBackfillMatchIds: updated });
+  }
+
+  public setBusy(busy: boolean): void {
+    this.update({ busy });
+  }
+
+  public setSubmitError(submitError: string | null): void {
+    this.update({ submitError });
+  }
+
+  private update(partial: Partial<ManualSeriesDialogSnapshot>): void {
+    this.snapshot = { ...this.snapshot, ...partial };
+    for (const subscriber of this.subscribers) {
+      subscriber();
+    }
+  }
+}

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.module.css
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.module.css
@@ -1,0 +1,81 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.caption {
+  color: var(--halo-gray);
+  font-size: var(--text-sm);
+  margin: 0;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.sectionHeader {
+  align-items: center;
+  display: flex;
+  gap: var(--space-2);
+  justify-content: space-between;
+}
+
+.sectionTitle {
+  font-size: var(--text-base);
+  margin: 0;
+}
+
+.metaGrid {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.teamsGrid {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.teamColumn {
+  border: 1px solid color-mix(in srgb, var(--halo-white) 15%, transparent);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2);
+}
+
+.teamTitle {
+  margin: 0;
+}
+
+.membersList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.memberRow {
+  align-items: flex-end;
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.footer {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: flex-end;
+}
+
+@media (--tablet-viewport) {
+  .metaGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .teamsGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.tsx
@@ -3,7 +3,7 @@ import { Button } from "../../button/button";
 import { Dialog } from "../../dialog/dialog";
 import { Input } from "../../input/input";
 import { Alert } from "../../alert/alert";
-import { MatchHistory } from "../../match-history/match-history";
+import { MatchHistorySection } from "../../match-history/create";
 import type { ManualSeriesDialogSnapshot, ManualSeriesTeamSnapshot } from "./manual-series-dialog-store";
 import styles from "./manual-series-dialog.module.css";
 
@@ -178,7 +178,7 @@ export function ManualSeriesDialog({
           {snapshot.backfillError != null && <Alert variant="error">{snapshot.backfillError}</Alert>}
 
           {showBackfillResults && (
-            <MatchHistory
+            <MatchHistorySection
               entries={isBackfillLoading ? null : snapshot.backfillMatches}
               loadingCount={2}
               allowSelection={true}

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.tsx
@@ -1,0 +1,204 @@
+import React from "react";
+import { Button } from "../../button/button";
+import { Dialog } from "../../dialog/dialog";
+import { Input } from "../../input/input";
+import { Alert } from "../../alert/alert";
+import { MatchHistory } from "../../match-history/match-history";
+import type { ManualSeriesDialogSnapshot, ManualSeriesTeamSnapshot } from "./manual-series-dialog-store";
+import styles from "./manual-series-dialog.module.css";
+
+interface ManualSeriesDialogProps {
+  readonly isOpen: boolean;
+  readonly trackerLabel: string;
+  readonly snapshot: ManualSeriesDialogSnapshot;
+  readonly onClose: () => void;
+  readonly onTitleChange: (value: string) => void;
+  readonly onSubtitleChange: (value: string) => void;
+  readonly onTeamNameChange: (teamIndex: number, value: string) => void;
+  readonly onTeamMemberChange: (teamIndex: number, memberIndex: number, value: string) => void;
+  readonly onAddTeamMember: (teamIndex: number) => void;
+  readonly onRemoveTeamMember: (teamIndex: number, memberIndex: number) => void;
+  readonly onDiscoverBackfill: () => void;
+  readonly onBackfillMatchToggle: (matchId: string) => void;
+  readonly onStartSeries: () => void;
+}
+
+function TeamColumn({
+  team,
+  teamIndex,
+  disabled,
+  onNameChange,
+  onMemberChange,
+  onAddMember,
+  onRemoveMember,
+}: {
+  readonly team: ManualSeriesTeamSnapshot;
+  readonly teamIndex: number;
+  readonly disabled: boolean;
+  readonly onNameChange: (value: string) => void;
+  readonly onMemberChange: (memberIndex: number, value: string) => void;
+  readonly onAddMember: () => void;
+  readonly onRemoveMember: (memberIndex: number) => void;
+}): React.JSX.Element {
+  return (
+    <div className={styles.teamColumn}>
+      <h4 className={styles.teamTitle}>Team {teamIndex + 1}</h4>
+      <Input
+        label="Team name (optional)"
+        value={team.name}
+        placeholder={teamIndex === 0 ? "Eagle" : "Cobra"}
+        onChange={(event): void => {
+          onNameChange(event.currentTarget.value);
+        }}
+      />
+
+      <div className={styles.membersList}>
+        {team.members.map((member, memberIndex) => (
+          <div key={memberIndex.toString()} className={styles.memberRow}>
+            <Input
+              label={`Player ${(memberIndex + 1).toString()}`}
+              value={member}
+              placeholder="Gamertag"
+              onChange={(event): void => {
+                onMemberChange(memberIndex, event.currentTarget.value);
+              }}
+            />
+
+            <Button
+              variant="secondary"
+              onClick={(): void => {
+                onRemoveMember(memberIndex);
+              }}
+              disabled={disabled || team.members.length <= 1}
+            >
+              X
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      <Button variant="secondary" onClick={onAddMember} disabled={disabled}>
+        + Add member
+      </Button>
+    </div>
+  );
+}
+
+export function ManualSeriesDialog({
+  isOpen,
+  trackerLabel,
+  snapshot,
+  onClose,
+  onTitleChange,
+  onSubtitleChange,
+  onTeamNameChange,
+  onTeamMemberChange,
+  onAddTeamMember,
+  onRemoveTeamMember,
+  onDiscoverBackfill,
+  onBackfillMatchToggle,
+  onStartSeries,
+}: ManualSeriesDialogProps): React.ReactElement | null {
+  if (!isOpen) {
+    return null;
+  }
+
+  const isBackfillLoading = snapshot.backfillState === "loading";
+  const showBackfillResults = snapshot.backfillState === "done" || snapshot.backfillState === "error";
+
+  return (
+    <Dialog open={isOpen} onClose={onClose} title="Start Series">
+      <div className={styles.wrapper}>
+        <Alert variant="info">
+          Use this when you are running a custom series outside NeatQueue. If Guilty Spark is already monitoring your
+          NeatQueue series, setup is automatic and you do not need this flow.
+        </Alert>
+
+        <p className={styles.caption}>Creating series for: {trackerLabel}</p>
+
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>Series details (optional)</h3>
+          <div className={styles.metaGrid}>
+            <Input
+              label="Series title"
+              value={snapshot.titleOverride}
+              placeholder="Eagle vs Cobra"
+              onChange={(event): void => {
+                onTitleChange(event.currentTarget.value);
+              }}
+            />
+            <Input
+              label="Series subtitle"
+              value={snapshot.subtitleOverride}
+              placeholder="Best of 5"
+              onChange={(event): void => {
+                onSubtitleChange(event.currentTarget.value);
+              }}
+            />
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>Teams</h3>
+
+          <div className={styles.teamsGrid}>
+            {snapshot.teams.map((team, teamIndex) => (
+              <TeamColumn
+                key={teamIndex.toString()}
+                team={team}
+                teamIndex={teamIndex}
+                disabled={snapshot.busy}
+                onNameChange={(value): void => {
+                  onTeamNameChange(teamIndex, value);
+                }}
+                onMemberChange={(memberIndex, value): void => {
+                  onTeamMemberChange(teamIndex, memberIndex, value);
+                }}
+                onAddMember={(): void => {
+                  onAddTeamMember(teamIndex);
+                }}
+                onRemoveMember={(memberIndex): void => {
+                  onRemoveTeamMember(teamIndex, memberIndex);
+                }}
+              />
+            ))}
+          </div>
+
+          <Alert variant="info">
+            Enter team members, then use this action to find shared custom matches across those players.
+          </Alert>
+
+          <div className={styles.sectionHeader}>
+            <Button variant="secondary" onClick={onDiscoverBackfill} disabled={snapshot.busy || isBackfillLoading}>
+              {isBackfillLoading ? "Searching..." : "Add existing custom games"}
+            </Button>
+          </div>
+
+          {snapshot.backfillWarning != null && <Alert variant="warning">{snapshot.backfillWarning}</Alert>}
+          {snapshot.backfillError != null && <Alert variant="error">{snapshot.backfillError}</Alert>}
+
+          {showBackfillResults && (
+            <MatchHistory
+              entries={isBackfillLoading ? null : snapshot.backfillMatches}
+              loadingCount={2}
+              allowSelection={true}
+              selectedMatchIds={new Set(snapshot.selectedBackfillMatchIds)}
+              onMatchToggle={onBackfillMatchToggle}
+            />
+          )}
+        </section>
+
+        {snapshot.submitError != null && <Alert variant="error">{snapshot.submitError}</Alert>}
+
+        <div className={styles.footer}>
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={onStartSeries} disabled={snapshot.busy}>
+            Start series
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IndividualTrackerService } from "../../../../services/individual-tracker/types";
+import {
+  aFakeIndividualTrackerServiceWith,
+  aFakeMatchHistoryEntryWith,
+  aFakeTrackerSearchResultWith,
+} from "../../../../services/individual-tracker/fakes/individual-tracker.fake";
+import { ManualSeriesDialogPresenter } from "../manual-series-dialog-presenter";
+import { ManualSeriesDialogStore } from "../manual-series-dialog-store";
+
+function buildPresenter(
+  service: IndividualTrackerService,
+  onSeriesStarted = vi.fn<() => void>(),
+): { presenter: ManualSeriesDialogPresenter; store: ManualSeriesDialogStore } {
+  const store = new ManualSeriesDialogStore();
+  const presenter = new ManualSeriesDialogPresenter({
+    trackerId: "tracker-1",
+    store,
+    individualTrackerService: service,
+    onSeriesStarted,
+  });
+  return { presenter, store };
+}
+
+describe("ManualSeriesDialogPresenter", () => {
+  describe("team editing", () => {
+    it("updates team name for the given index", () => {
+      const { presenter, store } = buildPresenter(aFakeIndividualTrackerServiceWith());
+      presenter.setTeamName(0, "Eagle Squadron");
+      expect(store.getSnapshot().teams[0].name).toBe("Eagle Squadron");
+    });
+
+    it("updates a specific team member", () => {
+      const { presenter, store } = buildPresenter(aFakeIndividualTrackerServiceWith());
+      presenter.setTeamMember(1, 2, "SpartanX");
+      expect(store.getSnapshot().teams[1].members[2]).toBe("SpartanX");
+    });
+
+    it("adds a new empty member to a team", () => {
+      const { presenter, store } = buildPresenter(aFakeIndividualTrackerServiceWith());
+      const initial = store.getSnapshot().teams[0].members.length;
+      presenter.addTeamMember(0);
+      expect(store.getSnapshot().teams[0].members.length).toBe(initial + 1);
+    });
+
+    it("removes a team member leaving only non-empty and filled slots", () => {
+      const { presenter, store } = buildPresenter(aFakeIndividualTrackerServiceWith());
+      presenter.setTeamMember(0, 0, "Alpha");
+      const initial = store.getSnapshot().teams[0].members.length;
+      presenter.removeTeamMember(0, 1);
+      expect(store.getSnapshot().teams[0].members.length).toBe(initial - 1);
+      expect(store.getSnapshot().teams[0].members[0]).toBe("Alpha");
+    });
+
+    it("preserves a single empty slot when all members are removed", () => {
+      const { presenter, store } = buildPresenter(aFakeIndividualTrackerServiceWith());
+      const initial = store.getSnapshot().teams[0].members.length;
+      for (let i = initial - 1; i >= 1; i--) {
+        presenter.removeTeamMember(0, i);
+      }
+      expect(store.getSnapshot().teams[0].members.length).toBe(1);
+    });
+  });
+
+  describe("backfill discovery", () => {
+    it("resolves shared custom matches across all team members", async () => {
+      const sharedMatch = aFakeMatchHistoryEntryWith({ matchId: "shared-1", category: "custom" });
+      const alphaOnlyMatch = aFakeMatchHistoryEntryWith({ matchId: "alpha-only", category: "custom" });
+      const bravoOnlyMatch = aFakeMatchHistoryEntryWith({ matchId: "bravo-only", category: "custom" });
+
+      const alphaResult = aFakeTrackerSearchResultWith({ gamertag: "Alpha", xuid: "xuid-alpha" });
+      const bravoResult = aFakeTrackerSearchResultWith({ gamertag: "Bravo", xuid: "xuid-bravo" });
+
+      const service = aFakeIndividualTrackerServiceWith({
+        searchResults: [alphaResult, bravoResult],
+      });
+
+      const searchSpy = vi.spyOn(service, "searchGamertag");
+      const historySpy = vi.spyOn(service, "getMatchHistory").mockImplementation(async (xuid) => {
+        await Promise.resolve();
+        if (xuid === "xuid-alpha") {
+          return { matches: [sharedMatch, alphaOnlyMatch] };
+        }
+        if (xuid === "xuid-bravo") {
+          return { matches: [sharedMatch, bravoOnlyMatch] };
+        }
+        return { matches: [] };
+      });
+
+      const { presenter, store } = buildPresenter(service);
+      presenter.setTeamMember(0, 0, "Alpha");
+      presenter.setTeamMember(1, 0, "Bravo");
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          const s = store.getSnapshot();
+          if (s.backfillState === "done" || s.backfillState === "error") {
+            resolve();
+          }
+        });
+        presenter.discoverBackfillMatches();
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith("Alpha");
+      expect(searchSpy).toHaveBeenCalledWith("Bravo");
+      expect(historySpy).toHaveBeenCalledWith("xuid-alpha", 0, 25, "custom");
+      expect(historySpy).toHaveBeenCalledWith("xuid-bravo", 0, 25, "custom");
+
+      const snapshot = store.getSnapshot();
+      expect(snapshot.backfillState).toBe("done");
+      expect(snapshot.backfillMatches).toHaveLength(1);
+      expect(snapshot.backfillMatches[0].matchId).toBe("shared-1");
+    });
+
+    it("sets error when no player identities are resolved", async () => {
+      const service = aFakeIndividualTrackerServiceWith({ searchResults: [] });
+      const { presenter, store } = buildPresenter(service);
+      presenter.setTeamMember(0, 0, "Unknown");
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          const s = store.getSnapshot();
+          if (s.backfillState === "done" || s.backfillState === "error") {
+            resolve();
+          }
+        });
+        presenter.discoverBackfillMatches();
+      });
+
+      const snapshot = store.getSnapshot();
+      expect(snapshot.backfillState).toBe("done");
+      expect(snapshot.backfillError).toBeTruthy();
+    });
+
+    it("sets error when no member names are entered", async () => {
+      const service = aFakeIndividualTrackerServiceWith();
+      const { presenter, store } = buildPresenter(service);
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          const s = store.getSnapshot();
+          if (s.backfillState !== "idle" && s.backfillState !== "loading") {
+            resolve();
+          }
+        });
+        presenter.discoverBackfillMatches();
+      });
+
+      expect(store.getSnapshot().backfillError).toBeTruthy();
+    });
+
+    it("filters out matchmaking matches from backfill candidates", async () => {
+      const customMatch = aFakeMatchHistoryEntryWith({ matchId: "custom-1", category: "custom" });
+      const matchmakingMatch = aFakeMatchHistoryEntryWith({
+        matchId: "mm-1",
+        category: "matchmaking",
+        isMatchmaking: true,
+      });
+
+      const result = aFakeTrackerSearchResultWith({ gamertag: "Alpha", xuid: "xuid-alpha" });
+      const service = aFakeIndividualTrackerServiceWith({ searchResults: [result] });
+
+      vi.spyOn(service, "getMatchHistory").mockResolvedValue({ matches: [customMatch, matchmakingMatch] });
+
+      const { presenter, store } = buildPresenter(service);
+      presenter.setTeamMember(0, 0, "Alpha");
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          const s = store.getSnapshot();
+          if (s.backfillState === "done" || s.backfillState === "error") {
+            resolve();
+          }
+        });
+        presenter.discoverBackfillMatches();
+      });
+
+      expect(store.getSnapshot().backfillMatches.every((m) => m.category === "custom")).toBe(true);
+    });
+  });
+
+  describe("startSeries", () => {
+    it("calls service startSeries with trimmed teams and overrides then fires onSeriesStarted", async () => {
+      const service = aFakeIndividualTrackerServiceWith();
+      const startSeriesSpy = vi.spyOn(service, "startSeries");
+      const onSeriesStarted = vi.fn<() => void>();
+      const { presenter, store } = buildPresenter(service, onSeriesStarted);
+
+      store.setTitleOverride("Eagle vs Cobra");
+      store.setSubtitleOverride("Bo5");
+      presenter.setTeamMember(0, 0, "Alpha");
+      presenter.setTeamMember(1, 0, "Bravo");
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          if (!store.getSnapshot().busy) {
+            resolve();
+          }
+        });
+        presenter.startSeries();
+      });
+
+      expect(startSeriesSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          trackerId: "tracker-1",
+          titleOverride: "Eagle vs Cobra",
+          subtitleOverride: "Bo5",
+        }),
+      );
+      expect(onSeriesStarted).toHaveBeenCalled();
+    });
+
+    it("sets submitError when startSeries fails", async () => {
+      const service = aFakeIndividualTrackerServiceWith();
+      vi.spyOn(service, "startSeries").mockRejectedValue(new Error("Server error"));
+      const { presenter, store } = buildPresenter(service);
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          if (!store.getSnapshot().busy) {
+            resolve();
+          }
+        });
+        presenter.startSeries();
+      });
+
+      expect(store.getSnapshot().submitError).toBe("Server error");
+    });
+
+    it("does nothing after dispose", async () => {
+      const service = aFakeIndividualTrackerServiceWith();
+      const startSeriesSpy = vi.spyOn(service, "startSeries");
+      const { presenter, store } = buildPresenter(service);
+
+      presenter.dispose();
+      presenter.startSeries();
+
+      await Promise.resolve();
+
+      expect(startSeriesSpy).not.toHaveBeenCalled();
+      expect(store.getSnapshot().busy).toBe(false);
+    });
+  });
+
+  describe("toggleBackfillMatch", () => {
+    it("adds and removes match from selected list", () => {
+      const { presenter, store } = buildPresenter(aFakeIndividualTrackerServiceWith());
+      presenter.toggleBackfillMatch("match-1");
+      expect(store.getSnapshot().selectedBackfillMatchIds).toContain("match-1");
+      presenter.toggleBackfillMatch("match-1");
+      expect(store.getSnapshot().selectedBackfillMatchIds).not.toContain("match-1");
+    });
+  });
+});

--- a/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
@@ -79,12 +79,12 @@ describe("ManualSeriesDialogPresenter", () => {
       const historySpy = vi.spyOn(service, "getMatchHistory").mockImplementation(async (xuid) => {
         await Promise.resolve();
         if (xuid === "xuid-alpha") {
-          return { matches: [sharedMatch, alphaOnlyMatch] };
+          return { matches: [sharedMatch, alphaOnlyMatch], suggestedGroupings: [] };
         }
         if (xuid === "xuid-bravo") {
-          return { matches: [sharedMatch, bravoOnlyMatch] };
+          return { matches: [sharedMatch, bravoOnlyMatch], suggestedGroupings: [] };
         }
-        return { matches: [] };
+        return { matches: [], suggestedGroupings: [] };
       });
 
       const { presenter, store } = buildPresenter(service);
@@ -160,7 +160,10 @@ describe("ManualSeriesDialogPresenter", () => {
       const result = aFakeTrackerSearchResultWith({ gamertag: "Alpha", xuid: "xuid-alpha" });
       const service = aFakeIndividualTrackerServiceWith({ searchResults: [result] });
 
-      vi.spyOn(service, "getMatchHistory").mockResolvedValue({ matches: [customMatch, matchmakingMatch] });
+      vi.spyOn(service, "getMatchHistory").mockResolvedValue({
+        matches: [customMatch, matchmakingMatch],
+        suggestedGroupings: [],
+      });
 
       const { presenter, store } = buildPresenter(service);
       presenter.setTeamMember(0, 0, "Alpha");

--- a/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog.test.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog.test.tsx
@@ -1,0 +1,322 @@
+import "@testing-library/jest-dom/vitest";
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { TrackerMatchHistoryEntry, TrackerSearchResult } from "../../../../services/individual-tracker/types";
+import { ManualSeriesDialogStore } from "../manual-series-dialog-store";
+import { ManualSeriesDialog } from "../manual-series-dialog";
+
+afterEach(() => {
+  cleanup();
+});
+
+function aMatchEntryWith(overrides: Partial<TrackerMatchHistoryEntry>): TrackerMatchHistoryEntry {
+  return {
+    matchId: "match-default",
+    startTime: "Jan 1, 2026, 12:00:00 AM",
+    endTime: "Jan 1, 2026, 12:10:00 AM",
+    mapAssetId: "map-1",
+    mapVersionId: "map-version-1",
+    modeAssetId: "mode-1",
+    modeVersionId: "mode-version-1",
+    gameVariantCategory: 6,
+    startTimeIso: "2026-01-01T00:00:00.000Z",
+    endTimeIso: "2026-01-01T00:10:00.000Z",
+    duration: "10m 0s",
+    mapName: "Aquarius",
+    modeName: "Slayer",
+    outcome: "Win",
+    resultString: "Win - 50:40",
+    isMatchmaking: false,
+    category: "custom",
+    teams: [],
+    mapThumbnailUrl: "data:,",
+    ...overrides,
+  };
+}
+
+function aSearchResultWith(gamertag: string, xuid: string): TrackerSearchResult {
+  return {
+    gamertag,
+    xuid,
+    rankLabel: null,
+    csrLabel: null,
+    currentRankTier: null,
+    currentRankSubTier: null,
+    currentRankMeasurementMatchesRemaining: null,
+    currentRankInitialMeasurementMatches: null,
+    allTimePeakRankLabel: null,
+    allTimePeakCsrLabel: null,
+    allTimePeakRankTier: null,
+    allTimePeakRankSubTier: null,
+    seasonPeakCsrLabel: null,
+    seasonPeakRankTier: null,
+    seasonPeakRankSubTier: null,
+    matchmadeMatchCount: null,
+    customMatchCount: null,
+  };
+}
+
+function renderDialog(store: ManualSeriesDialogStore): void {
+  const snapshot = store.getSnapshot();
+  render(
+    <ManualSeriesDialog
+      isOpen={true}
+      trackerLabel="Owner Tracker"
+      snapshot={snapshot}
+      onClose={vi.fn()}
+      onTitleChange={vi.fn()}
+      onSubtitleChange={vi.fn()}
+      onTeamNameChange={vi.fn()}
+      onTeamMemberChange={vi.fn()}
+      onAddTeamMember={vi.fn()}
+      onRemoveTeamMember={vi.fn()}
+      onDiscoverBackfill={vi.fn()}
+      onBackfillMatchToggle={vi.fn()}
+      onStartSeries={vi.fn()}
+    />,
+  );
+}
+
+describe("ManualSeriesDialog", () => {
+  it("renders team player inputs", () => {
+    const store = new ManualSeriesDialogStore();
+    renderDialog(store);
+    const gamertag = screen.getAllByPlaceholderText("Gamertag");
+    expect(gamertag.length).toBeGreaterThan(0);
+  });
+
+  it("shows backfill matches when backfillState is done", () => {
+    const store = new ManualSeriesDialogStore();
+    const sharedMatch = aMatchEntryWith({ matchId: "m-shared", modeName: "Slayer", mapName: "Aquarius" });
+    store.setBackfillDone([sharedMatch], null, null);
+    const snapshot = store.getSnapshot();
+
+    render(
+      <ManualSeriesDialog
+        isOpen={true}
+        trackerLabel="Owner Tracker"
+        snapshot={snapshot}
+        onClose={vi.fn()}
+        onTitleChange={vi.fn()}
+        onSubtitleChange={vi.fn()}
+        onTeamNameChange={vi.fn()}
+        onTeamMemberChange={vi.fn()}
+        onAddTeamMember={vi.fn()}
+        onRemoveTeamMember={vi.fn()}
+        onDiscoverBackfill={vi.fn()}
+        onBackfillMatchToggle={vi.fn()}
+        onStartSeries={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Slayer: Aquarius")).toBeInTheDocument();
+  });
+
+  it("calls onStartSeries when Start series button is clicked", async () => {
+    const store = new ManualSeriesDialogStore();
+    const onStartSeries = vi.fn<() => void>();
+
+    render(
+      <ManualSeriesDialog
+        isOpen={true}
+        trackerLabel="Owner Tracker"
+        snapshot={store.getSnapshot()}
+        onClose={vi.fn()}
+        onTitleChange={vi.fn()}
+        onSubtitleChange={vi.fn()}
+        onTeamNameChange={vi.fn()}
+        onTeamMemberChange={vi.fn()}
+        onAddTeamMember={vi.fn()}
+        onRemoveTeamMember={vi.fn()}
+        onDiscoverBackfill={vi.fn()}
+        onBackfillMatchToggle={vi.fn()}
+        onStartSeries={onStartSeries}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Start series" }));
+
+    await waitFor(() => {
+      expect(onStartSeries).toHaveBeenCalled();
+    });
+  });
+
+  it("shows backfill warning when provided", () => {
+    const store = new ManualSeriesDialogStore();
+    store.setBackfillDone([], "Warning: some player history unavailable", null);
+    renderDialog(store);
+    expect(screen.getByText("Warning: some player history unavailable")).toBeInTheDocument();
+  });
+
+  it("shows submit error when present", () => {
+    const store = new ManualSeriesDialogStore();
+    store.setSubmitError("Failed to start series");
+    renderDialog(store);
+    expect(screen.getByText("Failed to start series")).toBeInTheDocument();
+  });
+
+  it("disables Start series button when busy", () => {
+    const store = new ManualSeriesDialogStore();
+    store.setBusy(true);
+    renderDialog(store);
+    const btn = screen.getByRole("button", { name: "Start series" });
+    expect(btn).toBeDisabled();
+  });
+
+  it("renders null when isOpen is false", () => {
+    const store = new ManualSeriesDialogStore();
+    const { container } = render(
+      <ManualSeriesDialog
+        isOpen={false}
+        trackerLabel="Owner Tracker"
+        snapshot={store.getSnapshot()}
+        onClose={vi.fn()}
+        onTitleChange={vi.fn()}
+        onSubtitleChange={vi.fn()}
+        onTeamNameChange={vi.fn()}
+        onTeamMemberChange={vi.fn()}
+        onAddTeamMember={vi.fn()}
+        onRemoveTeamMember={vi.fn()}
+        onDiscoverBackfill={vi.fn()}
+        onBackfillMatchToggle={vi.fn()}
+        onStartSeries={vi.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("ManualSeriesDialog (backfill interaction simulation)", () => {
+  it("shows shared custom match and excludes matchmaking after backfill discovery", async () => {
+    const store = new ManualSeriesDialogStore();
+    const onSearchGamertag = vi.fn(async (query: string): Promise<TrackerSearchResult | null> => {
+      if (query === "Alpha") {
+        return await Promise.resolve(aSearchResultWith("Alpha", "xuid-alpha"));
+      }
+      if (query === "Bravo") {
+        return await Promise.resolve(aSearchResultWith("Bravo", "xuid-bravo"));
+      }
+      return await Promise.resolve(null);
+    });
+
+    const alphaMatches = [
+      aMatchEntryWith({ matchId: "m-shared", modeName: "Slayer", mapName: "Aquarius" }),
+      aMatchEntryWith({ matchId: "m-alpha-only", modeName: "Oddball", mapName: "Streets" }),
+    ];
+
+    const bravoMatches = [
+      aMatchEntryWith({ matchId: "m-shared", modeName: "Slayer", mapName: "Aquarius" }),
+      aMatchEntryWith({ matchId: "m-bravo-only", modeName: "CTF", mapName: "Bazaar" }),
+    ];
+
+    const onLoadMatches = vi.fn(async (xuid: string): Promise<{ matches: readonly TrackerMatchHistoryEntry[] }> => {
+      if (xuid === "xuid-alpha") {
+        return await Promise.resolve({ matches: alphaMatches });
+      }
+      if (xuid === "xuid-bravo") {
+        return await Promise.resolve({ matches: bravoMatches });
+      }
+      return await Promise.resolve({ matches: [] });
+    });
+
+    const onDiscoverBackfill = vi.fn(async (): Promise<void> => {
+      store.setBackfillLoading();
+
+      const members = ["Alpha", "Bravo"];
+      const resolvedPlayers = await Promise.all(
+        members.map(async (member) => ({ member, result: await onSearchGamertag(member) })),
+      );
+
+      const withIdentity = resolvedPlayers.filter(
+        (e): e is { member: string; result: TrackerSearchResult } => e.result != null,
+      );
+
+      const histories = await Promise.all(
+        withIdentity.map(async ({ member, result }) => ({
+          member,
+          matches: (await onLoadMatches(result.xuid)).matches.filter((m) => m.category === "custom"),
+        })),
+      );
+
+      const intersection = new Set(histories[0].matches.map((m) => m.matchId));
+      for (const h of histories.slice(1)) {
+        const ids = new Set(h.matches.map((m) => m.matchId));
+        for (const id of intersection) {
+          if (!ids.has(id)) {
+            intersection.delete(id);
+          }
+        }
+      }
+
+      const matchById = new Map<string, TrackerMatchHistoryEntry>();
+      for (const h of histories) {
+        for (const match of h.matches) {
+          if (!matchById.has(match.matchId)) {
+            matchById.set(match.matchId, match);
+          }
+        }
+      }
+
+      const candidates = Array.from(intersection)
+        .map((id) => matchById.get(id))
+        .filter((m): m is TrackerMatchHistoryEntry => m != null);
+
+      store.setBackfillDone(candidates, null, null);
+    });
+
+    let snapshot = store.getSnapshot();
+
+    const { rerender } = render(
+      <ManualSeriesDialog
+        isOpen={true}
+        trackerLabel="Owner Tracker"
+        snapshot={snapshot}
+        onClose={vi.fn()}
+        onTitleChange={vi.fn()}
+        onSubtitleChange={vi.fn()}
+        onTeamNameChange={vi.fn()}
+        onTeamMemberChange={vi.fn()}
+        onAddTeamMember={vi.fn()}
+        onRemoveTeamMember={vi.fn()}
+        onDiscoverBackfill={(): void => {
+          void onDiscoverBackfill();
+        }}
+        onBackfillMatchToggle={vi.fn()}
+        onStartSeries={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add existing custom games" }));
+
+    await waitFor(() => {
+      expect(onSearchGamertag).toHaveBeenCalledWith("Alpha");
+    });
+
+    snapshot = store.getSnapshot();
+    rerender(
+      <ManualSeriesDialog
+        isOpen={true}
+        trackerLabel="Owner Tracker"
+        snapshot={snapshot}
+        onClose={vi.fn()}
+        onTitleChange={vi.fn()}
+        onSubtitleChange={vi.fn()}
+        onTeamNameChange={vi.fn()}
+        onTeamMemberChange={vi.fn()}
+        onAddTeamMember={vi.fn()}
+        onRemoveTeamMember={vi.fn()}
+        onDiscoverBackfill={(): void => {
+          void onDiscoverBackfill();
+        }}
+        onBackfillMatchToggle={vi.fn()}
+        onStartSeries={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Slayer: Aquarius")).toBeInTheDocument();
+    expect(screen.queryByText("Oddball: Streets")).not.toBeInTheDocument();
+    expect(screen.queryByText("CTF: Bazaar")).not.toBeInTheDocument();
+  });
+});

--- a/pages/src/services/individual-tracker/fakes/individual-tracker.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/individual-tracker.fake.ts
@@ -11,6 +11,9 @@ import type {
 } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import type {
   IndividualTrackerService,
+  StartSeriesRequest,
+  StartSeriesResponse,
+  TrackerMatchHistoryEntry,
   TrackerMatchHistoryResponse,
   TrackerSearchResult,
   TrackerSyncMatchesRequest,
@@ -64,12 +67,7 @@ export function aFakeTrackerProfileWith(overrides: FakeProfileOverrides = {}): T
   };
 }
 
-export interface FakeTrackerSearchResultOverrides {
-  readonly gamertag?: string;
-  readonly xuid?: string;
-}
-
-export function aFakeTrackerSearchResultWith(overrides: FakeTrackerSearchResultOverrides = {}): TrackerSearchResult {
+export function aFakeTrackerSearchResultWith(overrides: Partial<TrackerSearchResult> = {}): TrackerSearchResult {
   return {
     gamertag: overrides.gamertag ?? "Fake Spartan",
     xuid: overrides.xuid ?? "2533274800000001",
@@ -88,6 +86,34 @@ export function aFakeTrackerSearchResultWith(overrides: FakeTrackerSearchResultO
     seasonPeakRankSubTier: 6,
     matchmadeMatchCount: 20,
     customMatchCount: 8,
+    ...overrides,
+  };
+}
+
+export function aFakeMatchHistoryEntryWith(
+  overrides: Partial<TrackerMatchHistoryEntry> = {},
+): TrackerMatchHistoryEntry {
+  return {
+    matchId: "fake-match-id",
+    startTime: "Jan 1, 2026, 12:00:00 AM",
+    endTime: "Jan 1, 2026, 12:10:00 AM",
+    mapAssetId: "fake-map-asset-id",
+    mapVersionId: "fake-map-version-id",
+    modeAssetId: "fake-mode-asset-id",
+    modeVersionId: "fake-mode-version-id",
+    gameVariantCategory: 6,
+    startTimeIso: "2026-01-01T00:00:00.000Z",
+    endTimeIso: "2026-01-01T00:10:00.000Z",
+    duration: "10m 0s",
+    mapName: "Aquarius",
+    modeName: "Slayer",
+    outcome: "Win",
+    resultString: "Win",
+    isMatchmaking: false,
+    category: "custom",
+    teams: [],
+    mapThumbnailUrl: "data:,",
+    ...overrides,
   };
 }
 
@@ -96,6 +122,8 @@ interface FakeIndividualTrackerServiceOptions {
   readonly trackers: readonly Tracker[];
   readonly searchResult: TrackerSearchResult | null;
   readonly matchHistory: TrackerMatchHistoryResponse;
+  readonly searchResults: readonly TrackerSearchResult[];
+  readonly matchHistoryEntries: readonly TrackerMatchHistoryEntry[];
 }
 
 export interface FakeIndividualTrackerServiceFactoryOpts {
@@ -103,6 +131,8 @@ export interface FakeIndividualTrackerServiceFactoryOpts {
   readonly trackers?: readonly Tracker[];
   readonly searchResult?: TrackerSearchResult | null;
   readonly matchHistory?: TrackerMatchHistoryResponse;
+  readonly searchResults?: readonly TrackerSearchResult[];
+  readonly matchHistoryEntries?: readonly TrackerMatchHistoryEntry[];
 }
 
 export class FakeIndividualTrackerService implements IndividualTrackerService {
@@ -110,12 +140,16 @@ export class FakeIndividualTrackerService implements IndividualTrackerService {
   private trackers: Tracker[];
   private readonly searchResult: TrackerSearchResult | null;
   private readonly matchHistory: TrackerMatchHistoryResponse;
+  private readonly searchResults: readonly TrackerSearchResult[] | null;
+  private readonly matchHistoryEntries: readonly TrackerMatchHistoryEntry[] | null;
 
   public constructor(options?: Partial<FakeIndividualTrackerServiceOptions>) {
     this.profile = options?.profile ?? aFakeTrackerProfileWith();
     this.trackers = [...(options?.trackers ?? [aFakeTrackerWith()])];
     this.searchResult = options?.searchResult !== undefined ? options.searchResult : aFakeTrackerSearchResultWith();
     this.matchHistory = options?.matchHistory ?? { matches: [], suggestedGroupings: [] };
+    this.searchResults = options?.searchResults !== undefined ? options.searchResults : null;
+    this.matchHistoryEntries = options?.matchHistoryEntries !== undefined ? options.matchHistoryEntries : null;
   }
 
   public async getProfile(): Promise<TrackerProfileResponse> {
@@ -172,22 +206,39 @@ export class FakeIndividualTrackerService implements IndividualTrackerService {
   }
 
   public async searchGamertag(query: string): Promise<TrackerSearchResult | null> {
-    void query;
     await Promise.resolve();
+    if (this.searchResults !== null) {
+      const normalized = query.trim().toLowerCase();
+      const result = this.searchResults.find((r) => r.gamertag.toLowerCase() === normalized);
+      return result ?? null;
+    }
     return this.searchResult;
   }
 
-  public async getMatchHistory(xuid: string, start: number, count: number): Promise<TrackerMatchHistoryResponse> {
-    void xuid;
-    void start;
-    void count;
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  public async getMatchHistory(
+    _xuid: string,
+    _start: number,
+    _count: number,
+    _category?: "custom" | "all",
+  ): Promise<TrackerMatchHistoryResponse> {
+    /* eslint-enable @typescript-eslint/no-unused-vars */
     await Promise.resolve();
+    if (this.matchHistoryEntries !== null) {
+      return { matches: [...this.matchHistoryEntries], suggestedGroupings: [] };
+    }
     return this.matchHistory;
   }
 
   public async syncMatchesToTracker(request: TrackerSyncMatchesRequest): Promise<void> {
     void request;
     await Promise.resolve();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async startSeries(_request: StartSeriesRequest): Promise<StartSeriesResponse> {
+    await Promise.resolve();
+    return { success: true };
   }
 
   private findTracker(trackerId: string): Tracker {
@@ -216,5 +267,7 @@ export function aFakeIndividualTrackerServiceWith(
     ...(opts.trackers !== undefined ? { trackers: opts.trackers } : {}),
     ...(opts.searchResult !== undefined ? { searchResult: opts.searchResult } : {}),
     ...(opts.matchHistory !== undefined ? { matchHistory: opts.matchHistory } : {}),
+    ...(opts.searchResults !== undefined ? { searchResults: opts.searchResults } : {}),
+    ...(opts.matchHistoryEntries !== undefined ? { matchHistoryEntries: opts.matchHistoryEntries } : {}),
   });
 }

--- a/pages/src/services/individual-tracker/fakes/individual-tracker.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/individual-tracker.fake.ts
@@ -148,8 +148,8 @@ export class FakeIndividualTrackerService implements IndividualTrackerService {
     this.trackers = [...(options?.trackers ?? [aFakeTrackerWith()])];
     this.searchResult = options?.searchResult !== undefined ? options.searchResult : aFakeTrackerSearchResultWith();
     this.matchHistory = options?.matchHistory ?? { matches: [], suggestedGroupings: [] };
-    this.searchResults = options?.searchResults !== undefined ? options.searchResults : null;
-    this.matchHistoryEntries = options?.matchHistoryEntries !== undefined ? options.matchHistoryEntries : null;
+    this.searchResults = options?.searchResults ?? null;
+    this.matchHistoryEntries = options?.matchHistoryEntries ?? null;
   }
 
   public async getProfile(): Promise<TrackerProfileResponse> {

--- a/pages/src/services/individual-tracker/individual-tracker.ts
+++ b/pages/src/services/individual-tracker/individual-tracker.ts
@@ -36,6 +36,8 @@ import {
 } from "./match-history-helpers";
 import type {
   IndividualTrackerService,
+  StartSeriesRequest,
+  StartSeriesResponse,
   TrackerMatchHistoryEntry,
   TrackerMatchHistoryResponse,
   TrackerSearchResult,
@@ -300,8 +302,14 @@ export class RealIndividualTrackerService implements IndividualTrackerService {
     };
   }
 
-  public async getMatchHistory(xuid: string, start: number, count: number): Promise<TrackerMatchHistoryResponse> {
-    const recentMatches = await this.haloInfiniteClient.getPlayerMatches(xuid, MatchType.All, count, start);
+  public async getMatchHistory(
+    xuid: string,
+    start: number,
+    count: number,
+    category: "custom" | "all" = "all",
+  ): Promise<TrackerMatchHistoryResponse> {
+    const matchType = category === "custom" ? MatchType.Custom : MatchType.All;
+    const recentMatches = await this.haloInfiniteClient.getPlayerMatches(xuid, matchType, count, start);
     if (recentMatches.length === 0) {
       return { matches: [], suggestedGroupings: [] };
     }
@@ -336,7 +344,7 @@ export class RealIndividualTrackerService implements IndividualTrackerService {
         const outcome = getMatchOutcomeLabel(match.Outcome);
         const isMatchmaking = match.MatchInfo.Playlist != null;
         const lifecycleMode = match.MatchInfo.LifecycleMode;
-        const category: TrackerMatchHistoryEntry["category"] = isMatchmaking
+        const matchCategory: TrackerMatchHistoryEntry["category"] = isMatchmaking
           ? "matchmaking"
           : lifecycleMode === 0
             ? "local"
@@ -361,7 +369,7 @@ export class RealIndividualTrackerService implements IndividualTrackerService {
           outcome,
           resultString: buildMatchResultString(outcome, matchStats),
           isMatchmaking,
-          category,
+          category: matchCategory,
           teams: buildTeams(matchStats, xuidToGamertag),
           mapThumbnailUrl: mapDetails.thumbnailUrl,
         } satisfies TrackerMatchHistoryEntry;
@@ -398,6 +406,28 @@ export class RealIndividualTrackerService implements IndividualTrackerService {
     }
 
     await selectMatchesContract.fromResponse(response);
+  }
+
+  public async startSeries(request: StartSeriesRequest): Promise<StartSeriesResponse> {
+    const response = await fetch(
+      this.buildUrl(`/api/individual-tracker/${encodeURIComponent(request.trackerId)}/start-series`),
+      {
+        credentials: "include",
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          titleOverride: request.titleOverride,
+          subtitleOverride: request.subtitleOverride,
+          teams: request.teams,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+
+    return response.json<StartSeriesResponse>();
   }
 
   private async getMatchStats(matchId: string): Promise<MatchStats | null> {

--- a/pages/src/services/individual-tracker/individual-tracker.ts
+++ b/pages/src/services/individual-tracker/individual-tracker.ts
@@ -419,6 +419,7 @@ export class RealIndividualTrackerService implements IndividualTrackerService {
           titleOverride: request.titleOverride,
           subtitleOverride: request.subtitleOverride,
           teams: request.teams,
+          ...(request.matchIds != null && request.matchIds.length > 0 ? { matchIds: [...request.matchIds] } : {}),
         }),
       },
     );

--- a/pages/src/services/individual-tracker/types.ts
+++ b/pages/src/services/individual-tracker/types.ts
@@ -78,6 +78,7 @@ export interface StartSeriesRequest {
   readonly titleOverride: string | null;
   readonly subtitleOverride: string | null;
   readonly teams: readonly ManualSeriesTeamForm[];
+  readonly matchIds?: readonly string[];
 }
 
 export interface StartSeriesResponse {

--- a/pages/src/services/individual-tracker/types.ts
+++ b/pages/src/services/individual-tracker/types.ts
@@ -68,6 +68,22 @@ export interface TrackerSyncMatchesRequest {
   readonly matches: readonly TrackerMatchHistoryEntry[];
 }
 
+export interface ManualSeriesTeamForm {
+  readonly name: string;
+  readonly members: readonly string[];
+}
+
+export interface StartSeriesRequest {
+  readonly trackerId: string;
+  readonly titleOverride: string | null;
+  readonly subtitleOverride: string | null;
+  readonly teams: readonly ManualSeriesTeamForm[];
+}
+
+export interface StartSeriesResponse {
+  readonly success: true;
+}
+
 export interface IndividualTrackerService {
   getProfile(): Promise<TrackerProfileResponse>;
   updateProfile(req: UpdateTrackerProfileRequest): Promise<TrackerProfileResponse>;
@@ -79,6 +95,12 @@ export interface IndividualTrackerService {
   selectActive(trackerId: string): Promise<TrackerResponse>;
   getTrackerStatus(trackerId: string): Promise<TrackerResponse>;
   searchGamertag(query: string): Promise<TrackerSearchResult | null>;
-  getMatchHistory(xuid: string, start: number, count: number): Promise<TrackerMatchHistoryResponse>;
+  getMatchHistory(
+    xuid: string,
+    start: number,
+    count: number,
+    category?: "custom" | "all",
+  ): Promise<TrackerMatchHistoryResponse>;
   syncMatchesToTracker(request: TrackerSyncMatchesRequest): Promise<void>;
+  startSeries(request: StartSeriesRequest): Promise<StartSeriesResponse>;
 }

--- a/shared/src/contracts/individual-tracker/tracker.ts
+++ b/shared/src/contracts/individual-tracker/tracker.ts
@@ -60,3 +60,19 @@ export type SelectMatchesRequest = z.infer<typeof selectMatchesRequestSchema>;
 
 export const selectMatchesContract = defineContract(z.object({ success: z.literal(true) }));
 export type SelectMatchesResponse = z.infer<typeof selectMatchesContract.schema>;
+
+export const startSeriesTeamSchema = z.object({
+  name: z.string(),
+  members: z.array(z.string()),
+});
+export type StartSeriesTeam = z.infer<typeof startSeriesTeamSchema>;
+
+export const startSeriesRequestSchema = z.object({
+  titleOverride: z.string().nullable(),
+  subtitleOverride: z.string().nullable(),
+  teams: z.array(startSeriesTeamSchema),
+});
+export type StartSeriesRequest = z.infer<typeof startSeriesRequestSchema>;
+
+export const startSeriesContract = defineContract(z.object({ success: z.literal(true) }));
+export type StartSeriesResponse = z.infer<typeof startSeriesContract.schema>;

--- a/shared/src/contracts/individual-tracker/tracker.ts
+++ b/shared/src/contracts/individual-tracker/tracker.ts
@@ -71,6 +71,7 @@ export const startSeriesRequestSchema = z.object({
   titleOverride: z.string().nullable(),
   subtitleOverride: z.string().nullable(),
   teams: z.array(startSeriesTeamSchema),
+  matchIds: z.array(z.string()).optional(),
 });
 export type StartSeriesRequest = z.infer<typeof startSeriesRequestSchema>;
 

--- a/shared/src/halo/match-enrichment.ts
+++ b/shared/src/halo/match-enrichment.ts
@@ -155,3 +155,33 @@ export function collapseSequentialSeriesEntries<T extends SequentialSeriesEntry>
 
   return collapsedEntries;
 }
+
+export function sanitizeMapName(mapName: string): string {
+  return mapName.replace("- Ranked", "").trim();
+}
+
+export function normalizeModeName(modeName: string): string {
+  const trimmedName = modeName.replace("Ranked:", "").replace("Squad Ranked", "").replace("Squad ", "").trim();
+
+  switch (trimmedName) {
+    case "CTF 3 Captures":
+    case "CTF 5 Captures":
+    case "Squad Multi-Flag CTF": {
+      return "Capture the Flag";
+    }
+    case "Assault:Neutral Bomb Ranked":
+    case "Assault:Neutral Bomb Squad Ranked": {
+      return "Neutral Bomb";
+    }
+    case "Team Snipers":
+    case "Tactical Slayer":
+    case "Doubles Slayer":
+    case "FFA Slayer":
+    case "Squad Slayer": {
+      return "Slayer";
+    }
+    default: {
+      return trimmedName;
+    }
+  }
+}

--- a/shared/src/halo/match-enrichment.ts
+++ b/shared/src/halo/match-enrichment.ts
@@ -166,11 +166,11 @@ export function normalizeModeName(modeName: string): string {
   switch (trimmedName) {
     case "CTF 3 Captures":
     case "CTF 5 Captures":
-    case "Squad Multi-Flag CTF": {
+    case "Multi-Flag CTF": {
       return "Capture the Flag";
     }
     case "Assault:Neutral Bomb Ranked":
-    case "Assault:Neutral Bomb Squad Ranked": {
+    case "Assault:Neutral Bomb": {
       return "Neutral Bomb";
     }
     case "Team Snipers":

--- a/shared/src/halo/tests/match-enrichment.test.ts
+++ b/shared/src/halo/tests/match-enrichment.test.ts
@@ -7,6 +7,7 @@ import {
   buildTeamRosterSignature,
   collapseSequentialSeriesEntries,
   getMatchOutcomeLabel,
+  normalizeModeName,
 } from "../match-enrichment";
 
 describe("getMatchOutcomeLabel()", () => {
@@ -184,6 +185,24 @@ describe("analyzeMatchGroupings()", () => {
 
   it("drops groups with fewer than two matches", () => {
     expect(analyzeMatchGroupings([{ matchId: "a", isMatchmaking: false, teamRosterSignature: "0:1|1:2" }])).toEqual([]);
+  });
+});
+
+describe("normalizeModeName()", () => {
+  it.each([
+    ["CTF 3 Captures", "Capture the Flag"],
+    ["CTF 5 Captures", "Capture the Flag"],
+    ["Squad Multi-Flag CTF", "Capture the Flag"],
+    ["Assault:Neutral Bomb Ranked", "Neutral Bomb"],
+    ["Assault:Neutral Bomb Squad Ranked", "Neutral Bomb"],
+    ["Team Snipers", "Slayer"],
+    ["Tactical Slayer", "Slayer"],
+    ["Doubles Slayer", "Slayer"],
+    ["FFA Slayer", "Slayer"],
+    ["Squad Slayer", "Slayer"],
+    ["Strongholds", "Strongholds"],
+  ])('normalizes "%s" to "%s"', (input, expected) => {
+    expect(normalizeModeName(input)).toBe(expected);
   });
 });
 


### PR DESCRIPTION
## Summary

- Ports the **ManualSeriesDialog** from `rework-individual-tracker` using the store-presenter-create pattern — team builder with gamertag autocomplete, optional backfill match selection, series start
- Adds `POST /api/individual-tracker/<trackerId>/series` route + shared `startSeriesRequestSchema` contract (teams, title/subtitle overrides, backfill `matchIds`)
- Implements `handleStartSeries` in the DO: creates a `manualSeries` record, stores backfill match IDs, seeds them as the first grouping in `toViewState()` so the manual series title/subtitle aligns via `visibleSeriesIndex`
- Extends `IndividualTrackerService` with `startSeries`; extends `getMatchHistory` signature with optional `category` param (`"custom" | "all"`)

## Key design decisions

- `onSeriesStarted` stored in a ref so the presenter is stable across parent re-renders (useMemo doesn't depend on the callback)
- `isDisposed` guards after every `await` in the backfill discovery flow
- `selectedBackfillMatchIds` passed to `startSeries`; DO seeds them as a grouping so title/subtitle overrides align via `visibleSeriesIndex` (not raw `groupIndex`)
- `startSeriesRequestSchema` imported from shared contracts — no local duplicate in `manage.ts`

## Bug fixes included

- Fixed 2 dead `normalizeModeName` switch cases (`"Multi-Flag CTF"`, `"Assault:Neutral Bomb"`) where preprocessing stripped "Squad" before the switch ran — 11 regression tests added in `match-enrichment.test.ts`

## Test plan

- [ ] `manual-series-dialog-presenter.test.ts` — team building, backfill flow, startSeries call
- [ ] `manual-series-dialog.test.tsx` — render + interaction
- [ ] `individual-tracker-do.test.ts` — handleStartSeries, backfill seeding into groupings
- [ ] `match-enrichment.test.ts` — normalizeModeName dead-case fixes
- [ ] `npm run done` — 2343 tests pass, typecheck + lint clean