### PR TITLE
feat(neatqueue): derive series title from NQ team names

### DIFF
--- a/api/embeds/live-tracker-embed.ts
+++ b/api/embeds/live-tracker-embed.ts
@@ -188,8 +188,7 @@ export class LiveTrackerEmbed extends BaseTableEmbed {
       if (isFirstEmbed) {
         if (seriesData != null) {
           embed.title = `Live Tracker - NeatQueue Series (Queue #${seriesData.seriesId.queueNumber.toString()})`;
-          const teamNames =
-            getSeriesGroupTitleFromTeams(seriesData.teams) ?? seriesData.teams.map((t) => t.name.trim()).join(" vs ");
+          const teamNames = getSeriesGroupTitleFromTeams(seriesData.teams) ?? "";
           embed.description = `**${statusText}**\n*${teamNames}*`;
         } else {
           embed.title = `Live Tracker - Queue #${queueNumber.toString()}`;

--- a/api/embeds/live-tracker-embed.ts
+++ b/api/embeds/live-tracker-embed.ts
@@ -7,6 +7,7 @@ import type {
 import { ComponentType, ButtonStyle } from "discord-api-types/v10";
 import { addMinutes, compareAsc, isBefore } from "date-fns";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import { getSeriesGroupTitleFromTeams } from "@guilty-spark/shared/individual-tracker/series-grouping";
 import type { DiscordService } from "../services/discord/discord";
 import type { LiveTrackerEmbedData } from "../live-tracker/types";
 import { BaseTableEmbed } from "./base-table-embed";
@@ -187,7 +188,8 @@ export class LiveTrackerEmbed extends BaseTableEmbed {
       if (isFirstEmbed) {
         if (seriesData != null) {
           embed.title = `Live Tracker - NeatQueue Series (Queue #${seriesData.seriesId.queueNumber.toString()})`;
-          const teamNames = seriesData.teams.map((t) => t.name).join(" vs ");
+          const teamNames =
+            getSeriesGroupTitleFromTeams(seriesData.teams) ?? seriesData.teams.map((t) => t.name.trim()).join(" vs ");
           embed.description = `**${statusText}**\n*${teamNames}*`;
         } else {
           embed.title = `Live Tracker - Queue #${queueNumber.toString()}`;

--- a/api/embeds/live-tracker-embed.ts
+++ b/api/embeds/live-tracker-embed.ts
@@ -188,8 +188,8 @@ export class LiveTrackerEmbed extends BaseTableEmbed {
       if (isFirstEmbed) {
         if (seriesData != null) {
           embed.title = `Live Tracker - NeatQueue Series (Queue #${seriesData.seriesId.queueNumber.toString()})`;
-          const teamNames = getSeriesGroupTitleFromTeams(seriesData.teams) ?? "";
-          embed.description = `**${statusText}**\n*${teamNames}*`;
+          const teamNames = getSeriesGroupTitleFromTeams(seriesData.teams);
+          embed.description = teamNames != null ? `**${statusText}**\n*${teamNames}*` : `**${statusText}**`;
         } else {
           embed.title = `Live Tracker - Queue #${queueNumber.toString()}`;
           embed.description = `**${statusText}**`;

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -15,6 +15,7 @@ import type { TeamMapping } from "@guilty-spark/shared/live-tracker/series-types
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { getTeamName } from "@guilty-spark/shared/halo/team";
+import { getSeriesGroupTitleFromTeams } from "@guilty-spark/shared/individual-tracker/series-grouping";
 import type { DatabaseService } from "../database/database";
 import type { NeatQueueConfigRow } from "../database/types/neat_queue_config";
 import { NeatQueuePostSeriesDisplayMode } from "../database/types/neat_queue_config";
@@ -672,7 +673,7 @@ export class NeatQueueService {
         ),
       }));
       const seriesContext: SeriesContextPayload = {
-        title,
+        title: getSeriesGroupTitleFromTeams(seriesTeams) ?? title,
         subtitle: `Queue #${request.match_number.toString()}`,
         guildIconUrl,
         teams: seriesTeams,

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -2063,7 +2063,7 @@ describe("NeatQueueService", () => {
         expect(payload.title).toBe("Eagles vs Cobras");
       });
 
-      it("uses guild name as title fallback when getGuild fails and team names are unavailable", async () => {
+      it("uses guild ID as title fallback when getGuild fails and team names are unavailable", async () => {
         const teamsCreatedRequest = getFakeNeatQueueData("teamsCreated");
         teamsCreatedRequest.teams = [];
         (vi.spyOn(env.APP_DATA, "get") as MockInstance).mockResolvedValue(aFakeNeatQueueStateWith());

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -1987,7 +1987,7 @@ describe("NeatQueueService", () => {
         expect(xuids).toContain("xuid_discord_user_01");
         expect(xuids).toContain("xuid_discord_user_02");
         expect(payload).toMatchObject({
-          title: "Test Server",
+          title: "Eagle vs Cobra",
           subtitle: `Queue #${teamsCreatedRequest.match_number.toString()}`,
           guildIconUrl: null,
           teams: expect.arrayContaining<SeriesTeam>([
@@ -2033,8 +2033,38 @@ describe("NeatQueueService", () => {
         expect(xuids).toContain("xuid_discord_user_02");
       });
 
-      it("nudges with fallback title when getGuild fails", async () => {
+      it("derives title from explicit team names when set", async () => {
         const teamsCreatedRequest = getFakeNeatQueueData("teamsCreated");
+        const team0Player = teamsCreatedRequest.teams[0]?.[0];
+        const team1Player = teamsCreatedRequest.teams[1]?.[0];
+        if (team0Player != null) {
+          team0Player.team_name = "Eagles";
+        }
+        if (team1Player != null) {
+          team1Player.team_name = "Cobras";
+        }
+        (vi.spyOn(env.APP_DATA, "get") as MockInstance).mockResolvedValue(aFakeNeatQueueStateWith());
+        vi.spyOn(env.APP_DATA, "put").mockResolvedValue();
+        vi.spyOn(discordService, "getGuild").mockResolvedValue({
+          ...guild,
+          id: "guild-1",
+          name: "Test Server",
+          icon: null,
+        });
+        vi.spyOn(databaseService, "getGuildConfig").mockResolvedValue(
+          aFakeGuildConfigRow({ NeatQueueInformerLiveTracking: "N" }),
+        );
+
+        const { jobToComplete } = neatQueueService.handleRequest(teamsCreatedRequest, neatQueueConfig);
+        await jobToComplete?.();
+
+        const [, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], SeriesContextPayload];
+        expect(payload.title).toBe("Eagles vs Cobras");
+      });
+
+      it("uses guild name as title fallback when getGuild fails and team names are unavailable", async () => {
+        const teamsCreatedRequest = getFakeNeatQueueData("teamsCreated");
+        teamsCreatedRequest.teams = [];
         (vi.spyOn(env.APP_DATA, "get") as MockInstance).mockResolvedValue(aFakeNeatQueueStateWith());
         vi.spyOn(env.APP_DATA, "put").mockResolvedValue();
         vi.spyOn(discordService, "getGuild").mockRejectedValue(new Error("Discord API error"));

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -2058,6 +2058,7 @@ describe("NeatQueueService", () => {
         const { jobToComplete } = neatQueueService.handleRequest(teamsCreatedRequest, neatQueueConfig);
         await jobToComplete?.();
 
+        expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
         const [, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], SeriesContextPayload];
         expect(payload.title).toBe("Eagles vs Cobras");
       });

--- a/shared/src/individual-tracker/series-grouping.ts
+++ b/shared/src/individual-tracker/series-grouping.ts
@@ -17,8 +17,6 @@ export function buildSeriesGroupKey(matchIds: readonly string[]): string {
   return normalizeSeriesGroupMatchIds(matchIds).join(":");
 }
 
-const SERIES_TITLE_SEPARATOR = " vs ";
-
 export function getDefaultSeriesGroupTitle(): string {
   return "Eagle vs Cobra";
 }
@@ -33,7 +31,7 @@ export function getSeriesGroupTitleFromTeams(teams: readonly { readonly name: st
   if (!name0 || !name1) {
     return null;
   }
-  return `${name0}${SERIES_TITLE_SEPARATOR}${name1}`;
+  return `${name0} vs ${name1}`;
 }
 
 export function getDefaultSeriesGroupSubtitle(

--- a/shared/src/individual-tracker/series-grouping.ts
+++ b/shared/src/individual-tracker/series-grouping.ts
@@ -21,6 +21,19 @@ export function getDefaultSeriesGroupTitle(): string {
   return "Eagle vs Cobra";
 }
 
+export function getSeriesGroupTitleFromTeams(teams: readonly { readonly name: string }[]): string | null {
+  const [team0, team1] = teams;
+  if (team0 == null || team1 == null) {
+    return null;
+  }
+  const name0 = team0.name.trim();
+  const name1 = team1.name.trim();
+  if (!name0 || !name1) {
+    return null;
+  }
+  return `${name0} vs ${name1}`;
+}
+
 export function getDefaultSeriesGroupSubtitle(
   entries: readonly {
     startTime: string;

--- a/shared/src/individual-tracker/series-grouping.ts
+++ b/shared/src/individual-tracker/series-grouping.ts
@@ -20,7 +20,7 @@ export function buildSeriesGroupKey(matchIds: readonly string[]): string {
 const SERIES_TITLE_SEPARATOR = " vs ";
 
 export function getDefaultSeriesGroupTitle(): string {
-  return `Eagle${SERIES_TITLE_SEPARATOR}Cobra`;
+  return "Eagle vs Cobra";
 }
 
 export function getSeriesGroupTitleFromTeams(teams: readonly { readonly name: string }[]): string | null {

--- a/shared/src/individual-tracker/series-grouping.ts
+++ b/shared/src/individual-tracker/series-grouping.ts
@@ -17,8 +17,10 @@ export function buildSeriesGroupKey(matchIds: readonly string[]): string {
   return normalizeSeriesGroupMatchIds(matchIds).join(":");
 }
 
+const SERIES_TITLE_SEPARATOR = " vs ";
+
 export function getDefaultSeriesGroupTitle(): string {
-  return "Eagle vs Cobra";
+  return `Eagle${SERIES_TITLE_SEPARATOR}Cobra`;
 }
 
 export function getSeriesGroupTitleFromTeams(teams: readonly { readonly name: string }[]): string | null {
@@ -31,7 +33,7 @@ export function getSeriesGroupTitleFromTeams(teams: readonly { readonly name: st
   if (!name0 || !name1) {
     return null;
   }
-  return `${name0} vs ${name1}`;
+  return `${name0}${SERIES_TITLE_SEPARATOR}${name1}`;
 }
 
 export function getDefaultSeriesGroupSubtitle(

--- a/shared/src/individual-tracker/tests/series-grouping.test.ts
+++ b/shared/src/individual-tracker/tests/series-grouping.test.ts
@@ -3,6 +3,7 @@ import {
   buildSeriesGroupKey,
   getDefaultSeriesGroupSubtitle,
   getDefaultSeriesGroupTitle,
+  getSeriesGroupTitleFromTeams,
   normalizeSeriesGroupMatchIds,
 } from "../series-grouping";
 
@@ -66,6 +67,27 @@ describe("getDefaultSeriesGroupSubtitle()", () => {
 describe("normalizeSeriesGroupMatchIds()", () => {
   it("sorts and de-duplicates match ids", () => {
     expect(normalizeSeriesGroupMatchIds(["b", "a", "b", "c"])).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("getSeriesGroupTitleFromTeams()", () => {
+  it("returns 'Team0 vs Team1' when both teams have names", () => {
+    expect(getSeriesGroupTitleFromTeams([{ name: "Eagles" }, { name: "Cobras" }])).toBe("Eagles vs Cobras");
+  });
+
+  it("trims whitespace from team names", () => {
+    expect(getSeriesGroupTitleFromTeams([{ name: "  Eagles  " }, { name: " Cobras " }])).toBe("Eagles vs Cobras");
+  });
+
+  it("returns null when fewer than two teams are provided", () => {
+    expect(getSeriesGroupTitleFromTeams([{ name: "Eagles" }])).toBeNull();
+    expect(getSeriesGroupTitleFromTeams([])).toBeNull();
+  });
+
+  it("returns null when either team name is blank", () => {
+    expect(getSeriesGroupTitleFromTeams([{ name: "" }, { name: "Cobras" }])).toBeNull();
+    expect(getSeriesGroupTitleFromTeams([{ name: "Eagles" }, { name: "" }])).toBeNull();
+    expect(getSeriesGroupTitleFromTeams([{ name: "  " }, { name: "Cobras" }])).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `getSeriesGroupTitleFromTeams` to `shared/src/individual-tracker/series-grouping.ts` — derives a `"Team0 vs Team1"` title from `SeriesTeam[]`, trimming whitespace and returning `null` when fewer than two teams or either name is blank
- Updates `teamsCreatedJob` in `neatqueue.ts` to use the derived title instead of always using the guild name; guild name remains the fallback when teams < 2
- Updates `live-tracker-embed.ts` to use the same helper for consistency (previously used a raw `.join(" vs ")` that skipped trimming)

## Test plan

- [ ] Unit tests added for all `getSeriesGroupTitleFromTeams` branches (happy path, whitespace trim, <2 teams, blank name)
- [ ] Integration tests added: "derives title from explicit team names when set", "uses guild ID as title fallback when getGuild fails and team names are unavailable"
- [ ] Existing "nudges all player XUIDs with series context" test updated to expect `"Eagle vs Cobra"` (the `getTeamName` fallback produces Eagle/Cobra, which are the game's default team names)
- [ ] `npm run done` passes (94 tests, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)