### PR TITLE
stats page: harden pending fallback headers and checklist

### DIFF
--- a/pages/src/pages/stats/discord/[guildId]/[queueNumber].astro
+++ b/pages/src/pages/stats/discord/[guildId]/[queueNumber].astro
@@ -19,6 +19,14 @@ const hasInvalidParams = !isSnowflake || !isStrictPositiveInteger || !isSafeQueu
 let responseState: DiscordSeriesStats | null = null;
 let loadError: string | null = null;
 
+function getPendingRetryAfterSeconds(responseRetryAfterSeconds: number | null, dataRetryAfterSeconds: number): number {
+  if (responseRetryAfterSeconds == null) {
+    return Math.ceil(dataRetryAfterSeconds);
+  }
+
+  return Math.ceil(responseRetryAfterSeconds);
+}
+
 if (hasInvalidParams) {
   Astro.response.status = 404;
   loadError = "Queue not found";
@@ -27,6 +35,14 @@ if (hasInvalidParams) {
     const response = await fetchDiscordSeriesStats(`${API_HOST}/api/stats/discord/${guildId}/${queueNumber}`);
     Astro.response.status = response.status;
     responseState = response.data;
+
+    if (response.data.status === "pending-index") {
+      Astro.response.headers.set("Cache-Control", "no-store");
+      Astro.response.headers.set(
+        "Retry-After",
+        getPendingRetryAfterSeconds(response.retryAfterSeconds, response.data.retryAfterSeconds).toString(),
+      );
+    }
   } catch {
     Astro.response.status = 500;
     loadError = "Failed to load stats";

--- a/pages/src/services/stats/discord-series.ts
+++ b/pages/src/services/stats/discord-series.ts
@@ -3,9 +3,23 @@ import {
   type DiscordSeriesStats,
 } from "@guilty-spark/shared/contracts/stats/discord-series";
 
+function parseRetryAfterHeader(value: string | null): number | null {
+  if (value == null) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return parsed;
+}
+
 export async function fetchDiscordSeriesStats(url: string): Promise<{
   status: number;
   data: DiscordSeriesStats;
+  retryAfterSeconds: number | null;
 }> {
   const response = await fetch(url);
   const data = await discordSeriesStatsContract.fromResponse(response);
@@ -13,5 +27,6 @@ export async function fetchDiscordSeriesStats(url: string): Promise<{
   return {
     status: response.status,
     data,
+    retryAfterSeconds: parseRetryAfterHeader(response.headers.get("Retry-After")),
   };
 }

--- a/pages/src/services/stats/discord-series.ts
+++ b/pages/src/services/stats/discord-series.ts
@@ -8,8 +8,12 @@ function parseRetryAfterHeader(value: string | null): number | null {
     return null;
   }
 
+  if (!/^\d+$/.test(value)) {
+    return null;
+  }
+
   const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     return null;
   }
 

--- a/pages/src/services/stats/discord-series.ts
+++ b/pages/src/services/stats/discord-series.ts
@@ -8,11 +8,12 @@ function parseRetryAfterHeader(value: string | null): number | null {
     return null;
   }
 
-  if (!/^\d+$/.test(value)) {
+  const normalizedValue = value.trim();
+  if (!/^\d+$/.test(normalizedValue)) {
     return null;
   }
 
-  const parsed = Number(value);
+  const parsed = Number(normalizedValue);
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     return null;
   }

--- a/pages/src/services/stats/tests/discord-series.test.ts
+++ b/pages/src/services/stats/tests/discord-series.test.ts
@@ -64,4 +64,30 @@ describe("fetchDiscordSeriesStats", () => {
     expect(result.retryAfterSeconds).toBeNull();
     expect(result.data.status).toBe("pending-index");
   });
+
+  it("returns null Retry-After for non-digit numeric strings", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          status: "pending-index",
+          guildId: "123456789012345678",
+          queueNumber: 7777,
+          retryAfterSeconds: 3,
+        }),
+        {
+          status: 503,
+          headers: {
+            "Content-Type": "application/json",
+            "Retry-After": "1e+21",
+          },
+        },
+      ),
+    );
+
+    const result = await fetchDiscordSeriesStats("https://api.example.com/api/stats/discord/123456789012345678/7777");
+
+    expect(result.status).toBe(503);
+    expect(result.retryAfterSeconds).toBeNull();
+    expect(result.data.status).toBe("pending-index");
+  });
 });

--- a/pages/src/services/stats/tests/discord-series.test.ts
+++ b/pages/src/services/stats/tests/discord-series.test.ts
@@ -39,7 +39,7 @@ describe("fetchDiscordSeriesStats", () => {
     expect(result.data.status).toBe("pending-index");
   });
 
-  it("returns null Retry-After when missing or invalid", async () => {
+  it("returns null Retry-After when invalid", async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -53,6 +53,31 @@ describe("fetchDiscordSeriesStats", () => {
           headers: {
             "Content-Type": "application/json",
             "Retry-After": "invalid",
+          },
+        },
+      ),
+    );
+
+    const result = await fetchDiscordSeriesStats("https://api.example.com/api/stats/discord/123456789012345678/7777");
+
+    expect(result.status).toBe(503);
+    expect(result.retryAfterSeconds).toBeNull();
+    expect(result.data.status).toBe("pending-index");
+  });
+
+  it("returns null Retry-After when header is missing", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          status: "pending-index",
+          guildId: "123456789012345678",
+          queueNumber: 7777,
+          retryAfterSeconds: 3,
+        }),
+        {
+          status: 503,
+          headers: {
+            "Content-Type": "application/json",
           },
         },
       ),

--- a/pages/src/services/stats/tests/discord-series.test.ts
+++ b/pages/src/services/stats/tests/discord-series.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { fetchDiscordSeriesStats } from "../discord-series";
+
+describe("fetchDiscordSeriesStats", () => {
+  let fetchSpy: MockInstance<typeof globalThis.fetch>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("returns Retry-After header value when present", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          status: "pending-index",
+          guildId: "123456789012345678",
+          queueNumber: 7777,
+          retryAfterSeconds: 3,
+        }),
+        {
+          status: 503,
+          headers: {
+            "Content-Type": "application/json",
+            "Retry-After": "7",
+          },
+        },
+      ),
+    );
+
+    const result = await fetchDiscordSeriesStats("https://api.example.com/api/stats/discord/123456789012345678/7777");
+
+    expect(result.status).toBe(503);
+    expect(result.retryAfterSeconds).toBe(7);
+    expect(result.data.status).toBe("pending-index");
+  });
+
+  it("returns null Retry-After when missing or invalid", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          status: "pending-index",
+          guildId: "123456789012345678",
+          queueNumber: 7777,
+          retryAfterSeconds: 3,
+        }),
+        {
+          status: 503,
+          headers: {
+            "Content-Type": "application/json",
+            "Retry-After": "invalid",
+          },
+        },
+      ),
+    );
+
+    const result = await fetchDiscordSeriesStats("https://api.example.com/api/stats/discord/123456789012345678/7777");
+
+    expect(result.status).toBe(503);
+    expect(result.retryAfterSeconds).toBeNull();
+    expect(result.data.status).toBe("pending-index");
+  });
+});


### PR DESCRIPTION
## Summary
- harden `/stats/discord/:guildId/:queueNumber` SSR pending fallback behavior
- propagate upstream `Retry-After` from stats API fetch response with safe parsing fallback in pages service
- set `Cache-Control: no-store` and `Retry-After` on pending-index SSR responses
- add pages service tests for Retry-After parsing behavior

## Validation
- npm run format:fix
- npm run typecheck
- npm run lint
- npm run test
