### PR TITLE
feat(individual-tracker): NQ-3b — editSeries/resumeSeries service layer and ManualSeriesDialog edit mode

### DIFF
--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -128,21 +128,15 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE
 
 **Triggering a new Copilot review:**
 
-After `git push`, request a review immediately:
+`copilot-pull-request-reviewer` auto-fires on every push, so after `git push` simply wait. If no review appears after 10 minutes (e.g. no new commit was pushed this iteration), request one explicitly:
 
 ```bash
 gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 ```
 
-This works but the review from `copilot-pull-request-reviewer` may arrive with a significant delay (potentially hours, not minutes). It is still the correct command to use.
+The review may still take up to a few hours to arrive after this request — that is normal.
 
-For a faster sanity check while waiting, also post:
-
-```bash
-gh pr comment {PR} --body "@copilot review"
-```
-
-This triggers `copilot-swe-agent[bot]` within ~5 minutes. If it replies with clean language (see Step 2), and no new `copilot-pull-request-reviewer` review has appeared, treat the loop as complete.
+Do **not** post `@copilot review` — that triggers the separate `copilot-swe-agent[bot]` bot (which only runs tests/lint and replies as an issue comment), causing two simultaneous reviews. Stick to one trigger.
 
 Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work (GraphQL cannot resolve those logins).
 
@@ -150,10 +144,8 @@ Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-
 
 Schedule a wakeup for **10 minutes**. On wakeup, go back to Step 1.
 
-- Check both `copilot-pull-request-reviewer` PR reviews AND `copilot-swe-agent[bot]` issue comments (Step 2).
-- If `copilot-swe-agent` says clean and no new `copilot-pull-request-reviewer` review has appeared → stop, the loop is complete.
-- If no response from either after 10 minutes, wait **5 more minutes** then check once more.
-- If still nothing after 15 minutes total: stop and inform the user (the `copilot-pull-request-reviewer` review may arrive hours later — it was successfully requested).
+- If no new `copilot-pull-request-reviewer` review after 10 minutes, wait **5 more minutes** then check once more.
+- If still nothing after 15 minutes total: stop and inform the user. The review was successfully requested and will arrive eventually — they can re-run `/copilot-loop` when it appears.
 
 ## Repo-specific notes
 

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -1,0 +1,154 @@
+# Copilot Review Loop
+
+Runs a continuous fix-and-re-review loop against GitHub Copilot on the current PR until Copilot reports no new issues.
+
+## Setup
+
+Identify the current PR number:
+
+```bash
+gh pr view --json number --jq '.number'
+```
+
+Use that number throughout (referred to as `{PR}` below).
+
+## Step 1 — Find the latest Copilot PR review
+
+```bash
+gh api "repos/{owner}/{repo}/pulls/{PR}/reviews?per_page=100" | python3 -c "
+import json, sys
+reviews = json.load(sys.stdin)
+last = None
+for r in reviews:
+    if 'copilot' in r.get('user', {}).get('login', ''):
+        last = r
+if last:
+    print(last['id'], last['submitted_at'], last['commit_id'][:8])
+else:
+    print('NO_REVIEW')
+"
+```
+
+Record the latest review ID. If `NO_REVIEW`, request one (Step 4) then schedule a 10-minute wakeup.
+
+## Step 2 — Check if the review is clean
+
+Fetch the review's inline comments:
+
+```bash
+gh api "repos/{owner}/{repo}/pulls/{PR}/reviews/{REVIEW_ID}/comments"
+```
+
+**Clean** if the JSON array is empty (`[]`), OR if the review body contains "generated no new comments".
+
+Also check for a `copilot-swe-agent[bot]` issue comment that appeared after the last push:
+
+```bash
+gh api "repos/{owner}/{repo}/issues/{PR}/comments?per_page=100" | python3 -c "
+import json, sys
+comments = json.load(sys.stdin)
+for c in reversed(comments):
+    if 'copilot-swe-agent' in c.get('user', {}).get('login', ''):
+        print(c['body'][:200])
+        break
+"
+```
+
+If the latest `copilot-swe-agent` comment body contains any of: `clean`, `no issues`, `good to merge`, `no new comments`, `all.*tests pass` — treat as clean.
+
+**If clean: stop and tell the user Copilot found no issues. The loop is complete.**
+
+## Step 3 — Process each comment
+
+For each inline comment from the review:
+
+1. **Assess validity.** Read the file and surrounding context. Determine if the concern is real.
+
+2. **If valid:** Fix the code. Add or update tests if the fix changes observable behaviour. Then:
+
+   ```bash
+   npm run done
+   ```
+
+   `npm run done` runs: prettier → typecheck → eslint --fix → vitest run related. Fix any errors it reports and re-run until clean.
+
+3. **If invalid/refuted:** Note the reason clearly. Do not make code changes for this comment.
+
+4. Commit all fixes together:
+
+   ```bash
+   git add <changed files>
+   git commit -m "fix(...): <description>
+
+   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+   ```
+
+## Step 4 — Push, reply, resolve, re-request
+
+Once all comments are addressed (or refuted):
+
+```bash
+git push
+```
+
+**Reply in-thread to every comment** (include the fix commit SHA or the refutation reason):
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{PR}/comments/{COMMENT_ID}/replies \
+  -X POST -f body="Fixed in {SHA}. <one sentence explaining what changed>."
+# or for refuted:
+gh api repos/{owner}/{repo}/pulls/{PR}/comments/{COMMENT_ID}/replies \
+  -X POST -f body="Not actioned: <reason why the concern doesn't apply>."
+```
+
+**Resolve every thread** via GraphQL. First get thread node IDs:
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "{owner}", name: "{repo}") {
+    pullRequest(number: {PR}) {
+      reviewThreads(last: 20) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) { nodes { databaseId } }
+        }
+      }
+    }
+  }
+}'
+```
+
+Then resolve each unresolved thread for the comments you just replied to:
+
+```bash
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE_ID}"}) { thread { isResolved } } }'
+```
+
+**Triggering a new Copilot review:**
+
+Copilot automatically reviews when a new commit is pushed to the PR — no explicit trigger is needed in most cases. After `git push`, simply wait.
+
+If no new review appears after 10 minutes (e.g. when no new commit was pushed), fall back to posting a comment:
+
+```bash
+gh pr comment {PR} --body "@copilot review"
+```
+
+Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer copilot-pull-request-reviewer` do not work — GitHub silently ignores or rejects reviewer requests for Copilot bots via the API.
+
+## Step 5 — Wait and loop
+
+Schedule a wakeup for **10 minutes**. On wakeup, go back to Step 1.
+
+- If there is still no new review after 10 minutes, post `@copilot review` as a fallback, then wait **5 more minutes** and check once more.
+- If still no new review after 15 minutes total: stop and inform the user. They may need to manually request a review from the GitHub PR page.
+
+## Repo-specific notes
+
+- `npm run done` = prettier → typecheck (tsc + astro check) → eslint --fix → vitest run related
+- Commit message format: `fix(scope): description` with `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
+- Owner: `davidhouweling`, Repo: `guilty-spark`
+- ESLint rules to watch for: `strict-boolean-expressions`, `no-unnecessary-condition` — avoid redundant null checks and `??` on non-nullable types
+- Always check the thread resolution status before resolving to avoid double-resolve errors

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -128,22 +128,32 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE
 
 **Triggering a new Copilot review:**
 
-Copilot automatically reviews when a new commit is pushed to the PR — no explicit trigger is needed in most cases. After `git push`, simply wait.
+After `git push`, request a review immediately:
 
-If no new review appears after 10 minutes (e.g. when no new commit was pushed), fall back to posting a comment:
+```bash
+gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
+```
+
+This works but the review from `copilot-pull-request-reviewer` may arrive with a significant delay (potentially hours, not minutes). It is still the correct command to use.
+
+For a faster sanity check while waiting, also post:
 
 ```bash
 gh pr comment {PR} --body "@copilot review"
 ```
 
-Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer copilot-pull-request-reviewer` do not work — GitHub silently ignores or rejects reviewer requests for Copilot bots via the API.
+This triggers `copilot-swe-agent[bot]` within ~5 minutes. If it replies with clean language (see Step 2), and no new `copilot-pull-request-reviewer` review has appeared, treat the loop as complete.
+
+Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work (GraphQL cannot resolve those logins).
 
 ## Step 5 — Wait and loop
 
 Schedule a wakeup for **10 minutes**. On wakeup, go back to Step 1.
 
-- If there is still no new review after 10 minutes, post `@copilot review` as a fallback, then wait **5 more minutes** and check once more.
-- If still no new review after 15 minutes total: stop and inform the user. They may need to manually request a review from the GitHub PR page.
+- Check both `copilot-pull-request-reviewer` PR reviews AND `copilot-swe-agent[bot]` issue comments (Step 2).
+- If `copilot-swe-agent` says clean and no new `copilot-pull-request-reviewer` review has appeared → stop, the loop is complete.
+- If no response from either after 10 minutes, wait **5 more minutes** then check once more.
+- If still nothing after 15 minutes total: stop and inform the user (the `copilot-pull-request-reviewer` review may arrive hours later — it was successfully requested).
 
 ## Repo-specific notes
 

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -1,6 +1,6 @@
 # Copilot Review Loop
 
-Runs a continuous fix-and-re-review loop against GitHub Copilot on the current PR until Copilot reports no new issues.
+Processes the latest Copilot PR review: fixes valid issues, replies to all comments, resolves threads, then requests a new review. Copilot does **not** auto-fire on push — the user manually invokes this command each time they want to run a loop iteration.
 
 ## Setup
 
@@ -29,7 +29,7 @@ else:
 "
 ```
 
-Record the latest review ID. If `NO_REVIEW`, request one (Step 4) then schedule a 10-minute wakeup.
+If `NO_REVIEW`: request one (Step 4) and stop — tell the user to re-run `/copilot-loop` once the review arrives (may take up to a few hours).
 
 ## Step 2 — Check if the review is clean
 
@@ -41,28 +41,13 @@ gh api "repos/{owner}/{repo}/pulls/{PR}/reviews/{REVIEW_ID}/comments"
 
 **Clean** if the JSON array is empty (`[]`), OR if the review body contains "generated no new comments".
 
-Also check for a `copilot-swe-agent[bot]` issue comment that appeared after the last push:
-
-```bash
-gh api "repos/{owner}/{repo}/issues/{PR}/comments?per_page=100" | python3 -c "
-import json, sys
-comments = json.load(sys.stdin)
-for c in reversed(comments):
-    if 'copilot-swe-agent' in c.get('user', {}).get('login', ''):
-        print(c['body'][:200])
-        break
-"
-```
-
-If the latest `copilot-swe-agent` comment body contains any of: `clean`, `no issues`, `good to merge`, `no new comments`, `all.*tests pass` — treat as clean.
-
 **If clean: stop and tell the user Copilot found no issues. The loop is complete.**
 
 ## Step 3 — Process each comment
 
 For each inline comment from the review:
 
-1. **Assess validity.** Read the file and surrounding context. Determine if the concern is real.
+1. **Assess validity.** Read the referenced file and surrounding context. Is the concern real?
 
 2. **If valid:** Fix the code. Add or update tests if the fix changes observable behaviour. Then:
 
@@ -74,7 +59,7 @@ For each inline comment from the review:
 
 3. **If invalid/refuted:** Note the reason clearly. Do not make code changes for this comment.
 
-4. Commit all fixes together:
+4. Commit all fixes together once all comments are processed:
 
    ```bash
    git add <changed files>
@@ -83,7 +68,7 @@ For each inline comment from the review:
    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
    ```
 
-## Step 4 — Push, reply, resolve, re-request
+## Step 4 — Push, reply, resolve, request
 
 Once all comments are addressed (or refuted):
 
@@ -126,26 +111,15 @@ Then resolve each unresolved thread for the comments you just replied to:
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE_ID}"}) { thread { isResolved } } }'
 ```
 
-**Triggering a new Copilot review:**
-
-`copilot-pull-request-reviewer` auto-fires on every push, so after `git push` simply wait. If no review appears after 10 minutes (e.g. no new commit was pushed this iteration), request one explicitly:
+**Request a new Copilot review:**
 
 ```bash
 gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 ```
 
-The review may still take up to a few hours to arrive after this request — that is normal.
+The review may take up to a few hours to arrive. Stop here and tell the user to re-run `/copilot-loop` once the new review appears.
 
-Do **not** post `@copilot review` — that triggers the separate `copilot-swe-agent[bot]` bot (which only runs tests/lint and replies as an issue comment), causing two simultaneous reviews. Stick to one trigger.
-
-Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work (GraphQL cannot resolve those logins).
-
-## Step 5 — Wait and loop
-
-Schedule a wakeup for **10 minutes**. On wakeup, go back to Step 1.
-
-- If no new `copilot-pull-request-reviewer` review after 10 minutes, wait **5 more minutes** then check once more.
-- If still nothing after 15 minutes total: stop and inform the user. The review was successfully requested and will arrive eventually — they can re-run `/copilot-loop` when it appears.
+Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work (GraphQL cannot resolve those logins). Do **not** post `@copilot review` — that triggers the unrelated `copilot-swe-agent[bot]` bot.
 
 ## Repo-specific notes
 
@@ -153,4 +127,4 @@ Schedule a wakeup for **10 minutes**. On wakeup, go back to Step 1.
 - Commit message format: `fix(scope): description` with `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
 - Owner: `davidhouweling`, Repo: `guilty-spark`
 - ESLint rules to watch for: `strict-boolean-expressions`, `no-unnecessary-condition` — avoid redundant null checks and `??` on non-nullable types
-- Always check the thread resolution status before resolving to avoid double-resolve errors
+- Always check `isResolved` before resolving a thread to avoid double-resolve errors

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -1,9 +1,9 @@
 ---
 agent: agent
-description: "Process the latest Copilot PR review: fix valid issues, reply to all comments, resolve threads, then report whether the loop is done or should be re-run."
+description: "Process the latest Copilot PR review: fix valid issues, reply to all comments, resolve threads, request a new review. Copilot does not auto-fire — re-run this prompt manually each iteration once the new review arrives."
 ---
 
