### PR TITLE
fix(individual-tracker): pass xuid from search result to start tracker, skip Xbox API lookup

### DIFF
--- a/api/routes/individual-tracker/manage.ts
+++ b/api/routes/individual-tracker/manage.ts
@@ -169,7 +169,7 @@ async function resumeSeriesDo(env: Env, userId: string, trackerId: string): Prom
 export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
   router.post("/api/individual-tracker/manage/start", async (request, env: Env) => {
     const services = installServices({ env });
-    const { authService, individualTrackerService, xboxService, logService } = services;
+    const { authService, individualTrackerService, logService } = services;
 
     try {
       const auth = await requireSession(request, authService);
@@ -182,24 +182,10 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
         return parsed.response;
       }
 
-      let xboxUser: Awaited<ReturnType<typeof xboxService.getUserByGamertag>>;
-      try {
-        xboxUser = await xboxService.getUserByGamertag(parsed.data.gamertag);
-      } catch (error) {
-        logService.warn(
-          "Individual tracker start: gamertag lookup failed",
-          new Map([
-            ["gamertag", parsed.data.gamertag],
-            ["error", String(error)],
-          ]),
-        );
-        return errorContract.toResponse({ error: "Gamertag not found" }, { status: 404, noStore: true });
-      }
-
       const createOptions: CreateTrackerOptions = {
         userId: auth.session.userId,
-        gamertag: xboxUser.gamertag,
-        xuid: xboxUser.xuid,
+        gamertag: parsed.data.gamertag,
+        xuid: parsed.data.xuid,
       };
 
       let tracker: IndividualTrackersRow;

--- a/api/routes/individual-tracker/tests/manage.test.ts
+++ b/api/routes/individual-tracker/tests/manage.test.ts
@@ -144,6 +144,22 @@ describe("/api/individual-tracker manage routes", () => {
     expect(res.status).toBe(400);
   });
 
+  it("returns 400 on start when xuid is missing", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith());
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(
+      postRequest("/api/individual-tracker/manage/start", { gamertag: "Master Chief" }),
+      env,
+    )) as Response;
+
+    expect(res.status).toBe(400);
+  });
+
   it("returns 404 on stop when the tracker is not owned", async () => {
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });

