### PR TITLE
feat(stats): add /stats fix command scaffolding (PR train 1/4)

### DIFF
--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -4,6 +4,7 @@ import type {
   APIEmbed,
   APIInteractionResponseDeferredChannelMessageWithSource,
   APIMessageComponentButtonInteraction,
+  APIMessageComponentSelectMenuInteraction,
 } from "discord-api-types/v10";
 import {
   EmbedType,
@@ -37,6 +38,10 @@ import { create } from "../../embeds/stats/create";
 export enum InteractionButton {
   Retry = "btn_stats_retry",
   LoadGames = "btn_stats_load_games",
+  FixPlayerSelect = "btn_stats_fix_player_select",
+  FixGamesSelect = "btn_stats_fix_games_select",
+  FixConfirm = "btn_stats_fix_confirm",
+  FixCancel = "btn_stats_fix_cancel",
 }
 
 export class StatsCommand extends BaseCommand {
@@ -86,6 +91,19 @@ export class StatsCommand extends BaseCommand {
             },
           ],
         },
+        {
+          type: ApplicationCommandOptionType.Subcommand,
+          name: "fix",
+          description: "Manually correct a series by selecting custom games",
+          options: [
+            {
+              type: ApplicationCommandOptionType.Integer,
+              name: "queue_number",
+              description: "The queue number to fix (optional if running from queue thread)",
+              required: false,
+            },
+          ],
+        },
       ],
     },
   ];
@@ -125,6 +143,9 @@ export class StatsCommand extends BaseCommand {
           case "match": {
             return this.handleMatchSubCommand(interaction, subcommand.mappedOptions);
           }
+          case "fix": {
+            return this.handleFixSubCommand(interaction, subcommand.mappedOptions);
+          }
           default: {
             throw new Error("Unknown subcommand");
           }
@@ -147,6 +168,38 @@ export class StatsCommand extends BaseCommand {
                 type: InteractionResponseType.DeferredMessageUpdate,
               },
               jobToComplete: async () => this.loadGamesJob(interaction as APIMessageComponentButtonInteraction),
+            };
+          }
+          case InteractionButton.FixPlayerSelect.toString(): {
+            return {
+              response: {
+                type: InteractionResponseType.DeferredMessageUpdate,
+              },
+              jobToComplete: async () => this.handleFixPlayerSelectJob(interaction as APIMessageComponentSelectMenuInteraction),
+            };
+          }
+          case InteractionButton.FixGamesSelect.toString(): {
+            return {
+              response: {
+                type: InteractionResponseType.DeferredMessageUpdate,
+              },
+              jobToComplete: async () => this.handleFixGamesSelectJob(interaction as APIMessageComponentSelectMenuInteraction),
+            };
+          }
+          case InteractionButton.FixConfirm.toString(): {
+            return {
+              response: {
+                type: InteractionResponseType.DeferredMessageUpdate,
+              },
+              jobToComplete: async () => this.handleFixConfirmationJob(interaction as APIMessageComponentButtonInteraction),
+            };
+          }
+          case InteractionButton.FixCancel.toString(): {
+            return {
+              response: {
+                type: InteractionResponseType.DeferredMessageUpdate,
+              },
+              jobToComplete: async () => this.handleFixCancelJob(interaction as APIMessageComponentButtonInteraction),
             };
           }
           default: {
@@ -695,5 +748,40 @@ export class StatsCommand extends BaseCommand {
         ]),
       );
     }
+  }
+
+  private handleFixSubCommand(
+    _interaction: APIApplicationCommandInteraction,
+    _options: Map<string, APIApplicationCommandInteractionDataBasicOption["value"]>,
+  ): ExecuteResponse {
+    throw new Error("handleFixSubCommand not implemented");
+  }
+
+  private fixSubCommandJob(_interaction: APIApplicationCommandInteraction, _queueNumber: number): Promise<void> {
+    throw new Error("fixSubCommandJob not implemented");
+  }
+
+  private fixSubCommandInThreadJob(_interaction: APIApplicationCommandInteraction): Promise<void> {
+    throw new Error("fixSubCommandInThreadJob not implemented");
+  }
+
+  private fixCommandStartFlow(_interaction: APIApplicationCommandInteraction, _queueData: unknown): Promise<void> {
+    throw new Error("fixCommandStartFlow not implemented");
+  }
+
+  private async handleFixPlayerSelectJob(_interaction: APIMessageComponentSelectMenuInteraction): Promise<void> {
+    throw new Error("handleFixPlayerSelectJob not implemented");
+  }
+
+  private async handleFixGamesSelectJob(_interaction: APIMessageComponentSelectMenuInteraction): Promise<void> {
+    throw new Error("handleFixGamesSelectJob not implemented");
+  }
+
+  private async handleFixConfirmationJob(_interaction: APIMessageComponentButtonInteraction): Promise<void> {
+    throw new Error("handleFixConfirmationJob not implemented");
+  }
+
+  private async handleFixCancelJob(_interaction: APIMessageComponentButtonInteraction): Promise<void> {
+    throw new Error("handleFixCancelJob not implemented");
   }
 }


### PR DESCRIPTION
## 1. context

This is PR 1 of a planned PR train to add manual NeatQueue stats correction via a new /stats fix flow.
The full feature spans command routing, service-layer helpers, and interactive correction steps, so it is being split into focused, reviewable PRs.

## 2. overview of the feature

Add a guided manual correction path for series stats when automatic resolution fails.
This first step introduces command and interaction scaffolding only, preparing the route and component IDs needed for later PRs.

## 3. what this PR does

- Adds /stats fix subcommand with optional queue_number
- Adds fix interaction button/select identifiers
- Wires fix subcommand dispatch in stats command interaction handler
- Wires message component routing for player select, games select, confirm, and cancel callbacks
- Adds initial fix handler placeholders to establish the execution path shape

## 4. a table presenting the PR train

| Step | Branch | PR | Scope | Status |
|---|---|---|---|---|
| 1 | stats-fix-command | This PR | Command structure and interaction routing | Open |
| 2 | stats-fix-pr2-services-tests | Follow-up PR | Service helper methods plus unit tests | Open |
| 3 | stats-fix-pr3-subcommand-player-select | Planned | Subcommand entry path and player selection flow | Planned |
| 4 | stats-fix-pr4-games-confirmation | Planned | Games selection, preview, confirmation, and final rewrite flow | Planned |
