### PR TITLE
Remove defined routes in api wrangler

### DIFF
--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -75,19 +75,6 @@
     // Staging environment
     "staging": {
       "name": "guilty-spark-staging",
-      "routes": [
-        "api-staging.guilty-spark.app/",
-        "api-staging.guilty-spark.app/auth/microsoft/start",
-        "api-staging.guilty-spark.app/auth/microsoft/callback",
-        "api-staging.guilty-spark.app/interactions",
-        "api-staging.guilty-spark.app/neatqueue",
-        "api-staging.guilty-spark.app/proxy/halo-infinite",
-        "api-staging.guilty-spark.app/auth/logout",
-        "api-staging.guilty-spark.app/auth/session",
-        "api-staging.guilty-spark.app/api/stats/*",
-        "api-staging.guilty-spark.app/api/tracker/*",
-        "api-staging.guilty-spark.app/ws/tracker/*",
-      ],
       "kv_namespaces": [
         {
           "binding": "APP_DATA",
@@ -123,19 +110,6 @@
     // Production environment
     "production": {
       "name": "guilty-spark",
-      "routes": [
-        "api.guilty-spark.app/",
-        "api.guilty-spark.app/auth/microsoft/start",
-        "api.guilty-spark.app/auth/microsoft/callback",
-        "api.guilty-spark.app/interactions",
-        "api.guilty-spark.app/neatqueue",
-        "api.guilty-spark.app/proxy/halo-infinite",
-        "api.guilty-spark.app/auth/logout",
-        "api.guilty-spark.app/auth/session",
-        "api.guilty-spark.app/api/stats/*",
-        "api.guilty-spark.app/api/tracker/*",
-        "api.guilty-spark.app/ws/tracker/*",
-      ],
       "kv_namespaces": [
         {
           "binding": "APP_DATA",


### PR DESCRIPTION
## Context

Previously we defined routes manually for the API endpoint as a way to mitigate bots probing the worker... but as the app has gotten more and more complex, let's just go with the app level router to take care of it and wear the consequences.