--- a/api/routes/individual-tracker/tests/manage.test.ts
+++ b/api/routes/individual-tracker/tests/manage.test.ts
@@ -54,7 +54,7 @@ describe("/api/individual-tracker manage routes", () => {
     individualTrackerRoutesRegisterHandler(router, localInstallServices);
 
     const res = (await router.fetch(
-      postRequest("/api/individual-tracker/manage/start", { gamertag: "Foo" }),
+      postRequest("/api/individual-tracker/manage/start", { gamertag: "Foo", xuid: "xuid-foo" }),
       env,
     )) as Response;
 
@@ -75,7 +75,7 @@ describe("/api/individual-tracker manage routes", () => {
     expect(res.status).toBe(401);
   });
 
-  it("starts a tracker: resolves the gamertag, creates the registry row, calls the DO start, returns the tracker", async () => {
+  it("starts a tracker: creates the registry row, calls the DO start, returns the tracker", async () => {
     const doStub = aFakeIndividualTrackerDOWith({
       startResponse: {
         success: true,
@@ -94,17 +94,13 @@ describe("/api/individual-tracker manage routes", () => {
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env: localEnv });
       vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith());
-      vi.spyOn(services.xboxService, "getUserByGamertag").mockResolvedValue({
-        xuid: "xuid-1",
-        gamertag: "ResolvedTag",
-      });
       vi.spyOn(services.individualTrackerService, "createTracker").mockResolvedValue(row);
       return services;
     });
     individualTrackerRoutesRegisterHandler(router, localInstallServices);
 
     const res = (await router.fetch(
-      postRequest("/api/individual-tracker/manage/start", { gamertag: "resolvedtag" }),
+      postRequest("/api/individual-tracker/manage/start", { gamertag: "ResolvedTag", xuid: "xuid-1" }),
       localEnv,
     )) as Response;
 
@@ -120,14 +116,13 @@ describe("/api/individual-tracker manage routes", () => {
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });
       vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith());
-      vi.spyOn(services.xboxService, "getUserByGamertag").mockResolvedValue({ xuid: "xuid-6", gamertag: "Sixth" });
       vi.spyOn(services.individualTrackerService, "createTracker").mockRejectedValue(new TrackerLimitReachedError());
       return services;
     });
     individualTrackerRoutesRegisterHandler(router, localInstallServices);
 
     const res = (await router.fetch(
-      postRequest("/api/individual-tracker/manage/start", { gamertag: "sixth" }),
+      postRequest("/api/individual-tracker/manage/start", { gamertag: "Sixth", xuid: "xuid-6" }),
       env,
     )) as Response;
 

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -164,14 +164,12 @@ export class LiveTrackersPresenter {
     const { status, gamertag, xuid, isLive, trackerId, isPinned } = item;
     const actions: TrackerRowAction[] = [];
 
-    if ((status === "not-started" || status === "stopped") && gamertag !== "") {
+    if ((status === "not-started" || status === "stopped") && gamertag !== "" && xuid != null) {
       actions.push({
         label: "Start tracker",
         disabled: snapshot.busy,
         onClick: (): void => {
-          if (xuid != null) {
-            void this.startTracker(gamertag, xuid);
-          }
+          void this.startTracker(gamertag, xuid);
         },
       });
     }

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -122,8 +122,11 @@ export class LiveTrackersPresenter {
     const pinnedRuntimeTracker =
       snapshot.xboxGamertag == null
         ? null
-        : (snapshot.runningTrackers.find((t) => t.gamertag.toLowerCase() === snapshot.xboxGamertag?.toLowerCase()) ??
-          null);
+        : (snapshot.runningTrackers.find((t) =>
+            snapshot.xboxXuid != null
+              ? t.xuid === snapshot.xboxXuid
+              : t.gamertag.toLowerCase() === snapshot.xboxGamertag?.toLowerCase(),
+          ) ?? null);
 
     if (snapshot.xboxGamertag != null) {
       const pinnedState =

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -131,6 +131,7 @@ export class LiveTrackersPresenter {
       rows.push({
         trackerId: pinnedRuntimeTracker?.trackerId ?? null,
         gamertag: snapshot.xboxGamertag,
+        xuid: pinnedRuntimeTracker?.xuid ?? snapshot.xboxXuid ?? null,
         status: pinnedState != null ? derivedStatus(pinnedState.status) : "not-started",
         isLive: pinnedRuntimeTracker != null && pinnedRuntimeTracker.trackerId === snapshot.activeTracker?.trackerId,
         isPinned: true,
@@ -146,6 +147,7 @@ export class LiveTrackersPresenter {
       rows.push({
         trackerId: tracker.trackerId,
         gamertag: tracker.gamertag,
+        xuid: tracker.xuid,
         status: trackerState != null ? derivedStatus(trackerState.status) : "stopped",
         isLive: tracker.trackerId === snapshot.activeTracker?.trackerId,
         isPinned: false,
@@ -159,7 +161,7 @@ export class LiveTrackersPresenter {
   public getActions(item: TrackerListItem): readonly TrackerRowAction[] {
     const snapshot = this.getSnapshot();
     const trackerItems = this.getTrackerItems();
-    const { status, gamertag, isLive, trackerId, isPinned } = item;
+    const { status, gamertag, xuid, isLive, trackerId, isPinned } = item;
     const actions: TrackerRowAction[] = [];
 
     if ((status === "not-started" || status === "stopped") && gamertag !== "") {
@@ -167,7 +169,9 @@ export class LiveTrackersPresenter {
         label: "Start tracker",
         disabled: snapshot.busy,
         onClick: (): void => {
-          void this.startTracker(gamertag !== snapshot.xboxGamertag ? gamertag : undefined);
+          if (xuid != null) {
+            void this.startTracker(gamertag, xuid);
+          }
         },
       });
     }
@@ -309,7 +313,7 @@ export class LiveTrackersPresenter {
       this.updateSnapshot((current) => ({
         ...current,
         activeTracker: liveTracker?.state ?? null,
-        runningTrackers: trackers.map((t) => ({ trackerId: t.trackerId, gamertag: t.gamertag })),
+        runningTrackers: trackers.map((t) => ({ trackerId: t.trackerId, gamertag: t.gamertag, xuid: t.xuid })),
         trackerStatuses: Object.fromEntries<TrackerState | null>(trackers.map((t) => [t.trackerId, t.state ?? null])),
       }));
     } catch (error) {
@@ -478,7 +482,13 @@ export class LiveTrackersPresenter {
           // authoritative and a stale poll response would resurrect deleted trackers.
           ...(this.refreshInFlight
             ? {}
-            : { runningTrackers: response.trackers.map((t) => ({ trackerId: t.trackerId, gamertag: t.gamertag })) }),
+            : {
+                runningTrackers: response.trackers.map((t) => ({
+                  trackerId: t.trackerId,
+                  gamertag: t.gamertag,
+                  xuid: t.xuid,
+                })),
+              }),
           trackerStatuses: mergedStatuses,
         };
       });
@@ -487,14 +497,10 @@ export class LiveTrackersPresenter {
     }
   }
 
-  private async startTracker(gamertag?: string): Promise<void> {
-    const targetGamertag = gamertag ?? this.getSnapshot().xboxGamertag;
-    if (targetGamertag == null) {
-      return;
-    }
+  private async startTracker(gamertag: string, xuid: string): Promise<void> {
     this.updateSnapshot((s) => ({ ...s, busy: true, errorMessage: null }));
     try {
-      await this.config.individualTrackerService.startTracker({ idleTimeoutHours: 1, gamertag: targetGamertag });
+      await this.config.individualTrackerService.startTracker({ idleTimeoutHours: 1, gamertag, xuid });
       await this.refresh();
       const afterRefresh = this.getSnapshot();
       if (afterRefresh.runningTrackers.length === 1 && afterRefresh.activeTracker == null) {

--- a/pages/src/components/individual-tracker-manager/live-trackers/tests/live-trackers-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/tests/live-trackers-presenter.test.ts
@@ -79,6 +79,7 @@ describe("LiveTrackersPresenter", () => {
     const pinnedTracker = aFakeTrackerWith({
       trackerId: "t1",
       gamertag: "Chief",
+      xuid: "xuid-1",
       status: "paused",
       isLive: false,
       state: aFakeTrackerState({ trackerId: "t1", gamertag: "Chief", status: "paused" }),

--- a/pages/src/components/individual-tracker-manager/live-trackers/types.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/types.ts
@@ -7,7 +7,7 @@ export interface LiveTrackersSnapshot {
   readonly xboxGamertag: string | null;
   readonly xboxXuid: string | null;
   readonly activeTracker: TrackerState | null;
-  readonly runningTrackers: readonly { trackerId: string; gamertag: string }[];
+  readonly runningTrackers: readonly { trackerId: string; gamertag: string; xuid: string }[];
   readonly trackerStatuses: Readonly<Record<string, TrackerState | null>>;
   readonly busy: boolean;
   readonly errorMessage: string | null;

--- a/pages/src/components/individual-tracker-manager/tracker-list/tests/tracker-list.test.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-list/tests/tracker-list.test.tsx
@@ -22,6 +22,7 @@ describe("TrackerList", () => {
     const item: TrackerListItem = {
       trackerId: "tracker-1",
       gamertag: "Chief",
+      xuid: null,
       status: "active",
       isLive: true,
       isPinned: false,
@@ -39,6 +40,7 @@ describe("TrackerList", () => {
     const item: TrackerListItem = {
       trackerId: "tracker-2",
       gamertag: "Arbiter",
+      xuid: null,
       status: "paused",
       isLive: false,
       isPinned: false,
@@ -55,6 +57,7 @@ describe("TrackerList", () => {
     const item: TrackerListItem = {
       trackerId: "tracker-3",
       gamertag: "Noble Six",
+      xuid: null,
       status: "active",
       isLive: false,
       isPinned: true,
@@ -70,6 +73,7 @@ describe("TrackerList", () => {
     const item: TrackerListItem = {
       trackerId: "tracker-5",
       gamertag: "Spartan",
+      xuid: null,
       status: "stopped",
       isLive: false,
       isPinned: false,
@@ -85,6 +89,7 @@ describe("TrackerList", () => {
     const item: TrackerListItem = {
       trackerId: "tracker-6",
       gamertag: "Rookie",
+      xuid: null,
       status: "not-started",
       isLive: false,
       isPinned: false,
@@ -100,6 +105,7 @@ describe("TrackerList", () => {
     const item: TrackerListItem = {
       trackerId: "tracker-4",
       gamertag: "Buck",
+      xuid: null,
       status: "active",
       isLive: false,
       isPinned: false,
@@ -113,8 +119,24 @@ describe("TrackerList", () => {
 
   it("renders a row per item", () => {
     const items: readonly TrackerListItem[] = [
-      { trackerId: "t-1", gamertag: "Alpha", status: "active", isLive: true, isPinned: false, hasActiveSeries: false },
-      { trackerId: "t-2", gamertag: "Bravo", status: "paused", isLive: false, isPinned: false, hasActiveSeries: false },
+      {
+        trackerId: "t-1",
+        gamertag: "Alpha",
+        xuid: null,
+        status: "active",
+        isLive: true,
+        isPinned: false,
+        hasActiveSeries: false,
+      },
+      {
+        trackerId: "t-2",
+        gamertag: "Bravo",
+        xuid: null,
+        status: "paused",
+        isLive: false,
+        isPinned: false,
+        hasActiveSeries: false,
+      },
     ];
 
     render(<TrackerList items={items} getActions={() => []} />);
@@ -129,6 +151,7 @@ describe("TrackerList", () => {
     const item: TrackerListItem = {
       trackerId: "tracker-1",
       gamertag: "Chief",
+      xuid: null,
       status: "active",
       isLive: false,
       isPinned: false,
@@ -148,6 +171,7 @@ describe("TrackerList", () => {
     const item: TrackerListItem = {
       trackerId: "tracker-1",
       gamertag: "Chief",
+      xuid: null,
       status: "active",
       isLive: false,
       isPinned: false,

--- a/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.tsx
@@ -10,6 +10,7 @@ export type TrackerDisplayStatus = "active" | "paused" | "stopped" | "not-starte
 export interface TrackerListItem {
   readonly trackerId: string | null;
   readonly gamertag: string;
+  readonly xuid: string | null;
   readonly status: TrackerDisplayStatus;
   readonly isLive: boolean;
   readonly isPinned: boolean;

--- a/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog-presenter.ts
@@ -189,7 +189,7 @@ export class AddTrackerDialogPresenter {
       return;
     }
     this.config.store.setBusy(true);
-    this.runStartTracker(snapshot.result.gamertag);
+    this.runStartTracker(snapshot.result.gamertag, snapshot.result.xuid);
   }
 
   private applyGroupingsUpdate(nextGroupings: readonly (readonly string[])[]): void {
@@ -285,13 +285,13 @@ export class AddTrackerDialogPresenter {
     }
   }
 
-  private runStartTracker(gamertag: string): void {
-    void this.doStartTracker(gamertag);
+  private runStartTracker(gamertag: string, xuid: string): void {
+    void this.doStartTracker(gamertag, xuid);
   }
 
-  private async doStartTracker(gamertag: string): Promise<void> {
+  private async doStartTracker(gamertag: string, xuid: string): Promise<void> {
     try {
-      await this.config.individualTrackerService.startTracker({ gamertag });
+      await this.config.individualTrackerService.startTracker({ gamertag, xuid });
       if (this.isDisposed) {
         return;
       }

--- a/pages/src/services/individual-tracker/fakes/individual-tracker.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/individual-tracker.fake.ts
@@ -249,7 +249,7 @@ export class FakeIndividualTrackerService implements IndividualTrackerService {
   public async getTrackers(): Promise<TrackerListResponse> {
     const { trackers } = await this.listTrackers();
     return {
-      trackers: trackers.map((t) => ({ trackerId: t.trackerId, gamertag: t.gamertag })),
+      trackers: trackers.map((t) => ({ trackerId: t.trackerId, gamertag: t.gamertag, xuid: t.xuid })),
       statuses: Object.fromEntries(trackers.map((t) => [t.trackerId, t.state ?? null])),
     };
   }

--- a/pages/src/services/individual-tracker/individual-tracker.ts
+++ b/pages/src/services/individual-tracker/individual-tracker.ts
@@ -521,7 +521,7 @@ export class RealIndividualTrackerService implements IndividualTrackerService {
   public async getTrackers(): Promise<TrackerListResponse> {
     const { trackers } = await this.listTrackers();
     return {
-      trackers: trackers.map((t) => ({ trackerId: t.trackerId, gamertag: t.gamertag })),
+      trackers: trackers.map((t) => ({ trackerId: t.trackerId, gamertag: t.gamertag, xuid: t.xuid })),
       statuses: Object.fromEntries(trackers.map((t) => [t.trackerId, t.state ?? null])),
     };
   }

--- a/pages/src/services/individual-tracker/tests/individual-tracker.test.ts
+++ b/pages/src/services/individual-tracker/tests/individual-tracker.test.ts
@@ -122,14 +122,14 @@ describe("RealIndividualTrackerService", () => {
   it("starts a tracker with a JSON body", async () => {
     fetchSpy.mockResolvedValueOnce(jsonResponse({ tracker: FAKE_TRACKER }));
 
-    const result = await service.startTracker({ gamertag: "Master Chief" });
+    const result = await service.startTracker({ gamertag: "Master Chief", xuid: "xuid_master_chief" });
 
     expect(fetchSpy).toHaveBeenCalledWith(
       "https://api.example.com/api/individual-tracker/manage/start",
       expect.objectContaining({
         credentials: "include",
         method: "POST",
-        body: JSON.stringify({ gamertag: "Master Chief" }),
+        body: JSON.stringify({ gamertag: "Master Chief", xuid: "xuid_master_chief" }),
       }),
     );
     expect(result).toEqual({ tracker: FAKE_TRACKER });

--- a/pages/src/services/individual-tracker/types.ts
+++ b/pages/src/services/individual-tracker/types.ts
@@ -119,6 +119,7 @@ export interface IndividualTrackerConnection {
 export interface TrackerReference {
   readonly trackerId: string;
   readonly gamertag: string;
+  readonly xuid: string;
 }
 
 export interface TrackerListResponse {

--- a/shared/src/contracts/individual-tracker/tracker.ts
+++ b/shared/src/contracts/individual-tracker/tracker.ts
@@ -30,6 +30,7 @@ export type Tracker = z.infer<typeof trackerSchema>;
 
 export const startTrackerRequestSchema = z.object({
   gamertag: z.string().min(1),
+  xuid: z.string(),
   searchStartTime: z.iso.datetime().optional(),
   idleTimeoutHours: z.number().positive().optional(),
 });

--- a/shared/src/contracts/individual-tracker/tracker.ts
+++ b/shared/src/contracts/individual-tracker/tracker.ts
@@ -30,7 +30,7 @@ export type Tracker = z.infer<typeof trackerSchema>;
 
 export const startTrackerRequestSchema = z.object({
   gamertag: z.string().min(1),
-  xuid: z.string(),
+  xuid: z.string().min(1),
   searchStartTime: z.iso.datetime().optional(),
   idleTimeoutHours: z.number().positive().optional(),
 });


### PR DESCRIPTION
## Summary

- Makes `xuid` a **required** field in `startTrackerRequestSchema` — it's always available from the search step that precedes start
- Removes the redundant `xboxService.getUserByGamertag` call from the manage/start route, which used separate Xbox account credentials (`XBOX_USERNAME`/`XBOX_PASSWORD`) and silently mapped any auth/network failure to a misleading "Gamertag not found" error
- Threads `xuid` through the pages-side start flow: `AddTrackerDialog` → `LiveTrackersPresenter` → `IndividualTrackerService`, and adds it to `TrackerReference`, `runningTrackers`, and `TrackerListItem` so the re-start action on stopped trackers also has the XUID available

## Test plan

- [ ] `npm run done` passes (typecheck, lint, vitest)
- [ ] Start a tracker from the Add Tracker dialog — confirm it succeeds without the "Gamertag not found" error
- [ ] Re-start a stopped tracker from the tracker list — confirm the XUID is passed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)