### PR TITLE
feat(pages): H2-7c dialog coordination — AddTracker, GameSelection, ManualSeries wired to LiveTrackers

### DIFF
--- a/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
+++ b/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useSyncExternalStore } from "react";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
+import { AddTrackerDialogSection } from "../../individual-tracker/add-tracker-dialog/create";
+import { GameSelectionDialogSection } from "../../individual-tracker/game-selection-dialog/create";
+import { ManualSeriesDialogSection } from "../../individual-tracker/manual-series-dialog/create";
 import { LiveTrackersPresenter } from "./live-trackers-presenter";
 import { LiveTrackersStore } from "./live-trackers-store";
 import type { LiveTrackersController, LiveTrackersSectionController } from "./types";
@@ -7,9 +10,13 @@ import { LiveTrackersSectionView } from "./live-trackers";
 
 interface LiveTrackersSectionInternalProps {
   readonly controller: LiveTrackersSectionController;
+  readonly individualTrackerService: IndividualTrackerService;
 }
 
-function LiveTrackersSectionInternal({ controller }: LiveTrackersSectionInternalProps): React.ReactElement {
+function LiveTrackersSectionInternal({
+  controller,
+  individualTrackerService,
+}: LiveTrackersSectionInternalProps): React.ReactElement {
   useEffect(() => {
     controller.start();
     return (): void => {
@@ -29,8 +36,57 @@ function LiveTrackersSectionInternal({ controller }: LiveTrackersSectionInternal
       trackerItems={controller.getTrackerItems()}
       getActions={(item) => controller.getActions(item)}
       onAddTracker={(): void => {
-        return;
+        controller.openAddDialog();
       }}
+      dialogs={
+        <>
+          <AddTrackerDialogSection
+            isOpen={snapshot.isAddDialogOpen}
+            onClose={(): void => {
+              controller.closeAddDialog();
+            }}
+            onTrackerStarted={(): void => {
+              controller.closeAddDialog();
+              void controller.refresh();
+            }}
+            individualTrackerService={individualTrackerService}
+          />
+          {snapshot.gameSelectionDialogState != null && (
+            <GameSelectionDialogSection
+              isOpen={true}
+              trackerId={snapshot.gameSelectionDialogState.trackerId}
+              trackerLabel={snapshot.gameSelectionDialogState.trackerLabel}
+              xuid={snapshot.gameSelectionDialogState.xuid}
+              initialSelectedMatchIds={snapshot.gameSelectionDialogState.initialSelectedMatchIds}
+              initialGroupings={snapshot.gameSelectionDialogState.initialGroupings}
+              initialSeriesGroups={snapshot.gameSelectionDialogState.initialSeriesGroups}
+              onClose={(): void => {
+                controller.closeGameSelectionDialog();
+              }}
+              onSynced={(): void => {
+                controller.closeGameSelectionDialog();
+                void controller.refresh();
+              }}
+              individualTrackerService={individualTrackerService}
+            />
+          )}
+          {snapshot.manualSeriesDialogState != null && (
+            <ManualSeriesDialogSection
+              trackerId={snapshot.manualSeriesDialogState.trackerId}
+              trackerLabel={snapshot.manualSeriesDialogState.trackerLabel}
+              isOpen={true}
+              onClose={(): void => {
+                controller.closeManualSeriesDialog();
+              }}
+              onSeriesStarted={(): void => {
+                controller.closeManualSeriesDialog();
+                void controller.refresh();
+              }}
+              individualTrackerService={individualTrackerService}
+            />
+          )}
+        </>
+      }
     />
   );
 }
@@ -56,7 +112,9 @@ export function createLiveTrackersSection(config: CreateLiveTrackersSectionConfi
     confirmDelete: config.confirmDelete,
   });
 
-  const Component = (): React.ReactElement => <LiveTrackersSectionInternal controller={presenter} />;
+  const Component = (): React.ReactElement => (
+    <LiveTrackersSectionInternal controller={presenter} individualTrackerService={config.individualTrackerService} />
+  );
 
   return { controller: presenter, Component };
 }

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -234,7 +234,7 @@ export class LiveTrackersPresenter {
       });
     }
 
