### PR TITLE
feat(pages): wire viewer kill matrix analytics

### DIFF
--- a/pages/src/apps/follow-live/create.tsx
+++ b/pages/src/apps/follow-live/create.tsx
@@ -68,6 +68,7 @@ export function FollowLiveApp({ apiHost, gamertag, variant = "viewer" }: FollowL
             gamertag={gamertag}
             followLiveService={services.followLiveService}
             individualTrackerViewService={services.individualTrackerViewService}
+            matchAnalyticsService={services.matchAnalyticsService}
             haloClient={services.haloClient}
           />
         ) : (

--- a/pages/src/apps/follow-live/services.ts
+++ b/pages/src/apps/follow-live/services.ts
@@ -4,33 +4,43 @@ import { installFollowLiveService } from "../../services/follow/install";
 import type { FollowLiveService } from "../../services/follow/follow-types";
 import { installIndividualTrackerViewService } from "../../services/individual-tracker/install";
 import type { IndividualTrackerViewService } from "../../services/individual-tracker/view-types";
+import { installMatchAnalyticsService } from "../../services/stats/install";
+import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import { getMode } from "../../services/mode";
 
 export interface Services {
   readonly followLiveService: FollowLiveService;
   readonly individualTrackerViewService: IndividualTrackerViewService;
+  readonly matchAnalyticsService: MatchAnalyticsService;
   readonly haloClient: HaloInfiniteClient;
 }
 
 export async function installServices(apiHost: string): Promise<Services> {
   if (getMode() === "FAKE") {
-    const [{ aFakeFollowLiveServiceWith }, { aFakeIndividualTrackerViewServiceWith }, { aFakeHaloClientWith }] =
-      await Promise.all([
-        import("../../services/follow/fakes/follow.fake"),
-        import("../../services/individual-tracker/fakes/view.fake"),
-        import("../../services/fakes/halo-client.fake"),
-      ]);
+    const [
+      { aFakeFollowLiveServiceWith },
+      { aFakeIndividualTrackerViewServiceWith },
+      { aFakeMatchAnalyticsServiceWith },
+      { aFakeHaloClientWith },
+    ] = await Promise.all([
+      import("../../services/follow/fakes/follow.fake"),
+      import("../../services/individual-tracker/fakes/view.fake"),
+      import("../../services/stats/fakes/match-analytics.fake"),
+      import("../../services/fakes/halo-client.fake"),
+    ]);
     return {
       followLiveService: aFakeFollowLiveServiceWith(),
       individualTrackerViewService: aFakeIndividualTrackerViewServiceWith(),
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
       haloClient: aFakeHaloClientWith(),
     };
   }
 
-  const [followLiveService, individualTrackerViewService] = await Promise.all([
+  const [followLiveService, individualTrackerViewService, matchAnalyticsService] = await Promise.all([
     installFollowLiveService(apiHost),
     installIndividualTrackerViewService(apiHost),
+    installMatchAnalyticsService(apiHost),
   ]);
   const haloClient = createHaloInfiniteClientProxy({ proxyBaseUrl: apiHost });
-  return { followLiveService, individualTrackerViewService, haloClient };
+  return { followLiveService, individualTrackerViewService, matchAnalyticsService, haloClient };
 }

--- a/pages/src/apps/individual-tracker-overlay/create.tsx
+++ b/pages/src/apps/individual-tracker-overlay/create.tsx
@@ -59,6 +59,7 @@ export function IndividualTrackerOverlayApp({ apiHost, trackerId }: IndividualTr
         services ? (
           <IndividualTrackerOverlayPage
             individualTrackerViewService={services.individualTrackerViewService}
+            matchAnalyticsService={services.matchAnalyticsService}
             haloClient={services.haloClient}
             trackerId={trackerId}
           />

--- a/pages/src/apps/individual-tracker-viewer/create.tsx
+++ b/pages/src/apps/individual-tracker-viewer/create.tsx
@@ -72,6 +72,7 @@ export function IndividualTrackerViewerApp({ apiHost, trackerId }: IndividualTra
         services ? (
           <IndividualTrackerViewerPage
             individualTrackerViewService={services.individualTrackerViewService}
+            matchAnalyticsService={services.matchAnalyticsService}
             haloClient={services.haloClient}
             trackerId={trackerId}
           />

--- a/pages/src/components/follow/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer.tsx
@@ -5,6 +5,7 @@ import { LoadingState } from "../loading-state/loading-state";
 import { IndividualTrackerViewerPage } from "../individual-tracker/viewer/create";
 import type { FollowLiveService } from "../../services/follow/follow-types";
 import type { IndividualTrackerViewService } from "../../services/individual-tracker/view-types";
+import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import { FollowTrackerTabs } from "./follow-tracker-tabs";
 import { useFollowLiveDirectory } from "./use-follow-live-directory";
 import styles from "./follow-live-viewer.module.css";
@@ -13,6 +14,7 @@ export interface FollowLiveViewerProps {
   readonly gamertag: string;
   readonly followLiveService: FollowLiveService;
   readonly individualTrackerViewService: IndividualTrackerViewService;
+  readonly matchAnalyticsService: MatchAnalyticsService;
   readonly haloClient: HaloInfiniteClient;
 }
 
@@ -20,6 +22,7 @@ export function FollowLiveViewer({
   gamertag,
   followLiveService,
   individualTrackerViewService,
+  matchAnalyticsService,
   haloClient,
 }: FollowLiveViewerProps): React.ReactElement {
   const { directory, directoryStatus, selectedTrackerId, isFollowingLive, onSelectTracker, onFollowLive } =
@@ -52,6 +55,7 @@ export function FollowLiveViewer({
           <IndividualTrackerViewerPage
             key={selectedTrackerId}
             individualTrackerViewService={individualTrackerViewService}
+            matchAnalyticsService={matchAnalyticsService}
             haloClient={haloClient}
             trackerId={selectedTrackerId}
           />

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -4,22 +4,26 @@ import { ComponentLoader } from "../../component-loader/component-loader";
 import { ErrorState } from "../../error-state/error-state";
 import { LoadingState } from "../../loading-state/loading-state";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
+import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import { useIndividualTrackerViewer } from "../viewer/use-individual-tracker-viewer";
 import { IndividualTrackerOverlay } from "./individual-tracker-overlay";
 
 interface IndividualTrackerOverlayPageProps {
   readonly individualTrackerViewService: IndividualTrackerViewService;
+  readonly matchAnalyticsService: MatchAnalyticsService;
   readonly haloClient: HaloInfiniteClient;
   readonly trackerId: string;
 }
 
 export function IndividualTrackerOverlayPage({
   individualTrackerViewService,
+  matchAnalyticsService,
   haloClient,
   trackerId,
 }: IndividualTrackerOverlayPageProps): React.ReactElement {
   const { snapshot, model, onSelectMatch, onDeselect, onRetry } = useIndividualTrackerViewer({
     individualTrackerViewService,
+    matchAnalyticsService,
     haloClient,
     trackerId,
   });

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -87,6 +87,7 @@ describe("IndividualTrackerOverlay", () => {
             ["4444444444", "Delta"],
           ]),
           medalMetadata: {},
+          analytics: null,
         }}
         selectedMatchId="m-1"
         onSelectMatch={() => undefined}
@@ -128,6 +129,7 @@ describe("IndividualTrackerOverlay", () => {
             ["4444444444", "Delta"],
           ]),
           medalMetadata: {},
+          analytics: null,
         }}
         selectedMatchId="m-1"
         onSelectMatch={() => undefined}

--- a/pages/src/components/individual-tracker/viewer/create.tsx
+++ b/pages/src/components/individual-tracker/viewer/create.tsx
@@ -4,22 +4,26 @@ import { ComponentLoader } from "../../component-loader/component-loader";
 import { ErrorState } from "../../error-state/error-state";
 import { LoadingState } from "../../loading-state/loading-state";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
+import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import { IndividualTrackerViewer } from "./individual-tracker-viewer";
 import { useIndividualTrackerViewer } from "./use-individual-tracker-viewer";
 
 interface IndividualTrackerViewerPageProps {
   readonly individualTrackerViewService: IndividualTrackerViewService;
+  readonly matchAnalyticsService: MatchAnalyticsService;
   readonly haloClient: HaloInfiniteClient;
   readonly trackerId: string;
 }
 
 export function IndividualTrackerViewerPage({
   individualTrackerViewService,
+  matchAnalyticsService,
   haloClient,
   trackerId,
 }: IndividualTrackerViewerPageProps): React.ReactElement {
   const { snapshot, model, onSelectMatch, onDeselect, onRetry } = useIndividualTrackerViewer({
     individualTrackerViewService,
+    matchAnalyticsService,
     haloClient,
     trackerId,
   });

--- a/pages/src/components/individual-tracker/viewer/stats-panel.tsx
+++ b/pages/src/components/individual-tracker/viewer/stats-panel.tsx
@@ -17,6 +17,7 @@ interface LoadedStatsPanelProps {
 
 function LoadedStatsPanel({ state }: LoadedStatsPanelProps): React.ReactElement {
   const { stats, playerMap, medalMetadata, analytics } = state;
+  const killMatrixPresenter = useMemo(() => new KillMatrixPresenter(), []);
   const data = useMemo<MatchStatsData[]>(() => {
     const presenter = createMatchStatsPresenter(stats.MatchInfo.GameVariantCategory);
     return presenter.getData(stats, playerMap, medalMetadata);
@@ -31,8 +32,8 @@ function LoadedStatsPanel({ state }: LoadedStatsPanelProps): React.ReactElement 
       [...playerMap.entries()].map(([xuid, gamertag]) => [xuid, { gamertag, teamId: null }]),
     );
 
-    return KillMatrixPresenter.present({ analytics, playersByXuid });
-  }, [analytics, playerMap]);
+    return killMatrixPresenter.present({ analytics, playersByXuid });
+  }, [analytics, killMatrixPresenter, playerMap]);
 
   return (
     <div className={styles.wrapper}>

--- a/pages/src/components/individual-tracker/viewer/stats-panel.tsx
+++ b/pages/src/components/individual-tracker/viewer/stats-panel.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react";
-import type { MatchStats as MatchStatsType } from "halo-infinite-api";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
-import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
+import { KillMatrixPresenter } from "../../stats/kill-matrix/kill-matrix-presenter";
 import { Alert } from "../../alert/alert";
 import { LoadingState } from "../../loading-state/loading-state";
 import { createMatchStatsPresenter } from "../../stats/create";
@@ -9,19 +8,31 @@ import { MatchStats } from "../../stats/match-stats";
 import type { MatchStatsData } from "../../stats/types";
 import { gameModeIconSrc } from "../game-mode-icon";
 import type { IndividualTrackerViewerViewModel } from "./types";
+import type { MatchStatsState } from "./viewer-store";
 import styles from "./stats-panel.module.css";
 
 interface LoadedStatsPanelProps {
-  readonly stats: MatchStatsType;
-  readonly playerMap: Map<string, string>;
-  readonly medalMetadata: MedalMetadata;
+  readonly state: Extract<MatchStatsState, { readonly status: "loaded" }>;
 }
 
-function LoadedStatsPanel({ stats, playerMap, medalMetadata }: LoadedStatsPanelProps): React.ReactElement {
+function LoadedStatsPanel({ state }: LoadedStatsPanelProps): React.ReactElement {
+  const { stats, playerMap, medalMetadata, analytics } = state;
   const data = useMemo<MatchStatsData[]>(() => {
     const presenter = createMatchStatsPresenter(stats.MatchInfo.GameVariantCategory);
     return presenter.getData(stats, playerMap, medalMetadata);
   }, [stats, playerMap, medalMetadata]);
+
+  const killMatrixRows = useMemo(() => {
+    if (analytics == null) {
+      return [];
+    }
+
+    const playersByXuid = new Map(
+      [...playerMap.entries()].map(([xuid, gamertag]) => [xuid, { gamertag, teamId: null }]),
+    );
+
+    return KillMatrixPresenter.present({ analytics, playersByXuid });
+  }, [analytics, playerMap]);
 
   return (
     <div className={styles.wrapper}>
@@ -37,6 +48,7 @@ function LoadedStatsPanel({ stats, playerMap, medalMetadata }: LoadedStatsPanelP
         score=""
         startTime={stats.MatchInfo.StartTime}
         endTime={stats.MatchInfo.EndTime}
+        killMatrixRows={killMatrixRows}
       />
     </div>
   );
@@ -67,7 +79,7 @@ export function StatsPanel({ state }: StatsPanelProps): React.ReactElement | nul
       );
     }
     case "loaded": {
-      return <LoadedStatsPanel stats={state.stats} playerMap={state.playerMap} medalMetadata={state.medalMetadata} />;
+      return <LoadedStatsPanel state={state} />;
     }
     default: {
       throw new UnreachableError(state);

--- a/pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx
@@ -46,7 +46,7 @@ describe("StatsPanel", () => {
       ["4444444444", "Delta"],
     ]);
 
-    render(<StatsPanel state={{ status: "loaded", stats, playerMap, medalMetadata: {} }} />);
+    render(<StatsPanel state={{ status: "loaded", stats, playerMap, medalMetadata: {}, analytics: null }} />);
 
     expect(screen.getByRole("tab", { name: "Players" })).toBeInTheDocument();
   });

--- a/pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { aFakeMatchStatsWith } from "../../../stats/fakes/data";
 import { StatsPanel } from "../stats-panel";
 
@@ -49,5 +49,52 @@ describe("StatsPanel", () => {
     render(<StatsPanel state={{ status: "loaded", stats, playerMap, medalMetadata: {}, analytics: null }} />);
 
     expect(screen.getByRole("tab", { name: "Players" })).toBeInTheDocument();
+  });
+
+  it("renders kill matrix table when analytics is available", () => {
+    const stats = aFakeMatchStatsWith();
+    const playerMap = new Map([
+      ["1111111111", "Alpha"],
+      ["2222222222", "Bravo"],
+      ["3333333333", "Charlie"],
+      ["4444444444", "Delta"],
+    ]);
+
+    render(
+      <StatsPanel
+        state={{
+          status: "loaded",
+          stats,
+          playerMap,
+          medalMetadata: {},
+          analytics: {
+            requestedModules: ["killMatrix"],
+            killMatrix: {
+              "1111111111:2222222222": {
+                count: 3,
+                headshotKills: 1,
+                perfects: 0,
+                weapons: [],
+              },
+            },
+            metadata: {
+              pairingQuality: {
+                unpairedDeathCount: 0,
+                maxTimeDeltaMs: 1,
+              },
+              perfectCounts: {
+                total: 0,
+                byXuid: {},
+              },
+            },
+          },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Kill Matrix" }));
+
+    expect(screen.getByLabelText("Match kill matrix")).toBeInTheDocument();
+    expect(screen.queryByText("Kill matrix data is not available for this match yet.")).not.toBeInTheDocument();
   });
 });

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
@@ -10,18 +10,24 @@ import {
 } from "../../../../services/individual-tracker/fakes/view.fake";
 import type { FakeIndividualTrackerViewService } from "../../../../services/individual-tracker/fakes/view.fake";
 import { aFakeHaloClientWith } from "../../../../services/fakes/halo-client.fake";
+import { aFakeMatchAnalyticsServiceWith } from "../../../../services/stats/fakes/match-analytics.fake";
+import type { MatchAnalyticsService } from "../../../../services/stats/match-analytics-types";
 import { aFakeMatchStatsWith } from "../../../stats/fakes/data";
 import { IndividualTrackerViewerPresenter } from "../viewer-presenter";
 import { IndividualTrackerViewerStore } from "../viewer-store";
 
 interface Harness {
   readonly service: FakeIndividualTrackerViewService;
+  readonly matchAnalyticsService: MatchAnalyticsService;
   readonly haloClient: Mocked<Pick<HaloInfiniteClient, "getMatchStats" | "getUsers" | "getMedalsMetadataFile">>;
   readonly store: IndividualTrackerViewerStore;
   readonly presenter: IndividualTrackerViewerPresenter;
 }
 
-function aHarness(service: FakeIndividualTrackerViewService): Harness {
+function aHarness(
+  service: FakeIndividualTrackerViewService,
+  matchAnalyticsService: MatchAnalyticsService = aFakeMatchAnalyticsServiceWith(),
+): Harness {
   const store = new IndividualTrackerViewerStore();
   const haloClient = {
     getMatchStats: vi.fn<HaloInfiniteClient["getMatchStats"]>().mockResolvedValue(aFakeMatchStatsWith()),
@@ -32,11 +38,12 @@ function aHarness(service: FakeIndividualTrackerViewService): Harness {
   };
   const presenter = new IndividualTrackerViewerPresenter({
     individualTrackerViewService: service,
+    matchAnalyticsService,
     haloClient: aFakeHaloClientWith(haloClient),
     store,
     trackerId: "tracker-1",
   });
-  return { service, haloClient, store, presenter };
+  return { service, matchAnalyticsService, haloClient, store, presenter };
 }
 
 describe("IndividualTrackerViewerPresenter", () => {
@@ -125,8 +132,9 @@ describe("IndividualTrackerViewerPresenter", () => {
     it("sets selectedMatchId in the store and transitions matchStatsState to loaded", async () => {
       const fakeStats = aFakeMatchStatsWith({ MatchId: "m-99" });
       const service = aFakeIndividualTrackerViewServiceWith();
-      const { haloClient, store, presenter } = aHarness(service);
+      const { haloClient, matchAnalyticsService, store, presenter } = aHarness(service);
       haloClient.getMatchStats.mockResolvedValue(fakeStats);
+      const getMatchAnalyticsSpy = vi.spyOn(matchAnalyticsService, "getMatchAnalytics");
 
       presenter.selectMatch("m-99");
 
@@ -140,6 +148,26 @@ describe("IndividualTrackerViewerPresenter", () => {
       const statsState = store.getSnapshot().matchStatsState;
       if (statsState?.status === "loaded") {
         expect(statsState.stats.MatchId).toBe("m-99");
+        expect(statsState.analytics).not.toBeNull();
+      }
+      expect(getMatchAnalyticsSpy).toHaveBeenCalledWith("m-99");
+    });
+
+    it("falls back to null analytics when analytics fetch fails", async () => {
+      const service = aFakeIndividualTrackerViewServiceWith();
+      const matchAnalyticsService = aFakeMatchAnalyticsServiceWith();
+      vi.spyOn(matchAnalyticsService, "getMatchAnalytics").mockRejectedValue(new Error("analytics failed"));
+      const { store, presenter } = aHarness(service, matchAnalyticsService);
+
+      presenter.selectMatch("m-1");
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().matchStatsState?.status).toBe("loaded");
+      });
+
+      const statsState = store.getSnapshot().matchStatsState;
+      if (statsState?.status === "loaded") {
+        expect(statsState.analytics).toBeNull();
       }
     });
 
@@ -221,14 +249,15 @@ describe("IndividualTrackerViewerPresenter", () => {
     });
 
     it("sets matchStatsState to error when getMatchStats rejects", async () => {
-      expect.assertions(2);
       const service = aFakeIndividualTrackerViewServiceWith();
       const { haloClient, store, presenter } = aHarness(service);
       haloClient.getMatchStats.mockRejectedValue(new Error("Network failure"));
 
       presenter.selectMatch("m-err");
 
-      await vi.waitFor(() => store.getSnapshot().matchStatsState?.status === "error");
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().matchStatsState?.status).toBe("error");
+      });
 
       const statsState = store.getSnapshot().matchStatsState;
       if (statsState?.status === "error") {

--- a/pages/src/components/individual-tracker/viewer/use-individual-tracker-viewer.ts
+++ b/pages/src/components/individual-tracker/viewer/use-individual-tracker-viewer.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
 import type { HaloInfiniteClient } from "halo-infinite-api";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
+import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import { IndividualTrackerViewerPresenter } from "./viewer-presenter";
 import type { IndividualTrackerViewerSnapshot } from "./viewer-store";
 import { IndividualTrackerViewerStore } from "./viewer-store";
@@ -8,6 +9,7 @@ import type { IndividualTrackerViewerViewModel } from "./types";
 
 interface UseIndividualTrackerViewerOpts {
   readonly individualTrackerViewService: IndividualTrackerViewService;
+  readonly matchAnalyticsService: MatchAnalyticsService;
   readonly haloClient: HaloInfiniteClient;
   readonly trackerId: string;
 }
@@ -22,6 +24,7 @@ export interface IndividualTrackerViewerHookResult {
 
 export function useIndividualTrackerViewer({
   individualTrackerViewService,
+  matchAnalyticsService,
   haloClient,
   trackerId,
 }: UseIndividualTrackerViewerOpts): IndividualTrackerViewerHookResult {
@@ -31,11 +34,12 @@ export function useIndividualTrackerViewer({
     () =>
       new IndividualTrackerViewerPresenter({
         individualTrackerViewService,
+        matchAnalyticsService,
         haloClient,
         store,
         trackerId,
       }),
-    [individualTrackerViewService, haloClient, store, trackerId],
+    [individualTrackerViewService, matchAnalyticsService, haloClient, store, trackerId],
   );
 
   useEffect(() => {

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -70,17 +70,16 @@ export class IndividualTrackerViewerPresenter {
 
   private async fetchMatchStats(matchId: string): Promise<void> {
     try {
-      const [stats, analytics] = await Promise.all([
-        this.config.haloClient.getMatchStats(matchId),
-        this.config.matchAnalyticsService.getMatchAnalytics(matchId).catch(() => null),
-      ]);
+      const analyticsPromise = this.config.matchAnalyticsService.getMatchAnalytics(matchId).catch(() => null);
+      const stats = await this.config.haloClient.getMatchStats(matchId);
       if (this.isStale(matchId)) {
         return;
       }
       const xuids = stats.Players.filter((p) => p.PlayerType === 1).map((p) => getPlayerXuid(p));
-      const [users, medalsMetadataFile] = await Promise.all([
+      const [users, medalsMetadataFile, analytics] = await Promise.all([
         this.config.haloClient.getUsers(xuids),
         this.config.haloClient.getMedalsMetadataFile(),
+        analyticsPromise,
       ]);
       if (this.isStale(matchId)) {
         return;

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -1,6 +1,7 @@
 import type { HaloInfiniteClient } from "halo-infinite-api";
 import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
+import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type {
   IndividualTrackerViewService,
   TrackerViewConnection,
@@ -12,6 +13,7 @@ import type { IndividualTrackerViewerViewModel } from "./types";
 
 interface Config {
   readonly individualTrackerViewService: IndividualTrackerViewService;
+  readonly matchAnalyticsService: MatchAnalyticsService;
   readonly haloClient: HaloInfiniteClient;
   readonly store: IndividualTrackerViewerStore;
   readonly trackerId: string;
@@ -68,7 +70,10 @@ export class IndividualTrackerViewerPresenter {
 
   private async fetchMatchStats(matchId: string): Promise<void> {
     try {
-      const stats = await this.config.haloClient.getMatchStats(matchId);
+      const [stats, analytics] = await Promise.all([
+        this.config.haloClient.getMatchStats(matchId),
+        this.config.matchAnalyticsService.getMatchAnalytics(matchId).catch(() => null),
+      ]);
       if (this.isStale(matchId)) {
         return;
       }
@@ -89,7 +94,7 @@ export class IndividualTrackerViewerPresenter {
       const medalMetadata: MedalMetadata = Object.fromEntries(
         medalsMetadataFile.medals.map((m) => [m.nameId, { name: m.name.value, sortingWeight: m.sortingWeight }]),
       );
-      this.config.store.setMatchStats(matchId, stats, playerMap, medalMetadata);
+      this.config.store.setMatchStats(matchId, stats, playerMap, medalMetadata, analytics);
     } catch (error) {
       if (this.isStale(matchId)) {
         return;

--- a/pages/src/components/individual-tracker/viewer/viewer-store.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-store.ts
@@ -1,5 +1,6 @@
 import type { MatchStats } from "halo-infinite-api";
 import type { TrackerLiveView, TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
 import type { TrackerViewConnectionStatus } from "../../../services/individual-tracker/view-types";
 import { ComponentLoaderStatus } from "../../component-loader/component-loader";
@@ -11,6 +12,7 @@ export type MatchStatsState =
       readonly stats: MatchStats;
       readonly playerMap: Map<string, string>;
       readonly medalMetadata: MedalMetadata;
+      readonly analytics: MatchAnalytics | null;
     }
   | { readonly status: "error"; readonly message: string };
 
@@ -81,11 +83,12 @@ export class IndividualTrackerViewerStore {
     stats: MatchStats,
     playerMap: Map<string, string>,
     medalMetadata: MedalMetadata,
+    analytics: MatchAnalytics | null,
   ): void {
     if (this.snapshot.selectedMatchId !== matchId) {
       return;
     }
-    this.update({ matchStatsState: { status: "loaded", stats, playerMap, medalMetadata } });
+    this.update({ matchStatsState: { status: "loaded", stats, playerMap, medalMetadata, analytics } });
   }
 
   public setMatchStatsError(matchId: string, message: string): void {


### PR DESCRIPTION
## 1. context
This is Step 5 in the Stage 2b PR train. Step 4 wired kill matrix analytics into Discord Series Stats, but the Individual Tracker Viewer path still rendered match stats without kill matrix data.

## 2. overview of the feature
Wire match analytics into the Individual Tracker Viewer flow so per-match kill matrix data is fetched with match stats and displayed in the existing stats tabs.

## 3. what this PR does
- Threads `matchAnalyticsService` through viewer entry points:
  - `pages/src/apps/individual-tracker-viewer/create.tsx`
  - `pages/src/components/individual-tracker/viewer/create.tsx`
  - `pages/src/components/individual-tracker/viewer/use-individual-tracker-viewer.ts`
- Extends viewer state/presenter for analytics:
  - `pages/src/components/individual-tracker/viewer/viewer-store.ts`
  - `pages/src/components/individual-tracker/viewer/viewer-presenter.ts`
- Renders kill matrix rows in viewer stats panel:
  - `pages/src/components/individual-tracker/viewer/stats-panel.tsx`
- Wires dependent viewer surfaces that reuse the same hook/page contracts:
  - `pages/src/components/individual-tracker/overlay/create.tsx`
  - `pages/src/apps/individual-tracker-overlay/create.tsx`
  - `pages/src/components/follow/follow-live-viewer.tsx`
  - `pages/src/apps/follow-live/services.ts`
  - `pages/src/apps/follow-live/create.tsx`
- Adds/updates tests for new analytics state shape and behavior:
  - `pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts`
  - `pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx`
  - `pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx`

Validation:
- `npx vitest run pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx`
- `npm run typecheck:pages`

## 4. PR train
| Step | Branch | PR | Base |
|---|---|---|---|
| 1 | `feature/stage-2b-kill-matrix-ui` | #547 | `main` |
| 2 | `feature/stage-2b-analytics-service` | #550 | `feature/stage-2b-kill-matrix-ui` |
| 3 | `feature/stage-2b-kill-matrix-table` | #551 | `feature/stage-2b-analytics-service` |
| 4 | `feature/stage-2b-discord-kill-matrix` | #554 | `feature/stage-2b-kill-matrix-table` |
| 5 | `feature/stage-2b-viewer-kill-matrix` | this PR | `feature/stage-2b-discord-kill-matrix` |
