### PR TITLE
Stage 2b PR Train Step 4: wire Discord kill matrix data

### DIFF
--- a/pages/src/apps/discord-series-stats/create.tsx
+++ b/pages/src/apps/discord-series-stats/create.tsx
@@ -18,12 +18,14 @@ interface DiscordSeriesStatsAppProps {
 
 interface DiscordSeriesStatsDataProps {
   readonly discordSeriesStatsService: DiscordSeriesStatsService;
+  readonly matchAnalyticsService: Services["matchAnalyticsService"];
   readonly guildId: string;
   readonly queueNumber: string;
 }
 
 function DiscordSeriesStatsData({
   discordSeriesStatsService,
+  matchAnalyticsService,
   guildId,
   queueNumber,
 }: DiscordSeriesStatsDataProps): ReactElement {
@@ -68,7 +70,7 @@ function DiscordSeriesStatsData({
       error={<ErrorState message={model.state === "error" ? model.message : "Failed to load stats"} />}
       loaded={
         model.state === "resolved" ? (
-          <DiscordSeriesStats data={model.data} />
+          <DiscordSeriesStats data={model.data} matchAnalyticsService={matchAnalyticsService} />
         ) : model.state === "pending-index" ? (
           <LoadingState
             text={`Stats are still indexing. Retry in ${Math.ceil(model.retryAfterSeconds).toString()}s.`}
@@ -126,6 +128,7 @@ export function DiscordSeriesStatsApp({ apiHost, guildId, queueNumber }: Discord
         services != null ? (
           <DiscordSeriesStatsData
             discordSeriesStatsService={services.discordSeriesStatsService}
+            matchAnalyticsService={services.matchAnalyticsService}
             guildId={guildId}
             queueNumber={queueNumber}
           />

--- a/pages/src/apps/discord-series-stats/create.tsx
+++ b/pages/src/apps/discord-series-stats/create.tsx
@@ -5,6 +5,7 @@ import { ErrorState } from "../../components/error-state/error-state";
 import { LoadingState } from "../../components/loading-state/loading-state";
 import { DiscordSeriesStats } from "../../components/discord-series-stats/create";
 import type { DiscordSeriesStatsService } from "../../services/stats/discord-series-types";
+import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import { DiscordSeriesStatsPresenter } from "./discord-series-stats-presenter";
 import { DiscordSeriesStatsStore } from "./discord-series-stats-store";
 import type { Services } from "./services";
@@ -18,7 +19,7 @@ interface DiscordSeriesStatsAppProps {
 
 interface DiscordSeriesStatsDataProps {
   readonly discordSeriesStatsService: DiscordSeriesStatsService;
-  readonly matchAnalyticsService: Services["matchAnalyticsService"];
+  readonly matchAnalyticsService: MatchAnalyticsService;
   readonly guildId: string;
   readonly queueNumber: string;
 }

--- a/pages/src/components/discord-series-stats/create.tsx
+++ b/pages/src/components/discord-series-stats/create.tsx
@@ -1,16 +1,58 @@
-import { useMemo, type ReactElement } from "react";
+import { useEffect, useMemo, useState, type ReactElement } from "react";
 import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
 import { DiscordSeriesStatsPresenter } from "./discord-series-stats-presenter";
 import { DiscordSeriesStatsView } from "./discord-series-stats-view";
+import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 
 interface DiscordSeriesStatsProps {
   readonly data: DiscordSeriesStatsResolved;
+  readonly matchAnalyticsService: MatchAnalyticsService;
 }
 
-export function DiscordSeriesStats({ data }: DiscordSeriesStatsProps): ReactElement {
+export function DiscordSeriesStats({ data, matchAnalyticsService }: DiscordSeriesStatsProps): ReactElement {
   const presenter = useMemo(() => new DiscordSeriesStatsPresenter(data.renderData), [data]);
 
   const model = useMemo(() => presenter.present(), [presenter]);
 
-  return <DiscordSeriesStatsView renderData={data.renderData} model={model} />;
+  const [analyticsByMatchId, setAnalyticsByMatchId] = useState<ReadonlyMap<string, MatchAnalytics>>(new Map());
+
+  useEffect(() => {
+    let cancelled = false;
+    const matchIds = data.matchIds;
+
+    void Promise.all(
+      matchIds.map(async (matchId) => {
+        try {
+          const analytics = await matchAnalyticsService.getMatchAnalytics(matchId);
+          return { matchId, analytics };
+        } catch {
+          return null;
+        }
+      }),
+    ).then((results) => {
+      if (cancelled) {
+        return;
+      }
+      const map = new Map<string, MatchAnalytics>();
+      for (const result of results) {
+        if (result != null) {
+          map.set(result.matchId, result.analytics);
+        }
+      }
+      setAnalyticsByMatchId(map);
+    });
+
+    return (): void => {
+      cancelled = true;
+    };
+  }, [data.matchIds, matchAnalyticsService]);
+
+  return (
+    <DiscordSeriesStatsView
+      renderData={data.renderData}
+      model={model}
+      analyticsByMatchId={analyticsByMatchId}
+    />
+  );
 }

--- a/pages/src/components/discord-series-stats/create.tsx
+++ b/pages/src/components/discord-series-stats/create.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState, type ReactElement } from "react";
 import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import { DiscordSeriesStatsPresenter } from "./discord-series-stats-presenter";
 import { DiscordSeriesStatsView } from "./discord-series-stats-view";
-import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
-import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 
 interface DiscordSeriesStatsProps {
   readonly data: DiscordSeriesStatsResolved;
@@ -19,7 +19,7 @@ export function DiscordSeriesStats({ data, matchAnalyticsService }: DiscordSerie
 
   useEffect(() => {
     let cancelled = false;
-    const matchIds = data.matchIds;
+    const {matchIds} = data;
 
     void Promise.all(
       matchIds.map(async (matchId) => {
@@ -48,11 +48,5 @@ export function DiscordSeriesStats({ data, matchAnalyticsService }: DiscordSerie
     };
   }, [data.matchIds, matchAnalyticsService]);
 
-  return (
-    <DiscordSeriesStatsView
-      renderData={data.renderData}
-      model={model}
-      analyticsByMatchId={analyticsByMatchId}
-    />
-  );
+  return <DiscordSeriesStatsView renderData={data.renderData} model={model} analyticsByMatchId={analyticsByMatchId} />;
 }

--- a/pages/src/components/discord-series-stats/create.tsx
+++ b/pages/src/components/discord-series-stats/create.tsx
@@ -19,7 +19,7 @@ export function DiscordSeriesStats({ data, matchAnalyticsService }: DiscordSerie
 
   useEffect(() => {
     let cancelled = false;
-    const {matchIds} = data;
+    const { matchIds } = data;
 
     void Promise.all(
       matchIds.map(async (matchId) => {

--- a/pages/src/components/discord-series-stats/discord-series-stats-view.tsx
+++ b/pages/src/components/discord-series-stats/discord-series-stats-view.tsx
@@ -34,6 +34,7 @@ export function DiscordSeriesStatsView({
   const handleToggleViewMode = useCallback((): void => {
     setViewMode((current) => (current === "standard" ? "wide" : "standard"));
   }, []);
+  const killMatrixPresenter = useMemo(() => new KillMatrixPresenter(), []);
 
   const allMatchKillMatrixRows = useMemo<ReadonlyMap<string, KillMatrixViewRow[]>>(
     () =>
@@ -44,15 +45,12 @@ export function DiscordSeriesStatsView({
             return [];
           }
           const playersByXuid = new Map(
-            Object.entries(match.playerXuidToGametag).map(([xuid, gamertag]) => [
-              xuid,
-              { gamertag, teamId: null },
-            ]),
+            Object.entries(match.playerXuidToGametag).map(([xuid, gamertag]) => [xuid, { gamertag, teamId: null }]),
           );
-          return [[match.matchId, KillMatrixPresenter.present({ analytics, playersByXuid })]];
+          return [[match.matchId, killMatrixPresenter.present({ analytics, playersByXuid })]];
         }),
       ),
-    [analyticsByMatchId, renderData.matches],
+    [analyticsByMatchId, killMatrixPresenter, renderData.matches],
   );
 
   const seriesKillMatrixRows = useMemo<KillMatrixViewRow[]>(

--- a/pages/src/components/discord-series-stats/discord-series-stats-view.tsx
+++ b/pages/src/components/discord-series-stats/discord-series-stats-view.tsx
@@ -1,9 +1,12 @@
-import { useCallback, useState, type CSSProperties, type ReactElement } from "react";
+import { useCallback, useMemo, useState, type CSSProperties, type ReactElement } from "react";
 import classNames from "classnames";
 import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { gameModeIconSrc } from "../individual-tracker/game-mode-icon";
 import { MatchStats as MatchStatsView } from "../stats/match-stats";
 import { SeriesStats } from "../stats/series-stats";
+import { KillMatrixPresenter } from "../stats/kill-matrix/kill-matrix-presenter";
+import type { KillMatrixViewRow } from "../stats/kill-matrix/types";
 import { Container } from "../container/container";
 import { Alert } from "../alert/alert";
 import { getTeamColorOrDefault } from "../team-colors/team-colors";
@@ -18,14 +21,44 @@ export type DiscordSeriesViewMode = "standard" | "wide";
 interface DiscordSeriesStatsViewProps {
   readonly renderData: DiscordSeriesStatsResolved["renderData"];
   readonly model: DiscordSeriesStatsViewModel;
+  readonly analyticsByMatchId: ReadonlyMap<string, MatchAnalytics>;
 }
 
-export function DiscordSeriesStatsView({ renderData, model }: DiscordSeriesStatsViewProps): ReactElement {
+export function DiscordSeriesStatsView({
+  renderData,
+  model,
+  analyticsByMatchId,
+}: DiscordSeriesStatsViewProps): ReactElement {
   const [viewMode, setViewMode] = useState<DiscordSeriesViewMode>("standard");
   const contentWidthClass = viewMode === "wide" ? styles.wide : undefined;
   const handleToggleViewMode = useCallback((): void => {
     setViewMode((current) => (current === "standard" ? "wide" : "standard"));
   }, []);
+
+  const allMatchKillMatrixRows = useMemo<ReadonlyMap<string, KillMatrixViewRow[]>>(
+    () =>
+      new Map(
+        renderData.matches.flatMap((match) => {
+          const analytics = analyticsByMatchId.get(match.matchId);
+          if (analytics == null) {
+            return [];
+          }
+          const playersByXuid = new Map(
+            Object.entries(match.playerXuidToGametag).map(([xuid, gamertag]) => [
+              xuid,
+              { gamertag, teamId: null },
+            ]),
+          );
+          return [[match.matchId, KillMatrixPresenter.present({ analytics, playersByXuid })]];
+        }),
+      ),
+    [analyticsByMatchId, renderData.matches],
+  );
+
+  const seriesKillMatrixRows = useMemo<KillMatrixViewRow[]>(
+    () => KillMatrixPresenter.aggregate([...allMatchKillMatrixRows.values()].flat()),
+    [allMatchKillMatrixRows],
+  );
 
   return (
     <>
@@ -129,6 +162,7 @@ export function DiscordSeriesStatsView({ renderData, model }: DiscordSeriesStats
               title="Series Totals"
               metadata={model.seriesStats.metadata}
               teamColors={model.teamColors}
+              killMatrixRows={seriesKillMatrixRows}
             />
           </Container>
         )}
@@ -160,6 +194,7 @@ export function DiscordSeriesStatsView({ renderData, model }: DiscordSeriesStats
                   startTime={match.startTime}
                   endTime={match.endTime}
                   teamColors={model.teamColors}
+                  killMatrixRows={allMatchKillMatrixRows.get(match.matchId)}
                 />
               ) : (
                 <Alert variant="warning">Failed to load detailed stats for match {match.matchId}.</Alert>

--- a/pages/src/components/discord-series-stats/tests/create.test.tsx
+++ b/pages/src/components/discord-series-stats/tests/create.test.tsx
@@ -50,7 +50,9 @@ function aFakeResolvedDataWith(overrides: Partial<DiscordSeriesStatsResolved> = 
 
 describe("DiscordSeriesStats", () => {
   it("renders header and top-level sections", () => {
-    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />);
+    render(
+      <DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />,
+    );
 
     expect(screen.getByRole("heading", { name: "Queue #7777 Series Stats" })).toBeInTheDocument();
     expect(screen.getByText("Series overview")).toBeInTheDocument();
@@ -60,13 +62,17 @@ describe("DiscordSeriesStats", () => {
   });
 
   it("shows warning when a match has invalid raw match data", () => {
-    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />);
+    render(
+      <DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />,
+    );
 
     expect(screen.getByText("Failed to load detailed stats for match match-1.")).toBeInTheDocument();
   });
 
   it("does not render series totals when no valid raw match data exists", () => {
-    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />);
+    render(
+      <DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />,
+    );
 
     expect(screen.queryByText("Series Totals")).not.toBeInTheDocument();
   });
@@ -88,7 +94,9 @@ describe("DiscordSeriesStats", () => {
   });
 
   it("toggles between standard and wide view", () => {
-    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />);
+    render(
+      <DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />,
+    );
 
     const toggleButton = screen.getByRole("button", { name: "Switch to wide view" });
     expect(toggleButton).toBeInTheDocument();

--- a/pages/src/components/discord-series-stats/tests/create.test.tsx
+++ b/pages/src/components/discord-series-stats/tests/create.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
 import { DiscordSeriesStats } from "../create";
 import { DiscordSeriesStatsPresenter } from "../discord-series-stats-presenter";
+import { aFakeMatchAnalyticsServiceWith } from "../../../services/stats/fakes/match-analytics.fake";
 
 afterEach(() => {
   cleanup();
@@ -49,7 +50,7 @@ function aFakeResolvedDataWith(overrides: Partial<DiscordSeriesStatsResolved> = 
 
 describe("DiscordSeriesStats", () => {
   it("renders header and top-level sections", () => {
-    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} />);
+    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />);
 
     expect(screen.getByRole("heading", { name: "Queue #7777 Series Stats" })).toBeInTheDocument();
     expect(screen.getByText("Series overview")).toBeInTheDocument();
@@ -59,13 +60,13 @@ describe("DiscordSeriesStats", () => {
   });
 
   it("shows warning when a match has invalid raw match data", () => {
-    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} />);
+    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />);
 
     expect(screen.getByText("Failed to load detailed stats for match match-1.")).toBeInTheDocument();
   });
 
   it("does not render series totals when no valid raw match data exists", () => {
-    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} />);
+    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />);
 
     expect(screen.queryByText("Series Totals")).not.toBeInTheDocument();
   });
@@ -77,6 +78,7 @@ describe("DiscordSeriesStats", () => {
     render(
       <DiscordSeriesStats
         data={aFakeResolvedDataWith({ renderData: { ...aFakeResolvedDataWith().renderData, medalMetadata } })}
+        matchAnalyticsService={aFakeMatchAnalyticsServiceWith()}
       />,
     );
 
@@ -86,7 +88,7 @@ describe("DiscordSeriesStats", () => {
   });
 
   it("toggles between standard and wide view", () => {
-    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} />);
+    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />);
 
     const toggleButton = screen.getByRole("button", { name: "Switch to wide view" });
     expect(toggleButton).toBeInTheDocument();

--- a/pages/src/components/discord-series-stats/tests/create.test.tsx
+++ b/pages/src/components/discord-series-stats/tests/create.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
 import { DiscordSeriesStats } from "../create";
 import { DiscordSeriesStatsPresenter } from "../discord-series-stats-presenter";
@@ -104,5 +104,24 @@ describe("DiscordSeriesStats", () => {
     fireEvent.click(toggleButton);
 
     expect(screen.getByRole("button", { name: "Switch to standard view" })).toBeInTheDocument();
+  });
+
+  it("fetches match analytics for each match id", async () => {
+    const matchAnalyticsService = aFakeMatchAnalyticsServiceWith();
+    const getMatchAnalyticsSpy = vi.spyOn(matchAnalyticsService, "getMatchAnalytics");
+
+    render(
+      <DiscordSeriesStats
+        data={aFakeResolvedDataWith({ matchIds: ["match-1", "match-2"] })}
+        matchAnalyticsService={matchAnalyticsService}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getMatchAnalyticsSpy).toHaveBeenCalledTimes(2);
+    });
+
+    expect(getMatchAnalyticsSpy).toHaveBeenCalledWith("match-1");
+    expect(getMatchAnalyticsSpy).toHaveBeenCalledWith("match-2");
   });
 });

--- a/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
@@ -28,7 +28,6 @@ export class KillMatrixPresenter {
         headshotKills: value.headshotKills,
         perfects: value.perfects,
         classification: this.classify(killer, victim),
-        topWeaponId: this.topWeaponId(value.weapons),
       });
     }
 
@@ -75,25 +74,6 @@ export class KillMatrixPresenter {
     }
 
     return "enemy-kill";
-  }
-
-  private topWeaponId(weapons: readonly { readonly weaponId: number; readonly count: number }[]): number | null {
-    if (weapons.length === 0) {
-      return null;
-    }
-
-    let maxWeaponId = weapons[0].weaponId;
-    let maxCount = weapons[0].count;
-
-    for (let i = 1; i < weapons.length; i++) {
-      const weapon = weapons[i];
-      if (weapon.count > maxCount) {
-        maxCount = weapon.count;
-        maxWeaponId = weapon.weaponId;
-      }
-    }
-
-    return maxWeaponId;
   }
 
   private parsePairKey(key: string): { killerXuid: string; victimXuid: string } {

--- a/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
@@ -100,4 +100,30 @@ export class KillMatrixPresenter {
     const [killerXuid, victimXuid] = key.split(":");
     return { killerXuid, victimXuid };
   }
+
+  public static aggregate(rows: readonly KillMatrixViewRow[]): KillMatrixViewRow[] {
+    const merged = new Map<string, KillMatrixViewRow>();
+
+    for (const row of rows) {
+      const existing = merged.get(row.key);
+      if (existing == null) {
+        merged.set(row.key, { ...row });
+      } else {
+        merged.set(row.key, {
+          ...existing,
+          count: existing.count + row.count,
+          headshotKills: existing.headshotKills + row.headshotKills,
+          perfects: existing.perfects + row.perfects,
+        });
+      }
+    }
+
+    return [...merged.values()].sort((left, right) => {
+      if (right.count !== left.count) {
+        return right.count - left.count;
+      }
+
+      return left.key.localeCompare(right.key);
+    });
+  }
 }

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { KillMatrixPresenter } from "../kill-matrix-presenter";
 import { aFakeMatchAnalyticsWith } from "../fakes/match-analytics.fake";
+import type { KillMatrixViewRow } from "../types";
 
 describe("KillMatrixPresenter", () => {
   it("expands and sorts kill matrix rows", () => {
@@ -73,5 +74,70 @@ describe("KillMatrixPresenter", () => {
     });
 
     expect(row.topWeaponId).toBe(6001);
+  });
+
+  describe("aggregate", () => {
+    it("sums counts for the same key across multiple rows", () => {
+      const rows: KillMatrixViewRow[] = [
+        {
+          key: "111:222",
+          killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          count: 3,
+          headshotKills: 1,
+          perfects: 0,
+          classification: "enemy-kill",
+          topWeaponId: 1001,
+        },
+        {
+          key: "111:222",
+          killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          count: 2,
+          headshotKills: 2,
+          perfects: 1,
+          classification: "enemy-kill",
+          topWeaponId: 2001,
+        },
+      ];
+
+      const result = KillMatrixPresenter.aggregate(rows);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ key: "111:222", count: 5, headshotKills: 3, perfects: 1 });
+    });
+
+    it("returns rows sorted by count descending", () => {
+      const rows: KillMatrixViewRow[] = [
+        {
+          key: "111:222",
+          killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          count: 1,
+          headshotKills: 0,
+          perfects: 0,
+          classification: "enemy-kill",
+          topWeaponId: null,
+        },
+        {
+          key: "333:444",
+          killer: { xuid: "333", gamertag: "Charlie", teamId: 0 },
+          victim: { xuid: "444", gamertag: "Delta", teamId: 1 },
+          count: 3,
+          headshotKills: 0,
+          perfects: 0,
+          classification: "enemy-kill",
+          topWeaponId: null,
+        },
+      ];
+
+      const result = KillMatrixPresenter.aggregate(rows);
+
+      expect(result.map((r) => r.key)).toEqual(["333:444", "111:222"]);
+    });
+
+    it("returns empty array when given no rows", () => {
+      expect(KillMatrixPresenter.aggregate([])).toEqual([]);
+    });
   });
 });

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts
@@ -20,7 +20,6 @@ describe("KillMatrixPresenter", () => {
     expect(rows.map((row) => row.key)).toEqual(["111:222", "333:444", "111:111"]);
     expect(rows[0]).toMatchObject({
       classification: "enemy-kill",
-      topWeaponId: 5001,
       killer: { gamertag: "Alpha" },
       victim: { gamertag: "Bravo" },
     });
@@ -48,34 +47,6 @@ describe("KillMatrixPresenter", () => {
     expect(row.classification).toBe("enemy-kill");
   });
 
-  it("returns a weapon even when all have zero count", () => {
-    const presenter = new KillMatrixPresenter();
-    const analytics = aFakeMatchAnalyticsWith({
-      killMatrix: {
-        "111:222": {
-          count: 1,
-          headshotKills: 0,
-          perfects: 0,
-          weapons: [
-            { weaponId: 6001, count: 0 },
-            { weaponId: 5001, count: 0 },
-            { weaponId: 7001, count: 0 },
-          ],
-        },
-      },
-    });
-
-    const [row] = presenter.present({
-      analytics,
-      playersByXuid: new Map([
-        ["111", { gamertag: "Alpha", teamId: 0 }],
-        ["222", { gamertag: "Bravo", teamId: 1 }],
-      ]),
-    });
-
-    expect(row.topWeaponId).toBe(6001);
-  });
-
   describe("aggregate", () => {
     it("sums counts for the same key across multiple rows", () => {
       const rows: KillMatrixViewRow[] = [
@@ -87,7 +58,6 @@ describe("KillMatrixPresenter", () => {
           headshotKills: 1,
           perfects: 0,
           classification: "enemy-kill",
-          topWeaponId: 1001,
         },
         {
           key: "111:222",
@@ -97,7 +67,6 @@ describe("KillMatrixPresenter", () => {
           headshotKills: 2,
           perfects: 1,
           classification: "enemy-kill",
-          topWeaponId: 2001,
         },
       ];
 
@@ -117,7 +86,6 @@ describe("KillMatrixPresenter", () => {
           headshotKills: 0,
           perfects: 0,
           classification: "enemy-kill",
-          topWeaponId: null,
         },
         {
           key: "333:444",
@@ -127,7 +95,6 @@ describe("KillMatrixPresenter", () => {
           headshotKills: 0,
           perfects: 0,
           classification: "enemy-kill",
-          topWeaponId: null,
         },
       ];
 

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-store.test.ts
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-store.test.ts
@@ -20,7 +20,6 @@ describe("KillMatrixStore", () => {
         count: 3,
         headshotKills: 1,
         perfects: 0,
-        topWeaponId: 1001,
       },
     ] satisfies readonly KillMatrixViewRow[]);
 

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -29,7 +29,6 @@ describe("KillMatrixTable", () => {
             headshotKills: 1,
             perfects: 0,
             classification: "enemy-kill",
-            topWeaponId: 1001,
           },
         ]}
       />,

--- a/pages/src/components/stats/kill-matrix/types.ts
+++ b/pages/src/components/stats/kill-matrix/types.ts
@@ -16,7 +16,6 @@ export interface KillMatrixViewRow {
   readonly headshotKills: number;
   readonly perfects: number;
   readonly classification: KillMatrixClassification;
-  readonly topWeaponId: number | null;
 }
 
 export type KillMatrixRaw = MatchAnalytics["killMatrix"];


### PR DESCRIPTION
## 1. context
This is Step 4 in the Stage 2b PR train. Steps 1-3 established shared tabs, analytics plumbing, and kill-matrix UI containers, but the Discord Series Stats path still rendered kill matrix tabs with empty-state only because analytics rows were not wired through.

## 2. overview of the feature
Wire real match analytics into the Discord Series Stats UI so kill matrix tabs show actual data for each match and as a series aggregate.

## 3. what this PR does
- Adds kill matrix aggregation support:
  - `pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts`
  - `pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts`
- Wires analytics fetch + render flow in Discord stats:
  - `pages/src/components/discord-series-stats/create.tsx`
  - `pages/src/components/discord-series-stats/discord-series-stats-view.tsx`
- Threads analytics service through app boundary:
  - `pages/src/apps/discord-series-stats/create.tsx`
- Updates component test setup to include analytics service dependency:
  - `pages/src/components/discord-series-stats/tests/create.test.tsx`

Validation:
- `npx vitest run pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts pages/src/components/discord-series-stats/tests/create.test.tsx pages/src/apps/discord-series-stats/tests/create.test.tsx pages/src/apps/discord-series-stats/tests/discord-series-stats-presenter.test.ts`
- `npm run typecheck:pages`

## 4. PR train
| Step | Branch | PR | Scope | Status |
|---|---|---|---|---|
| 1 | `feature/stage-2b-kill-matrix-ui` | #547 | Shared tab shell + tracker manager migration | Open |
| 2 | `feature/stage-2b-analytics-service` | #550 | Match analytics service + presenter plumbing | Open |
| 3 | `feature/stage-2b-kill-matrix-table` | #551 | Kill matrix table + tab integration in stats components | Open |
| 4 | `feature/stage-2b-discord-kill-matrix` | this PR | Real kill matrix data wiring for Discord Series Stats | Open |
| 5 | `feature/stage-2b-viewer-kill-matrix` | pending | Individual Tracker Viewer analytics fetch + kill matrix wiring | Planned |
