### PR TITLE
feat(stats-fix): implement fix entry and player select (PR train 3/4)

### DIFF
--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -16,6 +16,7 @@ import {
   InteractionType,
   MessageFlags,
   InteractionContextType,
+  PermissionFlagsBits,
 } from "discord-api-types/v10";
 import type { MatchStats, GameVariantCategory } from "halo-infinite-api";
 import { subHours } from "date-fns";
@@ -34,6 +35,14 @@ import type { GuildConfigRow } from "../../services/database/types/guild_config"
 import { StatsReturnType } from "../../services/database/types/guild_config";
 import { EndUserError } from "../../base/end-user-error";
 import { create } from "../../embeds/stats/create";
+
+interface FixFlowMetadata extends Record<string, unknown> {
+  guildId: string;
+  channelId: string;
+  queueData: QueueData;
+  selectedPlayerId?: string;
+  selectedMatchIds?: string[];
+}
 
 export enum InteractionButton {
   Retry = "btn_stats_retry",
@@ -124,6 +133,36 @@ export class StatsCommand extends BaseCommand {
         data: {
           component_type: ComponentType.Button,
           custom_id: InteractionButton.LoadGames,
+        },
+      },
+      {
+        type: InteractionType.MessageComponent,
+        data: {
+          component_type: ComponentType.StringSelect,
+          custom_id: InteractionButton.FixPlayerSelect,
+          values: [],
+        },
+      },
+      {
+        type: InteractionType.MessageComponent,
+        data: {
+          component_type: ComponentType.StringSelect,
+          custom_id: InteractionButton.FixGamesSelect,
+          values: [],
+        },
+      },
+      {
+        type: InteractionType.MessageComponent,
+        data: {
+          component_type: ComponentType.Button,
+          custom_id: InteractionButton.FixConfirm,
+        },
+      },
+      {
+        type: InteractionType.MessageComponent,
+        data: {
+          component_type: ComponentType.Button,
+          custom_id: InteractionButton.FixCancel,
         },
       },
     ];
@@ -751,14 +790,224 @@ export class StatsCommand extends BaseCommand {
   }
 
   private handleFixSubCommand(
-    _interaction: APIApplicationCommandInteraction,
-    _options: Map<string, APIApplicationCommandInteractionDataBasicOption["value"]>,
+    interaction: APIApplicationCommandInteraction,
+    options: Map<string, APIApplicationCommandInteractionDataBasicOption["value"]>,
   ): ExecuteResponse {
-    throw new Error("handleFixSubCommand not implemented");
+    const queueNumber = options.get("queue_number") as number | undefined;
+    const isThreadChannel = this.isThreadChannel(interaction.channel.type);
+
+    if (!isThreadChannel && queueNumber == null) {
+      throw new EndUserError("queue_number is required when running /stats fix outside a thread.");
+    }
+
+    if (isThreadChannel && queueNumber == null) {
+      return {
+        response: {
+          type: InteractionResponseType.DeferredChannelMessageWithSource,
+          data: {
+            flags: MessageFlags.Ephemeral,
+          },
+        },
+        jobToComplete: async () => this.fixSubCommandInThreadJob(interaction),
+      };
+    }
+
+    const parentChannelId = "parent_id" in interaction.channel ? interaction.channel.parent_id : undefined;
+    const channelId = isThreadChannel ? (parentChannelId ?? interaction.channel.id) : interaction.channel.id;
+
+    return {
+      response: {
+        type: InteractionResponseType.DeferredChannelMessageWithSource,
+        data: {
+          flags: MessageFlags.Ephemeral,
+        },
+      },
+      jobToComplete: async () => this.fixSubCommandJob(interaction, channelId, Preconditions.checkExists(queueNumber)),
+    };
   }
 
