### PR TITLE
Stage 2b PR Train Step 2: analytics service + kill matrix presenter

### DIFF
--- a/pages/src/apps/discord-series-stats/fakes/create.fake.ts
+++ b/pages/src/apps/discord-series-stats/fakes/create.fake.ts
@@ -5,6 +5,7 @@ import type {
   DiscordSeriesStatsPending,
   DiscordSeriesStatsResolved,
 } from "@guilty-spark/shared/contracts/stats/discord-series";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { DiscordSeriesStatsResult } from "../../../services/stats/discord-series-types";
 import type { Services } from "../services";
 
@@ -98,6 +99,23 @@ function toFakeResult(response: DiscordSeriesStats): DiscordSeriesStatsResult {
   };
 }
 
+function aFakeMatchAnalyticsWith(): MatchAnalytics {
+  return {
+    requestedModules: ["killMatrix"],
+    killMatrix: {},
+    metadata: {
+      pairingQuality: {
+        unpairedDeathCount: 0,
+        maxTimeDeltaMs: 0,
+      },
+      perfectCounts: {
+        total: 0,
+        byXuid: {},
+      },
+    },
+  };
+}
+
 export function aFakeDiscordSeriesStatsAppServicesWith(response: DiscordSeriesStats): Services {
   return {
     discordSeriesStatsService: {
@@ -106,6 +124,11 @@ export function aFakeDiscordSeriesStatsAppServicesWith(response: DiscordSeriesSt
       },
       getLookup: async (): Promise<{ status: number; retryAfterSeconds: number | null }> => {
         return Promise.resolve({ status: 200, retryAfterSeconds: null });
+      },
+    },
+    matchAnalyticsService: {
+      getMatchAnalytics: async (): Promise<MatchAnalytics> => {
+        return Promise.resolve(aFakeMatchAnalyticsWith());
       },
     },
   };

--- a/pages/src/apps/discord-series-stats/fakes/create.fake.ts
+++ b/pages/src/apps/discord-series-stats/fakes/create.fake.ts
@@ -5,8 +5,9 @@ import type {
   DiscordSeriesStatsPending,
   DiscordSeriesStatsResolved,
 } from "@guilty-spark/shared/contracts/stats/discord-series";
-import type { AnalyticsModule, MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { DiscordSeriesStatsResult } from "../../../services/stats/discord-series-types";
+import { aFakeDiscordSeriesStatsServiceWith } from "../../../services/stats/fakes/discord-series.fake";
+import { aFakeMatchAnalyticsServiceWith } from "../../../services/stats/fakes/match-analytics.fake";
 import type { Services } from "../services";
 
 export function aFakeResolvedDiscordSeriesStatsWith(
@@ -99,39 +100,9 @@ function toFakeResult(response: DiscordSeriesStats): DiscordSeriesStatsResult {
   };
 }
 
-function aFakeMatchAnalyticsWith(): MatchAnalytics {
-  return {
-    requestedModules: ["killMatrix"],
-    killMatrix: {},
-    metadata: {
-      pairingQuality: {
-        unpairedDeathCount: 0,
-        maxTimeDeltaMs: 0,
-      },
-      perfectCounts: {
-        total: 0,
-        byXuid: {},
-      },
-    },
-  };
-}
-
 export function aFakeDiscordSeriesStatsAppServicesWith(response: DiscordSeriesStats): Services {
   return {
-    discordSeriesStatsService: {
-      getStats: async (): Promise<DiscordSeriesStatsResult> => {
-        return Promise.resolve(toFakeResult(response));
-      },
-      getLookup: async (): Promise<{ status: number; retryAfterSeconds: number | null }> => {
-        return Promise.resolve({ status: 200, retryAfterSeconds: null });
-      },
-    },
-    matchAnalyticsService: {
-      getMatchAnalytics: async (matchId: string, modules?: readonly AnalyticsModule[]): Promise<MatchAnalytics> => {
-        void matchId;
-        void modules;
-        return Promise.resolve(aFakeMatchAnalyticsWith());
-      },
-    },
+    discordSeriesStatsService: aFakeDiscordSeriesStatsServiceWith({ result: toFakeResult(response) }),
+    matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
   };
 }

--- a/pages/src/apps/discord-series-stats/fakes/create.fake.ts
+++ b/pages/src/apps/discord-series-stats/fakes/create.fake.ts
@@ -5,7 +5,7 @@ import type {
   DiscordSeriesStatsPending,
   DiscordSeriesStatsResolved,
 } from "@guilty-spark/shared/contracts/stats/discord-series";
-import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import type { AnalyticsModule, MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { DiscordSeriesStatsResult } from "../../../services/stats/discord-series-types";
 import type { Services } from "../services";
 
@@ -127,7 +127,9 @@ export function aFakeDiscordSeriesStatsAppServicesWith(response: DiscordSeriesSt
       },
     },
     matchAnalyticsService: {
-      getMatchAnalytics: async (): Promise<MatchAnalytics> => {
+      getMatchAnalytics: async (matchId: string, modules?: readonly AnalyticsModule[]): Promise<MatchAnalytics> => {
+        void matchId;
+        void modules;
         return Promise.resolve(aFakeMatchAnalyticsWith());
       },
     },

--- a/pages/src/apps/discord-series-stats/services.ts
+++ b/pages/src/apps/discord-series-stats/services.ts
@@ -1,12 +1,20 @@
-import { installDiscordSeriesStatsService } from "../../services/stats/install";
+import { installDiscordSeriesStatsService, installMatchAnalyticsService } from "../../services/stats/install";
 import type { DiscordSeriesStatsService } from "../../services/stats/discord-series-types";
+import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 
 export interface Services {
   readonly discordSeriesStatsService: DiscordSeriesStatsService;
+  readonly matchAnalyticsService: MatchAnalyticsService;
 }
 
 export async function installServices(apiHost: string): Promise<Services> {
+  const [discordSeriesStatsService, matchAnalyticsService] = await Promise.all([
+    installDiscordSeriesStatsService(apiHost),
+    installMatchAnalyticsService(apiHost),
+  ]);
+
   return {
-    discordSeriesStatsService: await installDiscordSeriesStatsService(apiHost),
+    discordSeriesStatsService,
+    matchAnalyticsService,
   };
 }

--- a/pages/src/apps/individual-tracker-viewer/services.ts
+++ b/pages/src/apps/individual-tracker-viewer/services.ts
@@ -21,11 +21,12 @@ export interface Services {
 
 export async function installServices(apiHost: string): Promise<Services> {
   const haloClient = createHaloInfiniteClientProxy({ proxyBaseUrl: apiHost, credentials: "include" });
-  const [authService, individualTrackerService, individualTrackerViewService, matchAnalyticsService] = await Promise.all([
-    installAuthService(apiHost),
-    installIndividualTrackerService(apiHost, haloClient),
-    installIndividualTrackerViewService(apiHost),
-    installMatchAnalyticsService(apiHost),
-  ]);
+  const [authService, individualTrackerService, individualTrackerViewService, matchAnalyticsService] =
+    await Promise.all([
+      installAuthService(apiHost),
+      installIndividualTrackerService(apiHost, haloClient),
+      installIndividualTrackerViewService(apiHost),
+      installMatchAnalyticsService(apiHost),
+    ]);
   return { authService, individualTrackerService, individualTrackerViewService, haloClient, matchAnalyticsService };
 }

--- a/pages/src/apps/individual-tracker-viewer/services.ts
+++ b/pages/src/apps/individual-tracker-viewer/services.ts
@@ -8,20 +8,24 @@ import {
 } from "../../services/individual-tracker/install";
 import type { IndividualTrackerService } from "../../services/individual-tracker/types";
 import type { IndividualTrackerViewService } from "../../services/individual-tracker/view-types";
+import { installMatchAnalyticsService } from "../../services/stats/install";
+import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 
 export interface Services {
   readonly authService: AuthService;
   readonly individualTrackerService: IndividualTrackerService;
   readonly individualTrackerViewService: IndividualTrackerViewService;
   readonly haloClient: HaloInfiniteClient;
+  readonly matchAnalyticsService: MatchAnalyticsService;
 }
 
 export async function installServices(apiHost: string): Promise<Services> {
   const haloClient = createHaloInfiniteClientProxy({ proxyBaseUrl: apiHost, credentials: "include" });
-  const [authService, individualTrackerService, individualTrackerViewService] = await Promise.all([
+  const [authService, individualTrackerService, individualTrackerViewService, matchAnalyticsService] = await Promise.all([
     installAuthService(apiHost),
     installIndividualTrackerService(apiHost, haloClient),
     installIndividualTrackerViewService(apiHost),
+    installMatchAnalyticsService(apiHost),
   ]);
-  return { authService, individualTrackerService, individualTrackerViewService, haloClient };
+  return { authService, individualTrackerService, individualTrackerViewService, haloClient, matchAnalyticsService };
 }

--- a/pages/src/components/stats/kill-matrix/fakes/match-analytics.fake.ts
+++ b/pages/src/components/stats/kill-matrix/fakes/match-analytics.fake.ts
@@ -1,0 +1,35 @@
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+
+export function aFakeMatchAnalyticsWith(overrides: Partial<MatchAnalytics> = {}): MatchAnalytics {
+  return {
+    requestedModules: ["killMatrix"],
+    killMatrix: {
+      "111:222": {
+        count: 3,
+        headshotKills: 1,
+        perfects: 0,
+        weapons: [
+          { weaponId: 6001, count: 1 },
+          { weaponId: 5001, count: 2 },
+        ],
+      },
+      "111:111": {
+        count: 1,
+        headshotKills: 0,
+        perfects: 0,
+        weapons: [],
+      },
+      "333:444": {
+        count: 2,
+        headshotKills: 0,
+        perfects: 1,
+        weapons: [{ weaponId: 7001, count: 2 }],
+      },
+    },
+    metadata: {
+      pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 1 },
+      perfectCounts: { total: 1, byXuid: { "333": 1 } },
+    },
+    ...overrides,
+  };
+}

--- a/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
@@ -1,0 +1,93 @@
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import type { KillMatrixClassification, KillMatrixPlayer, KillMatrixViewRow } from "./types";
+
+interface KillMatrixPresenterPlayerLookup {
+  readonly gamertag: string;
+  readonly teamId: number | null;
+}
+
+export interface KillMatrixPresenterOptions {
+  readonly analytics: MatchAnalytics;
+  readonly playersByXuid: ReadonlyMap<string, KillMatrixPresenterPlayerLookup>;
+}
+
+function createFallbackPlayer(xuid: string): KillMatrixPlayer {
+  return {
+    xuid,
+    gamertag: xuid,
+    teamId: null,
+  };
+}
+
+function toPlayer(
+  xuid: string,
+  playersByXuid: ReadonlyMap<string, KillMatrixPresenterPlayerLookup>,
+): KillMatrixPlayer {
+  const entry = playersByXuid.get(xuid);
+  if (entry == null) {
+    return createFallbackPlayer(xuid);
+  }
+
+  return {
+    xuid,
+    gamertag: entry.gamertag,
+    teamId: entry.teamId,
+  };
+}
+
+function classify(killer: KillMatrixPlayer, victim: KillMatrixPlayer): KillMatrixClassification {
+  if (killer.xuid === victim.xuid) {
+    return "suicide";
+  }
+
+  if (killer.teamId != null && victim.teamId != null && killer.teamId === victim.teamId) {
+    return "betrayal";
+  }
+
+  return "enemy-kill";
+}
+
+function topWeaponId(weapons: readonly { readonly weaponId: number; readonly count: number }[]): number | null {
+  if (weapons.length === 0) {
+    return null;
+  }
+
+  const sorted = [...weapons].sort((a, b) => b.count - a.count);
+  return sorted[0]?.weaponId ?? null;
+}
+
+function parsePairKey(key: string): { killerXuid: string; victimXuid: string } {
+  const [killerXuid, victimXuid] = key.split(":");
+  return { killerXuid, victimXuid };
+}
+
+export class KillMatrixPresenter {
+  static present({ analytics, playersByXuid }: KillMatrixPresenterOptions): KillMatrixViewRow[] {
+    const rows: KillMatrixViewRow[] = [];
+
+    for (const [key, value] of Object.entries(analytics.killMatrix)) {
+      const { killerXuid, victimXuid } = parsePairKey(key);
+      const killer = toPlayer(killerXuid, playersByXuid);
+      const victim = toPlayer(victimXuid, playersByXuid);
+
+      rows.push({
+        key,
+        killer,
+        victim,
+        count: value.count,
+        headshotKills: value.headshotKills,
+        perfects: value.perfects,
+        classification: classify(killer, victim),
+        topWeaponId: topWeaponId(value.weapons),
+      });
+    }
+
+    return rows.sort((left, right) => {
+      if (right.count !== left.count) {
+        return right.count - left.count;
+      }
+
+      return left.key.localeCompare(right.key);
+    });
+  }
+}

--- a/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
@@ -11,92 +11,93 @@ export interface KillMatrixPresenterOptions {
   readonly playersByXuid: ReadonlyMap<string, KillMatrixPresenterPlayerLookup>;
 }
 
-function createFallbackPlayer(xuid: string): KillMatrixPlayer {
-  return {
-    xuid,
-    gamertag: xuid,
-    teamId: null,
-  };
-}
+export class KillMatrixPresenter {
+  public present({ analytics, playersByXuid }: KillMatrixPresenterOptions): KillMatrixViewRow[] {
+    const rows: KillMatrixViewRow[] = [];
 
-function toPlayer(xuid: string, playersByXuid: ReadonlyMap<string, KillMatrixPresenterPlayerLookup>): KillMatrixPlayer {
-  const entry = playersByXuid.get(xuid);
-  if (entry == null) {
-    return createFallbackPlayer(xuid);
-  }
+    for (const [key, value] of Object.entries(analytics.killMatrix)) {
+      const { killerXuid, victimXuid } = this.parsePairKey(key);
+      const killer = this.toPlayer(killerXuid, playersByXuid);
+      const victim = this.toPlayer(victimXuid, playersByXuid);
 
-  return {
-    xuid,
-    gamertag: entry.gamertag,
-    teamId: entry.teamId,
-  };
-}
-
-function classify(killer: KillMatrixPlayer, victim: KillMatrixPlayer): KillMatrixClassification {
-  if (killer.xuid === victim.xuid) {
-    return "suicide";
-  }
-
-  if (killer.teamId != null && victim.teamId != null && killer.teamId === victim.teamId) {
-    return "betrayal";
-  }
-
-  return "enemy-kill";
-}
-
-function topWeaponId(weapons: readonly { readonly weaponId: number; readonly count: number }[]): number | null {
-  if (weapons.length === 0) {
-    return null;
-  }
-
-  let maxWeaponId = weapons[0].weaponId;
-  let maxCount = weapons[0].count;
-
-  for (let i = 1; i < weapons.length; i++) {
-    const weapon = weapons[i];
-    if (weapon.count > maxCount) {
-      maxCount = weapon.count;
-      maxWeaponId = weapon.weaponId;
+      rows.push({
+        key,
+        killer,
+        victim,
+        count: value.count,
+        headshotKills: value.headshotKills,
+        perfects: value.perfects,
+        classification: this.classify(killer, victim),
+        topWeaponId: this.topWeaponId(value.weapons),
+      });
     }
-  }
 
-  return maxWeaponId;
-}
+    return rows.sort((left, right) => {
+      if (right.count !== left.count) {
+        return right.count - left.count;
+      }
 
-function parsePairKey(key: string): { killerXuid: string; victimXuid: string } {
-  const [killerXuid, victimXuid] = key.split(":");
-  return { killerXuid, victimXuid };
-}
-
-function presentKillMatrix({ analytics, playersByXuid }: KillMatrixPresenterOptions): KillMatrixViewRow[] {
-  const rows: KillMatrixViewRow[] = [];
-
-  for (const [key, value] of Object.entries(analytics.killMatrix)) {
-    const { killerXuid, victimXuid } = parsePairKey(key);
-    const killer = toPlayer(killerXuid, playersByXuid);
-    const victim = toPlayer(victimXuid, playersByXuid);
-
-    rows.push({
-      key,
-      killer,
-      victim,
-      count: value.count,
-      headshotKills: value.headshotKills,
-      perfects: value.perfects,
-      classification: classify(killer, victim),
-      topWeaponId: topWeaponId(value.weapons),
+      return left.key.localeCompare(right.key);
     });
   }
 
-  return rows.sort((left, right) => {
-    if (right.count !== left.count) {
-      return right.count - left.count;
+  private createFallbackPlayer(xuid: string): KillMatrixPlayer {
+    return {
+      xuid,
+      gamertag: xuid,
+      teamId: null,
+    };
+  }
+
+  private toPlayer(
+    xuid: string,
+    playersByXuid: ReadonlyMap<string, KillMatrixPresenterPlayerLookup>,
+  ): KillMatrixPlayer {
+    const entry = playersByXuid.get(xuid);
+    if (entry == null) {
+      return this.createFallbackPlayer(xuid);
     }
 
-    return left.key.localeCompare(right.key);
-  });
-}
+    return {
+      xuid,
+      gamertag: entry.gamertag,
+      teamId: entry.teamId,
+    };
+  }
 
-export const KillMatrixPresenter = {
-  present: presentKillMatrix,
-};
+  private classify(killer: KillMatrixPlayer, victim: KillMatrixPlayer): KillMatrixClassification {
+    if (killer.xuid === victim.xuid) {
+      return "suicide";
+    }
+
+    if (killer.teamId != null && victim.teamId != null && killer.teamId === victim.teamId) {
+      return "betrayal";
+    }
+
+    return "enemy-kill";
+  }
+
+  private topWeaponId(weapons: readonly { readonly weaponId: number; readonly count: number }[]): number | null {
+    if (weapons.length === 0) {
+      return null;
+    }
+
+    let maxWeaponId = weapons[0].weaponId;
+    let maxCount = weapons[0].count;
+
+    for (let i = 1; i < weapons.length; i++) {
+      const weapon = weapons[i];
+      if (weapon.count > maxCount) {
+        maxCount = weapon.count;
+        maxWeaponId = weapon.weaponId;
+      }
+    }
+
+    return maxWeaponId;
+  }
+
+  private parsePairKey(key: string): { killerXuid: string; victimXuid: string } {
+    const [killerXuid, victimXuid] = key.split(":");
+    return { killerXuid, victimXuid };
+  }
+}

--- a/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
@@ -49,8 +49,17 @@ function topWeaponId(weapons: readonly { readonly weaponId: number; readonly cou
     return null;
   }
 
-  const sorted = [...weapons].sort((a, b) => b.count - a.count);
-  return sorted[0]?.weaponId ?? null;
+  let maxWeaponId: number | null = null;
+  let maxCount = 0;
+
+  for (const weapon of weapons) {
+    if (weapon.count > maxCount) {
+      maxCount = weapon.count;
+      maxWeaponId = weapon.weaponId;
+    }
+  }
+
+  return maxWeaponId;
 }
 
 function parsePairKey(key: string): { killerXuid: string; victimXuid: string } {

--- a/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
@@ -49,10 +49,11 @@ function topWeaponId(weapons: readonly { readonly weaponId: number; readonly cou
     return null;
   }
 
-  let maxWeaponId: number | null = null;
-  let maxCount = 0;
+  let maxWeaponId = weapons[0].weaponId;
+  let maxCount = weapons[0].count;
 
-  for (const weapon of weapons) {
+  for (let i = 1; i < weapons.length; i++) {
+    const weapon = weapons[i];
     if (weapon.count > maxCount) {
       maxCount = weapon.count;
       maxWeaponId = weapon.weaponId;

--- a/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
@@ -19,10 +19,7 @@ function createFallbackPlayer(xuid: string): KillMatrixPlayer {
   };
 }
 
-function toPlayer(
-  xuid: string,
-  playersByXuid: ReadonlyMap<string, KillMatrixPresenterPlayerLookup>,
-): KillMatrixPlayer {
+function toPlayer(xuid: string, playersByXuid: ReadonlyMap<string, KillMatrixPresenterPlayerLookup>): KillMatrixPlayer {
   const entry = playersByXuid.get(xuid);
   if (entry == null) {
     return createFallbackPlayer(xuid);
@@ -61,33 +58,35 @@ function parsePairKey(key: string): { killerXuid: string; victimXuid: string } {
   return { killerXuid, victimXuid };
 }
 
-export class KillMatrixPresenter {
-  static present({ analytics, playersByXuid }: KillMatrixPresenterOptions): KillMatrixViewRow[] {
-    const rows: KillMatrixViewRow[] = [];
+function presentKillMatrix({ analytics, playersByXuid }: KillMatrixPresenterOptions): KillMatrixViewRow[] {
+  const rows: KillMatrixViewRow[] = [];
 
-    for (const [key, value] of Object.entries(analytics.killMatrix)) {
-      const { killerXuid, victimXuid } = parsePairKey(key);
-      const killer = toPlayer(killerXuid, playersByXuid);
-      const victim = toPlayer(victimXuid, playersByXuid);
+  for (const [key, value] of Object.entries(analytics.killMatrix)) {
+    const { killerXuid, victimXuid } = parsePairKey(key);
+    const killer = toPlayer(killerXuid, playersByXuid);
+    const victim = toPlayer(victimXuid, playersByXuid);
 
-      rows.push({
-        key,
-        killer,
-        victim,
-        count: value.count,
-        headshotKills: value.headshotKills,
-        perfects: value.perfects,
-        classification: classify(killer, victim),
-        topWeaponId: topWeaponId(value.weapons),
-      });
-    }
-
-    return rows.sort((left, right) => {
-      if (right.count !== left.count) {
-        return right.count - left.count;
-      }
-
-      return left.key.localeCompare(right.key);
+    rows.push({
+      key,
+      killer,
+      victim,
+      count: value.count,
+      headshotKills: value.headshotKills,
+      perfects: value.perfects,
+      classification: classify(killer, victim),
+      topWeaponId: topWeaponId(value.weapons),
     });
   }
+
+  return rows.sort((left, right) => {
+    if (right.count !== left.count) {
+      return right.count - left.count;
+    }
+
+    return left.key.localeCompare(right.key);
+  });
 }
+
+export const KillMatrixPresenter = {
+  present: presentKillMatrix,
+};

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts
@@ -78,4 +78,31 @@ describe("KillMatrixPresenter", () => {
     expect(row.victim.gamertag).toBe("888");
     expect(row.classification).toBe("enemy-kill");
   });
+
+  it("returns a weapon even when all have zero count", () => {
+    const analytics = aFakeAnalyticsWith({
+      killMatrix: {
+        "111:222": {
+          count: 1,
+          headshotKills: 0,
+          perfects: 0,
+          weapons: [
+            { weaponId: 6001, count: 0 },
+            { weaponId: 5001, count: 0 },
+            { weaponId: 7001, count: 0 },
+          ],
+        },
+      },
+    });
+
+    const [row] = KillMatrixPresenter.present({
+      analytics,
+      playersByXuid: new Map([
+        ["111", { gamertag: "Alpha", teamId: 0 }],
+        ["222", { gamertag: "Bravo", teamId: 1 }],
+      ]),
+    });
+
+    expect(row.topWeaponId).toBe(6001);
+  });
 });

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts
@@ -38,8 +38,9 @@ function aFakeAnalyticsWith(overrides: Partial<MatchAnalytics> = {}): MatchAnaly
 
 describe("KillMatrixPresenter", () => {
   it("expands and sorts kill matrix rows", () => {
+    const presenter = new KillMatrixPresenter();
     const analytics = aFakeAnalyticsWith();
-    const rows = KillMatrixPresenter.present({
+    const rows = presenter.present({
       analytics,
       playersByXuid: new Map([
         ["111", { gamertag: "Alpha", teamId: 0 }],
@@ -61,6 +62,7 @@ describe("KillMatrixPresenter", () => {
   });
 
   it("falls back to xuid when player details are missing", () => {
+    const presenter = new KillMatrixPresenter();
     const analytics = aFakeAnalyticsWith({
       killMatrix: {
         "999:888": {
@@ -72,7 +74,7 @@ describe("KillMatrixPresenter", () => {
       },
     });
 
-    const [row] = KillMatrixPresenter.present({ analytics, playersByXuid: new Map() });
+    const [row] = presenter.present({ analytics, playersByXuid: new Map() });
 
     expect(row.killer.gamertag).toBe("999");
     expect(row.victim.gamertag).toBe("888");
@@ -80,6 +82,7 @@ describe("KillMatrixPresenter", () => {
   });
 
   it("returns a weapon even when all have zero count", () => {
+    const presenter = new KillMatrixPresenter();
     const analytics = aFakeAnalyticsWith({
       killMatrix: {
         "111:222": {
@@ -95,7 +98,7 @@ describe("KillMatrixPresenter", () => {
       },
     });
 
-    const [row] = KillMatrixPresenter.present({
+    const [row] = presenter.present({
       analytics,
       playersByXuid: new Map([
         ["111", { gamertag: "Alpha", teamId: 0 }],

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import { KillMatrixPresenter } from "../kill-matrix-presenter";
+
+function aFakeAnalyticsWith(overrides: Partial<MatchAnalytics> = {}): MatchAnalytics {
+  return {
+    requestedModules: ["killMatrix"],
+    killMatrix: {
+      "111:222": {
+        count: 3,
+        headshotKills: 1,
+        perfects: 0,
+        weapons: [
+          { weaponId: 6001, count: 1 },
+          { weaponId: 5001, count: 2 },
+        ],
+      },
+      "111:111": {
+        count: 1,
+        headshotKills: 0,
+        perfects: 0,
+        weapons: [],
+      },
+      "333:444": {
+        count: 2,
+        headshotKills: 0,
+        perfects: 1,
+        weapons: [{ weaponId: 7001, count: 2 }],
+      },
+    },
+    metadata: {
+      pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 1 },
+      perfectCounts: { total: 1, byXuid: { "333": 1 } },
+    },
+    ...overrides,
+  };
+}
+
+describe("KillMatrixPresenter", () => {
+  it("expands and sorts kill matrix rows", () => {
+    const analytics = aFakeAnalyticsWith();
+    const rows = KillMatrixPresenter.present({
+      analytics,
+      playersByXuid: new Map([
+        ["111", { gamertag: "Alpha", teamId: 0 }],
+        ["222", { gamertag: "Bravo", teamId: 1 }],
+        ["333", { gamertag: "Charlie", teamId: 0 }],
+        ["444", { gamertag: "Delta", teamId: 0 }],
+      ]),
+    });
+
+    expect(rows.map((row) => row.key)).toEqual(["111:222", "333:444", "111:111"]);
+    expect(rows[0]).toMatchObject({
+      classification: "enemy-kill",
+      topWeaponId: 5001,
+      killer: { gamertag: "Alpha" },
+      victim: { gamertag: "Bravo" },
+    });
+    expect(rows[1]).toMatchObject({ classification: "betrayal" });
+    expect(rows[2]).toMatchObject({ classification: "suicide" });
+  });
+
+  it("falls back to xuid when player details are missing", () => {
+    const analytics = aFakeAnalyticsWith({
+      killMatrix: {
+        "999:888": {
+          count: 1,
+          headshotKills: 0,
+          perfects: 0,
+          weapons: [],
+        },
+      },
+    });
+
+    const [row] = KillMatrixPresenter.present({ analytics, playersByXuid: new Map() });
+
+    expect(row.killer.gamertag).toBe("999");
+    expect(row.victim.gamertag).toBe("888");
+    expect(row.classification).toBe("enemy-kill");
+  });
+});

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts
@@ -1,45 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { KillMatrixPresenter } from "../kill-matrix-presenter";
-
-function aFakeAnalyticsWith(overrides: Partial<MatchAnalytics> = {}): MatchAnalytics {
-  return {
-    requestedModules: ["killMatrix"],
-    killMatrix: {
-      "111:222": {
-        count: 3,
-        headshotKills: 1,
-        perfects: 0,
-        weapons: [
-          { weaponId: 6001, count: 1 },
-          { weaponId: 5001, count: 2 },
-        ],
-      },
-      "111:111": {
-        count: 1,
-        headshotKills: 0,
-        perfects: 0,
-        weapons: [],
-      },
-      "333:444": {
-        count: 2,
-        headshotKills: 0,
-        perfects: 1,
-        weapons: [{ weaponId: 7001, count: 2 }],
-      },
-    },
-    metadata: {
-      pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 1 },
-      perfectCounts: { total: 1, byXuid: { "333": 1 } },
-    },
-    ...overrides,
-  };
-}
+import { aFakeMatchAnalyticsWith } from "../fakes/match-analytics.fake";
 
 describe("KillMatrixPresenter", () => {
   it("expands and sorts kill matrix rows", () => {
     const presenter = new KillMatrixPresenter();
-    const analytics = aFakeAnalyticsWith();
+    const analytics = aFakeMatchAnalyticsWith();
     const rows = presenter.present({
       analytics,
       playersByXuid: new Map([
@@ -63,7 +29,7 @@ describe("KillMatrixPresenter", () => {
 
   it("falls back to xuid when player details are missing", () => {
     const presenter = new KillMatrixPresenter();
-    const analytics = aFakeAnalyticsWith({
+    const analytics = aFakeMatchAnalyticsWith({
       killMatrix: {
         "999:888": {
           count: 1,
@@ -83,7 +49,7 @@ describe("KillMatrixPresenter", () => {
 
   it("returns a weapon even when all have zero count", () => {
     const presenter = new KillMatrixPresenter();
-    const analytics = aFakeAnalyticsWith({
+    const analytics = aFakeMatchAnalyticsWith({
       killMatrix: {
         "111:222": {
           count: 1,

--- a/pages/src/components/stats/kill-matrix/types.ts
+++ b/pages/src/components/stats/kill-matrix/types.ts
@@ -1,0 +1,22 @@
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+
+export type KillMatrixClassification = "enemy-kill" | "betrayal" | "suicide";
+
+export interface KillMatrixPlayer {
+  readonly xuid: string;
+  readonly gamertag: string;
+  readonly teamId: number | null;
+}
+
+export interface KillMatrixViewRow {
+  readonly key: string;
+  readonly killer: KillMatrixPlayer;
+  readonly victim: KillMatrixPlayer;
+  readonly count: number;
+  readonly headshotKills: number;
+  readonly perfects: number;
+  readonly classification: KillMatrixClassification;
+  readonly topWeaponId: number | null;
+}
+
+export type KillMatrixRaw = MatchAnalytics["killMatrix"];

--- a/pages/src/services/stats/fakes/match-analytics.fake.ts
+++ b/pages/src/services/stats/fakes/match-analytics.fake.ts
@@ -1,0 +1,49 @@
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import type { MatchAnalyticsService } from "../match-analytics-types";
+
+function aFakeMatchAnalyticsWith(overrides: Partial<MatchAnalytics> = {}): MatchAnalytics {
+  return {
+    requestedModules: ["killMatrix"],
+    killMatrix: {
+      "2533274844642438:2533274881185517": {
+        count: 2,
+        headshotKills: 1,
+        perfects: 0,
+        weapons: [],
+      },
+    },
+    metadata: {
+      pairingQuality: {
+        unpairedDeathCount: 0,
+        maxTimeDeltaMs: 1,
+      },
+      perfectCounts: {
+        total: 0,
+        byXuid: {},
+      },
+    },
+    ...overrides,
+  };
+}
+
+interface FakeMatchAnalyticsServiceOptions {
+  readonly analytics: MatchAnalytics;
+}
+
+export class FakeMatchAnalyticsService implements MatchAnalyticsService {
+  private readonly analytics: MatchAnalytics;
+
+  constructor(options: Partial<FakeMatchAnalyticsServiceOptions> = {}) {
+    this.analytics = options.analytics ?? aFakeMatchAnalyticsWith();
+  }
+
+  async getMatchAnalytics(): Promise<MatchAnalytics> {
+    return this.analytics;
+  }
+}
+
+export function aFakeMatchAnalyticsServiceWith(
+  overrides: Partial<FakeMatchAnalyticsServiceOptions> = {},
+): FakeMatchAnalyticsService {
+  return new FakeMatchAnalyticsService(overrides);
+}

--- a/pages/src/services/stats/fakes/match-analytics.fake.ts
+++ b/pages/src/services/stats/fakes/match-analytics.fake.ts
@@ -1,4 +1,4 @@
-import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import type { AnalyticsModule, MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { MatchAnalyticsService } from "../match-analytics-types";
 
 function aFakeMatchAnalyticsWith(overrides: Partial<MatchAnalytics> = {}): MatchAnalytics {
@@ -37,7 +37,9 @@ export class FakeMatchAnalyticsService implements MatchAnalyticsService {
     this.analytics = options.analytics ?? aFakeMatchAnalyticsWith();
   }
 
-  async getMatchAnalytics(): Promise<MatchAnalytics> {
+  async getMatchAnalytics(matchId: string, modules?: readonly AnalyticsModule[]): Promise<MatchAnalytics> {
+    void matchId;
+    void modules;
     return Promise.resolve(this.analytics);
   }
 }

--- a/pages/src/services/stats/fakes/match-analytics.fake.ts
+++ b/pages/src/services/stats/fakes/match-analytics.fake.ts
@@ -38,7 +38,7 @@ export class FakeMatchAnalyticsService implements MatchAnalyticsService {
   }
 
   async getMatchAnalytics(): Promise<MatchAnalytics> {
-    return this.analytics;
+    return Promise.resolve(this.analytics);
   }
 }
 

--- a/pages/src/services/stats/install.ts
+++ b/pages/src/services/stats/install.ts
@@ -1,6 +1,8 @@
 import { getMode } from "../mode";
 import type { DiscordSeriesStatsService } from "./discord-series-types";
+import type { MatchAnalyticsService } from "./match-analytics-types";
 import { RealDiscordSeriesStatsService } from "./discord-series";
+import { RealMatchAnalyticsService } from "./match-analytics";
 
 export async function installDiscordSeriesStatsService(apiHost: string): Promise<DiscordSeriesStatsService> {
   if (getMode() === "FAKE") {
@@ -9,4 +11,13 @@ export async function installDiscordSeriesStatsService(apiHost: string): Promise
   }
 
   return new RealDiscordSeriesStatsService({ apiHost });
+}
+
+export async function installMatchAnalyticsService(apiHost: string): Promise<MatchAnalyticsService> {
+  if (getMode() === "FAKE") {
+    const { aFakeMatchAnalyticsServiceWith } = await import("./fakes/match-analytics.fake");
+    return aFakeMatchAnalyticsServiceWith();
+  }
+
+  return new RealMatchAnalyticsService({ apiHost });
 }

--- a/pages/src/services/stats/match-analytics-types.ts
+++ b/pages/src/services/stats/match-analytics-types.ts
@@ -1,7 +1,4 @@
-import type {
-  AnalyticsModule,
-  MatchAnalytics,
-} from "@guilty-spark/shared/contracts/stats/match-analytics";
+import type { AnalyticsModule, MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 
 export interface MatchAnalyticsService {
   getMatchAnalytics(matchId: string, modules?: readonly AnalyticsModule[]): Promise<MatchAnalytics>;

--- a/pages/src/services/stats/match-analytics-types.ts
+++ b/pages/src/services/stats/match-analytics-types.ts
@@ -1,0 +1,8 @@
+import type {
+  AnalyticsModule,
+  MatchAnalytics,
+} from "@guilty-spark/shared/contracts/stats/match-analytics";
+
+export interface MatchAnalyticsService {
+  getMatchAnalytics(matchId: string, modules?: readonly AnalyticsModule[]): Promise<MatchAnalytics>;
+}

--- a/pages/src/services/stats/match-analytics.ts
+++ b/pages/src/services/stats/match-analytics.ts
@@ -1,0 +1,33 @@
+import {
+  type AnalyticsModule,
+  matchAnalyticsContract,
+} from "@guilty-spark/shared/contracts/stats/match-analytics";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import type { MatchAnalyticsService } from "./match-analytics-types";
+
+interface RealMatchAnalyticsServiceOptions {
+  readonly apiHost: string;
+}
+
+const DEFAULT_MODULES: readonly AnalyticsModule[] = ["killMatrix"];
+
+function buildModulesQuery(modules: readonly AnalyticsModule[]): string {
+  return modules.join(",");
+}
+
+export class RealMatchAnalyticsService implements MatchAnalyticsService {
+  private readonly apiHost: string;
+
+  constructor({ apiHost }: RealMatchAnalyticsServiceOptions) {
+    this.apiHost = apiHost;
+  }
+
+  async getMatchAnalytics(matchId: string, modules: readonly AnalyticsModule[] = DEFAULT_MODULES): Promise<MatchAnalytics> {
+    const query = new URLSearchParams({ modules: buildModulesQuery(modules) });
+    const response = await fetch(`${this.apiHost}/api/stats/match-analytics/${matchId}?${query.toString()}`, {
+      credentials: "include",
+    });
+    const parsed = await matchAnalyticsContract.fromResponse(response);
+    return parsed.analytics;
+  }
+}

--- a/pages/src/services/stats/match-analytics.ts
+++ b/pages/src/services/stats/match-analytics.ts
@@ -26,7 +26,8 @@ export class RealMatchAnalyticsService implements MatchAnalyticsService {
     matchId: string,
     modules: readonly AnalyticsModule[] = DEFAULT_MODULES,
   ): Promise<MatchAnalytics> {
-    const query = new URLSearchParams({ modules: buildModulesQuery(modules) });
+    const normalizedModules = modules.length === 0 ? DEFAULT_MODULES : modules;
+    const query = new URLSearchParams({ modules: buildModulesQuery(normalizedModules) });
     const response = await fetch(`${this.apiHost}/api/stats/match-analytics/${matchId}?${query.toString()}`, {
       credentials: "include",
     });

--- a/pages/src/services/stats/match-analytics.ts
+++ b/pages/src/services/stats/match-analytics.ts
@@ -1,8 +1,8 @@
 import {
+  type MatchAnalytics,
   type AnalyticsModule,
   matchAnalyticsContract,
 } from "@guilty-spark/shared/contracts/stats/match-analytics";
-import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { MatchAnalyticsService } from "./match-analytics-types";
 
 interface RealMatchAnalyticsServiceOptions {
@@ -22,7 +22,10 @@ export class RealMatchAnalyticsService implements MatchAnalyticsService {
     this.apiHost = apiHost;
   }
 
-  async getMatchAnalytics(matchId: string, modules: readonly AnalyticsModule[] = DEFAULT_MODULES): Promise<MatchAnalytics> {
+  async getMatchAnalytics(
+    matchId: string,
+    modules: readonly AnalyticsModule[] = DEFAULT_MODULES,
+  ): Promise<MatchAnalytics> {
     const query = new URLSearchParams({ modules: buildModulesQuery(modules) });
     const response = await fetch(`${this.apiHost}/api/stats/match-analytics/${matchId}?${query.toString()}`, {
       credentials: "include",

--- a/pages/src/services/stats/match-analytics.ts
+++ b/pages/src/services/stats/match-analytics.ts
@@ -26,9 +26,10 @@ export class RealMatchAnalyticsService implements MatchAnalyticsService {
     matchId: string,
     modules: readonly AnalyticsModule[] = DEFAULT_MODULES,
   ): Promise<MatchAnalytics> {
+    const encodedMatchId = encodeURIComponent(matchId);
     const normalizedModules = modules.length === 0 ? DEFAULT_MODULES : modules;
     const query = new URLSearchParams({ modules: buildModulesQuery(normalizedModules) });
-    const response = await fetch(`${this.apiHost}/api/stats/match-analytics/${matchId}?${query.toString()}`, {
+    const response = await fetch(`${this.apiHost}/api/stats/match-analytics/${encodedMatchId}?${query.toString()}`, {
       credentials: "include",
     });
     const parsed = await matchAnalyticsContract.fromResponse(response);

--- a/pages/src/services/stats/tests/match-analytics.test.ts
+++ b/pages/src/services/stats/tests/match-analytics.test.ts
@@ -79,4 +79,23 @@ describe("RealMatchAnalyticsService", () => {
       { credentials: "include" },
     );
   });
+
+  it("encodes matchId path segment", async () => {
+    const analytics = aFakeAnalyticsResponseWith();
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ analytics }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+
+    await service.getMatchAnalytics("match/123?abc=1");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/stats/match-analytics/match%2F123%3Fabc%3D1?modules=killMatrix",
+      { credentials: "include" },
+    );
+  });
 });

--- a/pages/src/services/stats/tests/match-analytics.test.ts
+++ b/pages/src/services/stats/tests/match-analytics.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import { RealMatchAnalyticsService } from "../match-analytics";
+
+function aFakeAnalyticsResponseWith(overrides: Partial<MatchAnalytics> = {}): MatchAnalytics {
+  return {
+    requestedModules: ["killMatrix"],
+    killMatrix: {
+      "2533274844642438:2533274881185517": {
+        count: 2,
+        headshotKills: 1,
+        perfects: 0,
+        weapons: [],
+      },
+    },
+    metadata: {
+      pairingQuality: {
+        unpairedDeathCount: 0,
+        maxTimeDeltaMs: 1,
+      },
+      perfectCounts: {
+        total: 0,
+        byXuid: {},
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("RealMatchAnalyticsService", () => {
+  let fetchSpy: MockInstance<typeof globalThis.fetch>;
+  let service: RealMatchAnalyticsService;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    service = new RealMatchAnalyticsService({ apiHost: "https://api.example.com" });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("requests match analytics and parses response", async () => {
+    const analytics = aFakeAnalyticsResponseWith();
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ analytics }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+
+    const result = await service.getMatchAnalytics("match-123");
+
+    expect(result).toEqual(analytics);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/stats/match-analytics/match-123?modules=killMatrix",
+      { credentials: "include" },
+    );
+  });
+
+  it("supports explicit module requests", async () => {
+    const analytics = aFakeAnalyticsResponseWith();
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ analytics }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+
+    await service.getMatchAnalytics("match-123", ["killMatrix"]);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/stats/match-analytics/match-123?modules=killMatrix",
+      { credentials: "include" },
+    );
+  });
+});

--- a/pages/worker-configuration.d.ts
+++ b/pages/worker-configuration.d.ts
@@ -10251,7 +10251,7 @@ type AIGatewayHeaders = {
     [key: string]: string | number | boolean | object;
 };
 type AIGatewayUniversalRequest = {
-    provider: AIGatewayProviders | string; // eslint-disable-line
+    provider: AIGatewayProviders | string;  
     endpoint: string;
     headers: Partial<AIGatewayHeaders>;
     query: unknown;
@@ -10268,7 +10268,7 @@ declare abstract class AiGateway {
         extraHeaders?: object;
         signal?: AbortSignal;
     }): Promise<Response>;
-    getUrl(provider?: AIGatewayProviders | string): Promise<string>; // eslint-disable-line
+    getUrl(provider?: AIGatewayProviders | string): Promise<string>;  
 }
 // Copyright (c) 2022-2025 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:


### PR DESCRIPTION
## 1. context
This is Step 2 in the Stage 2b PR train for kill matrix UI rollout. Step 1 (#547) introduced a shared tab shell and migrated Individual Tracker Manager. This step adds analytics consumption plumbing and kill matrix presentation logic so UI wiring can stay focused in Step 3.

## 2. overview of the feature
Add a frontend match-analytics service and a kill-matrix presenter layer that transforms API analytics into view-ready rows. Also wire service installation through app service containers used by Discord Series Stats and Individual Tracker Viewer.

## 3. what this PR does
- Adds frontend analytics service contract + real implementation + fake:
  - `pages/src/services/stats/match-analytics-types.ts`
  - `pages/src/services/stats/match-analytics.ts`
  - `pages/src/services/stats/fakes/match-analytics.fake.ts`
  - `pages/src/services/stats/tests/match-analytics.test.ts`
- Extends stats installers:
  - `pages/src/services/stats/install.ts`
- Wires analytics service into app-level service containers:
  - `pages/src/apps/discord-series-stats/services.ts`
  - `pages/src/apps/individual-tracker-viewer/services.ts`
  - `pages/src/apps/discord-series-stats/fakes/create.fake.ts`
- Adds kill matrix presenter and types (no UI rendering yet):
  - `pages/src/components/stats/kill-matrix/types.ts`
  - `pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts`
  - `pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts`

Validation:
- `npx vitest run pages/src/services/stats/tests/match-analytics.test.ts pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts pages/src/apps/discord-series-stats/tests/create.test.tsx pages/src/apps/discord-series-stats/tests/discord-series-stats-presenter.test.ts pages/src/components/discord-series-stats/tests/create.test.tsx`
- `npm run typecheck:pages`

## 4. PR train
| Step | Branch | PR | Scope | Status |
|---|---|---|---|---|
| 1 | `feature/stage-2b-kill-matrix-ui` | #547 | Shared tab shell + Individual Tracker Manager migration + tests | Open |
| 2 | `feature/stage-2b-analytics-service` | this PR | Match analytics service plumbing + kill matrix presenter + tests | Open |
| 3 | `feature/stage-2b-kill-matrix-table` | pending | Kill matrix table UI and wiring into Match Stats, Series Stats, Individual Tracker Viewer + tests | Planned |
