### PR TITLE
fix(follow-live): show ErrorState with retry on initial directory load failure

### DIFF
--- a/pages/src/components/follow/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { HaloInfiniteClient } from "halo-infinite-api";
 import { Alert } from "../alert/alert";
+import { ErrorState } from "../error-state/error-state";
 import { LoadingState } from "../loading-state/loading-state";
 import { IndividualTrackerViewerPage } from "../individual-tracker/viewer/create";
 import type { FollowLiveService } from "../../services/follow/follow-types";
@@ -22,10 +23,10 @@ export function FollowLiveViewer({
   individualTrackerViewService,
   haloClient,
 }: FollowLiveViewerProps): React.ReactElement {
-  const { directory, directoryStatus, selectedTrackerId, isFollowingLive, onSelectTracker, onFollowLive } =
+  const { directory, directoryStatus, selectedTrackerId, isFollowingLive, onSelectTracker, onFollowLive, onRetry } =
     useFollowLiveDirectory({ followLiveService, gamertag });
 
-  const showBanner = directoryStatus === "error" || directoryStatus === "disconnected";
+  const showBanner = (directoryStatus === "error" && directory !== null) || directoryStatus === "disconnected";
 
   return (
     <div className={styles.container}>
@@ -55,7 +56,9 @@ export function FollowLiveViewer({
             haloClient={haloClient}
             trackerId={selectedTrackerId}
           />
-        ) : directoryStatus === "error" && directory === null ? null : directory === null ? (
+        ) : directoryStatus === "error" && directory === null ? (
+          <ErrorState message="Failed to load tracker directory" onRetry={onRetry} />
+        ) : directory === null ? (
           <LoadingState text="Loading tracker directory..." />
         ) : (
           <LoadingState text="No active tracker — waiting for a live game" />

--- a/pages/src/components/follow/tests/use-follow-live-directory.test.ts
+++ b/pages/src/components/follow/tests/use-follow-live-directory.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
 import { aFakeFollowLiveServiceWith } from "../../../services/follow/fakes/follow.fake";
@@ -230,6 +230,42 @@ describe("useFollowLiveDirectory", () => {
 
     expect(result.current.selectedTrackerId).toBe("tracker-1");
     expect(result.current.isFollowingLive).toBe(true);
+  });
+
+  it("sets directoryStatus to error when getDirectory fails", async () => {
+    const service = aFakeFollowLiveServiceWith();
+    vi.spyOn(service, "getDirectory").mockRejectedValue(new Error("Network error"));
+    const { result } = renderHook(() =>
+      useFollowLiveDirectory({ followLiveService: service, gamertag: "Spartan One" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.directoryStatus).toBe("error");
+    });
+
+    expect(result.current.directory).toBeNull();
+  });
+
+  it("onRetry re-fetches the directory after an error", async () => {
+    const service = aFakeFollowLiveServiceWith({ directory: aDirectory() });
+    vi.spyOn(service, "getDirectory").mockRejectedValueOnce(new Error("Network error"));
+    const { result } = renderHook(() =>
+      useFollowLiveDirectory({ followLiveService: service, gamertag: "Spartan One" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.directoryStatus).toBe("error");
+    });
+
+    act(() => {
+      result.current.onRetry();
+    });
+
+    await waitFor(() => {
+      expect(result.current.directoryStatus).toBe("connected");
+    });
+
+    expect(result.current.directory).not.toBeNull();
   });
 
   it("onFollowLive sets isFollowingLive to true and selects the live tracker", async () => {

--- a/pages/src/components/follow/use-follow-live-directory.ts
+++ b/pages/src/components/follow/use-follow-live-directory.ts
@@ -14,6 +14,7 @@ export interface FollowLiveDirectoryResult {
   readonly isFollowingLive: boolean;
   readonly onSelectTracker: (trackerId: string) => void;
   readonly onFollowLive: () => void;
+  readonly onRetry: () => void;
 }
 
 function findLiveTrackerId(directory: TrackerDirectory): string | null {
@@ -33,6 +34,7 @@ export function useFollowLiveDirectory({
   const [directoryStatus, setDirectoryStatus] = useState<DirectoryConnectionStatus>("connecting");
   const [selectedTrackerId, setSelectedTrackerId] = useState<string | null>(null);
   const [isFollowingLive, setIsFollowingLive] = useState(true);
+  const [retryCount, setRetryCount] = useState(0);
 
   // Refs let WS callbacks and action handlers read current values without
   // stale closures and without calling state setters inside updater functions.
@@ -104,7 +106,7 @@ export function useFollowLiveDirectory({
       statusSubscription.unsubscribe();
       connection.disconnect();
     };
-  }, [followLiveService, gamertag]);
+  }, [followLiveService, gamertag, retryCount]);
 
   const onSelectTracker = useCallback((trackerId: string): void => {
     const dir = directoryRef.current;
@@ -123,6 +125,10 @@ export function useFollowLiveDirectory({
     }
   }, []);
 
+  const onRetry = useCallback((): void => {
+    setRetryCount((c) => c + 1);
+  }, []);
+
   return {
     directory,
     directoryStatus,
@@ -130,5 +136,6 @@ export function useFollowLiveDirectory({
     isFollowingLive,
     onSelectTracker,
     onFollowLive,
+    onRetry,
   };
 }


### PR DESCRIPTION
## Summary

- When the initial `getDirectory` HTTP fetch fails, the viewer content area was silently rendering `null` — an empty space with no feedback to the user
- Adds `onRetry` to `useFollowLiveDirectory` (increments an internal `retryCount` that re-runs the `useEffect`, re-fetching and reconnecting)
- Changes `showBanner` in `FollowLiveViewer` to only show the Alert banner for post-load errors (`directory !== null`) or disconnection — not for the initial load failure, which is now covered by the `ErrorState` component
- Replaces the `null` content case with `<ErrorState message="Failed to load tracker directory" onRetry={onRetry} />`

## Test plan

- [ ] New test: `sets directoryStatus to error when getDirectory fails`
- [ ] New test: `onRetry re-fetches the directory after an error`
- [ ] All existing hook tests still pass
- [ ] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)