### PR TITLE
refactor: XUID_BATCH_SIZE constant + xbox withUnauthorizedRetry helper

### DIFF
--- a/api/services/xbox/xbox.ts
+++ b/api/services/xbox/xbox.ts
@@ -114,17 +114,7 @@ export class XboxService {
     }
 
     await this.maybeRefreshXstsToken();
-
-    try {
-      return await this.fetchUserByGamertag(gamertag);
-    } catch (err) {
-      if (this.isUnauthorizedError(err)) {
-        await this.clearToken();
-        await this.updateCredentials();
-        return this.fetchUserByGamertag(gamertag);
-      }
-      throw err;
-    }
+    return this.withUnauthorizedRetry(() => this.fetchUserByGamertag(gamertag));
   }
 
   private async fetchUserByGamertag(gamertag: string): Promise<XboxUserInfo> {
@@ -142,6 +132,19 @@ export class XboxService {
     return profileUserToXboxUserInfo(profileUser);
   }
 
+  private async withUnauthorizedRetry<T>(fetch: () => Promise<T>): Promise<T> {
+    try {
+      return await fetch();
+    } catch (err) {
+      if (this.isUnauthorizedError(err)) {
+        await this.clearToken();
+        await this.updateCredentials();
+        return fetch();
+      }
+      throw err;
+    }
+  }
+
   private isUnauthorizedError(err: unknown): boolean {
     return err instanceof Error && err.name === "XRFetchClientException" && err.message === "Unauthorized";
   }
@@ -152,17 +155,7 @@ export class XboxService {
     }
 
     await this.maybeRefreshXstsToken();
-
-    try {
-      return await this.fetchUsersByXuids(xuids);
-    } catch (err) {
-      if (this.isUnauthorizedError(err)) {
-        await this.clearToken();
-        await this.updateCredentials();
-        return this.fetchUsersByXuids(xuids);
-      }
-      throw err;
-    }
+    return this.withUnauthorizedRetry(() => this.fetchUsersByXuids(xuids));
   }
 
   private async fetchUsersByXuids(xuids: string[]): Promise<XboxUserInfo[]> {

--- a/api/services/xbox/xbox.ts
+++ b/api/services/xbox/xbox.ts
@@ -114,7 +114,7 @@ export class XboxService {
     }
 
     await this.maybeRefreshXstsToken();
-    return this.withUnauthorizedRetry(() => this.fetchUserByGamertag(gamertag));
+    return this.withUnauthorizedRetry(async () => this.fetchUserByGamertag(gamertag));
   }
 
   private async fetchUserByGamertag(gamertag: string): Promise<XboxUserInfo> {
@@ -155,7 +155,7 @@ export class XboxService {
     }
 
     await this.maybeRefreshXstsToken();
-    return this.withUnauthorizedRetry(() => this.fetchUsersByXuids(xuids));
+    return this.withUnauthorizedRetry(async () => this.fetchUsersByXuids(xuids));
   }
 
   private async fetchUsersByXuids(xuids: string[]): Promise<XboxUserInfo[]> {

--- a/pages/src/services/individual-tracker/individual-tracker.ts
+++ b/pages/src/services/individual-tracker/individual-tracker.ts
@@ -48,6 +48,8 @@ import type {
   TrackerSyncMatchesRequest,
 } from "./types";
 
+const XUID_BATCH_SIZE = 24;
+
 interface IndividualTrackerServiceOpts {
   readonly apiHost: string;
   readonly haloInfiniteClient: HaloInfiniteClient;
@@ -459,8 +461,8 @@ export class RealIndividualTrackerService implements IndividualTrackerService {
 
     const xuidList = Array.from(xuids);
     const chunks: string[][] = [];
-    for (let i = 0; i < xuidList.length; i += 24) {
-      chunks.push(xuidList.slice(i, i + 24));
+    for (let i = 0; i < xuidList.length; i += XUID_BATCH_SIZE) {
+      chunks.push(xuidList.slice(i, i + XUID_BATCH_SIZE));
     }
 
     const results = await Promise.allSettled(chunks.map(async (chunk) => this.haloInfiniteClient.getUsers(chunk)));


### PR DESCRIPTION
## Summary

- **`pages/src/services/individual-tracker/individual-tracker.ts`**: extracts the Halo Waypoint per-batch XUID limit into a named `XUID_BATCH_SIZE = 24` constant so the magic number is documented in one place.
- **`api/services/xbox/xbox.ts`**: extracts the shared `withUnauthorizedRetry<T>` private helper from `getUserByGamertag` and `getUsersByXuids`, which had identical try/catch → `clearToken` → `updateCredentials` → retry wrappers.

## Test plan

- [ ] `npm run typecheck` — 0 errors
- [ ] `npx vitest run api/services/xbox pages/src/services/individual-tracker` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)