### PR TITLE
feat(stats-fix): add service helpers and tests (PR train 2/4)

### DIFF
--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -757,18 +757,6 @@ export class StatsCommand extends BaseCommand {
     throw new Error("handleFixSubCommand not implemented");
   }
 
-  private fixSubCommandJob(_interaction: APIApplicationCommandInteraction, _queueNumber: number): Promise<void> {
-    throw new Error("fixSubCommandJob not implemented");
-  }
-
-  private fixSubCommandInThreadJob(_interaction: APIApplicationCommandInteraction): Promise<void> {
-    throw new Error("fixSubCommandInThreadJob not implemented");
-  }
-
-  private fixCommandStartFlow(_interaction: APIApplicationCommandInteraction, _queueData: unknown): Promise<void> {
-    throw new Error("fixCommandStartFlow not implemented");
-  }
-
   private async handleFixPlayerSelectJob(_interaction: APIMessageComponentSelectMenuInteraction): Promise<void> {
     throw new Error("handleFixPlayerSelectJob not implemented");
   }

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -986,6 +986,50 @@ export class DiscordService {
     return Preconditions.checkExists(this.userCache.get(userId));
   }
 
+  async computeMemberPermissions(guildId: string, userId: string): Promise<bigint> {
+    const [guild, guildMember] = await Promise.all([this.getGuild(guildId), this.getGuildMember(guildId, userId)]);
+
+    const everyoneRole = guild.roles.find((role) => role.id === guild.id);
+    let permissions = BigInt(everyoneRole?.permissions ?? "0");
+
+    for (const roleId of guildMember.roles) {
+      if (roleId === guild.id) {
+        continue;
+      }
+
+      const role = guild.roles.find((guildRole) => guildRole.id === roleId);
+      if (role == null) {
+        continue;
+      }
+
+      permissions |= BigInt(role.permissions);
+    }
+
+    if ((permissions & PermissionFlagsBits.Administrator) !== 0n) {
+      return ~0n;
+    }
+
+    return permissions;
+  }
+
+  async setInteractionMetadata(token: string, data: Record<string, unknown>): Promise<void> {
+    await this.env.APP_DATA.put(`interactionMetadata:${token}`, JSON.stringify(data), {
+      expirationTtl: TimeInSeconds["1_HOUR"],
+    });
+  }
+
+  async getInteractionMetadata<T extends Record<string, unknown>>(token: string): Promise<T | null> {
+    return this.env.APP_DATA.get<T>(`interactionMetadata:${token}`, "json");
+  }
+
+  async getThreads(channelId: string): Promise<APIChannel[]> {
+    const response = await this.fetch<{ threads: APIChannel[] }>(`/channels/${channelId}/threads/active`, {
+      method: "GET",
+    });
+
+    return response.threads;
+  }
+
   async getMessage(channelId: string, messageId: string): Promise<APIMessage> {
     return this.fetch<APIMessage>(Routes.channelMessage(channelId, messageId), {
       method: "GET",

--- a/api/services/discord/tests/discord.test.ts
+++ b/api/services/discord/tests/discord.test.ts
@@ -4,6 +4,7 @@ import type { verifyKey } from "discord-interactions";
 import type {
   APIApplicationCommandInteraction,
   APIChannel,
+  APIGuild,
   APIGuildMember,
   APIInteraction,
   APIMessage,
@@ -11,9 +12,11 @@ import type {
 import {
   ApplicationCommandOptionType,
   ApplicationCommandType,
+  ChannelType,
   ComponentType,
   InteractionType,
   Locale,
+  PermissionFlagsBits,
   MessageSearchAuthorType,
   MessageSearchSortMode,
 } from "discord-api-types/v10";
@@ -1220,6 +1223,113 @@ describe("DiscordService", () => {
       delete cloneInteraction.user;
 
       expect(() => discordService.getDiscordUserId(cloneInteraction)).toThrow("No user found on interaction");
+    });
+  });
+
+  describe("computeMemberPermissions()", () => {
+    it("combines @everyone and member role permissions", async () => {
+      const getGuildSpy = vi.spyOn(discordService, "getGuild").mockResolvedValue({
+        id: "fake-guild-id",
+        roles: [
+          {
+            id: "fake-guild-id",
+            name: "@everyone",
+            permissions: "1",
+          },
+          {
+            id: "mod-role",
+            name: "mod",
+            permissions: "4",
+          },
+        ],
+      } as APIGuild);
+
+      const getGuildMemberSpy = vi
+        .spyOn(discordService, "getGuildMember")
+        .mockResolvedValue(aGuildMemberWith({ roles: ["fake-guild-id", "mod-role"] }));
+
+      const permissions = await discordService.computeMemberPermissions("fake-guild-id", "fake-user-id");
+
+      expect(getGuildSpy).toHaveBeenCalledWith("fake-guild-id");
+      expect(getGuildMemberSpy).toHaveBeenCalledWith("fake-guild-id", "fake-user-id");
+      expect(permissions).toEqual(5n);
+    });
+
+    it("returns all permissions when administrator permission is present", async () => {
+      vi.spyOn(discordService, "getGuild").mockResolvedValue({
+        id: "fake-guild-id",
+        roles: [
+          {
+            id: "fake-guild-id",
+            name: "@everyone",
+            permissions: "1",
+          },
+          {
+            id: "admin-role",
+            name: "admin",
+            permissions: PermissionFlagsBits.Administrator.toString(),
+          },
+        ],
+      } as APIGuild);
+
+      vi.spyOn(discordService, "getGuildMember").mockResolvedValue(
+        aGuildMemberWith({ roles: ["fake-guild-id", "admin-role"] }),
+      );
+
+      const permissions = await discordService.computeMemberPermissions("fake-guild-id", "fake-user-id");
+
+      expect(permissions).toEqual(~0n);
+    });
+  });
+
+  describe("interaction metadata", () => {
+    it("stores interaction metadata in KV", async () => {
+      const putSpy = vi.spyOn(env.APP_DATA, "put");
+
+      await discordService.setInteractionMetadata("token-1", { queueNumber: 777, userId: "user-1" });
+
+      expect(putSpy).toHaveBeenCalledWith(
+        "interactionMetadata:token-1",
+        '{"queueNumber":777,"userId":"user-1"}',
+        { expirationTtl: 3600 },
+      );
+    });
+
+    it("retrieves interaction metadata from KV", async () => {
+      const getSpy = vi.spyOn(env.APP_DATA, "get").mockResolvedValue({ queueNumber: 888 } as never);
+
+      const metadata = await discordService.getInteractionMetadata<{ queueNumber: number }>("token-2");
+
+      expect(getSpy).toHaveBeenCalledWith("interactionMetadata:token-2", "json");
+      expect(metadata).toEqual({ queueNumber: 888 });
+    });
+  });
+
+  describe("getThreads()", () => {
+    it("fetches active threads for a channel", async () => {
+      const fakeThread: APIChannel = {
+        id: "thread-1",
+        type: ChannelType.PublicThread,
+      } as APIChannel;
+
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ threads: [fakeThread] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const threads = await discordService.getThreads("fake-channel");
+
+      expect(mockFetch).toHaveBeenCalledWith("https://discord.com/api/v10/channels/fake-channel/threads/active", {
+        body: null,
+        headers: new Headers({
+          Authorization: "Bot DISCORD_TOKEN",
+          "content-type": "application/json;charset=UTF-8",
+        }),
+        method: "GET",
+      });
+      expect(threads).toEqual([fakeThread]);
     });
   });
 

--- a/api/services/halo/halo.ts
+++ b/api/services/halo/halo.ts
@@ -582,6 +582,10 @@ export class HaloService {
     }
   }
 
+  async getPlayerCustomGames(playerXuid: string, count = 25): Promise<PlayerMatchHistory[]> {
+    return this.getPlayerMatches(playerXuid, MatchType.Custom, count, 0);
+  }
+
   async getEnrichedMatchHistory(
     gamertag: string,
     locale: string,

--- a/api/services/halo/tests/halo.test.ts
+++ b/api/services/halo/tests/halo.test.ts
@@ -1783,6 +1783,25 @@ describe("Halo service", () => {
     });
   });
 
+  describe("getPlayerCustomGames()", () => {
+    it("fetches custom matches for a player xuid", async () => {
+      const customGames = [
+        aFakePlayerMatchHistoryWith({ MatchId: "custom-1" }),
+        aFakePlayerMatchHistoryWith({ MatchId: "custom-2" }),
+      ];
+      infiniteClient.getPlayerMatches.mockResolvedValue(customGames);
+
+      const response = await haloService.getPlayerCustomGames("0000000000001", 12);
+
+      expect(infiniteClient.getPlayerMatches).toHaveBeenCalledWith("0000000000001", MatchType.Custom, 12, 0, {
+        cf: {
+          cacheTtlByStatus: { "200-299": 60, 404: 60, "500-599": 0 },
+        },
+      });
+      expect(response).toEqual(customGames);
+    });
+  });
+
   describe("getMatchDetails()", () => {
     it("returns the match details", async () => {
       const matchDetails = await haloService.getMatchDetails(["d81554d7-ddfe-44da-a6cb-000000000ctf"]);


### PR DESCRIPTION
## 1. context

This is PR 2 of the /stats fix PR train.
PR 1 introduced command-level scaffolding; this PR adds service-layer building blocks required by the interactive correction flow.

## 2. overview of the feature

Support manual stats correction with explicit helper APIs for permission checks, interaction metadata persistence, thread discovery, and custom-game retrieval.
All additions are covered by unit tests in this PR.

## 3. what this PR does

- Adds DiscordService.computeMemberPermissions for guild-level permission resolution (including Administrator override)
- Adds DiscordService.setInteractionMetadata and DiscordService.getInteractionMetadata backed by APP_DATA KV
- Adds DiscordService.getThreads to fetch active threads for a channel
- Adds HaloService.getPlayerCustomGames as a public wrapper for custom game history lookup
- Adds unit tests for all newly introduced service helpers

## 4. a table presenting the PR train

| Step | Branch | PR | Scope | Status |
|---|---|---|---|---|
| 1 | stats-fix-command | #548 | Command structure and interaction routing | Open |
| 2 | stats-fix-pr2-services-tests | This PR | Service helper methods plus unit tests | Open |
| 3 | stats-fix-pr3-subcommand-player-select | Planned | Subcommand entry path and player selection flow | Planned |
| 4 | stats-fix-pr4-games-confirmation | Planned | Games selection, preview, confirmation, and final rewrite flow | Planned |
