### PR TITLE
fix(api): restore Halo-scoped env Xbox auth for live tracker

### DIFF
--- a/api/services/xbox/tests/xbox.test.ts
+++ b/api/services/xbox/tests/xbox.test.ts
@@ -97,6 +97,13 @@ describe("Xbox Service", () => {
       await xboxService.maybeRefreshXstsToken();
 
       expect(authenticate).toHaveBeenCalled();
+      expect(authenticate).toHaveBeenCalledWith(
+        env.XBOX_USERNAME,
+        env.XBOX_PASSWORD,
+        {
+          XSTSRelyingParty: "https://prod.xsts.halowaypoint.com/",
+        },
+      );
     });
 
     it("does not refresh the token if it is not expired", async () => {

--- a/api/services/xbox/tests/xbox.test.ts
+++ b/api/services/xbox/tests/xbox.test.ts
@@ -97,13 +97,9 @@ describe("Xbox Service", () => {
       await xboxService.maybeRefreshXstsToken();
 
       expect(authenticate).toHaveBeenCalled();
-      expect(authenticate).toHaveBeenCalledWith(
-        env.XBOX_USERNAME,
-        env.XBOX_PASSWORD,
-        {
-          XSTSRelyingParty: "https://prod.xsts.halowaypoint.com/",
-        },
-      );
+      expect(authenticate).toHaveBeenCalledWith(env.XBOX_USERNAME, env.XBOX_PASSWORD, {
+        XSTSRelyingParty: "https://prod.xsts.halowaypoint.com/",
+      });
     });
 
     it("does not refresh the token if it is not expired", async () => {

--- a/api/services/xbox/xbox.ts
+++ b/api/services/xbox/xbox.ts
@@ -199,8 +199,7 @@ export class XboxService {
       this.env.XBOX_USERNAME as `${string}@${string}.${string}`,
       this.env.XBOX_PASSWORD,
       {
-        sandboxId: XBOX_LIVE_SANDBOX_ID,
-        XSTSRelyingParty: XBOX_LIVE_XSTS_RELYING_PARTY,
+        XSTSRelyingParty: HALO_XSTS_RELYING_PARTY,
       },
     );
 


### PR DESCRIPTION
## Summary

- restore env username/password Xbox credential refresh to request Halo-scoped XSTS (halowaypoint relying party)
- keep Microsoft access-token exchange flow intact for individual tracker user clients
- add a regression assertion that env credential refresh calls authenticate with Halo relying party

## Why
A recent change switched env-based credential refresh to Xbox Live scope, which breaks the live tracker Halo token flow.

## Validation
- npx vitest run api/services/xbox/tests/xbox.test.ts
- npx vitest run api/services/halo/tests/custom-spartan-token-provider.test.ts api/tests/server.test.ts api/routes/halo-proxy/tests/halo-proxy.test.ts
- npx vitest run api