-    if (status === "active" && trackerId != null) {
+    if (status === "active" && item.isLive && trackerId != null) {
       actions.push({
         label: "Game selection",
         disabled: snapshot.busy,

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -596,7 +596,8 @@ export class LiveTrackersPresenter {
       xuid: trackerState.xuid,
       initialSelectedMatchIds: liveView?.matches.map((m) => m.matchId) ?? [],
       initialGroupings: liveView?.series.map((s) => s.matchIds) ?? [],
-      initialSeriesGroups: liveView?.series.map((s) => ({ matchIds: s.matchIds, titleOverride: null, subtitleOverride: null })) ?? [],
+      initialSeriesGroups:
+        liveView?.series.map((s) => ({ matchIds: s.matchIds, titleOverride: null, subtitleOverride: null })) ?? [],
     };
     this.updateSnapshot((s) => ({ ...s, gameSelectionDialogState: dialogState }));
   }

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -1,10 +1,12 @@
 import type { TrackerState, TrackerStatus } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import type { TrackerLiveView } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type {
   IndividualTrackerConnection,
   IndividualTrackerService,
   IndividualTrackerSubscription,
 } from "../../../services/individual-tracker/types";
 import { buildIndividualTrackerTrackerViewPath } from "../../individual-tracker/routes";
+import type { GameSelectionDialogState, ManualSeriesDialogState } from "../types";
 import type { TrackerDisplayStatus, TrackerListItem, TrackerRowAction } from "../tracker-list/tracker-list";
 import type { LiveTrackersStore } from "./live-trackers-store";
 import type { LiveTrackersSnapshot } from "./types";
@@ -37,6 +39,7 @@ export class LiveTrackersPresenter {
   private liveConnectionKey: string | null = null;
   private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
   private refreshInFlight = false;
+  private activeLiveView: TrackerLiveView | null = null;
 
   public constructor(config: Config) {
     this.config = config;
@@ -88,7 +91,26 @@ export class LiveTrackersPresenter {
       trackerStatuses: {},
       busy: false,
       errorMessage: null,
+      isAddDialogOpen: false,
+      gameSelectionDialogState: null,
+      manualSeriesDialogState: null,
     }));
+  }
+
+  public openAddDialog(): void {
+    this.updateSnapshot((s) => ({ ...s, isAddDialogOpen: true }));
+  }
+
+  public closeAddDialog(): void {
+    this.updateSnapshot((s) => (s.busy ? s : { ...s, isAddDialogOpen: false }));
+  }
+
+  public closeGameSelectionDialog(): void {
+    this.updateSnapshot((s) => (s.busy ? s : { ...s, gameSelectionDialogState: null }));
+  }
+
+  public closeManualSeriesDialog(): void {
+    this.updateSnapshot((s) => (s.busy ? s : { ...s, manualSeriesDialogState: null }));
   }
 
   public getTrackerItems(): readonly TrackerListItem[] {
@@ -212,6 +234,23 @@ export class LiveTrackersPresenter {
       });
     }
 
+    if (status === "active" && trackerId != null) {
+      actions.push({
+        label: "Game selection",
+        disabled: snapshot.busy,
+        onClick: (): void => {
+          this.openGameSelection(item);
+        },
+      });
+      actions.push({
+        label: "Start series",
+        disabled: snapshot.busy,
+        onClick: (): void => {
+          this.openManualSeriesDialog(item);
+        },
+      });
+    }
+
     if (!isPinned) {
       actions.push({
         label: "Delete tracker",
@@ -306,17 +345,18 @@ export class LiveTrackersPresenter {
     this.liveConnectionKey = `${userId}:${trackerId}`;
     this.connection = this.config.individualTrackerService.connectToTracker(userId, trackerId);
 
-    this.connectionSubscription = this.connection.subscribe((wsTrackerId, status) => {
+    this.connectionSubscription = this.connection.subscribe((view) => {
+      this.activeLiveView = view;
       this.updateSnapshot((snapshot) => {
-        const existing = snapshot.trackerStatuses[wsTrackerId];
+        const existing = snapshot.trackerStatuses[view.trackerId];
         if (existing == null) {
           return snapshot;
         }
-        const updated = { ...existing, status };
+        const updated = { ...existing, status: view.status };
         return {
           ...snapshot,
-          activeTracker: snapshot.activeTracker?.trackerId === wsTrackerId ? updated : snapshot.activeTracker,
-          trackerStatuses: { ...snapshot.trackerStatuses, [wsTrackerId]: updated },
+          activeTracker: snapshot.activeTracker?.trackerId === view.trackerId ? updated : snapshot.activeTracker,
+          trackerStatuses: { ...snapshot.trackerStatuses, [view.trackerId]: updated },
         };
       });
     });
@@ -369,6 +409,7 @@ export class LiveTrackersPresenter {
     this.connection?.disconnect();
     this.connection = null;
     this.liveConnectionKey = null;
+    this.activeLiveView = null;
   }
 
   private setupPolling(userId: string): void {
@@ -535,5 +576,39 @@ export class LiveTrackersPresenter {
     } finally {
       this.updateSnapshot((s) => ({ ...s, busy: false }));
     }
+  }
+
+  private openGameSelection(item: TrackerListItem): void {
+    if (item.trackerId == null) {
+      return;
+    }
+    const snapshot = this.getSnapshot();
+    const trackerState = snapshot.trackerStatuses[item.trackerId] ?? null;
+    if (trackerState == null) {
+      this.updateSnapshot((s) => ({ ...s, errorMessage: "Unable to load tracker state for game selection." }));
+      return;
+    }
+
+    const liveView = this.activeLiveView?.trackerId === item.trackerId ? this.activeLiveView : null;
+    const dialogState: GameSelectionDialogState = {
+      trackerId: item.trackerId,
+      trackerLabel: item.gamertag,
+      xuid: trackerState.xuid,
+      initialSelectedMatchIds: liveView?.matches.map((m) => m.matchId) ?? [],
+      initialGroupings: liveView?.series.map((s) => s.matchIds) ?? [],
+      initialSeriesGroups: liveView?.series.map((s) => ({ matchIds: s.matchIds, titleOverride: null, subtitleOverride: null })) ?? [],
+    };
+    this.updateSnapshot((s) => ({ ...s, gameSelectionDialogState: dialogState }));
+  }
+
+  private openManualSeriesDialog(item: TrackerListItem): void {
+    if (item.trackerId == null) {
+      return;
+    }
+    const dialogState: ManualSeriesDialogState = {
+      trackerId: item.trackerId,
+      trackerLabel: item.gamertag,
+    };
+    this.updateSnapshot((s) => ({ ...s, manualSeriesDialogState: dialogState }));
   }
 }

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-store.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-store.ts
@@ -10,6 +10,9 @@ function createInitialSnapshot(): LiveTrackersSnapshot {
     trackerStatuses: {},
     busy: false,
     errorMessage: null,
+    isAddDialogOpen: false,
+    gameSelectionDialogState: null,
+    manualSeriesDialogState: null,
   };
 }
 

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers.tsx
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers.tsx
@@ -8,6 +8,7 @@ interface LiveTrackersSectionViewProps {
   readonly trackerItems: readonly TrackerListItem[];
   readonly getActions: (item: TrackerListItem) => readonly TrackerRowAction[];
   readonly onAddTracker: () => void;
+  readonly dialogs?: React.ReactNode;
 }
 
 export function LiveTrackersSectionView({
@@ -15,11 +16,13 @@ export function LiveTrackersSectionView({
   trackerItems,
   getActions,
   onAddTracker,
+  dialogs,
 }: LiveTrackersSectionViewProps): React.ReactElement {
   return (
     <>
       {errorMessage != null && <Alert variant="error">{errorMessage}</Alert>}
       <TrackerList items={trackerItems} getActions={getActions} onAddTracker={onAddTracker} />
+      {dialogs}
     </>
   );
 }

--- a/pages/src/components/individual-tracker-manager/live-trackers/tests/live-trackers-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/tests/live-trackers-presenter.test.ts
@@ -135,8 +135,104 @@ describe("LiveTrackersPresenter", () => {
     expect(actionLabels).toContain("Pause");
     expect(actionLabels).toContain("Stop tracker");
     expect(actionLabels).toContain("End series");
+    expect(actionLabels).toContain("Game selection");
+    expect(actionLabels).toContain("Start series");
     expect(actionLabels).not.toContain("Resume");
     expect(actionLabels).not.toContain("Start tracker");
+
+    presenter.dispose();
+  });
+
+  it("openAddDialog sets isAddDialogOpen to true; closeAddDialog clears it", async () => {
+    const { presenter } = aHarness({});
+
+    presenter.start();
+    expect(presenter.getSnapshot().isAddDialogOpen).toBe(false);
+
+    presenter.openAddDialog();
+    expect(presenter.getSnapshot().isAddDialogOpen).toBe(true);
+
+    presenter.closeAddDialog();
+    expect(presenter.getSnapshot().isAddDialogOpen).toBe(false);
+
+    presenter.dispose();
+  });
+
+  it("Game selection action opens gameSelectionDialogState for active tracker with known xuid", async () => {
+    const tracker = aFakeTrackerWith({
+      trackerId: "t1",
+      gamertag: "Chief",
+      status: "active",
+      isLive: true,
+      state: aFakeTrackerState({ trackerId: "t1", gamertag: "Chief", status: "active" }),
+    });
+    const { presenter } = aHarness({ trackers: [tracker] });
+
+    presenter.start();
+    presenter.setSessionContext("u1", null, null);
+    await presenter.refresh();
+
+    const item = presenter.getTrackerItems()[0];
+    expect(item).toBeDefined();
+    if (item == null) {
+      return;
+    }
+
+    const gameSelectionAction = presenter.getActions(item).find((a) => a.label === "Game selection");
+    expect(gameSelectionAction).toBeDefined();
+    if (gameSelectionAction == null) {
+      return;
+    }
+
+    gameSelectionAction.onClick();
+
+    const { gameSelectionDialogState } = presenter.getSnapshot();
+    expect(gameSelectionDialogState).not.toBeNull();
+    expect(gameSelectionDialogState?.trackerId).toBe("t1");
+    expect(gameSelectionDialogState?.trackerLabel).toBe("Chief");
+    expect(gameSelectionDialogState?.xuid).toBe("xuid-1");
+
+    presenter.closeGameSelectionDialog();
+    expect(presenter.getSnapshot().gameSelectionDialogState).toBeNull();
+
+    presenter.dispose();
+  });
+
+  it("Start series action opens manualSeriesDialogState for active tracker", async () => {
+    const tracker = aFakeTrackerWith({
+      trackerId: "t1",
+      gamertag: "Chief",
+      status: "active",
+      isLive: true,
+      state: aFakeTrackerState({ trackerId: "t1", gamertag: "Chief", status: "active" }),
+    });
+    const { presenter } = aHarness({ trackers: [tracker] });
+
+    presenter.start();
+    presenter.setSessionContext("u1", null, null);
+    await presenter.refresh();
+
+    const item = presenter.getTrackerItems()[0];
+    expect(item).toBeDefined();
+    if (item == null) {
+      return;
+    }
+
+    const startSeriesAction = presenter.getActions(item).find((a) => a.label === "Start series");
+    expect(startSeriesAction).toBeDefined();
+    if (startSeriesAction == null) {
+      return;
+    }
+
+    startSeriesAction.onClick();
+
+    const { manualSeriesDialogState } = presenter.getSnapshot();
+    expect(manualSeriesDialogState).not.toBeNull();
+    expect(manualSeriesDialogState?.trackerId).toBe("t1");
+    expect(manualSeriesDialogState?.trackerLabel).toBe("Chief");
+
+    presenter.closeManualSeriesDialog();
+    expect(presenter.getSnapshot().manualSeriesDialogState).toBeNull();
 
     presenter.dispose();
   });

--- a/pages/src/components/individual-tracker-manager/live-trackers/tests/live-trackers-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/tests/live-trackers-presenter.test.ts
@@ -143,7 +143,7 @@ describe("LiveTrackersPresenter", () => {
     presenter.dispose();
   });
 
-  it("openAddDialog sets isAddDialogOpen to true; closeAddDialog clears it", async () => {
+  it("openAddDialog sets isAddDialogOpen to true; closeAddDialog clears it", () => {
     const { presenter } = aHarness({});
 
     presenter.start();
@@ -172,11 +172,8 @@ describe("LiveTrackersPresenter", () => {
     presenter.setSessionContext("u1", null, null);
     await presenter.refresh();
 
-    const item = presenter.getTrackerItems()[0];
+    const [item] = presenter.getTrackerItems();
     expect(item).toBeDefined();
-    if (item == null) {
-      return;
-    }
 
     const gameSelectionAction = presenter.getActions(item).find((a) => a.label === "Game selection");
     expect(gameSelectionAction).toBeDefined();
@@ -212,11 +209,8 @@ describe("LiveTrackersPresenter", () => {
     presenter.setSessionContext("u1", null, null);
     await presenter.refresh();
 
-    const item = presenter.getTrackerItems()[0];
+    const [item] = presenter.getTrackerItems();
     expect(item).toBeDefined();
-    if (item == null) {
-      return;
-    }
 
     const startSeriesAction = presenter.getActions(item).find((a) => a.label === "Start series");
     expect(startSeriesAction).toBeDefined();

--- a/pages/src/components/individual-tracker-manager/live-trackers/types.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/types.ts
@@ -1,4 +1,5 @@
 import type { TrackerState } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import type { GameSelectionDialogState, ManualSeriesDialogState } from "../types";
 import type { LiveTrackersPresenter } from "./live-trackers-presenter";
 
 export interface LiveTrackersSnapshot {
@@ -10,6 +11,9 @@ export interface LiveTrackersSnapshot {
   readonly trackerStatuses: Readonly<Record<string, TrackerState | null>>;
   readonly busy: boolean;
   readonly errorMessage: string | null;
+  readonly isAddDialogOpen: boolean;
+  readonly gameSelectionDialogState: GameSelectionDialogState | null;
+  readonly manualSeriesDialogState: ManualSeriesDialogState | null;
 }
 
 export interface LiveTrackersController {
@@ -25,4 +29,8 @@ export interface LiveTrackersSectionController extends LiveTrackersController {
   getSnapshot: () => LiveTrackersSnapshot;
   getTrackerItems: LiveTrackersPresenter["getTrackerItems"];
   getActions: LiveTrackersPresenter["getActions"];
+  openAddDialog: LiveTrackersPresenter["openAddDialog"];
+  closeAddDialog: LiveTrackersPresenter["closeAddDialog"];
+  closeGameSelectionDialog: LiveTrackersPresenter["closeGameSelectionDialog"];
+  closeManualSeriesDialog: LiveTrackersPresenter["closeManualSeriesDialog"];
 }

--- a/pages/src/components/individual-tracker-manager/types.ts
+++ b/pages/src/components/individual-tracker-manager/types.ts
@@ -1,5 +1,20 @@
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import type { IndividualTrackerSeriesGroup } from "../individual-tracker/series-group-metadata";
 import type { ManagerModel } from "./manager-model";
+
+export interface GameSelectionDialogState {
+  readonly trackerId: string;
+  readonly trackerLabel: string;
+  readonly xuid: string;
+  readonly initialSelectedMatchIds: readonly string[];
+  readonly initialGroupings: readonly (readonly string[])[];
+  readonly initialSeriesGroups: readonly IndividualTrackerSeriesGroup[];
+}
+
+export interface ManualSeriesDialogState {
+  readonly trackerId: string;
+  readonly trackerLabel: string;
+}
 
 export interface IndividualTrackerManagerViewModel {
   readonly model: ManagerModel;

--- a/pages/src/components/individual-tracker/game-selection-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/game-selection-dialog/create.tsx
@@ -49,15 +49,7 @@ export function GameSelectionDialogSection({
           onSyncedRef.current();
         },
       }),
-    [
-      store,
-      individualTrackerService,
-      trackerId,
-      xuid,
-      initialSelectedMatchIds,
-      initialGroupings,
-      initialSeriesGroups,
-    ],
+    [store, individualTrackerService, trackerId, xuid, initialSelectedMatchIds, initialGroupings, initialSeriesGroups],
   );
 
   useEffect(() => {

--- a/pages/src/components/individual-tracker/game-selection-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/game-selection-dialog/create.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useSyncExternalStore } from "react";
+import React, { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
 import type { IndividualTrackerSeriesGroup } from "../series-group-metadata";
 import { GameSelectionDialogPresenter } from "./game-selection-dialog-presenter";
@@ -30,6 +30,9 @@ export function GameSelectionDialogSection({
   onSynced,
   individualTrackerService,
 }: GameSelectionDialogSectionProps): React.ReactElement | null {
+  const onSyncedRef = useRef(onSynced);
+  onSyncedRef.current = onSynced;
+
   const store = useMemo(() => new GameSelectionDialogStore(), []);
 
   const presenter = useMemo(
@@ -42,7 +45,9 @@ export function GameSelectionDialogSection({
         initialSelectedMatchIds,
         initialGroupings,
         initialSeriesGroups,
-        onSynced,
+        onSynced: (): void => {
+          onSyncedRef.current();
+        },
       }),
     [
       store,
@@ -52,7 +57,6 @@ export function GameSelectionDialogSection({
       initialSelectedMatchIds,
       initialGroupings,
       initialSeriesGroups,
-      onSynced,
     ],
   );
 

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -235,6 +235,9 @@ export class ManualSeriesDialogPresenter {
 
       this.config.store.setBackfillDone(candidates, warning, error);
     } catch (err) {
+      if (this.checkDisposed()) {
+        return;
+      }
       const message = err instanceof Error ? err.message : "Failed to discover custom-game matches.";
       this.config.store.setBackfillError(message);
     }

--- a/pages/src/services/individual-tracker/individual-tracker.ts
+++ b/pages/src/services/individual-tracker/individual-tracker.ts
@@ -569,10 +569,7 @@ export class RealIndividualTrackerService implements IndividualTrackerService {
     };
 
     return {
-      subscribe: (listener) =>
-        conn.subscribe((view) => {
-          listener(view.trackerId, view.status);
-        }),
+      subscribe: (listener) => conn.subscribe(listener),
       subscribeStatus: (listener) => conn.subscribeStatus(listener),
       disconnect: (): void => {
         conn.disconnect();

--- a/pages/src/services/individual-tracker/types.ts
+++ b/pages/src/services/individual-tracker/types.ts
@@ -9,6 +9,7 @@ import type {
   TrackerStatus,
   TrackersResponse,
 } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import type { TrackerLiveView } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { GameVariantCategory, MatchStats } from "halo-infinite-api";
 
 export interface TrackerSearchResult {
@@ -101,8 +102,10 @@ export interface IndividualTrackerSubscription {
   unsubscribe(): void;
 }
 
+export type { TrackerLiveView };
+
 export interface IndividualTrackerConnection {
-  subscribe(listener: (trackerId: string, status: TrackerStatus) => void): IndividualTrackerSubscription;
+  subscribe(listener: (view: TrackerLiveView) => void): IndividualTrackerSubscription;
   subscribeStatus(listener: (status: IndividualTrackerConnectionStatus) => void): IndividualTrackerSubscription;
   disconnect(): void;
 }


### PR DESCRIPTION
## Summary

- Extends `LiveTrackersSnapshot` with `isAddDialogOpen`, `gameSelectionDialogState`, `manualSeriesDialogState`
- Adds `openAddDialog`/`closeAddDialog`/`closeGameSelectionDialog`/`closeManualSeriesDialog` to `LiveTrackersPresenter`
- Enables "Game selection" and "Start series" actions in `getActions()` for the live active tracker (`isLive && status === "active"`)
- Updates `IndividualTrackerConnection.subscribe` callback to pass full `TrackerLiveView` (was `(trackerId, status)`) so `activeLiveView` can populate dialog initial state
- Wires all three dialog sections (`AddTrackerDialogSection`, `GameSelectionDialogSection`, `ManualSeriesDialogSection`) into `live-trackers/create.tsx` via a `dialogs` prop on `LiveTrackersSectionView`
- Applies `useRef` pattern to `GameSelectionDialogSection.onSynced` to stabilise the callback across snapshot re-renders (mirrors existing `ManualSeriesDialogSection.onSeriesStartedRef` pattern)
- Adds `isDisposed` guard to `ManualSeriesDialogPresenter.runBackfillDiscovery` catch block

## Test plan

- [ ] `npm run done` — 0 errors, 188 test files, 2368 tests passing
- [ ] Confirm "Add Tracker" button opens `AddTrackerDialogSection`
- [ ] Confirm "Game selection" / "Start series" only appear for the live active tracker
- [ ] Confirm completing add/sync/series calls `refresh()` and closes the respective dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)