### PR TITLE
/stats page: Handle Discord stats route rate limiting

### DIFF
--- a/api/routes/stats/discord-series.ts
+++ b/api/routes/stats/discord-series.ts
@@ -108,20 +108,19 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
   router.get("/api/stats/discord/:guildId/:queueNumber", async (request, env: Env) => {
     const services = installServices({ env });
     const { discordService, logService } = services;
+    const parsedParams = parsePathParams(
+      request.params,
+      discordSeriesStatsParamsSchema,
+      "Invalid guildId or queueNumber",
+    );
+    if (!parsedParams.success) {
+      return parsedParams.response;
+    }
+
+    const { guildId, queueNumber } = parsedParams.data;
+    const cacheKey = getCacheKey(guildId, queueNumber);
 
     try {
-      const parsedParams = parsePathParams(
-        request.params,
-        discordSeriesStatsParamsSchema,
-        "Invalid guildId or queueNumber",
-      );
-      if (!parsedParams.success) {
-        return parsedParams.response;
-      }
-
-      const { guildId, queueNumber } = parsedParams.data;
-      const cacheKey = getCacheKey(guildId, queueNumber);
-
       const cached = await env.APP_DATA.get<DiscordSeriesStats>(cacheKey, { type: "json" });
       if (cached != null && typeof cached === "object") {
         const cachedParseResult = discordSeriesStatsContract.safeParse(cached);
@@ -211,17 +210,6 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
       return discordSeriesStatsContract.toResponse(resolvedResponse, { status: 200 });
     } catch (error) {
       if (error instanceof DiscordError && error.httpStatus === 429) {
-        const parsedParams = parsePathParams(
-          request.params,
-          discordSeriesStatsParamsSchema,
-          "Invalid guildId or queueNumber",
-        );
-        if (!parsedParams.success) {
-          return parsedParams.response;
-        }
-
-        const { guildId, queueNumber } = parsedParams.data;
-        const cacheKey = getCacheKey(guildId, queueNumber);
         const retryAfterSeconds = sanitizeRetryAfterSeconds((error.restError as { retry_after?: unknown }).retry_after);
 
         const pendingResponse: DiscordSeriesStats = {
@@ -239,16 +227,6 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
       }
 
       if (error instanceof DiscordError && error.httpStatus === 403) {
-        const parsedParams = parsePathParams(
-          request.params,
-          discordSeriesStatsParamsSchema,
-          "Invalid guildId or queueNumber",
-        );
-        if (!parsedParams.success) {
-          return parsedParams.response;
-        }
-        const { guildId, queueNumber } = parsedParams.data;
-
         return discordSeriesStatsContract.toResponse(
           {
             status: "forbidden",

--- a/api/routes/stats/discord-series.ts
+++ b/api/routes/stats/discord-series.ts
@@ -92,6 +92,18 @@ function extractMatchIdsFromEmbeds(embeds: readonly APIEmbed[]): string[] {
   return [...matchIds];
 }
 
+function sanitizeRetryAfterSeconds(retryAfterValue: unknown): number {
+  if (typeof retryAfterValue !== "number") {
+    return DEFAULT_PENDING_RETRY_SECONDS;
+  }
+
+  if (!Number.isFinite(retryAfterValue) || retryAfterValue <= 0) {
+    return DEFAULT_PENDING_RETRY_SECONDS;
+  }
+
+  return retryAfterValue;
+}
+
 export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installServices) => {
   router.get("/api/stats/discord/:guildId/:queueNumber", async (request, env: Env) => {
     const services = installServices({ env });
@@ -136,10 +148,7 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
       });
 
       if ("retry_after" in searchResponse) {
-        const retryAfterValue =
-          typeof searchResponse.retry_after === "number" ? searchResponse.retry_after : DEFAULT_PENDING_RETRY_SECONDS;
-        const retryAfterSeconds =
-          Number.isFinite(retryAfterValue) && retryAfterValue > 0 ? retryAfterValue : DEFAULT_PENDING_RETRY_SECONDS;
+        const retryAfterSeconds = sanitizeRetryAfterSeconds(searchResponse.retry_after);
 
         const pendingResponse: DiscordSeriesStats = {
           status: "pending-index",
@@ -201,6 +210,34 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
 
       return discordSeriesStatsContract.toResponse(resolvedResponse, { status: 200 });
     } catch (error) {
+      if (error instanceof DiscordError && error.httpStatus === 429) {
+        const parsedParams = parsePathParams(
+          request.params,
+          discordSeriesStatsParamsSchema,
+          "Invalid guildId or queueNumber",
+        );
+        if (!parsedParams.success) {
+          return parsedParams.response;
+        }
+
+        const { guildId, queueNumber } = parsedParams.data;
+        const cacheKey = getCacheKey(guildId, queueNumber);
+        const retryAfterSeconds = sanitizeRetryAfterSeconds((error.restError as { retry_after?: unknown }).retry_after);
+
+        const pendingResponse: DiscordSeriesStats = {
+          status: "pending-index",
+          guildId,
+          queueNumber,
+          retryAfterSeconds,
+        };
+
+        await env.APP_DATA.put(cacheKey, JSON.stringify(pendingResponse), {
+          expirationTtl: PENDING_CACHE_TTL_SECONDS,
+        });
+
+        return discordSeriesStatsContract.toResponse(pendingResponse, getResponseOptions(pendingResponse));
+      }
+
       if (error instanceof DiscordError && error.httpStatus === 403) {
         const parsedParams = parsePathParams(
           request.params,

--- a/api/routes/stats/tests/discord-series.test.ts
+++ b/api/routes/stats/tests/discord-series.test.ts
@@ -371,6 +371,37 @@ describe("/api/stats/discord/:guildId/:queueNumber", () => {
     });
   });
 
+  it("returns pending-index when Discord service throws 429", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.discordService, "searchGuildMessages").mockRejectedValue(
+        new DiscordError(429, {
+          code: 0,
+          message: "You are being rate limited.",
+        }),
+      );
+      return services;
+    });
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(
+      new Request("http://localhost/api/stats/discord/123456789012345678/7777"),
+      env,
+    )) as Response;
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("retry-after")).toBe("2");
+    expect(res.headers.get("cache-control")).toBe("no-store");
+
+    const body = await res.json<DiscordSeriesStatsResponse>();
+    expect(body).toEqual({
+      status: "pending-index",
+      guildId: "123456789012345678",
+      queueNumber: 7777,
+      retryAfterSeconds: 2,
+    });
+  });
+
   it("returns internal error response when Discord search fails unexpectedly", async () => {
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });


### PR DESCRIPTION
Stage B1 slice for Discord series stats resilience.

Summary:
- Return pending-index for Discord 429 responses with Retry-After and no-store semantics.
- Keep cached pending-index responses consistent with non-cached behavior.
- Constrain queue numbers to safe integers at the contract/page boundary.

Validation:
- npm run lint
- npm run typecheck
- npm run test

This is the first small B1 follow-up slice after the merged Stage A stats flow.