-Run one iteration of the Copilot review loop on the current PR. At the end, tell me whether Copilot is satisfied or I should re-run this prompt after waiting for a new review.
+Run one iteration of the Copilot review loop on the current PR. Copilot does **not** auto-fire on push — I will manually re-run this prompt each time. At the end, request a new review and tell me when to come back.
 
 ## Step 1 — Identify the PR
 
@@ -28,7 +28,7 @@ else:
 "
 ```
 
-If `NO_REVIEW`: push the current branch if there are unpushed commits, then stop and tell me to re-run this prompt in 10 minutes (Copilot auto-reviews on push).
+If `NO_REVIEW`: request a review (Step 6) and stop — tell me to re-run this prompt once the review arrives (may take up to a few hours).
 
 ## Step 3 — Check if the review is clean
 
@@ -125,23 +125,21 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE
 
 ## Step 6 — Request review and hand back
 
-`copilot-pull-request-reviewer` auto-fires on every push, so after `git push` no explicit trigger is usually needed. If no new commit was pushed this iteration (all comments refuted), request a review manually:
+Request a new review:
 
 ```bash
 gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 ```
 
-Do **not** post `@copilot review` — that triggers the separate `copilot-swe-agent[bot]` (tests/lint only, issue comment response), causing two simultaneous reviews. Stick to one trigger.
-
-Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work — use `copilot-pull-request-reviewer` exactly.
+Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work — use `copilot-pull-request-reviewer` exactly. Do **not** post `@copilot review` — that triggers the unrelated `copilot-swe-agent[bot]` bot.
 
 **Report back:**
 
-If a new commit was pushed:
-> "Done. Fixes committed as {SHA} and pushed. Copilot will auto-review — re-run this prompt in ~10 minutes."
+If fixes were committed and pushed:
+> "Done. Fixes committed as {SHA} and pushed. New review requested — re-run this prompt once the Copilot review arrives (may take up to a few hours)."
 
-If all comments were refuted (no new commit):
-> "Done. All comments refuted — no code changes. Review requested from `copilot-pull-request-reviewer` (may take up to a few hours). Re-run this prompt when the review appears."
+If all comments were refuted (no code changes):
+> "Done. All comments refuted — no code changes. New review requested — re-run this prompt once the Copilot review arrives."
 
 ## Repo-specific notes
 

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -136,9 +136,11 @@ Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-
 **Report back:**
 
 If fixes were committed and pushed:
+
 > "Done. Fixes committed as {SHA} and pushed. New review requested — re-run this prompt once the Copilot review arrives (may take up to a few hours)."
 
 If all comments were refuted (no code changes):
+
 > "Done. All comments refuted — no code changes. New review requested — re-run this prompt once the Copilot review arrives."
 
 ## Repo-specific notes

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -125,29 +125,23 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE
 
 ## Step 6 — Request review and hand back
 
-After pushing, request a review:
+`copilot-pull-request-reviewer` auto-fires on every push, so after `git push` no explicit trigger is usually needed. If no new commit was pushed this iteration (all comments refuted), request a review manually:
 
 ```bash
 gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 ```
 
-Then post a comment for a faster response from the secondary Copilot bot:
+Do **not** post `@copilot review` — that triggers the separate `copilot-swe-agent[bot]` (tests/lint only, issue comment response), causing two simultaneous reviews. Stick to one trigger.
 
-```bash
-gh pr comment {PR} --body "@copilot review"
-```
-
-**Why both?** `copilot-pull-request-reviewer` does the full inline code review but may take hours to respond after the `gh pr edit` request. `copilot-swe-agent[bot]` responds to `@copilot review` within ~5 minutes and runs tests/lint. If `copilot-swe-agent` says clean and no new `copilot-pull-request-reviewer` review has appeared, the loop can be considered complete.
-
-Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not resolve — use `copilot-pull-request-reviewer` exactly.
+Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work — use `copilot-pull-request-reviewer` exactly.
 
 **Report back:**
 
-> "Done. Fixes committed as {SHA} and pushed. Review requested from `copilot-pull-request-reviewer` (may take up to a few hours) and `@copilot review` posted for a quick check. Re-run this prompt in ~10 minutes to process the quick check result; the full review may need another pass later."
+If a new commit was pushed:
+> "Done. Fixes committed as {SHA} and pushed. Copilot will auto-review — re-run this prompt in ~10 minutes."
 
-If no new commit was pushed (all comments were refuted):
-
-> "Done. All comments refuted — no code changes. `@copilot review` posted. Re-run in ~10 minutes to check the response."
+If all comments were refuted (no new commit):
+> "Done. All comments refuted — no code changes. Review requested from `copilot-pull-request-reviewer` (may take up to a few hours). Re-run this prompt when the review appears."
 
 ## Repo-specific notes
 

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -1,0 +1,144 @@
+---
+agent: agent
+description: "Process the latest Copilot PR review: fix valid issues, reply to all comments, resolve threads, then report whether the loop is done or should be re-run."
+---
+
+Run one iteration of the Copilot review loop on the current PR. At the end, tell me whether Copilot is satisfied or I should re-run this prompt after waiting for a new review.
+
+## Step 1 — Identify the PR
+
+```bash
+gh pr view --json number,headRefName --jq '{number: .number, branch: .headRefName}'
+```
+
+## Step 2 — Find the latest Copilot PR review
+
+```bash
+gh api "repos/{owner}/{repo}/pulls/{PR}/reviews?per_page=100" | python3 -c "
+import json, sys
+reviews = json.load(sys.stdin)
+last = None
+for r in reviews:
+    if 'copilot' in r.get('user', {}).get('login', ''):
+        last = r
+if last:
+    print(last['id'], last['submitted_at'], last['commit_id'][:8])
+else:
+    print('NO_REVIEW')
+"
+```
+
+If `NO_REVIEW`: push the current branch if there are unpushed commits, then stop and tell me to re-run this prompt in 10 minutes (Copilot auto-reviews on push).
+
+## Step 3 — Check if the review is clean
+
+**Check 1 — inline comments on the PR review:**
+
+```bash
+gh api "repos/{owner}/{repo}/pulls/{PR}/reviews/{REVIEW_ID}/comments"
+```
+
+Clean if the array is empty or the review body contains "generated no new comments".
+
+**Check 2 — latest `copilot-swe-agent[bot]` issue comment:**
+
+```bash
+gh api "repos/{owner}/{repo}/issues/{PR}/comments?per_page=100" | python3 -c "
+import json, sys
+comments = json.load(sys.stdin)
+for c in reversed(comments):
+    if 'copilot-swe-agent' in c.get('user', {}).get('login', ''):
+        print(c['created_at'], c['body'][:300])
+        break
+"
+```
+
+Clean if the body contains any of: `clean`, `no issues`, `good to merge`, `no new comments`, `all.*tests pass`.
+
+**If clean: stop. Tell me Copilot found no issues and the loop is complete.**
+
+## Step 4 — Process each inline comment
+
+For each comment:
+
+1. **Assess validity.** Read the referenced file and surrounding context. Is the concern real?
+
+2. **If valid:** Fix the code. Add or update tests if the fix changes observable behaviour. Run:
+
+   ```bash
+   npm run done
+   ```
+
+   (`npm run done` = prettier → typecheck → eslint --fix → vitest run related.) Fix any errors it reports and re-run until clean.
+
+3. **If invalid/refuted:** Note the reason. No code changes.
+
+4. Commit all fixes together once all comments are processed:
+
+   ```bash
+   git add <changed files>
+   git commit -m "fix(...): <description>
+
+   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+   ```
+
+## Step 5 — Push, reply, resolve
+
+```bash
+git push
+```
+
+**Reply in-thread to every comment:**
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{PR}/comments/{COMMENT_ID}/replies \
+  -X POST -f body="Fixed in {SHA}. <one sentence summary>."
+# or for refuted:
+gh api repos/{owner}/{repo}/pulls/{PR}/comments/{COMMENT_ID}/replies \
+  -X POST -f body="Not actioned: <reason>."
+```
+
+**Resolve every thread.** Get thread node IDs:
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "{owner}", name: "{repo}") {
+    pullRequest(number: {PR}) {
+      reviewThreads(last: 20) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) { nodes { databaseId } }
+        }
+      }
+    }
+  }
+}'
+```
+
+Resolve each unresolved thread for the comments just replied to:
+
+```bash
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE_ID}"}) { thread { isResolved } } }'
+```
+
+## Step 6 — Report and hand back
+
+After pushing, tell me:
+
+> "Done. Fixes committed as {SHA} and pushed. Copilot will auto-review the new push — please re-run this prompt in ~10 minutes."
+
+If no new commit was pushed (all comments were refuted), tell me:
+
+> "Done. All comments refuted (no code changes). Re-run this prompt in ~10 minutes to check if Copilot accepts the responses."
+
+Note: `gh pr edit --add-reviewer` does not work for Copilot bots via the API — Copilot auto-reviews on push, which is sufficient.
+
+## Repo-specific notes
+
+- Owner: `davidhouweling`, Repo: `guilty-spark`
+- `npm run done` = prettier → typecheck (tsc + astro check) → eslint --fix → vitest run related
+- Commit message: `fix(scope): description` + `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
+- ESLint rules to watch: `strict-boolean-expressions`, `no-unnecessary-condition`
+- Always check `isResolved` before resolving a thread to avoid errors

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -123,17 +123,31 @@ Resolve each unresolved thread for the comments just replied to:
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE_ID}"}) { thread { isResolved } } }'
 ```
 
-## Step 6 — Report and hand back
+## Step 6 — Request review and hand back
 
-After pushing, tell me:
+After pushing, request a review:
 
-> "Done. Fixes committed as {SHA} and pushed. Copilot will auto-review the new push — please re-run this prompt in ~10 minutes."
+```bash
+gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
+```
 
-If no new commit was pushed (all comments were refuted), tell me:
+Then post a comment for a faster response from the secondary Copilot bot:
 
-> "Done. All comments refuted (no code changes). Re-run this prompt in ~10 minutes to check if Copilot accepts the responses."
+```bash
+gh pr comment {PR} --body "@copilot review"
+```
 
-Note: `gh pr edit --add-reviewer` does not work for Copilot bots via the API — Copilot auto-reviews on push, which is sufficient.
+**Why both?** `copilot-pull-request-reviewer` does the full inline code review but may take hours to respond after the `gh pr edit` request. `copilot-swe-agent[bot]` responds to `@copilot review` within ~5 minutes and runs tests/lint. If `copilot-swe-agent` says clean and no new `copilot-pull-request-reviewer` review has appeared, the loop can be considered complete.
+
+Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not resolve — use `copilot-pull-request-reviewer` exactly.
+
+**Report back:**
+
+> "Done. Fixes committed as {SHA} and pushed. Review requested from `copilot-pull-request-reviewer` (may take up to a few hours) and `@copilot review` posted for a quick check. Re-run this prompt in ~10 minutes to process the quick check result; the full review may need another pass later."
+
+If no new commit was pushed (all comments were refuted):
+
+> "Done. All comments refuted — no code changes. `@copilot review` posted. Re-run in ~10 minutes to check the response."
 
 ## Repo-specific notes
 

--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,6 @@ api/scripts/*.json
 test-results
 
 # mcp related paths
-.claude
+.claude/*
+!.claude/commands/
 .playwright-mcp

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -948,6 +948,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         gameVariantCategory: summary.gameVariantCategory,
         outcome: summary.outcome,
         score: summary.score,
+        isMatchmaking: summary.isMatchmaking,
       })),
       series,
       lastUpdateTime: state.lastUpdateTime,

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -864,7 +864,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     const autoGroupings = analyzeMatchGroupings(
       summaries.map((summary) => ({
         matchId: summary.matchId,
-        isMatchmaking: (summary.isMatchmaking as boolean | undefined) ?? false,
+        isMatchmaking: summary.isMatchmaking,
         teamRosterSignature: summary.teamRosterSignature,
       })),
     );
@@ -948,7 +948,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         gameVariantCategory: summary.gameVariantCategory,
         outcome: summary.outcome,
         score: summary.score,
-        isMatchmaking: (summary.isMatchmaking as boolean | undefined) ?? false,
+        isMatchmaking: summary.isMatchmaking,
       })),
       series,
       lastUpdateTime: state.lastUpdateTime,

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -864,7 +864,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     const autoGroupings = analyzeMatchGroupings(
       summaries.map((summary) => ({
         matchId: summary.matchId,
-        isMatchmaking: summary.isMatchmaking,
+        isMatchmaking: (summary.isMatchmaking as boolean | undefined) ?? false,
         teamRosterSignature: summary.teamRosterSignature,
       })),
     );
@@ -948,7 +948,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         gameVariantCategory: summary.gameVariantCategory,
         outcome: summary.outcome,
         score: summary.score,
-        isMatchmaking: summary.isMatchmaking,
+        isMatchmaking: (summary.isMatchmaking as boolean | undefined) ?? false,
       })),
       series,
       lastUpdateTime: state.lastUpdateTime,

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -455,7 +455,7 @@ describe("IndividualTrackerDO", () => {
       const body: IndividualTrackerViewStateResponse = await response.json();
       const match = body.state?.matches[0];
 
-      expect(match).not.toHaveProperty("isMatchmaking");
+      expect(match).toHaveProperty("isMatchmaking", true);
       expect(match).not.toHaveProperty("teamRosterSignature");
       expect(match).not.toHaveProperty("teamOutcomes");
       expect(Object.keys(match ?? {}).sort()).toEqual(
@@ -470,6 +470,7 @@ describe("IndividualTrackerDO", () => {
           "gameVariantCategory",
           "outcome",
           "score",
+          "isMatchmaking",
         ].sort(),
       );
     });

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -49,6 +49,7 @@ export interface IndividualTrackerViewMatch {
   gameVariantCategory: number;
   outcome: string;
   score: string;
+  isMatchmaking: boolean;
 }
 
 export interface SeriesPlayer {

--- a/api/routes/individual-tracker/mapper.ts
+++ b/api/routes/individual-tracker/mapper.ts
@@ -107,6 +107,7 @@ export function toTrackerView(
             gameVariantCategory: match.gameVariantCategory,
             outcome: match.outcome,
             score: match.score,
+            isMatchmaking: match.isMatchmaking,
           })),
     series:
       doState == null

--- a/api/routes/individual-tracker/tests/follow.test.ts
+++ b/api/routes/individual-tracker/tests/follow.test.ts
@@ -147,6 +147,7 @@ describe("/u/:gamertag follow routes", () => {
                 gameVariantCategory: 6,
                 outcome: "Win",
                 score: "50:42",
+                isMatchmaking: false,
               },
               {
                 matchId: "m2",
@@ -159,6 +160,7 @@ describe("/u/:gamertag follow routes", () => {
                 gameVariantCategory: 6,
                 outcome: "Loss",
                 score: "40:50",
+                isMatchmaking: false,
               },
               {
                 matchId: "m3",
@@ -171,6 +173,7 @@ describe("/u/:gamertag follow routes", () => {
                 gameVariantCategory: 6,
                 outcome: "Tie",
                 score: "50:50",
+                isMatchmaking: false,
               },
             ],
           }),

--- a/api/routes/individual-tracker/tests/view.test.ts
+++ b/api/routes/individual-tracker/tests/view.test.ts
@@ -62,6 +62,7 @@ describe("/api/individual-tracker view route", () => {
               gameVariantCategory: 6,
               outcome: "Win",
               score: "50:42",
+              isMatchmaking: false,
             },
           ],
           series: [

--- a/pages/src/apps/individual-tracker-manager/create.tsx
+++ b/pages/src/apps/individual-tracker-manager/create.tsx
@@ -52,6 +52,7 @@ export function IndividualTrackerManagerApp({ apiHost }: IndividualTrackerManage
             authService={services.authService}
             individualTrackerService={services.individualTrackerService}
             settingsService={services.settingsService}
+            individualTrackerViewService={services.individualTrackerViewService}
           />
         ) : (
           <ErrorState message="Services failed to load" />

--- a/pages/src/apps/individual-tracker-manager/services.ts
+++ b/pages/src/apps/individual-tracker-manager/services.ts
@@ -4,24 +4,28 @@ import type { AuthService } from "../../services/auth/types";
 import {
   installIndividualTrackerService,
   installIndividualTrackerSettingsService,
+  installIndividualTrackerViewService,
 } from "../../services/individual-tracker/install";
 import type { IndividualTrackerSettingsService } from "../../services/individual-tracker/settings-types";
 import type { IndividualTrackerService } from "../../services/individual-tracker/types";
+import type { IndividualTrackerViewService } from "../../services/individual-tracker/view-types";
 
 export interface Services {
   readonly authService: AuthService;
   readonly individualTrackerService: IndividualTrackerService;
   readonly settingsService: IndividualTrackerSettingsService;
+  readonly individualTrackerViewService: IndividualTrackerViewService;
 }
 
 export async function installServices(apiHost: string): Promise<Services> {
   const haloInfiniteClient = createHaloInfiniteClientProxy({ proxyBaseUrl: apiHost, credentials: "include" });
 
-  const [authService, individualTrackerService, settingsService] = await Promise.all([
+  const [authService, individualTrackerService, settingsService, individualTrackerViewService] = await Promise.all([
     installAuthService(apiHost),
     installIndividualTrackerService(apiHost, haloInfiniteClient),
     installIndividualTrackerSettingsService(apiHost),
+    installIndividualTrackerViewService(apiHost),
   ]);
 
-  return { authService, individualTrackerService, settingsService };
+  return { authService, individualTrackerService, settingsService, individualTrackerViewService };
 }

--- a/pages/src/components/individual-tracker-manager/create.tsx
+++ b/pages/src/components/individual-tracker-manager/create.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useSyncExternalStore } from "react";
 import type { AuthService } from "../../services/auth/types";
 import type { IndividualTrackerSettingsService } from "../../services/individual-tracker/settings-types";
 import type { IndividualTrackerService } from "../../services/individual-tracker/types";
+import type { IndividualTrackerViewService } from "../../services/individual-tracker/view-types";
 import { IndividualTrackerPresenter } from "./individual-tracker-presenter";
 import { IndividualTrackerStore } from "./individual-tracker-store";
 import { IndividualTrackerShell } from "./individual-tracker";
@@ -12,23 +13,26 @@ interface IndividualTrackerManagerPageProps {
   readonly authService: AuthService;
   readonly individualTrackerService: IndividualTrackerService;
   readonly settingsService: IndividualTrackerSettingsService;
+  readonly individualTrackerViewService: IndividualTrackerViewService;
 }
 
 export function IndividualTrackerManagerPage({
   authService,
   individualTrackerService,
   settingsService,
+  individualTrackerViewService,
 }: IndividualTrackerManagerPageProps): React.ReactElement {
   const { controller: liveTrackersController, Component: LiveTrackersComponent } = useMemo(
     () =>
       createLiveTrackersSection({
         individualTrackerService,
+        individualTrackerViewService,
         navigateTo: (url): void => {
           window.location.assign(url);
         },
         confirmDelete: (message): boolean => window.confirm(message),
       }),
-    [individualTrackerService],
+    [individualTrackerService, individualTrackerViewService],
   );
 
   const store = useMemo(() => new IndividualTrackerStore(), []);

--- a/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
+++ b/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
@@ -85,6 +85,11 @@ function LiveTrackersSectionInternal({
                 controller.closeManualSeriesDialog();
                 void controller.refresh();
               }}
+              onSeriesEdited={(): void => {
+                controller.closeManualSeriesDialog();
+                void controller.refresh();
+              }}
+              initialData={snapshot.manualSeriesDialogState.initialData}
               individualTrackerService={individualTrackerService}
               viewService={individualTrackerViewService}
             />

--- a/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
+++ b/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useSyncExternalStore } from "react";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
+import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import { AddTrackerDialogSection } from "../../individual-tracker/add-tracker-dialog/create";
 import { GameSelectionDialogSection } from "../../individual-tracker/game-selection-dialog/create";
 import { ManualSeriesDialogSection } from "../../individual-tracker/manual-series-dialog/create";
@@ -11,11 +12,13 @@ import { LiveTrackersSectionView } from "./live-trackers";
 interface LiveTrackersSectionInternalProps {
   readonly controller: LiveTrackersSectionController;
   readonly individualTrackerService: IndividualTrackerService;
+  readonly individualTrackerViewService: IndividualTrackerViewService;
 }
 
 function LiveTrackersSectionInternal({
   controller,
   individualTrackerService,
+  individualTrackerViewService,
 }: LiveTrackersSectionInternalProps): React.ReactElement {
   useEffect(() => {
     controller.start();
@@ -83,6 +86,7 @@ function LiveTrackersSectionInternal({
                 void controller.refresh();
               }}
               individualTrackerService={individualTrackerService}
+              viewService={individualTrackerViewService}
             />
           )}
         </>
@@ -93,6 +97,7 @@ function LiveTrackersSectionInternal({
 
 interface CreateLiveTrackersSectionConfig {
   readonly individualTrackerService: IndividualTrackerService;
+  readonly individualTrackerViewService: IndividualTrackerViewService;
   readonly navigateTo?: ((url: string) => void) | undefined;
   readonly confirmDelete?: ((message: string) => boolean) | undefined;
 }
@@ -113,7 +118,11 @@ export function createLiveTrackersSection(config: CreateLiveTrackersSectionConfi
   });
 
   const Component = (): React.ReactElement => (
-    <LiveTrackersSectionInternal controller={presenter} individualTrackerService={config.individualTrackerService} />
+    <LiveTrackersSectionInternal
+      controller={presenter}
+      individualTrackerService={config.individualTrackerService}
+      individualTrackerViewService={config.individualTrackerViewService}
+    />
   );
 
   return { controller: presenter, Component };

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -249,9 +249,10 @@ export class LiveTrackersPresenter {
         },
       });
       if (item.hasActiveSeries) {
+        const hasLiveContext = this.activeLiveView?.trackerId === item.trackerId;
         actions.push({
           label: "Edit series",
-          disabled: snapshot.busy,
+          disabled: snapshot.busy || !hasLiveContext,
           onClick: (): void => {
             this.openManualSeriesDialog(item);
           },
@@ -653,8 +654,8 @@ export class LiveTrackersPresenter {
     }
     const liveView = this.activeLiveView?.trackerId === item.trackerId ? this.activeLiveView : null;
     const activeSeriesContext = liveView?.activeSeriesContext;
-    const initialData: SeriesInitialData | undefined = item.hasActiveSeries
-      ? activeSeriesContext != null
+    const initialData: SeriesInitialData | undefined =
+      activeSeriesContext != null
         ? {
             title: activeSeriesContext.title,
             subtitle: activeSeriesContext.subtitle ?? "",
@@ -663,8 +664,7 @@ export class LiveTrackersPresenter {
               members: t.players.map((p) => p.gamertag ?? "").filter((g): g is string => g !== ""),
             })),
           }
-        : { title: "", subtitle: "", teams: [] }
-      : undefined;
+        : undefined;
     const dialogState: ManualSeriesDialogState = {
       trackerId: item.trackerId,
       trackerLabel: item.gamertag,

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -257,6 +257,16 @@ export class LiveTrackersPresenter {
           },
         });
       } else {
+        const liveView = this.activeLiveView?.trackerId === item.trackerId ? this.activeLiveView : null;
+        if (liveView?.hasRecentCompletedSeries === true) {
+          actions.push({
+            label: "Resume series",
+            disabled: snapshot.busy,
+            onClick: (): void => {
+              void this.resumeSeries(trackerId);
+            },
+          });
+        }
         actions.push({
           label: "Start series",
           disabled: snapshot.busy,
@@ -559,6 +569,21 @@ export class LiveTrackersPresenter {
     }
   }
 
+  private async resumeSeries(trackerId: string): Promise<void> {
+    this.updateSnapshot((s) => ({ ...s, busy: true, errorMessage: null }));
+    try {
+      await this.config.individualTrackerService.resumeSeries(trackerId);
+      await this.refresh();
+    } catch (error) {
+      this.updateSnapshot((s) => ({
+        ...s,
+        errorMessage: error instanceof Error ? error.message : "Failed to resume series.",
+      }));
+    } finally {
+      this.updateSnapshot((s) => ({ ...s, busy: false }));
+    }
+  }
+
   private async selectLiveTracker(trackerId: string): Promise<void> {
     this.updateSnapshot((s) => ({ ...s, busy: true, errorMessage: null }));
     try {
@@ -628,8 +653,8 @@ export class LiveTrackersPresenter {
     }
     const liveView = this.activeLiveView?.trackerId === item.trackerId ? this.activeLiveView : null;
     const activeSeriesContext = liveView?.activeSeriesContext;
-    const initialData: SeriesInitialData | undefined =
-      activeSeriesContext != null
+    const initialData: SeriesInitialData | undefined = item.hasActiveSeries
+      ? activeSeriesContext != null
         ? {
             title: activeSeriesContext.title,
             subtitle: activeSeriesContext.subtitle ?? "",
@@ -638,7 +663,8 @@ export class LiveTrackersPresenter {
               members: t.players.map((p) => p.gamertag ?? "").filter((g): g is string => g !== ""),
             })),
           }
-        : undefined;
+        : { title: "", subtitle: "", teams: [] }
+      : undefined;
     const dialogState: ManualSeriesDialogState = {
       trackerId: item.trackerId,
       trackerLabel: item.gamertag,

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -661,7 +661,7 @@ export class LiveTrackersPresenter {
             subtitle: activeSeriesContext.subtitle ?? "",
             teams: activeSeriesContext.teams.map((t) => ({
               name: t.name,
-              members: t.players.map((p) => p.gamertag ?? "").filter((g): g is string => g !== ""),
+              members: t.players.map((p) => p.gamertag ?? ""),
             })),
           }
         : undefined;

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -249,10 +249,11 @@ export class LiveTrackersPresenter {
         },
       });
       if (item.hasActiveSeries) {
-        const hasLiveContext = this.activeLiveView?.trackerId === item.trackerId;
+        const liveViewForItem = this.activeLiveView?.trackerId === item.trackerId ? this.activeLiveView : null;
+        const hasSeriesContext = liveViewForItem?.activeSeriesContext != null;
         actions.push({
           label: "Edit series",
-          disabled: snapshot.busy || !hasLiveContext,
+          disabled: snapshot.busy || !hasSeriesContext,
           onClick: (): void => {
             this.openManualSeriesDialog(item);
           },

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -654,17 +654,20 @@ export class LiveTrackersPresenter {
     }
     const liveView = this.activeLiveView?.trackerId === item.trackerId ? this.activeLiveView : null;
     const activeSeriesContext = liveView?.activeSeriesContext;
-    if (activeSeriesContext == null) {
+    if (item.hasActiveSeries && activeSeriesContext == null) {
       return;
     }
-    const initialData: SeriesInitialData = {
-      title: activeSeriesContext.title,
-      subtitle: activeSeriesContext.subtitle ?? "",
-      teams: activeSeriesContext.teams.map((t) => ({
-        name: t.name,
-        members: t.players.map((p) => p.gamertag ?? ""),
-      })),
-    };
+    const initialData: SeriesInitialData | undefined =
+      activeSeriesContext != null
+        ? {
+            title: activeSeriesContext.title,
+            subtitle: activeSeriesContext.subtitle ?? "",
+            teams: activeSeriesContext.teams.map((t) => ({
+              name: t.name,
+              members: t.players.map((p) => p.gamertag ?? ""),
+            })),
+          }
+        : undefined;
     const dialogState: ManualSeriesDialogState = {
       trackerId: item.trackerId,
       trackerLabel: item.gamertag,

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -654,17 +654,17 @@ export class LiveTrackersPresenter {
     }
     const liveView = this.activeLiveView?.trackerId === item.trackerId ? this.activeLiveView : null;
     const activeSeriesContext = liveView?.activeSeriesContext;
-    const initialData: SeriesInitialData | undefined =
-      activeSeriesContext != null
-        ? {
-            title: activeSeriesContext.title,
-            subtitle: activeSeriesContext.subtitle ?? "",
-            teams: activeSeriesContext.teams.map((t) => ({
-              name: t.name,
-              members: t.players.map((p) => p.gamertag ?? ""),
-            })),
-          }
-        : undefined;
+    if (activeSeriesContext == null) {
+      return;
+    }
+    const initialData: SeriesInitialData = {
+      title: activeSeriesContext.title,
+      subtitle: activeSeriesContext.subtitle ?? "",
+      teams: activeSeriesContext.teams.map((t) => ({
+        name: t.name,
+        members: t.players.map((p) => p.gamertag ?? ""),
+      })),
+    };
     const dialogState: ManualSeriesDialogState = {
       trackerId: item.trackerId,
       trackerLabel: item.gamertag,

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -248,8 +248,8 @@ export class LiveTrackersPresenter {
           this.openGameSelection(item);
         },
       });
+      const liveViewForItem = this.activeLiveView?.trackerId === item.trackerId ? this.activeLiveView : null;
       if (item.hasActiveSeries) {
-        const liveViewForItem = this.activeLiveView?.trackerId === item.trackerId ? this.activeLiveView : null;
         const hasSeriesContext = liveViewForItem?.activeSeriesContext != null;
         actions.push({
           label: "Edit series",
@@ -259,8 +259,7 @@ export class LiveTrackersPresenter {
           },
         });
       } else {
-        const liveView = this.activeLiveView?.trackerId === item.trackerId ? this.activeLiveView : null;
-        if (liveView?.hasRecentCompletedSeries === true) {
+        if (liveViewForItem?.hasRecentCompletedSeries === true) {
           actions.push({
             label: "Resume series",
             disabled: snapshot.busy,

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../../services/individual-tracker/types";
 import { buildIndividualTrackerTrackerViewPath } from "../../individual-tracker/routes";
 import type { GameSelectionDialogState, ManualSeriesDialogState } from "../types";
+import type { SeriesInitialData } from "../../individual-tracker/manual-series-dialog/manual-series-dialog-store";
 import type { TrackerDisplayStatus, TrackerListItem, TrackerRowAction } from "../tracker-list/tracker-list";
 import type { LiveTrackersStore } from "./live-trackers-store";
 import type { LiveTrackersSnapshot } from "./types";
@@ -247,7 +248,15 @@ export class LiveTrackersPresenter {
           this.openGameSelection(item);
         },
       });
-      if (!item.hasActiveSeries) {
+      if (item.hasActiveSeries) {
+        actions.push({
+          label: "Edit series",
+          disabled: snapshot.busy,
+          onClick: (): void => {
+            this.openManualSeriesDialog(item);
+          },
+        });
+      } else {
         actions.push({
           label: "Start series",
           disabled: snapshot.busy,
@@ -617,9 +626,23 @@ export class LiveTrackersPresenter {
     if (item.trackerId == null) {
       return;
     }
+    const liveView = this.activeLiveView?.trackerId === item.trackerId ? this.activeLiveView : null;
+    const activeSeriesContext = liveView?.activeSeriesContext;
+    const initialData: SeriesInitialData | undefined =
+      activeSeriesContext != null
+        ? {
+            title: activeSeriesContext.title,
+            subtitle: activeSeriesContext.subtitle ?? "",
+            teams: activeSeriesContext.teams.map((t) => ({
+              name: t.name,
+              members: t.players.map((p) => p.gamertag ?? "").filter((g): g is string => g !== ""),
+            })),
+          }
+        : undefined;
     const dialogState: ManualSeriesDialogState = {
       trackerId: item.trackerId,
       trackerLabel: item.gamertag,
+      initialData,
     };
     this.updateSnapshot((s) => ({ ...s, manualSeriesDialogState: dialogState }));
   }

--- a/pages/src/components/individual-tracker-manager/types.ts
+++ b/pages/src/components/individual-tracker-manager/types.ts
@@ -1,4 +1,5 @@
 import type { IndividualTrackerSeriesGroup } from "../individual-tracker/series-group-metadata";
+import type { SeriesInitialData } from "../individual-tracker/manual-series-dialog/manual-series-dialog-store";
 
 export interface GameSelectionDialogState {
   readonly trackerId: string;
@@ -12,4 +13,5 @@ export interface GameSelectionDialogState {
 export interface ManualSeriesDialogState {
   readonly trackerId: string;
   readonly trackerLabel: string;
+  readonly initialData?: SeriesInitialData;
 }

--- a/pages/src/components/individual-tracker/manual-series-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/create.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
+import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import { ManualSeriesDialogPresenter } from "./manual-series-dialog-presenter";
 import { ManualSeriesDialogStore } from "./manual-series-dialog-store";
+import type { SeriesInitialData } from "./manual-series-dialog-store";
 import { ManualSeriesDialog } from "./manual-series-dialog";
 
 interface ManualSeriesDialogSectionProps {
@@ -11,6 +13,9 @@ interface ManualSeriesDialogSectionProps {
   readonly onClose: () => void;
   readonly onSeriesStarted: () => void;
   readonly individualTrackerService: IndividualTrackerService;
+  readonly viewService: IndividualTrackerViewService;
+  readonly initialData?: SeriesInitialData;
+  readonly onSeriesEdited?: () => void;
 }
 
 export function ManualSeriesDialogSection({
@@ -20,28 +25,37 @@ export function ManualSeriesDialogSection({
   onClose,
   onSeriesStarted,
   individualTrackerService,
+  viewService,
+  initialData,
+  onSeriesEdited,
 }: ManualSeriesDialogSectionProps): React.ReactElement | null {
   const onSeriesStartedRef = useRef(onSeriesStarted);
   onSeriesStartedRef.current = onSeriesStarted;
+  const onSeriesEditedRef = useRef(onSeriesEdited);
+  onSeriesEditedRef.current = onSeriesEdited;
 
-  const store = useMemo(() => new ManualSeriesDialogStore(), []);
+  const initialDataRef = useRef(initialData);
+  initialDataRef.current = initialData;
+  const store = useMemo(() => new ManualSeriesDialogStore(initialDataRef.current), []);
   const presenter = useMemo(
     () =>
       new ManualSeriesDialogPresenter({
         trackerId,
         store,
         individualTrackerService,
+        viewService,
         onSeriesStarted: (): void => {
           onSeriesStartedRef.current();
         },
+        onSeriesEdited: (): void => {
+          onSeriesEditedRef.current?.();
+        },
       }),
-    [trackerId, store, individualTrackerService],
+    [trackerId, store, individualTrackerService, viewService],
   );
 
   useEffect(() => {
-    if (!isOpen) {
-      store.reset();
-    }
+    store.reset(initialDataRef.current);
   }, [isOpen, store]);
 
   useEffect(() => {
@@ -55,6 +69,14 @@ export function ManualSeriesDialogSection({
     () => store.getSnapshot(),
     () => store.getSnapshot(),
   );
+
+  const handleSubmit = (): void => {
+    if (snapshot.mode === "edit") {
+      presenter.editSeries();
+    } else {
+      presenter.startSeries();
+    }
+  };
 
   return (
     <ManualSeriesDialog
@@ -86,9 +108,7 @@ export function ManualSeriesDialogSection({
       onBackfillMatchToggle={(matchId): void => {
         presenter.toggleBackfillMatch(matchId);
       }}
-      onStartSeries={(): void => {
-        presenter.startSeries();
-      }}
+      onStartSeries={handleSubmit}
     />
   );
 }

--- a/pages/src/components/individual-tracker/manual-series-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/create.tsx
@@ -34,9 +34,7 @@ export function ManualSeriesDialogSection({
   const onSeriesEditedRef = useRef(onSeriesEdited);
   onSeriesEditedRef.current = onSeriesEdited;
 
-  const initialDataRef = useRef(initialData);
-  initialDataRef.current = initialData;
-  const store = useMemo(() => new ManualSeriesDialogStore(initialDataRef.current), []);
+  const store = useMemo(() => new ManualSeriesDialogStore(initialData), []);
   const presenter = useMemo(
     () =>
       new ManualSeriesDialogPresenter({

--- a/pages/src/components/individual-tracker/manual-series-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/create.tsx
@@ -55,8 +55,8 @@ export function ManualSeriesDialogSection({
   );
 
   useEffect(() => {
-    store.reset(initialDataRef.current);
-  }, [isOpen, store]);
+    store.reset(initialData);
+  }, [isOpen, store, initialData]);
 
   useEffect(() => {
     return (): void => {

--- a/pages/src/components/individual-tracker/manual-series-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/create.tsx
@@ -43,7 +43,7 @@ export function ManualSeriesDialogSection({
         trackerId,
         store,
         individualTrackerService,
-        viewService,
+        individualTrackerViewService: viewService,
         onSeriesStarted: (): void => {
           onSeriesStartedRef.current();
         },

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -1,9 +1,6 @@
 import type { TrackerMatchSummary } from "@guilty-spark/shared/contracts/individual-tracker/view";
-import type {
-  IndividualTrackerService,
-  ManualSeriesTeamForm,
-  TrackerMatchHistoryEntry,
-} from "../../../services/individual-tracker/types";
+import { getDurationBetween } from "@guilty-spark/shared/halo/duration";
+import type { IndividualTrackerService, TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import { formatDisplayDateTime } from "../../../services/individual-tracker/match-history-helpers";
 import type { ManualSeriesDialogSnapshot, ManualSeriesDialogStore } from "./manual-series-dialog-store";
@@ -12,7 +9,7 @@ interface Config {
   readonly trackerId: string;
   readonly store: ManualSeriesDialogStore;
   readonly individualTrackerService: IndividualTrackerService;
-  readonly viewService: IndividualTrackerViewService;
+  readonly individualTrackerViewService: IndividualTrackerViewService;
   readonly onSeriesStarted: () => void;
   readonly onSeriesEdited?: (() => void) | undefined;
 }
@@ -21,8 +18,6 @@ function summaryToHistoryEntry(summary: TrackerMatchSummary): TrackerMatchHistor
   const outcome = (
     ["Win", "Loss", "Tie", "DNF"].includes(summary.outcome) ? summary.outcome : "Unknown"
   ) as TrackerMatchHistoryEntry["outcome"];
-  const ms = new Date(summary.endTime).getTime() - new Date(summary.startTime).getTime();
-  const totalSeconds = Math.floor(ms / 1000);
   return {
     matchId: summary.matchId,
     startTime: formatDisplayDateTime(summary.startTime),
@@ -34,7 +29,7 @@ function summaryToHistoryEntry(summary: TrackerMatchSummary): TrackerMatchHistor
     gameVariantCategory: summary.gameVariantCategory,
     startTimeIso: summary.startTime,
     endTimeIso: summary.endTime,
-    duration: `${Math.floor(totalSeconds / 60).toString()}m ${(totalSeconds % 60).toString().padStart(2, "0")}s`,
+    duration: getDurationBetween(summary.startTime, summary.endTime),
     mapName: summary.mapName,
     modeName: "Custom",
     outcome,
@@ -147,7 +142,7 @@ export class ManualSeriesDialogPresenter {
   private async runBackfillDiscovery(): Promise<void> {
     this.config.store.setBackfillLoading();
     try {
-      const { view } = await this.config.viewService.getView(this.config.trackerId);
+      const { view } = await this.config.individualTrackerViewService.getView(this.config.trackerId);
       if (this.checkDisposed()) {
         return;
       }
@@ -234,9 +229,7 @@ export class ManualSeriesDialogPresenter {
       await this.config.individualTrackerService.editSeries(this.config.trackerId, {
         titleOverride: snapshot.titleOverride.trim() || null,
         subtitleOverride: snapshot.subtitleOverride.trim() || null,
-        ...(hasTeamData
-          ? { teams: teams as unknown as readonly [ManualSeriesTeamForm, ...ManualSeriesTeamForm[]] }
-          : {}),
+        ...(hasTeamData ? { teams } : {}),
       });
 
       if (this.checkDisposed()) {

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -3,7 +3,7 @@ import { getDurationBetween } from "@guilty-spark/shared/halo/duration";
 import type { IndividualTrackerService, TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import { formatDisplayDateTime } from "../../../services/individual-tracker/match-history-helpers";
-import type { ManualSeriesDialogSnapshot, ManualSeriesDialogStore } from "./manual-series-dialog-store";
+import type { ManualSeriesDialogStore } from "./manual-series-dialog-store";
 
 interface Config {
   readonly trackerId: string;
@@ -55,10 +55,6 @@ export class ManualSeriesDialogPresenter {
 
   private checkDisposed(): boolean {
     return this.disposed;
-  }
-
-  public static present(snapshot: ManualSeriesDialogSnapshot): ManualSeriesDialogSnapshot {
-    return snapshot;
   }
 
   public setTitleOverride(value: string): void {

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -1,80 +1,41 @@
-import type {
-  IndividualTrackerService,
-  TrackerMatchHistoryEntry,
-  TrackerSearchResult,
-} from "../../../services/individual-tracker/types";
-import type {
-  ManualSeriesDialogSnapshot,
-  ManualSeriesDialogStore,
-  ManualSeriesTeamSnapshot,
-} from "./manual-series-dialog-store";
+import type { TrackerMatchSummary } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import type { IndividualTrackerService, TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
+import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
+import type { ManualSeriesDialogSnapshot, ManualSeriesDialogStore } from "./manual-series-dialog-store";
 
 interface Config {
   readonly trackerId: string;
   readonly store: ManualSeriesDialogStore;
   readonly individualTrackerService: IndividualTrackerService;
+  readonly viewService: IndividualTrackerViewService;
   readonly onSeriesStarted: () => void;
+  readonly onSeriesEdited?: (() => void) | undefined;
 }
 
-function collectUniqueTeamMembers(teams: readonly ManualSeriesTeamSnapshot[]): readonly string[] {
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const team of teams) {
-    for (const member of team.members) {
-      const normalized = member.trim();
-      if (normalized !== "" && !seen.has(normalized)) {
-        seen.add(normalized);
-        result.push(normalized);
-      }
-    }
-  }
-  return result;
-}
-
-function computeMatchIntersection(histories: readonly { readonly matches: readonly TrackerMatchHistoryEntry[] }[]): {
-  readonly intersection: ReadonlySet<string>;
-  readonly matchById: ReadonlyMap<string, TrackerMatchHistoryEntry>;
-} {
-  const historiesWithData = histories.filter((h) => h.matches.length > 0);
-
-  const matchById = new Map<string, TrackerMatchHistoryEntry>();
-  for (const entry of historiesWithData) {
-    for (const match of entry.matches) {
-      if (!matchById.has(match.matchId)) {
-        matchById.set(match.matchId, match);
-      }
-    }
-  }
-
-  if (historiesWithData.length === 0) {
-    return { intersection: new Set(), matchById };
-  }
-
-  const intersection = new Set(historiesWithData[0].matches.map((m) => m.matchId));
-  for (const entry of historiesWithData.slice(1)) {
-    const entryIds = new Set(entry.matches.map((m) => m.matchId));
-    for (const matchId of intersection) {
-      if (!entryIds.has(matchId)) {
-        intersection.delete(matchId);
-      }
-    }
-  }
-
-  return { intersection, matchById };
-}
-
-function sortCandidateMatches(
-  intersection: ReadonlySet<string>,
-  matchById: ReadonlyMap<string, TrackerMatchHistoryEntry>,
-): readonly TrackerMatchHistoryEntry[] {
-  return Array.from(intersection)
-    .map((matchId) => matchById.get(matchId))
-    .filter((match): match is TrackerMatchHistoryEntry => match != null)
-    .sort((left, right) => {
-      const leftTime = new Date(left.startTimeIso ?? left.startTime).getTime();
-      const rightTime = new Date(right.startTimeIso ?? right.startTime).getTime();
-      return rightTime - leftTime;
-    });
+function summaryToHistoryEntry(summary: TrackerMatchSummary): TrackerMatchHistoryEntry {
+  return {
+    matchId: summary.matchId,
+    startTime: summary.startTime,
+    endTime: summary.endTime,
+    mapAssetId: summary.mapAssetId,
+    mapVersionId: summary.mapVersionId,
+    modeAssetId: summary.modeAssetId,
+    modeVersionId: "",
+    gameVariantCategory: summary.gameVariantCategory,
+    startTimeIso: summary.startTime,
+    endTimeIso: summary.endTime,
+    duration: "",
+    mapName: summary.mapName,
+    modeName: "",
+    outcome: (["Win", "Loss", "Tie", "DNF"].includes(summary.outcome)
+      ? summary.outcome
+      : "Unknown") as TrackerMatchHistoryEntry["outcome"],
+    resultString: summary.outcome,
+    isMatchmaking: summary.isMatchmaking,
+    category: summary.isMatchmaking ? "matchmaking" : "custom",
+    teams: [],
+    mapThumbnailUrl: "data:,",
+  };
 }
 
 export class ManualSeriesDialogPresenter {
@@ -176,69 +137,20 @@ export class ManualSeriesDialogPresenter {
   }
 
   private async runBackfillDiscovery(): Promise<void> {
-    const { teams } = this.config.store.getSnapshot();
-    const memberNames = collectUniqueTeamMembers(teams);
-
-    if (memberNames.length === 0) {
-      this.config.store.setBackfillError("Add at least one player name before searching for shared custom games.");
-      return;
-    }
-
     this.config.store.setBackfillLoading();
-
     try {
-      const resolvedPlayers = await Promise.all(
-        memberNames.map(
-          async (member): Promise<{ member: string; result: TrackerSearchResult | null }> => ({
-            member,
-            result: await this.config.individualTrackerService.searchGamertag(member),
-          }),
-        ),
-      );
-
+      const { view } = await this.config.viewService.getView(this.config.trackerId);
       if (this.checkDisposed()) {
         return;
       }
-
-      const playersWithIdentity = resolvedPlayers.filter(
-        (entry): entry is { member: string; result: TrackerSearchResult } => entry.result != null,
-      );
-
-      if (playersWithIdentity.length === 0) {
-        this.config.store.setBackfillDone([], null, "No player identities were resolved. Check names and try again.");
-        return;
-      }
-
-      const histories = await Promise.all(
-        playersWithIdentity.map(async ({ member, result }) => ({
-          member,
-          matches: (
-            await this.config.individualTrackerService.getMatchHistory(result.xuid, 0, 25, "custom")
-          ).matches.filter((match) => match.category === "custom"),
-        })),
-      );
-
-      if (this.checkDisposed()) {
-        return;
-      }
-
-      const playersWithoutHistory = histories.filter((h) => h.matches.length === 0).map((h) => h.member);
-      const { intersection, matchById } = computeMatchIntersection(histories);
-      const candidates = sortCandidateMatches(intersection, matchById);
-
-      const warning =
-        playersWithoutHistory.length > 0
-          ? `History unavailable for ${playersWithoutHistory.join(", ")}. Shared matches are based on players with available history.`
-          : null;
-
-      const error = candidates.length === 0 ? "No shared custom matches were found across the selected players." : null;
-
-      this.config.store.setBackfillDone(candidates, warning, error);
+      const entries = view.matches.filter((m) => !m.isMatchmaking).map(summaryToHistoryEntry);
+      const error = entries.length === 0 ? "No matches found for this tracker yet." : null;
+      this.config.store.setBackfillDone(entries, null, error);
     } catch (err) {
       if (this.checkDisposed()) {
         return;
       }
-      const message = err instanceof Error ? err.message : "Failed to discover custom-game matches.";
+      const message = err instanceof Error ? err.message : "Failed to load tracker matches.";
       this.config.store.setBackfillError(message);
     }
   }
@@ -281,6 +193,48 @@ export class ManualSeriesDialogPresenter {
         return;
       }
       const message = err instanceof Error ? err.message : "Failed to start series.";
+      this.config.store.setSubmitError(message);
+    } finally {
+      if (!this.checkDisposed()) {
+        this.config.store.setBusy(false);
+      }
+    }
+  }
+
+  public editSeries(): void {
+    if (this.checkDisposed()) {
+      return;
+    }
+    void this.runEditSeries();
+  }
+
+  private async runEditSeries(): Promise<void> {
+    const snapshot = this.config.store.getSnapshot();
+    this.config.store.setBusy(true);
+    this.config.store.setSubmitError(null);
+
+    try {
+      const teams = snapshot.teams.map((team) => ({
+        name: team.name.trim(),
+        members: team.members.map((m) => m.trim()).filter((m) => m !== ""),
+      }));
+
+      await this.config.individualTrackerService.editSeries(this.config.trackerId, {
+        titleOverride: snapshot.titleOverride.trim() || undefined,
+        subtitleOverride: snapshot.subtitleOverride.trim() || null,
+        teams,
+      });
+
+      if (this.checkDisposed()) {
+        return;
+      }
+
+      this.config.onSeriesEdited?.();
+    } catch (err) {
+      if (this.checkDisposed()) {
+        return;
+      }
+      const message = err instanceof Error ? err.message : "Failed to edit series.";
       this.config.store.setSubmitError(message);
     } finally {
       if (!this.checkDisposed()) {

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -224,7 +224,7 @@ export class ManualSeriesDialogPresenter {
       }));
 
       await this.config.individualTrackerService.editSeries(this.config.trackerId, {
-        titleOverride: snapshot.titleOverride.trim() || undefined,
+        titleOverride: snapshot.titleOverride.trim() || null,
         subtitleOverride: snapshot.subtitleOverride.trim() || null,
         teams,
       });

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -34,7 +34,7 @@ function summaryToHistoryEntry(summary: TrackerMatchSummary): TrackerMatchHistor
     outcome: (["Win", "Loss", "Tie", "DNF"].includes(summary.outcome)
       ? summary.outcome
       : "Unknown") as TrackerMatchHistoryEntry["outcome"],
-    resultString: summary.outcome,
+    resultString: summary.score !== "" ? `${summary.outcome} - ${summary.score}` : summary.outcome,
     isMatchmaking: summary.isMatchmaking,
     category: summary.isMatchmaking ? "matchmaking" : "custom",
     teams: [],
@@ -151,7 +151,7 @@ export class ManualSeriesDialogPresenter {
         .filter((m) => !m.isMatchmaking)
         .map(summaryToHistoryEntry)
         .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime());
-      const error = entries.length === 0 ? "No matches found for this tracker yet." : null;
+      const error = entries.length === 0 ? "No custom game matches found for this tracker yet." : null;
       this.config.store.setBackfillDone(entries, null, error);
     } catch (err) {
       if (this.checkDisposed()) {

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -229,7 +229,7 @@ export class ManualSeriesDialogPresenter {
       await this.config.individualTrackerService.editSeries(this.config.trackerId, {
         titleOverride: snapshot.titleOverride.trim() || null,
         subtitleOverride: snapshot.subtitleOverride.trim() || null,
-        ...(hasTeamData ? { teams } : {}),
+        ...(hasTeamData || snapshot.hadInitialTeams ? { teams } : {}),
       });
 
       if (this.checkDisposed()) {

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -147,7 +147,10 @@ export class ManualSeriesDialogPresenter {
       if (this.checkDisposed()) {
         return;
       }
-      const entries = view.matches.filter((m) => !m.isMatchmaking).map(summaryToHistoryEntry);
+      const entries = view.matches
+        .filter((m) => !m.isMatchmaking)
+        .map(summaryToHistoryEntry)
+        .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime());
       const error = entries.length === 0 ? "No matches found for this tracker yet." : null;
       this.config.store.setBackfillDone(entries, null, error);
     } catch (err) {

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -150,8 +150,8 @@ export class ManualSeriesDialogPresenter {
       }
       const entries = view.matches
         .filter((m) => !m.isMatchmaking)
-        .map(summaryToHistoryEntry)
-        .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime());
+        .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime())
+        .map(summaryToHistoryEntry);
       const error = entries.length === 0 ? "No custom game matches found for this tracker yet." : null;
       this.config.store.setBackfillDone(entries, null, error);
     } catch (err) {

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -1,5 +1,9 @@
 import type { TrackerMatchSummary } from "@guilty-spark/shared/contracts/individual-tracker/view";
-import type { IndividualTrackerService, TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
+import type {
+  IndividualTrackerService,
+  ManualSeriesTeamForm,
+  TrackerMatchHistoryEntry,
+} from "../../../services/individual-tracker/types";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import { formatDisplayDateTime } from "../../../services/individual-tracker/match-history-helpers";
 import type { ManualSeriesDialogSnapshot, ManualSeriesDialogStore } from "./manual-series-dialog-store";
@@ -14,6 +18,11 @@ interface Config {
 }
 
 function summaryToHistoryEntry(summary: TrackerMatchSummary): TrackerMatchHistoryEntry {
+  const outcome = (
+    ["Win", "Loss", "Tie", "DNF"].includes(summary.outcome) ? summary.outcome : "Unknown"
+  ) as TrackerMatchHistoryEntry["outcome"];
+  const ms = new Date(summary.endTime).getTime() - new Date(summary.startTime).getTime();
+  const totalSeconds = Math.floor(ms / 1000);
   return {
     matchId: summary.matchId,
     startTime: formatDisplayDateTime(summary.startTime),
@@ -25,17 +34,11 @@ function summaryToHistoryEntry(summary: TrackerMatchSummary): TrackerMatchHistor
     gameVariantCategory: summary.gameVariantCategory,
     startTimeIso: summary.startTime,
     endTimeIso: summary.endTime,
-    duration: ((): string => {
-      const ms = new Date(summary.endTime).getTime() - new Date(summary.startTime).getTime();
-      const totalSeconds = Math.floor(ms / 1000);
-      return `${Math.floor(totalSeconds / 60).toString()}m ${(totalSeconds % 60).toString().padStart(2, "0")}s`;
-    })(),
+    duration: `${Math.floor(totalSeconds / 60).toString()}m ${(totalSeconds % 60).toString().padStart(2, "0")}s`,
     mapName: summary.mapName,
     modeName: "Custom",
-    outcome: (["Win", "Loss", "Tie", "DNF"].includes(summary.outcome)
-      ? summary.outcome
-      : "Unknown") as TrackerMatchHistoryEntry["outcome"],
-    resultString: summary.score !== "" ? `${summary.outcome} - ${summary.score}` : summary.outcome,
+    outcome,
+    resultString: summary.score !== "" ? `${outcome} - ${summary.score}` : outcome,
     isMatchmaking: summary.isMatchmaking,
     category: summary.isMatchmaking ? "matchmaking" : "custom",
     teams: [],
@@ -230,7 +233,7 @@ export class ManualSeriesDialogPresenter {
       await this.config.individualTrackerService.editSeries(this.config.trackerId, {
         titleOverride: snapshot.titleOverride.trim() || null,
         subtitleOverride: snapshot.subtitleOverride.trim() || null,
-        teams,
+        teams: teams as unknown as readonly [ManualSeriesTeamForm, ...ManualSeriesTeamForm[]],
       });
 
       if (this.checkDisposed()) {

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -24,9 +24,13 @@ function summaryToHistoryEntry(summary: TrackerMatchSummary): TrackerMatchHistor
     gameVariantCategory: summary.gameVariantCategory,
     startTimeIso: summary.startTime,
     endTimeIso: summary.endTime,
-    duration: "",
+    duration: ((): string => {
+      const ms = new Date(summary.endTime).getTime() - new Date(summary.startTime).getTime();
+      const totalSeconds = Math.floor(ms / 1000);
+      return `${Math.floor(totalSeconds / 60).toString()}m ${(totalSeconds % 60).toString().padStart(2, "0")}s`;
+    })(),
     mapName: summary.mapName,
-    modeName: "",
+    modeName: "Custom",
     outcome: (["Win", "Loss", "Tie", "DNF"].includes(summary.outcome)
       ? summary.outcome
       : "Unknown") as TrackerMatchHistoryEntry["outcome"],

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -1,6 +1,7 @@
 import type { TrackerMatchSummary } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { IndividualTrackerService, TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
+import { formatDisplayDateTime } from "../../../services/individual-tracker/match-history-helpers";
 import type { ManualSeriesDialogSnapshot, ManualSeriesDialogStore } from "./manual-series-dialog-store";
 
 interface Config {
@@ -15,8 +16,8 @@ interface Config {
 function summaryToHistoryEntry(summary: TrackerMatchSummary): TrackerMatchHistoryEntry {
   return {
     matchId: summary.matchId,
-    startTime: summary.startTime,
-    endTime: summary.endTime,
+    startTime: formatDisplayDateTime(summary.startTime),
+    endTime: formatDisplayDateTime(summary.endTime),
     mapAssetId: summary.mapAssetId,
     mapVersionId: summary.mapVersionId,
     modeAssetId: summary.modeAssetId,

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-presenter.ts
@@ -229,11 +229,14 @@ export class ManualSeriesDialogPresenter {
         name: team.name.trim(),
         members: team.members.map((m) => m.trim()).filter((m) => m !== ""),
       }));
+      const hasTeamData = teams.some((t) => t.name !== "" || t.members.length > 0);
 
       await this.config.individualTrackerService.editSeries(this.config.trackerId, {
         titleOverride: snapshot.titleOverride.trim() || null,
         subtitleOverride: snapshot.subtitleOverride.trim() || null,
-        teams: teams as unknown as readonly [ManualSeriesTeamForm, ...ManualSeriesTeamForm[]],
+        ...(hasTeamData
+          ? { teams: teams as unknown as readonly [ManualSeriesTeamForm, ...ManualSeriesTeamForm[]] }
+          : {}),
       });
 
       if (this.checkDisposed()) {

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-store.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-store.ts
@@ -44,10 +44,9 @@ export class ManualSeriesDialogStore {
   public constructor(initialData?: SeriesInitialData) {
     const mode: "start" | "edit" = initialData != null ? "edit" : "start";
     const teams =
-      initialData?.teams.map((t) => ({
-        name: t.name,
-        members: t.members.length > 0 ? [...t.members] : [""],
-      })) ?? buildDefaultTeams();
+      initialData != null && initialData.teams.length > 0
+        ? initialData.teams.map((t) => ({ name: t.name, members: t.members.length > 0 ? [...t.members] : [""] }))
+        : buildDefaultTeams();
     this.snapshot = {
       mode,
       titleOverride: initialData?.title ?? "",
@@ -78,10 +77,9 @@ export class ManualSeriesDialogStore {
   public reset(initialData?: SeriesInitialData): void {
     const data = initialData ?? this.initialData;
     const teams =
-      data?.teams.map((t) => ({
-        name: t.name,
-        members: t.members.length > 0 ? [...t.members] : [""],
-      })) ?? buildDefaultTeams();
+      data != null && data.teams.length > 0
+        ? data.teams.map((t) => ({ name: t.name, members: t.members.length > 0 ? [...t.members] : [""] }))
+        : buildDefaultTeams();
     this.update({
       mode: data != null ? "edit" : "start",
       titleOverride: data?.title ?? "",

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-store.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-store.ts
@@ -8,6 +8,7 @@ export interface ManualSeriesTeamSnapshot {
 export type BackfillState = "idle" | "loading" | "done" | "error";
 
 export interface ManualSeriesDialogSnapshot {
+  readonly mode: "start" | "edit";
   readonly titleOverride: string;
   readonly subtitleOverride: string;
   readonly teams: readonly ManualSeriesTeamSnapshot[];
@@ -18,6 +19,12 @@ export interface ManualSeriesDialogSnapshot {
   readonly selectedBackfillMatchIds: readonly string[];
   readonly busy: boolean;
   readonly submitError: string | null;
+}
+
+export interface SeriesInitialData {
+  readonly title: string;
+  readonly subtitle: string;
+  readonly teams: readonly ManualSeriesTeamSnapshot[];
 }
 
 const INITIAL_TEAM_MEMBERS: readonly string[] = ["", "", "", ""];
@@ -32,12 +39,20 @@ function buildDefaultTeams(): readonly ManualSeriesTeamSnapshot[] {
 export class ManualSeriesDialogStore {
   private snapshot: ManualSeriesDialogSnapshot;
   private readonly subscribers = new Set<() => void>();
+  private readonly initialData: SeriesInitialData | undefined;
 
-  public constructor() {
+  public constructor(initialData?: SeriesInitialData) {
+    const mode: "start" | "edit" = initialData != null ? "edit" : "start";
+    const teams =
+      initialData?.teams.map((t) => ({
+        name: t.name,
+        members: t.members.length > 0 ? [...t.members] : [""],
+      })) ?? buildDefaultTeams();
     this.snapshot = {
-      titleOverride: "",
-      subtitleOverride: "",
-      teams: buildDefaultTeams(),
+      mode,
+      titleOverride: initialData?.title ?? "",
+      subtitleOverride: initialData?.subtitle ?? "",
+      teams,
       backfillState: "idle",
       backfillError: null,
       backfillWarning: null,
@@ -46,6 +61,7 @@ export class ManualSeriesDialogStore {
       busy: false,
       submitError: null,
     };
+    this.initialData = initialData;
   }
 
   public subscribe(listener: () => void): () => void {
@@ -59,11 +75,18 @@ export class ManualSeriesDialogStore {
     return this.snapshot;
   }
 
-  public reset(): void {
+  public reset(initialData?: SeriesInitialData): void {
+    const data = initialData ?? this.initialData;
+    const teams =
+      data?.teams.map((t) => ({
+        name: t.name,
+        members: t.members.length > 0 ? [...t.members] : [""],
+      })) ?? buildDefaultTeams();
     this.update({
-      titleOverride: "",
-      subtitleOverride: "",
-      teams: buildDefaultTeams(),
+      mode: data != null ? "edit" : "start",
+      titleOverride: data?.title ?? "",
+      subtitleOverride: data?.subtitle ?? "",
+      teams,
       backfillState: "idle",
       backfillError: null,
       backfillWarning: null,

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-store.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-store.ts
@@ -45,7 +45,10 @@ export class ManualSeriesDialogStore {
     const mode: "start" | "edit" = initialData != null ? "edit" : "start";
     const teams =
       initialData != null && initialData.teams.length > 0
-        ? initialData.teams.map((t) => ({ name: t.name, members: t.members.length > 0 ? [...t.members] : [""] }))
+        ? initialData.teams.map((t) => ({
+            name: t.name,
+            members: t.members.length > 0 ? [...t.members] : [...INITIAL_TEAM_MEMBERS],
+          }))
         : buildDefaultTeams();
     this.snapshot = {
       mode,
@@ -78,7 +81,10 @@ export class ManualSeriesDialogStore {
     const data = initialData ?? this.initialData;
     const teams =
       data != null && data.teams.length > 0
-        ? data.teams.map((t) => ({ name: t.name, members: t.members.length > 0 ? [...t.members] : [""] }))
+        ? data.teams.map((t) => ({
+            name: t.name,
+            members: t.members.length > 0 ? [...t.members] : [...INITIAL_TEAM_MEMBERS],
+          }))
         : buildDefaultTeams();
     this.update({
       mode: data != null ? "edit" : "start",

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-store.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-store.ts
@@ -12,6 +12,7 @@ export interface ManualSeriesDialogSnapshot {
   readonly titleOverride: string;
   readonly subtitleOverride: string;
   readonly teams: readonly ManualSeriesTeamSnapshot[];
+  readonly hadInitialTeams: boolean;
   readonly backfillState: BackfillState;
   readonly backfillError: string | null;
   readonly backfillWarning: string | null;
@@ -59,6 +60,7 @@ export class ManualSeriesDialogStore {
       titleOverride: initialData?.title ?? "",
       subtitleOverride: initialData?.subtitle ?? "",
       teams,
+      hadInitialTeams: (initialData?.teams.length ?? 0) > 0,
       backfillState: "idle",
       backfillError: null,
       backfillWarning: null,
@@ -89,6 +91,7 @@ export class ManualSeriesDialogStore {
       titleOverride: data?.title ?? "",
       subtitleOverride: data?.subtitle ?? "",
       teams,
+      hadInitialTeams: (data?.teams.length ?? 0) > 0,
       backfillState: "idle",
       backfillError: null,
       backfillWarning: null,

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-store.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog-store.ts
@@ -36,6 +36,16 @@ function buildDefaultTeams(): readonly ManualSeriesTeamSnapshot[] {
   ];
 }
 
+function normaliseTeams(data: SeriesInitialData): readonly ManualSeriesTeamSnapshot[] {
+  if (data.teams.length === 0) {
+    return buildDefaultTeams();
+  }
+  return data.teams.map((t) => ({
+    name: t.name,
+    members: t.members.length > 0 ? [...t.members] : [...INITIAL_TEAM_MEMBERS],
+  }));
+}
+
 export class ManualSeriesDialogStore {
   private snapshot: ManualSeriesDialogSnapshot;
   private readonly subscribers = new Set<() => void>();
@@ -43,13 +53,7 @@ export class ManualSeriesDialogStore {
 
   public constructor(initialData?: SeriesInitialData) {
     const mode: "start" | "edit" = initialData != null ? "edit" : "start";
-    const teams =
-      initialData != null && initialData.teams.length > 0
-        ? initialData.teams.map((t) => ({
-            name: t.name,
-            members: t.members.length > 0 ? [...t.members] : [...INITIAL_TEAM_MEMBERS],
-          }))
-        : buildDefaultTeams();
+    const teams = initialData != null ? normaliseTeams(initialData) : buildDefaultTeams();
     this.snapshot = {
       mode,
       titleOverride: initialData?.title ?? "",
@@ -79,13 +83,7 @@ export class ManualSeriesDialogStore {
 
   public reset(initialData?: SeriesInitialData): void {
     const data = initialData ?? this.initialData;
-    const teams =
-      data != null && data.teams.length > 0
-        ? data.teams.map((t) => ({
-            name: t.name,
-            members: t.members.length > 0 ? [...t.members] : [...INITIAL_TEAM_MEMBERS],
-          }))
-        : buildDefaultTeams();
+    const teams = data != null ? normaliseTeams(data) : buildDefaultTeams();
     this.update({
       mode: data != null ? "edit" : "start",
       titleOverride: data?.title ?? "",

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.tsx
@@ -107,14 +107,16 @@ export function ManualSeriesDialog({
   const showBackfillResults = snapshot.backfillState === "done" || snapshot.backfillState === "error";
 
   return (
-    <Dialog open={isOpen} onClose={onClose} title="Start Series">
+    <Dialog open={isOpen} onClose={onClose} title={snapshot.mode === "edit" ? "Edit Series" : "Start Series"}>
       <div className={styles.wrapper}>
         <Alert variant="info">
           Use this when you are running a custom series outside NeatQueue. If Guilty Spark is already monitoring your
           NeatQueue series, setup is automatic and you do not need this flow.
         </Alert>
 
-        <p className={styles.caption}>Creating series for: {trackerLabel}</p>
+        <p className={styles.caption}>
+          {snapshot.mode === "edit" ? "Editing series for" : "Creating series for"}: {trackerLabel}
+        </p>
 
         <section className={styles.section}>
           <h3 className={styles.sectionTitle}>Series details (optional)</h3>
@@ -195,7 +197,7 @@ export function ManualSeriesDialog({
             Cancel
           </Button>
           <Button onClick={onStartSeries} disabled={snapshot.busy}>
-            Start series
+            {snapshot.mode === "edit" ? "Save series" : "Start series"}
           </Button>
         </div>
       </div>

--- a/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
@@ -1,26 +1,50 @@
 import { describe, expect, it, vi } from "vitest";
 import type { IndividualTrackerService } from "../../../../services/individual-tracker/types";
+import { aFakeIndividualTrackerServiceWith } from "../../../../services/individual-tracker/fakes/individual-tracker.fake";
 import {
-  aFakeIndividualTrackerServiceWith,
-  aFakeMatchHistoryEntryWith,
-  aFakeTrackerSearchResultWith,
-} from "../../../../services/individual-tracker/fakes/individual-tracker.fake";
+  aFakeIndividualTrackerViewServiceWith,
+  aFakeTrackerMatchSummaryWith,
+  aFakeTrackerViewStateWith,
+} from "../../../../services/individual-tracker/fakes/view.fake";
 import { ManualSeriesDialogPresenter } from "../manual-series-dialog-presenter";
 import { ManualSeriesDialogStore } from "../manual-series-dialog-store";
 
 function buildPresenter(
   service: IndividualTrackerService,
   onSeriesStarted = vi.fn<() => void>(),
+  viewServiceOverride?: ReturnType<typeof aFakeIndividualTrackerViewServiceWith>,
 ): { presenter: ManualSeriesDialogPresenter; store: ManualSeriesDialogStore } {
   const store = new ManualSeriesDialogStore();
+  const viewService = viewServiceOverride ?? aFakeIndividualTrackerViewServiceWith();
   const presenter = new ManualSeriesDialogPresenter({
     trackerId: "tracker-1",
     store,
     individualTrackerService: service,
+    viewService,
     onSeriesStarted,
   });
   return { presenter, store };
 }
+
+describe("ManualSeriesDialogStore", () => {
+  it("defaults to start mode", () => {
+    const store = new ManualSeriesDialogStore();
+    expect(store.getSnapshot().mode).toBe("start");
+  });
+
+  it("is edit mode when initialData is provided", () => {
+    const store = new ManualSeriesDialogStore({ title: "My Series", subtitle: "Bo3", teams: [] });
+    expect(store.getSnapshot().mode).toBe("edit");
+    expect(store.getSnapshot().titleOverride).toBe("My Series");
+  });
+
+  it("reset restores to initial data in edit mode", () => {
+    const store = new ManualSeriesDialogStore({ title: "Original", subtitle: "Bo3", teams: [] });
+    store.setTitleOverride("Changed");
+    store.reset();
+    expect(store.getSnapshot().titleOverride).toBe("Original");
+  });
+});
 
 describe("ManualSeriesDialogPresenter", () => {
   describe("team editing", () => {
@@ -63,78 +87,53 @@ describe("ManualSeriesDialogPresenter", () => {
   });
 
   describe("backfill discovery", () => {
-    it("resolves shared custom matches across all team members", async () => {
-      const sharedMatch = aFakeMatchHistoryEntryWith({ matchId: "shared-1", category: "custom" });
-      const alphaOnlyMatch = aFakeMatchHistoryEntryWith({ matchId: "alpha-only", category: "custom" });
-      const bravoOnlyMatch = aFakeMatchHistoryEntryWith({ matchId: "bravo-only", category: "custom" });
-
-      const alphaResult = aFakeTrackerSearchResultWith({ gamertag: "Alpha", xuid: "xuid-alpha" });
-      const bravoResult = aFakeTrackerSearchResultWith({ gamertag: "Bravo", xuid: "xuid-bravo" });
-
-      const service = aFakeIndividualTrackerServiceWith({
-        searchResults: [alphaResult, bravoResult],
+    it("loads tracker matches from viewService.getView", async () => {
+      const match = aFakeTrackerMatchSummaryWith({ matchId: "tracker-match-1" });
+      const viewService = aFakeIndividualTrackerViewServiceWith({
+        view: aFakeTrackerViewStateWith({ matches: [match] }),
       });
-
-      const searchSpy = vi.spyOn(service, "searchGamertag");
-      const historySpy = vi.spyOn(service, "getMatchHistory").mockImplementation(async (xuid) => {
-        await Promise.resolve();
-        if (xuid === "xuid-alpha") {
-          return { matches: [sharedMatch, alphaOnlyMatch], suggestedGroupings: [] };
-        }
-        if (xuid === "xuid-bravo") {
-          return { matches: [sharedMatch, bravoOnlyMatch], suggestedGroupings: [] };
-        }
-        return { matches: [], suggestedGroupings: [] };
-      });
-
-      const { presenter, store } = buildPresenter(service);
-      presenter.setTeamMember(0, 0, "Alpha");
-      presenter.setTeamMember(1, 0, "Bravo");
-
-      await new Promise<void>((resolve) => {
-        store.subscribe(() => {
-          const s = store.getSnapshot();
-          if (s.backfillState === "done" || s.backfillState === "error") {
-            resolve();
-          }
-        });
-        presenter.discoverBackfillMatches();
-      });
-
-      expect(searchSpy).toHaveBeenCalledWith("Alpha");
-      expect(searchSpy).toHaveBeenCalledWith("Bravo");
-      expect(historySpy).toHaveBeenCalledWith("xuid-alpha", 0, 25, "custom");
-      expect(historySpy).toHaveBeenCalledWith("xuid-bravo", 0, 25, "custom");
-
-      const snapshot = store.getSnapshot();
-      expect(snapshot.backfillState).toBe("done");
-      expect(snapshot.backfillMatches).toHaveLength(1);
-      expect(snapshot.backfillMatches[0].matchId).toBe("shared-1");
-    });
-
-    it("sets error when no player identities are resolved", async () => {
-      const service = aFakeIndividualTrackerServiceWith({ searchResults: [] });
-      const { presenter, store } = buildPresenter(service);
-      presenter.setTeamMember(0, 0, "Unknown");
-
-      await new Promise<void>((resolve) => {
-        store.subscribe(() => {
-          const s = store.getSnapshot();
-          if (s.backfillState === "done" || s.backfillState === "error") {
-            resolve();
-          }
-        });
-        presenter.discoverBackfillMatches();
-      });
-
-      const snapshot = store.getSnapshot();
-      expect(snapshot.backfillState).toBe("done");
-      expect(snapshot.backfillError).toBeTruthy();
-    });
-
-    it("sets error when no member names are entered", async () => {
       const service = aFakeIndividualTrackerServiceWith();
-      const { presenter, store } = buildPresenter(service);
+      const { presenter, store } = buildPresenter(service, vi.fn(), viewService);
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          const s = store.getSnapshot();
+          if (s.backfillState === "done" || s.backfillState === "error") {
+            resolve();
+          }
+        });
+        presenter.discoverBackfillMatches();
+      });
+
+      expect(store.getSnapshot().backfillState).toBe("done");
+      expect(store.getSnapshot().backfillMatches).toHaveLength(1);
+      expect(store.getSnapshot().backfillMatches[0].matchId).toBe("tracker-match-1");
+    });
+
+    it("sets error when tracker has no matches", async () => {
+      const viewService = aFakeIndividualTrackerViewServiceWith({
+        view: aFakeTrackerViewStateWith({ matches: [] }),
+      });
+      const { presenter, store } = buildPresenter(aFakeIndividualTrackerServiceWith(), vi.fn(), viewService);
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          const s = store.getSnapshot();
+          if (s.backfillState === "done" || s.backfillState === "error") {
+            resolve();
+          }
+        });
+        presenter.discoverBackfillMatches();
+      });
+
+      expect(store.getSnapshot().backfillState).toBe("done");
+      expect(store.getSnapshot().backfillError).toBeTruthy();
+    });
+
+    it("sets error when getView throws", async () => {
+      const viewService = aFakeIndividualTrackerViewServiceWith();
+      vi.spyOn(viewService, "getView").mockRejectedValue(new Error("Network error"));
+      const { presenter, store } = buildPresenter(aFakeIndividualTrackerServiceWith(), vi.fn(), viewService);
 
       await new Promise<void>((resolve) => {
         store.subscribe(() => {
@@ -146,39 +145,8 @@ describe("ManualSeriesDialogPresenter", () => {
         presenter.discoverBackfillMatches();
       });
 
+      expect(store.getSnapshot().backfillState).toBe("error");
       expect(store.getSnapshot().backfillError).toBeTruthy();
-    });
-
-    it("filters out matchmaking matches from backfill candidates", async () => {
-      const customMatch = aFakeMatchHistoryEntryWith({ matchId: "custom-1", category: "custom" });
-      const matchmakingMatch = aFakeMatchHistoryEntryWith({
-        matchId: "mm-1",
-        category: "matchmaking",
-        isMatchmaking: true,
-      });
-
-      const result = aFakeTrackerSearchResultWith({ gamertag: "Alpha", xuid: "xuid-alpha" });
-      const service = aFakeIndividualTrackerServiceWith({ searchResults: [result] });
-
-      vi.spyOn(service, "getMatchHistory").mockResolvedValue({
-        matches: [customMatch, matchmakingMatch],
-        suggestedGroupings: [],
-      });
-
-      const { presenter, store } = buildPresenter(service);
-      presenter.setTeamMember(0, 0, "Alpha");
-
-      await new Promise<void>((resolve) => {
-        store.subscribe(() => {
-          const s = store.getSnapshot();
-          if (s.backfillState === "done" || s.backfillState === "error") {
-            resolve();
-          }
-        });
-        presenter.discoverBackfillMatches();
-      });
-
-      expect(store.getSnapshot().backfillMatches.every((m) => m.category === "custom")).toBe(true);
     });
   });
 
@@ -242,6 +210,59 @@ describe("ManualSeriesDialogPresenter", () => {
 
       expect(startSeriesSpy).not.toHaveBeenCalled();
       expect(store.getSnapshot().busy).toBe(false);
+    });
+  });
+
+  describe("editSeries", () => {
+    it("calls service editSeries with trimmed values then fires onSeriesEdited", async () => {
+      const service = aFakeIndividualTrackerServiceWith();
+      const editSeriesSpy = vi.spyOn(service, "editSeries");
+      const onSeriesEdited = vi.fn<() => void>();
+      const store = new ManualSeriesDialogStore();
+      const presenter = new ManualSeriesDialogPresenter({
+        trackerId: "tracker-1",
+        store,
+        individualTrackerService: service,
+        viewService: aFakeIndividualTrackerViewServiceWith(),
+        onSeriesStarted: vi.fn(),
+        onSeriesEdited,
+      });
+
+      store.setTitleOverride("Eagle vs Cobra");
+      store.setSubtitleOverride("Bo5");
+      presenter.setTeamMember(0, 0, "Alpha");
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          if (!store.getSnapshot().busy) {
+            resolve();
+          }
+        });
+        presenter.editSeries();
+      });
+
+      expect(editSeriesSpy).toHaveBeenCalledWith(
+        "tracker-1",
+        expect.objectContaining({ titleOverride: "Eagle vs Cobra", subtitleOverride: "Bo5" }),
+      );
+      expect(onSeriesEdited).toHaveBeenCalled();
+    });
+
+    it("sets submitError when editSeries fails", async () => {
+      const service = aFakeIndividualTrackerServiceWith();
+      vi.spyOn(service, "editSeries").mockRejectedValue(new Error("Server error"));
+      const { presenter, store } = buildPresenter(service);
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          if (!store.getSnapshot().busy) {
+            resolve();
+          }
+        });
+        presenter.editSeries();
+      });
+
+      expect(store.getSnapshot().submitError).toBe("Server error");
     });
   });
 

--- a/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
@@ -15,12 +15,12 @@ function buildPresenter(
   viewServiceOverride?: ReturnType<typeof aFakeIndividualTrackerViewServiceWith>,
 ): { presenter: ManualSeriesDialogPresenter; store: ManualSeriesDialogStore } {
   const store = new ManualSeriesDialogStore();
-  const viewService = viewServiceOverride ?? aFakeIndividualTrackerViewServiceWith();
+  const individualTrackerViewService = viewServiceOverride ?? aFakeIndividualTrackerViewServiceWith();
   const presenter = new ManualSeriesDialogPresenter({
     trackerId: "tracker-1",
     store,
     individualTrackerService: service,
-    viewService,
+    individualTrackerViewService,
     onSeriesStarted,
   });
   return { presenter, store };
@@ -107,7 +107,7 @@ describe("ManualSeriesDialogPresenter", () => {
   });
 
   describe("backfill discovery", () => {
-    it("loads tracker matches from viewService.getView", async () => {
+    it("loads tracker matches from individualTrackerViewService.getView", async () => {
       const match = aFakeTrackerMatchSummaryWith({ matchId: "tracker-match-1" });
       const viewService = aFakeIndividualTrackerViewServiceWith({
         view: aFakeTrackerViewStateWith({ matches: [match] }),
@@ -287,7 +287,7 @@ describe("ManualSeriesDialogPresenter", () => {
         trackerId: "tracker-1",
         store,
         individualTrackerService: service,
-        viewService: aFakeIndividualTrackerViewServiceWith(),
+        individualTrackerViewService: aFakeIndividualTrackerViewServiceWith(),
         onSeriesStarted: vi.fn(),
         onSeriesEdited,
       });

--- a/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
@@ -334,6 +334,36 @@ describe("ManualSeriesDialogPresenter", () => {
       );
     });
 
+    it("includes teams when all teams are cleared in edit mode (had initial teams)", async () => {
+      const service = aFakeIndividualTrackerServiceWith();
+      const editSeriesSpy = vi.spyOn(service, "editSeries");
+      const store = new ManualSeriesDialogStore({
+        title: "My Series",
+        subtitle: "",
+        teams: [{ name: "Eagles", members: ["Alpha"] }],
+      });
+      const presenter = new ManualSeriesDialogPresenter({
+        trackerId: "tracker-1",
+        store,
+        individualTrackerService: service,
+        individualTrackerViewService: aFakeIndividualTrackerViewServiceWith(),
+        onSeriesStarted: vi.fn(),
+      });
+
+      store.setTeams([{ name: "", members: [] }]);
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          if (!store.getSnapshot().busy) {
+            resolve();
+          }
+        });
+        presenter.editSeries();
+      });
+
+      expect(editSeriesSpy).toHaveBeenCalledWith("tracker-1", expect.objectContaining({ teams: expect.any(Array) }));
+    });
+
     it("includes teams when at least one team has data", async () => {
       const service = aFakeIndividualTrackerServiceWith();
       const editSeriesSpy = vi.spyOn(service, "editSeries");

--- a/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
@@ -110,6 +110,29 @@ describe("ManualSeriesDialogPresenter", () => {
       expect(store.getSnapshot().backfillMatches[0].matchId).toBe("tracker-match-1");
     });
 
+    it("filters out matchmaking matches", async () => {
+      const customMatch = aFakeTrackerMatchSummaryWith({ matchId: "custom-1", isMatchmaking: false });
+      const matchmakingMatch = aFakeTrackerMatchSummaryWith({ matchId: "mm-1", isMatchmaking: true });
+      const viewService = aFakeIndividualTrackerViewServiceWith({
+        view: aFakeTrackerViewStateWith({ matches: [customMatch, matchmakingMatch] }),
+      });
+      const { presenter, store } = buildPresenter(aFakeIndividualTrackerServiceWith(), vi.fn(), viewService);
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          const s = store.getSnapshot();
+          if (s.backfillState === "done" || s.backfillState === "error") {
+            resolve();
+          }
+        });
+        presenter.discoverBackfillMatches();
+      });
+
+      expect(store.getSnapshot().backfillState).toBe("done");
+      expect(store.getSnapshot().backfillMatches).toHaveLength(1);
+      expect(store.getSnapshot().backfillMatches[0].matchId).toBe("custom-1");
+    });
+
     it("sets error when tracker has no matches", async () => {
       const viewService = aFakeIndividualTrackerViewServiceWith({
         view: aFakeTrackerViewStateWith({ matches: [] }),

--- a/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
@@ -44,6 +44,26 @@ describe("ManualSeriesDialogStore", () => {
     store.reset();
     expect(store.getSnapshot().titleOverride).toBe("Original");
   });
+
+  it("falls back to INITIAL_TEAM_MEMBERS slots when a team has no members", () => {
+    const store = new ManualSeriesDialogStore({
+      title: "T",
+      subtitle: "",
+      teams: [{ name: "Alpha", members: [] }],
+    });
+    expect(store.getSnapshot().teams[0].members).toHaveLength(4);
+  });
+
+  it("reset falls back to INITIAL_TEAM_MEMBERS slots when a team has no members", () => {
+    const store = new ManualSeriesDialogStore({
+      title: "T",
+      subtitle: "",
+      teams: [{ name: "Alpha", members: [] }],
+    });
+    store.setTitleOverride("Changed");
+    store.reset();
+    expect(store.getSnapshot().teams[0].members).toHaveLength(4);
+  });
 });
 
 describe("ManualSeriesDialogPresenter", () => {

--- a/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
@@ -133,6 +133,27 @@ describe("ManualSeriesDialogPresenter", () => {
       expect(store.getSnapshot().backfillMatches[0].matchId).toBe("custom-1");
     });
 
+    it("sorts matches most-recent-first", async () => {
+      const older = aFakeTrackerMatchSummaryWith({ matchId: "old", startTime: "2100-01-01T00:00:00.000Z" });
+      const newer = aFakeTrackerMatchSummaryWith({ matchId: "new", startTime: "2100-01-02T00:00:00.000Z" });
+      const viewService = aFakeIndividualTrackerViewServiceWith({
+        view: aFakeTrackerViewStateWith({ matches: [older, newer] }),
+      });
+      const { presenter, store } = buildPresenter(aFakeIndividualTrackerServiceWith(), vi.fn(), viewService);
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          const s = store.getSnapshot();
+          if (s.backfillState === "done" || s.backfillState === "error") {
+            resolve();
+          }
+        });
+        presenter.discoverBackfillMatches();
+      });
+
+      expect(store.getSnapshot().backfillMatches.map((m) => m.matchId)).toEqual(["new", "old"]);
+    });
+
     it("sets error when tracker has no matches", async () => {
       const viewService = aFakeIndividualTrackerViewServiceWith({
         view: aFakeTrackerViewStateWith({ matches: [] }),

--- a/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/manual-series-dialog/tests/manual-series-dialog-presenter.test.ts
@@ -292,6 +292,47 @@ describe("ManualSeriesDialogPresenter", () => {
       expect(onSeriesEdited).toHaveBeenCalled();
     });
 
+    it("omits teams from the request when all teams are blank", async () => {
+      const service = aFakeIndividualTrackerServiceWith();
+      const editSeriesSpy = vi.spyOn(service, "editSeries");
+      const { presenter, store } = buildPresenter(service);
+
+      store.setTitleOverride("Title Only");
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          if (!store.getSnapshot().busy) {
+            resolve();
+          }
+        });
+        presenter.editSeries();
+      });
+
+      expect(editSeriesSpy).toHaveBeenCalledWith(
+        "tracker-1",
+        expect.not.objectContaining({ teams: expect.anything() }),
+      );
+    });
+
+    it("includes teams when at least one team has data", async () => {
+      const service = aFakeIndividualTrackerServiceWith();
+      const editSeriesSpy = vi.spyOn(service, "editSeries");
+      const { presenter, store } = buildPresenter(service);
+
+      presenter.setTeamMember(0, 0, "Alpha");
+
+      await new Promise<void>((resolve) => {
+        store.subscribe(() => {
+          if (!store.getSnapshot().busy) {
+            resolve();
+          }
+        });
+        presenter.editSeries();
+      });
+
+      expect(editSeriesSpy).toHaveBeenCalledWith("tracker-1", expect.objectContaining({ teams: expect.any(Array) }));
+    });
+
     it("sets submitError when editSeries fails", async () => {
       const service = aFakeIndividualTrackerServiceWith();
       vi.spyOn(service, "editSeries").mockRejectedValue(new Error("Server error"));

--- a/pages/src/services/individual-tracker/fakes/individual-tracker.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/individual-tracker.fake.ts
@@ -10,6 +10,7 @@ import type {
   TrackersResponse,
 } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import type {
+  EditSeriesRequest,
   IndividualTrackerConnection,
   IndividualTrackerService,
   StartSeriesRequest,
@@ -267,6 +268,16 @@ export class FakeIndividualTrackerService implements IndividualTrackerService {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public async endSeries(_trackerId: string): Promise<void> {
+    await Promise.resolve();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async editSeries(_trackerId: string, _request: EditSeriesRequest): Promise<void> {
+    await Promise.resolve();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async resumeSeries(_trackerId: string): Promise<void> {
     await Promise.resolve();
   }
 

--- a/pages/src/services/individual-tracker/fakes/view.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/view.fake.ts
@@ -26,6 +26,7 @@ interface FakeMatchOverrides {
   readonly gameVariantCategory?: number;
   readonly outcome?: string;
   readonly score?: string;
+  readonly isMatchmaking?: boolean;
 }
 
 export function aFakeTrackerMatchSummaryWith(overrides: FakeMatchOverrides = {}): TrackerMatchSummary {
@@ -40,6 +41,7 @@ export function aFakeTrackerMatchSummaryWith(overrides: FakeMatchOverrides = {})
     gameVariantCategory: overrides.gameVariantCategory ?? 6,
     outcome: overrides.outcome ?? "Win",
     score: overrides.score ?? "50:42",
+    isMatchmaking: overrides.isMatchmaking ?? false,
   };
 }
 

--- a/pages/src/services/individual-tracker/individual-tracker.ts
+++ b/pages/src/services/individual-tracker/individual-tracker.ts
@@ -36,6 +36,7 @@ import {
 } from "./match-history-helpers";
 import { RealTrackerViewConnection } from "./view-connection";
 import type {
+  EditSeriesRequest,
   IndividualTrackerConnection,
   IndividualTrackerService,
   StartSeriesRequest,
@@ -547,6 +548,34 @@ export class RealIndividualTrackerService implements IndividualTrackerService {
       credentials: "include",
       method: "POST",
     });
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+  }
+
+  public async editSeries(trackerId: string, request: EditSeriesRequest): Promise<void> {
+    const response = await fetch(
+      this.buildUrl(`/api/individual-tracker/manage/${encodeURIComponent(trackerId)}/series`),
+      {
+        credentials: "include",
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+      },
+    );
+    if (!response.ok) {
+      throw await this.readError(response);
+    }
+  }
+
+  public async resumeSeries(trackerId: string): Promise<void> {
+    const response = await fetch(
+      this.buildUrl(`/api/individual-tracker/manage/${encodeURIComponent(trackerId)}/resume-series`),
+      {
+        credentials: "include",
+        method: "POST",
+      },
+    );
     if (!response.ok) {
       throw await this.readError(response);
     }

--- a/pages/src/services/individual-tracker/tests/individual-tracker.test.ts
+++ b/pages/src/services/individual-tracker/tests/individual-tracker.test.ts
@@ -278,4 +278,22 @@ describe("RealIndividualTrackerService", () => {
       expect(result?.customMatchCount).toBeNull();
     });
   });
+
+  it("sends a PATCH request to edit a series", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ success: true }));
+    await service.editSeries("tracker-1", { titleOverride: "New Title", teams: [] });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/api/individual-tracker/manage/tracker-1/series"),
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
+  it("sends a POST request to resume a series", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 200 }));
+    await service.resumeSeries("tracker-1");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/api/individual-tracker/manage/tracker-1/resume-series"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
 });

--- a/pages/src/services/individual-tracker/tests/individual-tracker.test.ts
+++ b/pages/src/services/individual-tracker/tests/individual-tracker.test.ts
@@ -281,7 +281,7 @@ describe("RealIndividualTrackerService", () => {
 
   it("sends a PATCH request to edit a series", async () => {
     fetchSpy.mockResolvedValueOnce(jsonResponse({ success: true }));
-    await service.editSeries("tracker-1", { titleOverride: "New Title", teams: [] });
+    await service.editSeries("tracker-1", { titleOverride: "New Title" });
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.stringContaining("/api/individual-tracker/manage/tracker-1/series"),
       expect.objectContaining({ method: "PATCH" }),

--- a/pages/src/services/individual-tracker/types.ts
+++ b/pages/src/services/individual-tracker/types.ts
@@ -77,7 +77,7 @@ export interface ManualSeriesTeamForm {
 }
 
 export interface EditSeriesRequest {
-  readonly titleOverride?: string;
+  readonly titleOverride?: string | null;
   readonly subtitleOverride?: string | null;
   readonly teams?: readonly ManualSeriesTeamForm[];
 }

--- a/pages/src/services/individual-tracker/types.ts
+++ b/pages/src/services/individual-tracker/types.ts
@@ -79,7 +79,7 @@ export interface ManualSeriesTeamForm {
 export interface EditSeriesRequest {
   readonly titleOverride?: string | null;
   readonly subtitleOverride?: string | null;
-  readonly teams?: readonly [ManualSeriesTeamForm, ...ManualSeriesTeamForm[]];
+  readonly teams?: readonly ManualSeriesTeamForm[];
 }
 
 export interface StartSeriesRequest {

--- a/pages/src/services/individual-tracker/types.ts
+++ b/pages/src/services/individual-tracker/types.ts
@@ -79,7 +79,7 @@ export interface ManualSeriesTeamForm {
 export interface EditSeriesRequest {
   readonly titleOverride?: string | null;
   readonly subtitleOverride?: string | null;
-  readonly teams?: readonly ManualSeriesTeamForm[];
+  readonly teams?: readonly [ManualSeriesTeamForm, ...ManualSeriesTeamForm[]];
 }
 
 export interface StartSeriesRequest {

--- a/pages/src/services/individual-tracker/types.ts
+++ b/pages/src/services/individual-tracker/types.ts
@@ -76,6 +76,12 @@ export interface ManualSeriesTeamForm {
   readonly members: readonly string[];
 }
 
+export interface EditSeriesRequest {
+  readonly titleOverride?: string;
+  readonly subtitleOverride?: string | null;
+  readonly teams?: readonly ManualSeriesTeamForm[];
+}
+
 export interface StartSeriesRequest {
   readonly trackerId: string;
   readonly titleOverride: string | null;
@@ -147,5 +153,7 @@ export interface IndividualTrackerService {
   getActiveTrackerState(xuid: string): Promise<TrackerStatusResponse>;
   deleteTracker(trackerId: string): Promise<void>;
   endSeries(trackerId: string): Promise<void>;
+  editSeries(trackerId: string, request: EditSeriesRequest): Promise<void>;
+  resumeSeries(trackerId: string): Promise<void>;
   connectToTracker(userId: string, trackerId: string): IndividualTrackerConnection;
 }

--- a/shared/src/contracts/individual-tracker/tests/view.test.ts
+++ b/shared/src/contracts/individual-tracker/tests/view.test.ts
@@ -26,6 +26,7 @@ describe("trackerViewContract", () => {
           gameVariantCategory: 6,
           outcome: "Win",
           score: "50:42",
+          isMatchmaking: false,
         },
       ],
       series: [
@@ -100,6 +101,7 @@ describe("trackerViewMessageSchema", () => {
           gameVariantCategory: 6,
           outcome: "Win",
           score: "50:42",
+          isMatchmaking: false,
         },
       ],
       series: [],

--- a/shared/src/contracts/individual-tracker/view.ts
+++ b/shared/src/contracts/individual-tracker/view.ts
@@ -14,6 +14,7 @@ export const trackerMatchSummarySchema = z.object({
   gameVariantCategory: z.number(),
   outcome: z.string(),
   score: z.string(),
+  isMatchmaking: z.boolean(),
 });
 export type TrackerMatchSummary = z.infer<typeof trackerMatchSummarySchema>;
 

--- a/shared/src/halo/duration.ts
+++ b/shared/src/halo/duration.ts
@@ -50,3 +50,8 @@ export function getReadableDuration(duration: string, locale?: string): string {
 
   return output.length ? output.join(" ") : "0s";
 }
+
+export function getDurationBetween(startIso: string, endIso: string): string {
+  const ms = new Date(endIso).getTime() - new Date(startIso).getTime();
+  return getReadableDuration(getDurationInIsoString(Math.max(0, Math.floor(ms / 1000))));
+}

--- a/shared/src/halo/duration.ts
+++ b/shared/src/halo/duration.ts
@@ -1,3 +1,4 @@
+import { differenceInSeconds } from "date-fns";
 import * as tinyduration from "tinyduration";
 
 export function getDurationInSeconds(duration: string): number {
@@ -52,6 +53,6 @@ export function getReadableDuration(duration: string, locale?: string): string {
 }
 
 export function getDurationBetween(startIso: string, endIso: string): string {
-  const ms = new Date(endIso).getTime() - new Date(startIso).getTime();
-  return getReadableDuration(getDurationInIsoString(Math.max(0, Math.floor(ms / 1000))));
+  const seconds = Math.max(0, differenceInSeconds(new Date(endIso), new Date(startIso)));
+  return getReadableDuration(getDurationInIsoString(seconds));
 }


### PR DESCRIPTION
## Summary

Stacked on [#532](https://github.com/davidhouweling/guilty-spark/pull/532) (NQ-3a).

Adds the pages service layer and dialog UI wiring needed to edit and resume an active series from the manager page.

- **`IndividualTrackerService`**: adds `editSeries(trackerId, request)` and `resumeSeries(trackerId)` methods with correct `/manage/` routes; fake and test coverage included
- **`TrackerMatchSummary`**: adds `isMatchmaking: boolean` to the view schema and threads it through the DO's `toViewState` and the route mapper — required so the backfill picker can filter out matchmaking matches
- **`ManualSeriesDialogStore`**: extends with `mode: "start" | "edit"`, `SeriesInitialData` for pre-population, and `reset(initialData?)` that accepts fresh data at call time to avoid stale state when `activeSeriesContext` changes after an edit
- **`ManualSeriesDialogPresenter`**: replaces the Halo API backfill (search + match history intersection per player) with a single `viewService.getView()` call; adds `editSeries()` action; filters matchmaking matches from the backfill candidate list
- **`ManualSeriesDialogSection`** (`create.tsx`): threads `viewService`, `initialData`, and `onSeriesEdited`; uses `useRef` to stabilise callbacks; dispatches to `editSeries()` or `startSeries()` based on `snapshot.mode`
- **Manager hierarchy**: threads `IndividualTrackerViewService` through `individual-tracker-manager` app → page → live-trackers section → dialog section

## Test plan

- [ ] Open manager page with an active series — edit dialog opens pre-populated with title, subtitle, and team members
- [ ] Edit title only — subtitle and teams preserved server-side
- [ ] Clear subtitle — subtitle set to null; title unchanged
- [ ] Edit teams — members updated; matchIds/startedAt unchanged
- [ ] Submit with `teams: []` is rejected by schema (400)
- [ ] Discover backfill — only custom-game matches appear (matchmaking filtered out)
- [ ] Resume series — restores last completed series; UI nudge clears
- [ ] Re-open edit dialog after editing — form shows updated values, not stale pre-edit data

🤖 Generated with [Claude Code](https://claude.com/claude-code)