### PR TITLE
stats: warm discord series route after series post

### DIFF
--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -678,7 +678,13 @@ export class StatsCommand extends BaseCommand {
         ]),
       );
     } catch (error) {
-      logService.warn(error as Error, new Map([["guildId", guildId], ["queueNumber", queueNumber.toString()]]));
+      logService.warn(
+        error as Error,
+        new Map([
+          ["guildId", guildId],
+          ["queueNumber", queueNumber.toString()],
+        ]),
+      );
     }
   }
 }

--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -670,7 +670,7 @@ export class StatsCommand extends BaseCommand {
       }
 
       logService.warn(
-        "Discord series stats warm request returned non-OK status",
+        `Discord series stats warm request returned non-OK status: ${response.status.toString()}`,
         new Map([
           ["guildId", guildId],
           ["queueNumber", queueNumber.toString()],

--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -255,9 +255,11 @@ export class StatsCommand extends BaseCommand {
 
       await this.postSeriesEmbedsToThread(thread.id, series, guildConfig, locale);
       await this.postGameStatsOrButton(thread.id, series, guildConfig, locale);
-      void this.warmDiscordSeriesStatsRoute(guildId, queueData.queue);
 
-      await haloService.updateDiscordAssociations();
+      await Promise.all([
+        haloService.updateDiscordAssociations(),
+        this.warmDiscordSeriesStatsRoute(guildId, queueData.queue),
+      ]);
     } catch (error) {
       if (error instanceof EndUserError && computedQueue != null && endDateTime != null) {
         error.appendData({
@@ -359,9 +361,11 @@ export class StatsCommand extends BaseCommand {
 
         await this.postSeriesEmbedsToThread(threadChannelId, series, guildConfig, locale);
         await this.postGameStatsOrButton(threadChannelId, series, guildConfig, locale);
-        void this.warmDiscordSeriesStatsRoute(guildId, queueData.queue);
 
-        await haloService.updateDiscordAssociations();
+        await Promise.all([
+          haloService.updateDiscordAssociations(),
+          this.warmDiscordSeriesStatsRoute(guildId, queueData.queue),
+        ]);
       }
     } catch (error) {
       if (error instanceof EndUserError) {

--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -255,6 +255,7 @@ export class StatsCommand extends BaseCommand {
 
       await this.postSeriesEmbedsToThread(thread.id, series, guildConfig, locale);
       await this.postGameStatsOrButton(thread.id, series, guildConfig, locale);
+      void this.warmDiscordSeriesStatsRoute(guildId, queueData.queue);
 
       await haloService.updateDiscordAssociations();
     } catch (error) {
@@ -358,6 +359,7 @@ export class StatsCommand extends BaseCommand {
 
         await this.postSeriesEmbedsToThread(threadChannelId, series, guildConfig, locale);
         await this.postGameStatsOrButton(threadChannelId, series, guildConfig, locale);
+        void this.warmDiscordSeriesStatsRoute(guildId, queueData.queue);
 
         await haloService.updateDiscordAssociations();
       }
@@ -655,5 +657,28 @@ export class StatsCommand extends BaseCommand {
       gameVariantCategory: match.MatchInfo.GameVariantCategory,
       locale,
     });
+  }
+
+  private async warmDiscordSeriesStatsRoute(guildId: string, queueNumber: number): Promise<void> {
+    const { logService } = this.services;
+    const url = `${this.env.HOST_URL}/api/stats/discord/${guildId}/${queueNumber.toString()}`;
+
+    try {
+      const response = await fetch(url, { method: "GET" });
+      if (response.ok) {
+        return;
+      }
+
+      logService.warn(
+        "Discord series stats warm request returned non-OK status",
+        new Map([
+          ["guildId", guildId],
+          ["queueNumber", queueNumber.toString()],
+          ["status", response.status.toString()],
+        ]),
+      );
+    } catch (error) {
+      logService.warn(error as Error, new Map([["guildId", guildId], ["queueNumber", queueNumber.toString()]]));
+    }
   }
 }

--- a/api/commands/stats/tests/stats.test.ts
+++ b/api/commands/stats/tests/stats.test.ts
@@ -117,6 +117,7 @@ describe("StatsCommand", () => {
   let statsCommand: StatsCommand;
   let services: Services;
   let env: Env;
+  let fetchSpy: MockInstance<typeof globalThis.fetch>;
   let updateDeferredReplySpy: MockInstance<typeof services.discordService.updateDeferredReply>;
   let updateDeferredReplyWithErrorSpy: MockInstance<typeof services.discordService.updateDeferredReplyWithError>;
 
@@ -124,6 +125,7 @@ describe("StatsCommand", () => {
     services = installFakeServicesWith();
     env = aFakeEnvWith();
     statsCommand = new StatsCommand(services, env);
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
 
     updateDeferredReplySpy = vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue(apiMessage);
     updateDeferredReplyWithErrorSpy = vi
@@ -366,6 +368,14 @@ describe("StatsCommand", () => {
         await jobToComplete?.();
 
         expect(updateDiscordAssociationsSpy).toHaveBeenCalledWith();
+      });
+
+      it("warms the discord series stats route after posting embeds", async () => {
+        await jobToComplete?.();
+
+        expect(fetchSpy).toHaveBeenCalledWith("http://localhost:8787/api/stats/discord/fake-guild-id/777", {
+          method: "GET",
+        });
       });
 
       it("calls discordService.updateDeferredReplyWithError with an error when an error is thrown", async () => {
@@ -661,6 +671,16 @@ describe("StatsCommand", () => {
           await jobToComplete?.();
 
           expect(updateDiscordAssociationsSpy).toHaveBeenCalled();
+        });
+
+        it("warms the discord series stats route after posting embeds", async () => {
+          getMessagesSpy.mockResolvedValue([threadFirstMessage]);
+
+          await jobToComplete?.();
+
+          expect(fetchSpy).toHaveBeenCalledWith("http://localhost:8787/api/stats/discord/fake-guild-id/777", {
+            method: "GET",
+          });
         });
 
         it("appends previous error data when new error occurs", async () => {

--- a/api/commands/stats/tests/stats.test.ts
+++ b/api/commands/stats/tests/stats.test.ts
@@ -1,5 +1,5 @@
 import type { MockInstance } from "vitest";
-import { describe, beforeEach, vi, it, expect } from "vitest";
+import { describe, afterEach, beforeEach, vi, it, expect } from "vitest";
 import type {
   APIApplicationCommandInteraction,
   APIApplicationCommandInteractionDataBasicOption,
@@ -131,6 +131,10 @@ describe("StatsCommand", () => {
     updateDeferredReplyWithErrorSpy = vi
       .spyOn(services.discordService, "updateDeferredReplyWithError")
       .mockResolvedValue(apiMessage);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe("execute(): subcommand neatqueue", () => {


### PR DESCRIPTION
## Summary
- add a best-effort warm request to `/api/stats/discord/:guildId/:queueNumber` after successful `stats neatqueue` posting
- apply warm trigger in both neatqueue execution paths (channel flow and in-thread flow)
- keep warm failures non-blocking and log via `logService.warn`
- add command tests asserting the warm request is dispatched in both paths

## Validation
- npx vitest run api/commands/stats/tests/stats.test.ts
- npx eslint api/commands/stats/stats.ts api/commands/stats/tests/stats.test.ts
- npm run typecheck:api
