### PR TITLE
Stats route: cache headers for resolved responses

### DIFF
--- a/api/routes/stats/discord-series.ts
+++ b/api/routes/stats/discord-series.ts
@@ -127,13 +127,6 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
       if (cached != null && typeof cached === "object") {
         const cachedParseResult = discordSeriesStatsContract.safeParse(cached);
         if (cachedParseResult.success) {
-          if (cachedParseResult.data.status === "resolved") {
-            return discordSeriesStatsContract.toResponse(cachedParseResult.data, {
-              status: 200,
-              headers: { "Cache-Control": RESOLVED_CACHE_CONTROL_HEADER },
-            });
-          }
-
           return discordSeriesStatsContract.toResponse(
             cachedParseResult.data,
             getResponseOptions(cachedParseResult.data),
@@ -216,10 +209,7 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
 
       await env.APP_DATA.put(cacheKey, JSON.stringify(resolvedResponse), { expirationTtl: RESOLVED_CACHE_TTL_SECONDS });
 
-      return discordSeriesStatsContract.toResponse(resolvedResponse, {
-        status: 200,
-        headers: { "Cache-Control": RESOLVED_CACHE_CONTROL_HEADER },
-      });
+      return discordSeriesStatsContract.toResponse(resolvedResponse, getResponseOptions(resolvedResponse));
     } catch (error) {
       if (error instanceof DiscordError && error.httpStatus === 429) {
         const retryAfterSeconds = sanitizeRetryAfterSeconds((error.restError as { retry_after?: unknown }).retry_after);

--- a/api/routes/stats/discord-series.ts
+++ b/api/routes/stats/discord-series.ts
@@ -17,7 +17,8 @@ const DEFAULT_PENDING_RETRY_SECONDS = 2;
 const PENDING_CACHE_TTL_SECONDS = 60 * 5;
 const RESOLVED_CACHE_TTL_SECONDS = 60 * 60 * 24;
 const NOT_FOUND_CACHE_TTL_SECONDS = 60 * 5;
-const RESOLVED_CACHE_CONTROL_HEADER = "public, s-maxage=86400, stale-while-revalidate=300";
+const RESOLVED_STALE_WHILE_REVALIDATE_SECONDS = 60 * 5;
+const RESOLVED_CACHE_CONTROL_HEADER = `public, s-maxage=${RESOLVED_CACHE_TTL_SECONDS.toString()}, stale-while-revalidate=${RESOLVED_STALE_WHILE_REVALIDATE_SECONDS.toString()}`;
 
 const MATCH_ID_REGEX = /https:\/\/halodatahive\.com\/Infinite\/Match\/([a-zA-Z0-9-]+)/g;
 
@@ -105,13 +106,6 @@ function sanitizeRetryAfterSeconds(retryAfterValue: unknown): number {
   return retryAfterValue;
 }
 
-function createResolvedResponse(response: DiscordSeriesStats): Response {
-  return Response.json(discordSeriesStatsContract.parse(response), {
-    status: 200,
-    headers: { "Cache-Control": RESOLVED_CACHE_CONTROL_HEADER },
-  });
-}
-
 export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installServices) => {
   router.get("/api/stats/discord/:guildId/:queueNumber", async (request, env: Env) => {
     const services = installServices({ env });
@@ -134,10 +128,16 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
         const cachedParseResult = discordSeriesStatsContract.safeParse(cached);
         if (cachedParseResult.success) {
           if (cachedParseResult.data.status === "resolved") {
-            return createResolvedResponse(cachedParseResult.data);
+            return discordSeriesStatsContract.toResponse(cachedParseResult.data, {
+              status: 200,
+              headers: { "Cache-Control": RESOLVED_CACHE_CONTROL_HEADER },
+            });
           }
 
-          return discordSeriesStatsContract.toResponse(cachedParseResult.data, getResponseOptions(cachedParseResult.data));
+          return discordSeriesStatsContract.toResponse(
+            cachedParseResult.data,
+            getResponseOptions(cachedParseResult.data),
+          );
         }
 
         logService.warn(
@@ -216,7 +216,10 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
 
       await env.APP_DATA.put(cacheKey, JSON.stringify(resolvedResponse), { expirationTtl: RESOLVED_CACHE_TTL_SECONDS });
 
-      return createResolvedResponse(resolvedResponse);
+      return discordSeriesStatsContract.toResponse(resolvedResponse, {
+        status: 200,
+        headers: { "Cache-Control": RESOLVED_CACHE_CONTROL_HEADER },
+      });
     } catch (error) {
       if (error instanceof DiscordError && error.httpStatus === 429) {
         const retryAfterSeconds = sanitizeRetryAfterSeconds((error.restError as { retry_after?: unknown }).retry_after);

--- a/api/routes/stats/discord-series.ts
+++ b/api/routes/stats/discord-series.ts
@@ -17,6 +17,7 @@ const DEFAULT_PENDING_RETRY_SECONDS = 2;
 const PENDING_CACHE_TTL_SECONDS = 60 * 5;
 const RESOLVED_CACHE_TTL_SECONDS = 60 * 60 * 24;
 const NOT_FOUND_CACHE_TTL_SECONDS = 60 * 5;
+const RESOLVED_CACHE_CONTROL_HEADER = "public, s-maxage=86400, stale-while-revalidate=300";
 
 const MATCH_ID_REGEX = /https:\/\/halodatahive\.com\/Infinite\/Match\/([a-zA-Z0-9-]+)/g;
 
@@ -31,7 +32,7 @@ function getResponseOptions(response: DiscordSeriesStats): {
 } {
   switch (response.status) {
     case "resolved": {
-      return { status: 200 };
+      return { status: 200, headers: { "Cache-Control": RESOLVED_CACHE_CONTROL_HEADER } };
     }
     case "pending-index": {
       return {
@@ -104,6 +105,13 @@ function sanitizeRetryAfterSeconds(retryAfterValue: unknown): number {
   return retryAfterValue;
 }
 
+function createResolvedResponse(response: DiscordSeriesStats): Response {
+  return Response.json(discordSeriesStatsContract.parse(response), {
+    status: 200,
+    headers: { "Cache-Control": RESOLVED_CACHE_CONTROL_HEADER },
+  });
+}
+
 export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installServices) => {
   router.get("/api/stats/discord/:guildId/:queueNumber", async (request, env: Env) => {
     const services = installServices({ env });
@@ -125,10 +133,11 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
       if (cached != null && typeof cached === "object") {
         const cachedParseResult = discordSeriesStatsContract.safeParse(cached);
         if (cachedParseResult.success) {
-          return discordSeriesStatsContract.toResponse(
-            cachedParseResult.data,
-            getResponseOptions(cachedParseResult.data),
-          );
+          if (cachedParseResult.data.status === "resolved") {
+            return createResolvedResponse(cachedParseResult.data);
+          }
+
+          return discordSeriesStatsContract.toResponse(cachedParseResult.data, getResponseOptions(cachedParseResult.data));
         }
 
         logService.warn(
@@ -207,7 +216,7 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
 
       await env.APP_DATA.put(cacheKey, JSON.stringify(resolvedResponse), { expirationTtl: RESOLVED_CACHE_TTL_SECONDS });
 
-      return discordSeriesStatsContract.toResponse(resolvedResponse, { status: 200 });
+      return createResolvedResponse(resolvedResponse);
     } catch (error) {
       if (error instanceof DiscordError && error.httpStatus === 429) {
         const retryAfterSeconds = sanitizeRetryAfterSeconds((error.restError as { retry_after?: unknown }).retry_after);

--- a/api/routes/stats/tests/discord-series.test.ts
+++ b/api/routes/stats/tests/discord-series.test.ts
@@ -92,6 +92,7 @@ describe("/api/stats/discord/:guildId/:queueNumber", () => {
     )) as Response;
 
     expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("public, s-maxage=86400, stale-while-revalidate=300");
     const body = await res.json<DiscordSeriesStatsResponse>();
     expect(body).toEqual({
       status: "resolved",
@@ -181,6 +182,7 @@ describe("/api/stats/discord/:guildId/:queueNumber", () => {
     )) as Response;
 
     expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("public, s-maxage=86400, stale-while-revalidate=300");
     const body = await res.json<DiscordSeriesStatsResponse>();
     expect(body).toEqual({
       status: "resolved",


### PR DESCRIPTION
Stage B1 follow-up slice for stats endpoint caching behavior.

Summary:
- Return Cache-Control header value public, s-maxage=86400, stale-while-revalidate=300 for resolved stats responses.
- Preserve this behavior for both freshly resolved and cached resolved responses.
- Keep existing pending-index and error semantics unchanged.

Validation:
- npx vitest run api/routes/stats/tests/discord-series.test.ts
- npx eslint api/routes/stats/discord-series.ts api/routes/stats/tests/discord-series.test.ts
- npm run typecheck:api

Small focused slice intended for quick review.