-  private async handleFixPlayerSelectJob(_interaction: APIMessageComponentSelectMenuInteraction): Promise<void> {
-    throw new Error("handleFixPlayerSelectJob not implemented");
+  private async fixSubCommandJob(
+    interaction: APIApplicationCommandInteraction,
+    channelId: string,
+    queueNumber: number,
+  ): Promise<void> {
+    const { discordService } = this.services;
+
+    try {
+      const guildId = Preconditions.checkExists(interaction.guild_id, "No guild ID found in interaction");
+      const queueData = await discordService.getTeamsFromQueueResult(guildId, channelId, queueNumber);
+
+      await this.fixCommandStartFlow(interaction, channelId, queueData);
+    } catch (error) {
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
+    }
+  }
+
+  private async fixSubCommandInThreadJob(interaction: APIApplicationCommandInteraction): Promise<void> {
+    const { discordService } = this.services;
+
+    try {
+      if (!this.isThreadChannel(interaction.channel.type)) {
+        throw new EndUserError("This command must be run in a thread channel.");
+      }
+
+      const guildId = Preconditions.checkExists(interaction.guild_id, "No guild ID found in interaction");
+      const threadMessages = await discordService.getMessages(interaction.channel.id);
+      const firstMessage = threadMessages[threadMessages.length - 1];
+
+      if (
+        firstMessage?.referenced_message?.author.bot !== true ||
+        firstMessage.referenced_message.author.id !== NEAT_QUEUE_BOT_USER_ID
+      ) {
+        throw new EndUserError("The first message in this thread is not from NeatQueue.");
+      }
+
+      const queueData = await discordService.getTeamsFromMessage(guildId, firstMessage.referenced_message);
+      const parentChannelId = "parent_id" in interaction.channel ? interaction.channel.parent_id : undefined;
+      const channelId = parentChannelId ?? interaction.channel.id;
+
+      await this.fixCommandStartFlow(interaction, channelId, queueData);
+    } catch (error) {
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
+    }
+  }
+
+  private async fixCommandStartFlow(
+    interaction: APIApplicationCommandInteraction,
+    channelId: string,
+    queueData: QueueData,
+  ): Promise<void> {
+    const { discordService } = this.services;
+
+    const guildId = Preconditions.checkExists(interaction.guild_id, "No guild ID found in interaction");
+    const userId = discordService.getDiscordUserId(interaction);
+    const permissions = await discordService.computeMemberPermissions(guildId, userId);
+    const isAdmin = (permissions & PermissionFlagsBits.Administrator) !== 0n;
+    const queuePlayerIds = new Set(queueData.teams.flatMap((team) => team.players.map((player) => player.user.id)));
+
+    if (!isAdmin && !queuePlayerIds.has(userId)) {
+      throw new EndUserError("Only players from that queue (or admins) can run /stats fix.");
+    }
+
+    const selectOptions = queueData.teams.flatMap((team) =>
+      team.players.map((player) => {
+        const label = player.nick ?? player.user.global_name ?? player.user.username;
+
+        return {
+          label: label.slice(0, 100),
+          value: player.user.id,
+          description: team.name.slice(0, 100),
+        };
+      }),
+    );
+
+    await discordService.updateDeferredReply(interaction.token, {
+      content: "Select a player from the queue to load candidate custom games.",
+      components: [
+        {
+          type: ComponentType.ActionRow,
+          components: [
+            {
+              type: ComponentType.StringSelect,
+              custom_id: InteractionButton.FixPlayerSelect,
+              min_values: 1,
+              max_values: 1,
+              options: selectOptions,
+            },
+          ],
+        },
+        {
+          type: ComponentType.ActionRow,
+          components: [
+            {
+              type: ComponentType.Button,
+              custom_id: InteractionButton.FixCancel,
+              label: "Cancel",
+              style: 2,
+            },
+          ],
+        },
+      ],
+    });
+
+    const message = await discordService.getMessageFromInteractionToken(interaction.token);
+    await this.setFixMetadata(message.id, {
+      guildId,
+      channelId,
+      queueData,
+    });
+  }
+
+  private async handleFixPlayerSelectJob(interaction: APIMessageComponentSelectMenuInteraction): Promise<void> {
+    const { databaseService, discordService, haloService } = this.services;
+
+    try {
+      const selectedPlayerId = Preconditions.checkExists(interaction.data.values[0], "No player selected");
+      const metadata = await this.getFixMetadata(interaction.message.id);
+      if (metadata == null) {
+        throw new EndUserError("Could not find fix-flow state. Please run /stats fix again.");
+      }
+
+      const association = (await databaseService.getDiscordAssociations([selectedPlayerId]))[0];
+      if (association?.XboxId == null || association.XboxId === "") {
+        throw new EndUserError("That player does not have a linked Xbox account.");
+      }
+
+      const games = await haloService.getPlayerCustomGames(association.XboxId, 25);
+      if (games.length === 0) {
+        throw new EndUserError("No recent custom games were found for that player.");
+      }
+
+      const gameOptions = games.map((game, index) => {
+        const startTime = new Date(game.MatchInfo.StartTime).toISOString().replace("T", " ").slice(0, 16);
+        const label = `${(index + 1).toString()}. ${startTime}`;
+
+        return {
+          label: label.slice(0, 100),
+          value: game.MatchId,
+          description: game.MatchId.slice(0, 100),
+          default: true,
+        };
+      });
+
+      const selectedMatchIds = gameOptions.map((option) => option.value);
+      await this.setFixMetadata(interaction.message.id, {
+        ...metadata,
+        selectedPlayerId,
+        selectedMatchIds,
+      });
+
+      await discordService.updateDeferredReply(interaction.token, {
+        content: "Select the custom games that belong to this series.",
+        components: [
+          {
+            type: ComponentType.ActionRow,
+            components: [
+              {
+                type: ComponentType.StringSelect,
+                custom_id: InteractionButton.FixGamesSelect,
+                min_values: 1,
+                max_values: Math.min(gameOptions.length, 25),
+                options: gameOptions,
+              },
+            ],
+          },
+          {
+            type: ComponentType.ActionRow,
+            components: [
+              {
+                type: ComponentType.Button,
+                custom_id: InteractionButton.FixCancel,
+                label: "Cancel",
+                style: 2,
+              },
+            ],
+          },
+        ],
+      });
+    } catch (error) {
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
+    }
   }
 
   private async handleFixGamesSelectJob(_interaction: APIMessageComponentSelectMenuInteraction): Promise<void> {
@@ -771,5 +1020,29 @@ export class StatsCommand extends BaseCommand {
 
   private async handleFixCancelJob(_interaction: APIMessageComponentButtonInteraction): Promise<void> {
     throw new Error("handleFixCancelJob not implemented");
+  }
+
+  private isThreadChannel(channelType: ChannelType): boolean {
+    return (
+      channelType === ChannelType.PublicThread ||
+      channelType === ChannelType.PrivateThread ||
+      channelType === ChannelType.AnnouncementThread
+    );
+  }
+
+  private async setFixMetadata(messageId: string, metadata: FixFlowMetadata): Promise<void> {
+    await this.services.discordService.setInteractionMetadata(this.fixMetadataKey(messageId), metadata);
+  }
+
+  private async getFixMetadata(messageId: string): Promise<FixFlowMetadata | null> {
+    const metadata = await this.services.discordService.getInteractionMetadata<FixFlowMetadata>(
+      this.fixMetadataKey(messageId),
+    );
+
+    return metadata;
+  }
+
+  private fixMetadataKey(messageId: string): string {
+    return `statsFix:${messageId}`;
   }
 }

--- a/api/commands/stats/tests/stats.test.ts
+++ b/api/commands/stats/tests/stats.test.ts
@@ -7,6 +7,7 @@ import type {
   APIThreadChannel,
   APIMessage,
   APIMessageComponentButtonInteraction,
+  APIMessageComponentSelectMenuInteraction,
 } from "discord-api-types/v10";
 import {
   ApplicationCommandOptionType,
@@ -14,6 +15,7 @@ import {
   ChannelType,
   ComponentType,
   EmbedType,
+  PermissionFlagsBits,
   InteractionResponseType,
   InteractionType,
   Locale,
@@ -33,10 +35,10 @@ import {
   textChannel,
   threadChannel,
 } from "../../../services/discord/fakes/data";
-import { getMatchStats, getPlayerXuidsToGametags } from "../../../services/halo/fakes/data";
+import { getMatchStats, getPlayerMatches, getPlayerXuidsToGametags } from "../../../services/halo/fakes/data";
 import { StatsReturnType } from "../../../services/database/types/guild_config";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
-import { aFakeGuildConfigRow } from "../../../services/database/fakes/database.fake";
+import { aFakeDiscordAssociationsRow, aFakeGuildConfigRow } from "../../../services/database/fakes/database.fake";
 import { EndUserError } from "../../../base/end-user-error";
 import type { MatchPlayer } from "../../../services/halo/types";
 import {
@@ -108,6 +110,35 @@ const applicationCommandInteractionStatsMatch: APIApplicationCommandInteraction 
             name: "id",
             type: ApplicationCommandOptionType.String,
             value: "d81554d7-ddfe-44da-a6cb-000000000ctf",
+          },
+        ],
+        type: ApplicationCommandOptionType.Subcommand,
+      },
+    ],
+    type: ApplicationCommandType.ChatInput,
+  },
+};
+
+const applicationCommandInteractionStatsFix: APIApplicationCommandInteraction = {
+  ...fakeBaseAPIApplicationCommandInteraction,
+  type: InteractionType.ApplicationCommand,
+  guild: {
+    features: [],
+    id: "fake-guild-id",
+    locale: Locale.EnglishUS,
+  },
+  guild_id: "fake-guild-id",
+  data: {
+    id: "fake-command-id",
+    name: "stats",
+    options: [
+      {
+        name: "fix",
+        options: [
+          {
+            name: "queue_number",
+            type: ApplicationCommandOptionType.Integer,
+            value: 777,
           },
         ],
         type: ApplicationCommandOptionType.Subcommand,
@@ -815,6 +846,246 @@ describe("StatsCommand", () => {
         expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledOnce();
         expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith("fake-token", error);
       });
+    });
+  });
+
+  describe("execute(): subcommand fix", () => {
+    beforeEach(() => {
+      vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
+        name: "fix",
+        mappedOptions: new Map<string, APIApplicationCommandInteractionDataBasicOption["value"]>([["queue_number", 777]]),
+        options: [],
+      });
+    });
+
+    it("returns deferred ephemeral response", () => {
+      const { response, jobToComplete } = statsCommand.execute(applicationCommandInteractionStatsFix);
+
+      expect(response).toEqual({
+        type: InteractionResponseType.DeferredChannelMessageWithSource,
+        data: {
+          flags: MessageFlags.Ephemeral,
+        },
+      });
+      expect(jobToComplete).toBeInstanceOf(Function);
+    });
+
+    it("returns immediate error when queue_number is missing outside thread", () => {
+      vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
+        name: "fix",
+        mappedOptions: new Map<string, APIApplicationCommandInteractionDataBasicOption["value"]>(),
+        options: [],
+      });
+
+      const { response } = statsCommand.execute(applicationCommandInteractionStatsFix);
+
+      expect(response).toEqual({
+        type: InteractionResponseType.ChannelMessageWithSource,
+        data: {
+          content: "Error: queue_number is required when running /stats fix outside a thread.",
+          flags: MessageFlags.Ephemeral,
+        },
+      });
+    });
+
+    it("starts player selection flow when user is queue player", async () => {
+      const queuePlayerInteraction: APIApplicationCommandInteraction = {
+        ...applicationCommandInteractionStatsFix,
+        member: {
+          ...Preconditions.checkExists(applicationCommandInteractionStatsFix.member),
+          user: {
+            ...Preconditions.checkExists(applicationCommandInteractionStatsFix.member?.user),
+            id: "000000000000000001",
+          },
+        },
+      };
+
+      vi.spyOn(services.discordService, "getTeamsFromQueueResult").mockResolvedValue(discordNeatQueueData);
+      vi.spyOn(services.discordService, "computeMemberPermissions").mockResolvedValue(0n);
+      vi.spyOn(services.discordService, "getMessageFromInteractionToken").mockResolvedValue({
+        ...apiMessage,
+        id: "fix-flow-message-id",
+      });
+      const setInteractionMetadataSpy = vi
+        .spyOn(services.discordService, "setInteractionMetadata")
+        .mockResolvedValue();
+
+      const { jobToComplete } = statsCommand.execute(queuePlayerInteraction);
+      await jobToComplete?.();
+
+      expect(updateDeferredReplySpy).toHaveBeenCalledWith(
+        "fake-token",
+        expect.objectContaining({
+          components: expect.arrayContaining([
+            expect.objectContaining({
+              type: ComponentType.ActionRow,
+              components: [
+                expect.objectContaining({
+                  type: ComponentType.StringSelect,
+                  custom_id: "btn_stats_fix_player_select",
+                }),
+              ],
+            }),
+          ]),
+        }),
+      );
+      expect(setInteractionMetadataSpy).toHaveBeenCalledWith(
+        "statsFix:fix-flow-message-id",
+        expect.objectContaining({
+          guildId: "fake-guild-id",
+          channelId: "fake-channel-id",
+        }),
+      );
+    });
+
+    it("rejects users that are not queue players and not admins", async () => {
+      vi.spyOn(services.discordService, "getTeamsFromQueueResult").mockResolvedValue(discordNeatQueueData);
+      vi.spyOn(services.discordService, "computeMemberPermissions").mockResolvedValue(0n);
+
+      const notPlayerInteraction: APIApplicationCommandInteraction = {
+        ...applicationCommandInteractionStatsFix,
+        member: {
+          ...Preconditions.checkExists(applicationCommandInteractionStatsFix.member),
+          user: {
+            ...Preconditions.checkExists(applicationCommandInteractionStatsFix.member?.user),
+            id: "not-in-queue",
+          },
+        },
+      };
+
+      const { jobToComplete } = statsCommand.execute(notPlayerInteraction);
+      await jobToComplete?.();
+
+      expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+        "fake-token",
+        expect.objectContaining({
+          message: "Only players from that queue (or admins) can run /stats fix.",
+        }),
+      );
+    });
+
+    it("allows admins that are not queue players", async () => {
+      vi.spyOn(services.discordService, "getTeamsFromQueueResult").mockResolvedValue(discordNeatQueueData);
+      vi.spyOn(services.discordService, "computeMemberPermissions").mockResolvedValue(PermissionFlagsBits.Administrator);
+      vi.spyOn(services.discordService, "getMessageFromInteractionToken").mockResolvedValue({
+        ...apiMessage,
+        id: "fix-flow-message-id",
+      });
+      vi.spyOn(services.discordService, "setInteractionMetadata").mockResolvedValue();
+
+      const adminInteraction: APIApplicationCommandInteraction = {
+        ...applicationCommandInteractionStatsFix,
+        member: {
+          ...Preconditions.checkExists(applicationCommandInteractionStatsFix.member),
+          user: {
+            ...Preconditions.checkExists(applicationCommandInteractionStatsFix.member?.user),
+            id: "not-in-queue",
+          },
+        },
+      };
+
+      const { jobToComplete } = statsCommand.execute(adminInteraction);
+      await jobToComplete?.();
+
+      expect(updateDeferredReplySpy).toHaveBeenCalled();
+      expect(updateDeferredReplyWithErrorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("execute(): message component fix player select", () => {
+    it("loads candidate games and shows multi-select", async () => {
+      const interaction: APIMessageComponentSelectMenuInteraction = {
+        ...fakeButtonClickInteraction,
+        data: {
+          component_type: ComponentType.StringSelect,
+          custom_id: "btn_stats_fix_player_select",
+          values: ["000000000000000001"],
+        },
+        message: {
+          ...fakeButtonClickInteraction.message,
+          id: "fix-flow-message-id",
+        },
+      };
+
+      vi.spyOn(services.discordService, "getInteractionMetadata").mockResolvedValue({
+        guildId: "fake-guild-id",
+        channelId: "fake-channel-id",
+        queueData: discordNeatQueueData,
+      });
+      vi.spyOn(services.databaseService, "getDiscordAssociations").mockResolvedValue([
+        aFakeDiscordAssociationsRow({
+          DiscordId: "000000000000000001",
+          XboxId: "xuid-1",
+        }),
+      ]);
+      vi.spyOn(services.haloService, "getPlayerCustomGames").mockResolvedValue(getPlayerMatches().slice(0, 3));
+      const setInteractionMetadataSpy = vi
+        .spyOn(services.discordService, "setInteractionMetadata")
+        .mockResolvedValue();
+
+      const { response, jobToComplete } = statsCommand.execute(interaction);
+      expect(response).toEqual({ type: InteractionResponseType.DeferredMessageUpdate });
+
+      await jobToComplete?.();
+
+      expect(updateDeferredReplySpy).toHaveBeenCalledWith(
+        "fake-token",
+        expect.objectContaining({
+          components: expect.arrayContaining([
+            expect.objectContaining({
+              components: [
+                expect.objectContaining({
+                  custom_id: "btn_stats_fix_games_select",
+                }),
+              ],
+            }),
+          ]),
+        }),
+      );
+      expect(setInteractionMetadataSpy).toHaveBeenCalledWith(
+        "statsFix:fix-flow-message-id",
+        expect.objectContaining({
+          selectedPlayerId: "000000000000000001",
+          selectedMatchIds: expect.any(Array),
+        }),
+      );
+    });
+
+    it("returns an error when selected player has no linked xbox account", async () => {
+      const interaction: APIMessageComponentSelectMenuInteraction = {
+        ...fakeButtonClickInteraction,
+        data: {
+          component_type: ComponentType.StringSelect,
+          custom_id: "btn_stats_fix_player_select",
+          values: ["000000000000000001"],
+        },
+        message: {
+          ...fakeButtonClickInteraction.message,
+          id: "fix-flow-message-id",
+        },
+      };
+
+      vi.spyOn(services.discordService, "getInteractionMetadata").mockResolvedValue({
+        guildId: "fake-guild-id",
+        channelId: "fake-channel-id",
+        queueData: discordNeatQueueData,
+      });
+      vi.spyOn(services.databaseService, "getDiscordAssociations").mockResolvedValue([
+        aFakeDiscordAssociationsRow({
+          DiscordId: "000000000000000001",
+          XboxId: "",
+        }),
+      ]);
+
+      const { jobToComplete } = statsCommand.execute(interaction);
+      await jobToComplete?.();
+
+      expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+        "fake-token",
+        expect.objectContaining({
+          message: "That player does not have a linked Xbox account.",
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
## 1. context

This is PR 3 of the /stats fix PR train.
PRs 1 and 2 established command scaffolding and service helpers; this step implements the entry path and first interaction stage for manual correction.

## 2. overview of the feature

Add the beginning of the guided correction flow:
- start /stats fix from either a queue thread or channel with queue_number
- validate caller permissions (queue participant or admin)
- prompt user to select a queue player
- load that player’s recent custom games and present multi-select candidates

## 3. what this PR does

- Implements /stats fix subcommand routing and execution jobs for:
  - regular channel mode (explicit queue_number)
  - thread mode (derive queue from thread starter message)
- Adds permission gating using guild permissions + queue participant membership
- Stores interaction metadata for multi-step flow continuity
- Implements fix player select handler to fetch linked Xbox account and candidate custom games
- Updates ephemeral interaction message to games multi-select stage
- Adds tests for:
  - deferred ephemeral fix response behavior
  - queue_number validation
  - permission acceptance/rejection rules
  - player-select success and missing-association failure paths

## 4. a table presenting the PR train

| Step | Branch | PR | Scope | Status |
|---|---|---|---|---|
| 1 | stats-fix-command | #548 | Command structure and interaction routing | Open |
| 2 | stats-fix-pr2-services-tests | #549 | Service helper methods plus unit tests | Open |
| 3 | stats-fix-pr3-subcommand-player-select | This PR | Subcommand entry path and player selection flow | Open |
| 4 | stats-fix-pr4-games-confirmation | Planned | Games selection, preview, confirmation, and final rewrite flow | Planned |
