### PR TITLE
fix(live-tracker): add missing tracker status HTTP route

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -39,6 +39,26 @@ export class Server {
 
     discordInteractionsRoute(this.router, this.installServices);
 
+    this.router.get("/tracker/:guildId/:queueNumber/status", async (request, env: Env) => {
+      const { guildId, queueNumber } = request.params as {
+        guildId: string;
+        queueNumber: string;
+      };
+
+      const queueNum = parseInt(queueNumber, 10);
+      if (isNaN(queueNum)) {
+        return new Response("Invalid queue number", { status: 400 });
+      }
+
+      const doId = env.LIVE_TRACKER_DO.idFromName(`${guildId}:${queueNum.toString()}`);
+      const stub = env.LIVE_TRACKER_DO.get(doId);
+
+      const doUrl = new URL(request.url);
+      doUrl.pathname = "/status";
+
+      return await stub.fetch(new Request(doUrl.toString()));
+    });
+
     this.router.get("/ws/tracker/:guildId/:queueNumber", async (request, env: Env) => {
       try {
         // Extract parameters from itty-router

--- a/api/tests/server.test.ts
+++ b/api/tests/server.test.ts
@@ -627,6 +627,32 @@ describe("Server", () => {
     });
   });
 
+  describe("GET /tracker/:guildId/:queueNumber/status", () => {
+    it("returns 400 when queueNumber is not a valid number", async () => {
+      const req = new Request("http://localhost/tracker/guild123/notanumber/status", { method: "GET" });
+      const res = (await server.router.fetch(req, env)) as Response;
+      expect(res.status).toBe(400);
+      const text = await res.text();
+      expect(text).toBe("Invalid queue number");
+    });
+
+    it("forwards the DO 200 response when the tracker exists", async () => {
+      const req = new Request("http://localhost/tracker/guild123/42/status", { method: "GET" });
+      const res = (await server.router.fetch(req, env)) as Response;
+      expect(res.status).toBe(200);
+    });
+
+    it("forwards the DO 404 when no tracker exists for the given guild and queue", async () => {
+      const fakeEnv = aFakeEnvWith();
+      const stub = fakeEnv.LIVE_TRACKER_DO.get(fakeEnv.LIVE_TRACKER_DO.idFromName("any"));
+      vi.spyOn(stub, "fetch").mockResolvedValue(new Response("Not Found", { status: 404 }));
+
+      const req = new Request("http://localhost/tracker/guild123/42/status", { method: "GET" });
+      const res = (await server.router.fetch(req, fakeEnv)) as Response;
+      expect(res.status).toBe(404);
+    });
+  });
+
   describe("GET /ws/tracker/:guildId/:queueNumber", () => {
     it("returns 400 when queueNumber is not a valid number", async () => {
       const req = new Request("http://localhost/ws/tracker/guild123/notanumber", { method: "GET" });

--- a/pages/src/components/live-tracker/create.tsx
+++ b/pages/src/components/live-tracker/create.tsx
@@ -45,7 +45,9 @@ export function LiveTracker({ liveTrackerService }: LiveTrackerProps): React.Rea
 
   const loaderStatus = snapshot.hasReceivedInitialData
     ? ComponentLoaderStatus.LOADED
-    : snapshot.connectionState === "error" || snapshot.connectionState === "stopped"
+    : snapshot.connectionState === "error" ||
+        snapshot.connectionState === "stopped" ||
+        snapshot.connectionState === "not_found"
       ? ComponentLoaderStatus.ERROR
       : ComponentLoaderStatus.LOADING;
 
@@ -166,7 +168,7 @@ export function LiveTracker({ liveTrackerService }: LiveTrackerProps): React.Rea
   return (
     <ComponentLoader
       status={loaderStatus}
-      loading={<LoadingState />}
+      loading={<LoadingState text={snapshot.statusText} />}
       error={
         <ErrorState
           message={snapshot.statusText}

--- a/pages/src/components/live-tracker/tests/live-tracker.test.tsx
+++ b/pages/src/components/live-tracker/tests/live-tracker.test.tsx
@@ -4,7 +4,11 @@ import { describe, expect, it, vi, afterEach } from "vitest";
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
 
 import type { LiveTrackerMessage, LiveTrackerStateMessage } from "@guilty-spark/shared/live-tracker/types";
-import type { LiveTrackerConnection, SteppableLiveTrackerConnection } from "../../../services/live-tracker/types";
+import type {
+  LiveTrackerConnection,
+  LiveTrackerStatusListener,
+  SteppableLiveTrackerConnection,
+} from "../../../services/live-tracker/types";
 import { aFakeLiveTrackerScenarioWith } from "../../../services/live-tracker/fakes/scenario";
 import { aFakeLiveTrackerServiceWith } from "../../../services/live-tracker/fakes/live-tracker.fake";
 import { LiveTracker } from "../create";
@@ -82,7 +86,7 @@ describe("LiveTracker", () => {
     render(<LiveTracker liveTrackerService={liveTrackerService} />);
 
     await waitFor(() => {
-      expect(screen.getByText("Establishing Connection...")).toBeInTheDocument();
+      expect(screen.getByText("Connecting...")).toBeInTheDocument();
     });
 
     if (!isSteppableLiveTrackerConnection(connection)) {
@@ -100,5 +104,33 @@ describe("LiveTracker", () => {
     });
 
     expect(screen.getByText("Matches")).toBeInTheDocument();
+  });
+
+  it("shows an error state when the tracker is not found", async () => {
+    window.history.pushState({}, "", "/tracker?server=1&queue=3");
+
+    const notFoundConnection: LiveTrackerConnection = {
+      subscribe: () => ({ unsubscribe: () => undefined }),
+      subscribeStatus: (listener: LiveTrackerStatusListener) => {
+        queueMicrotask(() => {
+          listener("not_found");
+        });
+        return { unsubscribe: () => undefined };
+      },
+      disconnect: () => undefined,
+    };
+
+    const liveTrackerService = aFakeLiveTrackerServiceWith();
+    vi.spyOn(liveTrackerService, "connect").mockResolvedValue(notFoundConnection);
+
+    render(<LiveTracker liveTrackerService={liveTrackerService} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Connection Failed")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("No active tracker found for this queue. Start a tracker first."),
+    ).toBeInTheDocument();
   });
 });

--- a/pages/src/components/live-tracker/tests/live-tracker.test.tsx
+++ b/pages/src/components/live-tracker/tests/live-tracker.test.tsx
@@ -129,8 +129,6 @@ describe("LiveTracker", () => {
       expect(screen.getByText("Connection Failed")).toBeInTheDocument();
     });
 
-    expect(
-      screen.getByText("No active tracker found for this queue. Start a tracker first."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("No active tracker found for this queue. Start a tracker first.")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Adds `GET /tracker/:guildId/:queueNumber/status` to `server.ts`, forwarding to the `LiveTrackerDO`'s existing `/status` handler
- Fixes `LiveTracker` component staying stuck on "Establishing Connection..." when the tracker is not found
- Surfaces `snapshot.statusText` in the loading spinner so reconnection attempts show contextual messages

## Root cause (API)

`checkTrackerExists` in the frontend (`pages/src/services/live-tracker/live-tracker.ts`) makes a preflight HTTP call to `/tracker/:guildId/:queueNumber/status` before opening a WebSocket. This endpoint was never registered in `server.ts` — the `LiveTrackerDO` has an internal `/status` handler but it was never exposed as a public route.

**Why it accidentally worked before:** Cloudflare's wrangler routes for production were granular (`api.guilty-spark.app/api/tracker/*`, `api.guilty-spark.app/ws/tracker/*`), so requests to `/tracker/*` (no `/api/` prefix) were never forwarded to the Worker at all. The preflight hit a network-level miss, the `catch {}` block assumed the tracker existed, and the WebSocket proceeded normally.

**Why #557 broke it:** Replacing those routes with the wildcard `api.guilty-spark.app/*` means the Worker now handles every path. The itty-router catch-all returns a clean HTTP 404, which `checkTrackerExists` interprets as "tracker not found" — preventing any WebSocket connection from opening.

## Root cause (UI)

`LiveTracker` component computed `loaderStatus` as `ERROR` for `connectionState === "error" | "stopped"` but not `"not_found"`, so the component stayed on `LOADING` ("Establishing Connection...") indefinitely when the tracker did not exist.

Additionally, the `LoadingState` was rendered with no text (falling back to "Establishing Connection...") even during reconnection attempts where `statusText` contained a useful message like "Lost connection, reconnecting... (Attempt 1/10)".

## Test plan

- [x] `npx vitest run api/tests/server.test.ts` — 28 tests pass (3 new)
- [x] `npx vitest run pages/src/components/live-tracker/` — 58 tests pass (1 new, 1 updated)
- [x] `npm run typecheck:api` — clean
- [x] `npm run typecheck:pages` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)