### PR TITLE
refactor(stats): rename *Presenter → *Formatter

### DIFF
--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -1,9 +1,9 @@
 import type { MatchStats } from "halo-infinite-api";
 import { differenceInSeconds, isValid, parseISO } from "date-fns";
 import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
-import { createMatchStatsPresenter } from "../stats/create";
-import { SeriesTeamStatsPresenter } from "../stats/series-team-stats-presenter";
-import { SeriesPlayerStatsPresenter } from "../stats/series-player-stats-presenter";
+import { createMatchStatsFormatter } from "../stats/create";
+import { SeriesTeamStatsFormatter } from "../stats/series-team-stats-presenter";
+import { SeriesPlayerStatsFormatter } from "../stats/series-player-stats-presenter";
 import type { MatchStatsData } from "../stats/types";
 import { DEFAULT_TEAM_COLORS, getTeamColorOrDefault, type TeamColor } from "../team-colors/team-colors";
 
@@ -102,11 +102,11 @@ export class DiscordSeriesStatsPresenter {
       }
 
       try {
-        const presenter = createMatchStatsPresenter(match.rawMatch.MatchInfo.GameVariantCategory);
+        const formatter = createMatchStatsFormatter(match.rawMatch.MatchInfo.GameVariantCategory);
         const playerMap = new Map<string, string>(Object.entries(match.playerXuidToGametag));
         return {
           matchId: match.matchId,
-          data: presenter.getData(match.rawMatch, playerMap, this.renderData.medalMetadata),
+          data: formatter.getData(match.rawMatch, playerMap, this.renderData.medalMetadata),
         };
       } catch {
         return { matchId: match.matchId, data: null };
@@ -125,8 +125,8 @@ export class DiscordSeriesStatsPresenter {
 
     if (rawMatches.length > 0) {
       try {
-        const teamPresenter = new SeriesTeamStatsPresenter();
-        const playerPresenter = new SeriesPlayerStatsPresenter();
+        const teamFormatter = new SeriesTeamStatsFormatter();
+        const playerFormatter = new SeriesPlayerStatsFormatter();
         const playersMap = new Map<string, string>();
 
         for (const match of this.renderData.matches) {
@@ -136,8 +136,8 @@ export class DiscordSeriesStatsPresenter {
         }
 
         seriesStats = {
-          teamData: teamPresenter.getSeriesData(rawMatches, playersMap, this.renderData.medalMetadata),
-          playerData: playerPresenter.getSeriesData(rawMatches, playersMap, this.renderData.medalMetadata),
+          teamData: teamFormatter.getSeriesData(rawMatches, playersMap, this.renderData.medalMetadata),
+          playerData: playerFormatter.getSeriesData(rawMatches, playersMap, this.renderData.medalMetadata),
           metadata: calculateSeriesMetadata(this.renderData.matches, this.renderData.seriesScore),
         };
       } catch {

--- a/pages/src/components/discord-series-stats/discord-series-stats-view.tsx
+++ b/pages/src/components/discord-series-stats/discord-series-stats-view.tsx
@@ -5,7 +5,7 @@ import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-
 import { gameModeIconSrc } from "../individual-tracker/game-mode-icon";
 import { MatchStats as MatchStatsView } from "../stats/match-stats";
 import { SeriesStats } from "../stats/series-stats";
-import { KillMatrixPresenter } from "../stats/kill-matrix/kill-matrix-presenter";
+import { KillMatrixFormatter } from "../stats/kill-matrix/kill-matrix-presenter";
 import type { KillMatrixViewRow } from "../stats/kill-matrix/types";
 import { Container } from "../container/container";
 import { Alert } from "../alert/alert";
@@ -34,7 +34,7 @@ export function DiscordSeriesStatsView({
   const handleToggleViewMode = useCallback((): void => {
     setViewMode((current) => (current === "standard" ? "wide" : "standard"));
   }, []);
-  const killMatrixPresenter = useMemo(() => new KillMatrixPresenter(), []);
+  const killMatrixPresenter = useMemo(() => new KillMatrixFormatter(), []);
 
   const allMatchKillMatrixRows = useMemo<ReadonlyMap<string, KillMatrixViewRow[]>>(
     () =>
@@ -54,7 +54,7 @@ export function DiscordSeriesStatsView({
   );
 
   const seriesKillMatrixRows = useMemo<KillMatrixViewRow[]>(
-    () => KillMatrixPresenter.aggregate([...allMatchKillMatrixRows.values()].flat()),
+    () => KillMatrixFormatter.aggregate([...allMatchKillMatrixRows.values()].flat()),
     [allMatchKillMatrixRows],
   );
 

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -3,7 +3,7 @@ import { getTeamName } from "@guilty-spark/shared/halo/team";
 import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type { TickerMatchGroup } from "../../information-ticker/information-ticker";
-import { createMatchStatsPresenter } from "../../stats/create";
+import { createMatchStatsFormatter } from "../../stats/create";
 import type { OverlayTab } from "../../streamer-overlay/tabs-bar";
 import type { IndividualTrackerViewerRenderModel, ViewerSeriesTab, ViewerTimelineItem } from "../viewer/types";
 import type { MatchStatsState } from "../viewer/viewer-store";
@@ -62,9 +62,9 @@ export function buildTickerGroups(matchStatsState: MatchStatsState | null, match
   }
 
   const { stats } = matchStatsState;
-  const presenter = createMatchStatsPresenter(stats.MatchInfo.GameVariantCategory);
+  const formatter = createMatchStatsFormatter(stats.MatchInfo.GameVariantCategory);
   const playerMap = new Map(stats.Players.map((p) => [getPlayerXuid(p), getPlayerXuid(p)]));
-  const data = presenter.getData(stats, playerMap, {});
+  const data = formatter.getData(stats, playerMap, {});
 
   return [
     {

--- a/pages/src/components/individual-tracker/viewer/stats-panel.tsx
+++ b/pages/src/components/individual-tracker/viewer/stats-panel.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo } from "react";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
-import { KillMatrixPresenter } from "../../stats/kill-matrix/kill-matrix-presenter";
+import { KillMatrixFormatter } from "../../stats/kill-matrix/kill-matrix-presenter";
 import { Alert } from "../../alert/alert";
 import { LoadingState } from "../../loading-state/loading-state";
-import { createMatchStatsPresenter } from "../../stats/create";
+import { createMatchStatsFormatter } from "../../stats/create";
 import { MatchStats } from "../../stats/match-stats";
 import type { MatchStatsData } from "../../stats/types";
 import { gameModeIconSrc } from "../game-mode-icon";
@@ -17,10 +17,10 @@ interface LoadedStatsPanelProps {
 
 function LoadedStatsPanel({ state }: LoadedStatsPanelProps): React.ReactElement {
   const { stats, playerMap, medalMetadata, analytics } = state;
-  const killMatrixPresenter = useMemo(() => new KillMatrixPresenter(), []);
+  const killMatrixPresenter = useMemo(() => new KillMatrixFormatter(), []);
   const data = useMemo<MatchStatsData[]>(() => {
-    const presenter = createMatchStatsPresenter(stats.MatchInfo.GameVariantCategory);
-    return presenter.getData(stats, playerMap, medalMetadata);
+    const formatter = createMatchStatsFormatter(stats.MatchInfo.GameVariantCategory);
+    return formatter.getData(stats, playerMap, medalMetadata);
   }, [stats, playerMap, medalMetadata]);
 
   const killMatrixRows = useMemo(() => {

--- a/pages/src/components/live-tracker/create.tsx
+++ b/pages/src/components/live-tracker/create.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useMemo, useSyncExternalStore, useRef } from "react";
 import { ComponentLoader, ComponentLoaderStatus } from "../component-loader/component-loader";
 import { ErrorState } from "../error-state/error-state";
 import { LoadingState } from "../loading-state/loading-state";
-import { createMatchStatsPresenter } from "../stats/create";
+import { createMatchStatsFormatter } from "../stats/create";
 import type { MatchStatsData } from "../stats/types";
-import { SeriesTeamStatsPresenter } from "../stats/series-team-stats-presenter";
-import { SeriesPlayerStatsPresenter } from "../stats/series-player-stats-presenter";
+import { SeriesTeamStatsFormatter } from "../stats/series-team-stats-presenter";
+import { SeriesPlayerStatsFormatter } from "../stats/series-player-stats-presenter";
 import { calculateSeriesMetadata, type SeriesMetadata } from "../stats/series-metadata";
 import type { LiveTrackerService } from "../../services/live-tracker/types";
 import { LiveTrackerPresenter } from "./live-tracker-presenter";
@@ -110,11 +110,11 @@ export function LiveTracker({ liveTrackerService }: LiveTrackerProps): React.Rea
 
       try {
         const matchStats = match.rawMatchStats;
-        const matchStatsPresenter = createMatchStatsPresenter(matchStats.MatchInfo.GameVariantCategory);
+        const matchStatsFormatter = createMatchStatsFormatter(matchStats.MatchInfo.GameVariantCategory);
         const playerMap = new Map<string, string>(Object.entries(match.playerXuidToGametag));
         return {
           matchId: match.matchId,
-          data: matchStatsPresenter.getData(matchStats, playerMap, medalMetadata),
+          data: matchStatsFormatter.getData(matchStats, playerMap, medalMetadata),
         };
       } catch (error) {
         console.error("Error processing match stats:", error);
@@ -142,8 +142,8 @@ export function LiveTracker({ liveTrackerService }: LiveTrackerProps): React.Rea
     }
 
     try {
-      const teamPresenter = new SeriesTeamStatsPresenter();
-      const playerPresenter = new SeriesPlayerStatsPresenter();
+      const teamFormatter = new SeriesTeamStatsFormatter();
+      const playerFormatter = new SeriesPlayerStatsFormatter();
 
       const allPlayerXuidToGametag = new Map<string, string>();
       for (const match of model.state.matches) {
@@ -155,8 +155,8 @@ export function LiveTracker({ liveTrackerService }: LiveTrackerProps): React.Rea
       const metadata = calculateSeriesMetadata(model.state.matches, model.state.seriesScore);
 
       return {
-        teamData: teamPresenter.getSeriesData(rawMatchStats, allPlayerXuidToGametag, model.state.medalMetadata),
-        playerData: playerPresenter.getSeriesData(rawMatchStats, allPlayerXuidToGametag, model.state.medalMetadata),
+        teamData: teamFormatter.getSeriesData(rawMatchStats, allPlayerXuidToGametag, model.state.medalMetadata),
+        playerData: playerFormatter.getSeriesData(rawMatchStats, allPlayerXuidToGametag, model.state.medalMetadata),
         metadata,
       };
     } catch (error) {

--- a/pages/src/components/stats/attrition-match-stats-presenter.ts
+++ b/pages/src/components/stats/attrition-match-stats-presenter.ts
@@ -1,7 +1,7 @@
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class AttritionMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class AttritionMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(): StatsCollection {
     return new Map([]);
   }

--- a/pages/src/components/stats/base-match-stats-presenter.ts
+++ b/pages/src/components/stats/base-match-stats-presenter.ts
@@ -12,7 +12,7 @@ import {
 } from "@guilty-spark/shared/halo/match-stats";
 import type { MatchStatsData, MatchStatsPlayerData, MatchStatsValues } from "./types";
 
-export abstract class BaseMatchStatsPresenter {
+export abstract class BaseMatchStatsFormatter {
   protected abstract getPlayerObjectiveStats(stats: Stats): StatsCollection;
 
   protected getPlayerSlayerStats(stats: Stats, rank: number): StatsCollection {

--- a/pages/src/components/stats/create.ts
+++ b/pages/src/components/stats/create.ts
@@ -1,46 +1,46 @@
 import { GameVariantCategory } from "halo-infinite-api";
-import { AttritionMatchStatsPresenter } from "./attrition-match-stats-presenter";
-import type { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
-import { CtfMatchStatsPresenter } from "./ctf-match-stats-presenter";
-import { EliminationMatchStatsPresenter } from "./elimination-match-stats-presenter";
-import { EscalationMatchStatsPresenter } from "./escalation-match-stats-presenter";
-import { ExtractionMatchStatsPresenter } from "./extraction-match-stats-presenter";
-import { FiestaMatchStatsPresenter } from "./fiesta-match-stats-presenter";
-import { FirefightMatchStatsPresenter } from "./firefight-match-stats-presenter";
-import { GrifballMatchStatsPresenter } from "./grifball-match-stats-presenter";
-import { InfectionMatchStatsPresenter } from "./infection-match-stats-presenter";
-import { KOTHMatchStatsPresenter } from "./koth-match-stats-presenter";
-import { LandGrabMatchStatsPresenter } from "./land-grab-match-stats-presenter";
-import { MinigameMatchStatsPresenter } from "./minigame-match-stats-presenter";
-import { OddballMatchStatsPresenter } from "./oddball-match-stats-presenter";
-import { SlayerMatchStatsPresenter } from "./slayer-match-stats-presenter";
-import { StockpileMatchStatsPresenter } from "./stockpile-match-stats-presenter";
-import { StrongholdsMatchStatsPresenter } from "./strongholds-match-stats-presenter";
-import { TotalControlMatchStatsPresenter } from "./total-control-match-stats-presenter";
-import { UnknownMatchStatsPresenter } from "./unknown-match-stats-presenter";
-import { VIPMatchStatsPresenter } from "./vip-match-stats-presenter";
+import { AttritionMatchStatsFormatter } from "./attrition-match-stats-presenter";
+import type { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
+import { CtfMatchStatsFormatter } from "./ctf-match-stats-presenter";
+import { EliminationMatchStatsFormatter } from "./elimination-match-stats-presenter";
+import { EscalationMatchStatsFormatter } from "./escalation-match-stats-presenter";
+import { ExtractionMatchStatsFormatter } from "./extraction-match-stats-presenter";
+import { FiestaMatchStatsFormatter } from "./fiesta-match-stats-presenter";
+import { FirefightMatchStatsFormatter } from "./firefight-match-stats-presenter";
+import { GrifballMatchStatsFormatter } from "./grifball-match-stats-presenter";
+import { InfectionMatchStatsFormatter } from "./infection-match-stats-presenter";
+import { KOTHMatchStatsFormatter } from "./koth-match-stats-presenter";
+import { LandGrabMatchStatsFormatter } from "./land-grab-match-stats-presenter";
+import { MinigameMatchStatsFormatter } from "./minigame-match-stats-presenter";
+import { OddballMatchStatsFormatter } from "./oddball-match-stats-presenter";
+import { SlayerMatchStatsFormatter } from "./slayer-match-stats-presenter";
+import { StockpileMatchStatsFormatter } from "./stockpile-match-stats-presenter";
+import { StrongholdsMatchStatsFormatter } from "./strongholds-match-stats-presenter";
+import { TotalControlMatchStatsFormatter } from "./total-control-match-stats-presenter";
+import { UnknownMatchStatsFormatter } from "./unknown-match-stats-presenter";
+import { VIPMatchStatsFormatter } from "./vip-match-stats-presenter";
 
-const presenters = new Map<GameVariantCategory, BaseMatchStatsPresenter>([
-  [GameVariantCategory.MultiplayerSlayer, new SlayerMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerAttrition, new AttritionMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerElimination, new EliminationMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerOddball, new OddballMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerStrongholds, new StrongholdsMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerTotalControl, new TotalControlMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerFiesta, new FiestaMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerKingOfTheHill, new KOTHMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerCtf, new CtfMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerExtraction, new ExtractionMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerStockpile, new StockpileMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerInfection, new InfectionMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerVIP, new VIPMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerEscalation, new EscalationMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerGrifball, new GrifballMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerLandGrab, new LandGrabMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerMinigame, new MinigameMatchStatsPresenter()],
-  [GameVariantCategory.MultiplayerFirefight, new FirefightMatchStatsPresenter()],
+const formatters = new Map<GameVariantCategory, BaseMatchStatsFormatter>([
+  [GameVariantCategory.MultiplayerSlayer, new SlayerMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerAttrition, new AttritionMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerElimination, new EliminationMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerOddball, new OddballMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerStrongholds, new StrongholdsMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerTotalControl, new TotalControlMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerFiesta, new FiestaMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerKingOfTheHill, new KOTHMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerCtf, new CtfMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerExtraction, new ExtractionMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerStockpile, new StockpileMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerInfection, new InfectionMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerVIP, new VIPMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerEscalation, new EscalationMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerGrifball, new GrifballMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerLandGrab, new LandGrabMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerMinigame, new MinigameMatchStatsFormatter()],
+  [GameVariantCategory.MultiplayerFirefight, new FirefightMatchStatsFormatter()],
 ]);
 
-export function createMatchStatsPresenter(category: GameVariantCategory): BaseMatchStatsPresenter {
-  return presenters.get(category) ?? new UnknownMatchStatsPresenter();
+export function createMatchStatsFormatter(category: GameVariantCategory): BaseMatchStatsFormatter {
+  return formatters.get(category) ?? new UnknownMatchStatsFormatter();
 }

--- a/pages/src/components/stats/ctf-match-stats-presenter.ts
+++ b/pages/src/components/stats/ctf-match-stats-presenter.ts
@@ -1,9 +1,9 @@
 import type { GameVariantCategory, Stats } from "halo-infinite-api";
 import { getCtfObjectiveStats } from "@guilty-spark/shared/halo/objective-stats";
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class CtfMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class CtfMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(stats: Stats<GameVariantCategory.MultiplayerCtf>): StatsCollection {
     return new Map(getCtfObjectiveStats(stats));
   }

--- a/pages/src/components/stats/elimination-match-stats-presenter.ts
+++ b/pages/src/components/stats/elimination-match-stats-presenter.ts
@@ -1,9 +1,9 @@
 import type { GameVariantCategory, Stats } from "halo-infinite-api";
 import { getEliminationObjectiveStats } from "@guilty-spark/shared/halo/objective-stats";
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class EliminationMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class EliminationMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(stats: Stats<GameVariantCategory.MultiplayerElimination>): StatsCollection {
     return new Map(getEliminationObjectiveStats(stats));
   }

--- a/pages/src/components/stats/escalation-match-stats-presenter.ts
+++ b/pages/src/components/stats/escalation-match-stats-presenter.ts
@@ -1,7 +1,7 @@
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class EscalationMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class EscalationMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(): StatsCollection {
     return new Map();
   }

--- a/pages/src/components/stats/extraction-match-stats-presenter.ts
+++ b/pages/src/components/stats/extraction-match-stats-presenter.ts
@@ -1,9 +1,9 @@
 import type { GameVariantCategory, Stats } from "halo-infinite-api";
 import { getExtractionObjectiveStats } from "@guilty-spark/shared/halo/objective-stats";
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class ExtractionMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class ExtractionMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(stats: Stats<GameVariantCategory.MultiplayerExtraction>): StatsCollection {
     return new Map(getExtractionObjectiveStats(stats));
   }

--- a/pages/src/components/stats/fiesta-match-stats-presenter.ts
+++ b/pages/src/components/stats/fiesta-match-stats-presenter.ts
@@ -1,7 +1,7 @@
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class FiestaMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class FiestaMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(): StatsCollection {
     return new Map([]);
   }

--- a/pages/src/components/stats/firefight-match-stats-presenter.ts
+++ b/pages/src/components/stats/firefight-match-stats-presenter.ts
@@ -1,9 +1,9 @@
 import type { GameVariantCategory, Stats } from "halo-infinite-api";
 import { getFirefightObjectiveStats } from "@guilty-spark/shared/halo/objective-stats";
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class FirefightMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class FirefightMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(stats: Stats<GameVariantCategory.MultiplayerFirefight>): StatsCollection {
     return new Map(getFirefightObjectiveStats(stats));
   }

--- a/pages/src/components/stats/grifball-match-stats-presenter.ts
+++ b/pages/src/components/stats/grifball-match-stats-presenter.ts
@@ -1,7 +1,7 @@
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class GrifballMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class GrifballMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(): StatsCollection {
     return new Map([]);
   }

--- a/pages/src/components/stats/infection-match-stats-presenter.ts
+++ b/pages/src/components/stats/infection-match-stats-presenter.ts
@@ -1,9 +1,9 @@
 import type { GameVariantCategory, Stats } from "halo-infinite-api";
 import { getInfectionObjectiveStats } from "@guilty-spark/shared/halo/objective-stats";
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class InfectionMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class InfectionMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(stats: Stats<GameVariantCategory.MultiplayerInfection>): StatsCollection {
     return new Map(getInfectionObjectiveStats(stats));
   }

--- a/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-presenter.ts
@@ -1,18 +1,18 @@
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { KillMatrixClassification, KillMatrixPlayer, KillMatrixViewRow } from "./types";
 
-interface KillMatrixPresenterPlayerLookup {
+interface KillMatrixFormatterPlayerLookup {
   readonly gamertag: string;
   readonly teamId: number | null;
 }
 
-export interface KillMatrixPresenterOptions {
+export interface KillMatrixFormatterOptions {
   readonly analytics: MatchAnalytics;
-  readonly playersByXuid: ReadonlyMap<string, KillMatrixPresenterPlayerLookup>;
+  readonly playersByXuid: ReadonlyMap<string, KillMatrixFormatterPlayerLookup>;
 }
 
-export class KillMatrixPresenter {
-  public present({ analytics, playersByXuid }: KillMatrixPresenterOptions): KillMatrixViewRow[] {
+export class KillMatrixFormatter {
+  public present({ analytics, playersByXuid }: KillMatrixFormatterOptions): KillMatrixViewRow[] {
     const rows: KillMatrixViewRow[] = [];
 
     for (const [key, value] of Object.entries(analytics.killMatrix)) {
@@ -50,7 +50,7 @@ export class KillMatrixPresenter {
 
   private toPlayer(
     xuid: string,
-    playersByXuid: ReadonlyMap<string, KillMatrixPresenterPlayerLookup>,
+    playersByXuid: ReadonlyMap<string, KillMatrixFormatterPlayerLookup>,
   ): KillMatrixPlayer {
     const entry = playersByXuid.get(xuid);
     if (entry == null) {

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-presenter.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { KillMatrixPresenter } from "../kill-matrix-presenter";
+import { KillMatrixFormatter } from "../kill-matrix-presenter";
 import { aFakeMatchAnalyticsWith } from "../fakes/match-analytics.fake";
 import type { KillMatrixViewRow } from "../types";
 
-describe("KillMatrixPresenter", () => {
+describe("KillMatrixFormatter", () => {
   it("expands and sorts kill matrix rows", () => {
-    const presenter = new KillMatrixPresenter();
+    const presenter = new KillMatrixFormatter();
     const analytics = aFakeMatchAnalyticsWith();
     const rows = presenter.present({
       analytics,
@@ -28,7 +28,7 @@ describe("KillMatrixPresenter", () => {
   });
 
   it("falls back to xuid when player details are missing", () => {
-    const presenter = new KillMatrixPresenter();
+    const presenter = new KillMatrixFormatter();
     const analytics = aFakeMatchAnalyticsWith({
       killMatrix: {
         "999:888": {
@@ -70,7 +70,7 @@ describe("KillMatrixPresenter", () => {
         },
       ];
 
-      const result = KillMatrixPresenter.aggregate(rows);
+      const result = KillMatrixFormatter.aggregate(rows);
 
       expect(result).toHaveLength(1);
       expect(result[0]).toMatchObject({ key: "111:222", count: 5, headshotKills: 3, perfects: 1 });
@@ -98,13 +98,13 @@ describe("KillMatrixPresenter", () => {
         },
       ];
 
-      const result = KillMatrixPresenter.aggregate(rows);
+      const result = KillMatrixFormatter.aggregate(rows);
 
       expect(result.map((r) => r.key)).toEqual(["333:444", "111:222"]);
     });
 
     it("returns empty array when given no rows", () => {
-      expect(KillMatrixPresenter.aggregate([])).toEqual([]);
+      expect(KillMatrixFormatter.aggregate([])).toEqual([]);
     });
   });
 });

--- a/pages/src/components/stats/koth-match-stats-presenter.ts
+++ b/pages/src/components/stats/koth-match-stats-presenter.ts
@@ -1,9 +1,9 @@
 import type { GameVariantCategory, Stats } from "halo-infinite-api";
 import { getStrongholdsObjectiveStats } from "@guilty-spark/shared/halo/objective-stats";
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class KOTHMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class KOTHMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(stats: Stats<GameVariantCategory.MultiplayerKingOfTheHill>): StatsCollection {
     return new Map(getStrongholdsObjectiveStats(stats));
   }

--- a/pages/src/components/stats/land-grab-match-stats-presenter.ts
+++ b/pages/src/components/stats/land-grab-match-stats-presenter.ts
@@ -1,7 +1,7 @@
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class LandGrabMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class LandGrabMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(): StatsCollection {
     return new Map([]);
   }

--- a/pages/src/components/stats/minigame-match-stats-presenter.ts
+++ b/pages/src/components/stats/minigame-match-stats-presenter.ts
@@ -1,7 +1,7 @@
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class MinigameMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class MinigameMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(): StatsCollection {
     return new Map([]);
   }

--- a/pages/src/components/stats/oddball-match-stats-presenter.ts
+++ b/pages/src/components/stats/oddball-match-stats-presenter.ts
@@ -1,9 +1,9 @@
 import type { GameVariantCategory, Stats } from "halo-infinite-api";
 import { getOddballObjectiveStats } from "@guilty-spark/shared/halo/objective-stats";
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class OddballMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class OddballMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(stats: Stats<GameVariantCategory.MultiplayerOddball>): StatsCollection {
     return new Map(getOddballObjectiveStats(stats));
   }

--- a/pages/src/components/stats/series-player-stats-presenter.ts
+++ b/pages/src/components/stats/series-player-stats-presenter.ts
@@ -12,7 +12,7 @@ import { getPlayerSlayerStats as getSharedPlayerSlayerStats } from "@guilty-spar
 import { getBestStatValues, getBestTeamStatValues, getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
 import type { MatchStatsData, MatchStatsPlayerData } from "./types";
 
-export class SeriesPlayerStatsPresenter {
+export class SeriesPlayerStatsFormatter {
   getSeriesData(
     matches: MatchStats[],
     players: Map<string, string>,

--- a/pages/src/components/stats/series-team-stats-presenter.ts
+++ b/pages/src/components/stats/series-team-stats-presenter.ts
@@ -9,7 +9,7 @@ import { getBestStatValues, getPlayerXuid, getTeamPlayersFromMatches } from "@gu
 import { aggregatePlayerCoreStats } from "@guilty-spark/shared/halo/series-player";
 import type { MatchStatsData, MatchStatsPlayerData, MatchStatsValues } from "./types";
 
-export class SeriesTeamStatsPresenter {
+export class SeriesTeamStatsFormatter {
   getSeriesData(
     matches: MatchStats[],
     players: Map<string, string>,

--- a/pages/src/components/stats/slayer-match-stats-presenter.ts
+++ b/pages/src/components/stats/slayer-match-stats-presenter.ts
@@ -1,7 +1,7 @@
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class SlayerMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class SlayerMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(): StatsCollection {
     return new Map([]);
   }

--- a/pages/src/components/stats/stockpile-match-stats-presenter.ts
+++ b/pages/src/components/stats/stockpile-match-stats-presenter.ts
@@ -1,9 +1,9 @@
 import type { GameVariantCategory, Stats } from "halo-infinite-api";
 import { getStockpileObjectiveStats } from "@guilty-spark/shared/halo/objective-stats";
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class StockpileMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class StockpileMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(stats: Stats<GameVariantCategory.MultiplayerStockpile>): StatsCollection {
     return new Map(getStockpileObjectiveStats(stats));
   }

--- a/pages/src/components/stats/strongholds-match-stats-presenter.ts
+++ b/pages/src/components/stats/strongholds-match-stats-presenter.ts
@@ -1,9 +1,9 @@
 import type { GameVariantCategory, Stats } from "halo-infinite-api";
 import { getStrongholdsObjectiveStats } from "@guilty-spark/shared/halo/objective-stats";
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class StrongholdsMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class StrongholdsMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(stats: Stats<GameVariantCategory.MultiplayerStrongholds>): StatsCollection {
     return new Map(getStrongholdsObjectiveStats(stats));
   }

--- a/pages/src/components/stats/tests/base-match-stats-presenter.test.ts
+++ b/pages/src/components/stats/tests/base-match-stats-presenter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "../base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "../base-match-stats-presenter";
 import {
   aFakeMatchStatsWith,
   aFakePlayerWith,
@@ -9,14 +9,14 @@ import {
   aFakeCoreStatsWith,
 } from "../fakes/data";
 
-class TestMatchStatsPresenter extends BaseMatchStatsPresenter {
+class TestMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(): StatsCollection {
     return new Map([]);
   }
 }
 
-describe("BaseMatchStatsPresenter", () => {
-  const presenter = new TestMatchStatsPresenter();
+describe("BaseMatchStatsFormatter", () => {
+  const presenter = new TestMatchStatsFormatter();
 
   describe("getData", () => {
     it("returns data for each team", () => {

--- a/pages/src/components/stats/tests/series-player-stats-presenter.test.ts
+++ b/pages/src/components/stats/tests/series-player-stats-presenter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { SeriesPlayerStatsPresenter } from "../series-player-stats-presenter";
+import { SeriesPlayerStatsFormatter } from "../series-player-stats-presenter";
 import {
   aFakeMatchStatsWith,
   aFakePlayerWith,
@@ -8,8 +8,8 @@ import {
   aFakeTeamWith,
 } from "../fakes/data";
 
-describe("SeriesPlayerStatsPresenter", () => {
-  const presenter = new SeriesPlayerStatsPresenter();
+describe("SeriesPlayerStatsFormatter", () => {
+  const presenter = new SeriesPlayerStatsFormatter();
 
   describe("getSeriesData", () => {
     it("returns data for each team", () => {

--- a/pages/src/components/stats/tests/series-team-stats-presenter.test.ts
+++ b/pages/src/components/stats/tests/series-team-stats-presenter.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { SeriesTeamStatsPresenter } from "../series-team-stats-presenter";
+import { SeriesTeamStatsFormatter } from "../series-team-stats-presenter";
 import { aFakeMatchStatsWith, aFakeTeamWith, aFakeCoreStatsWith, aFakeMedalMetadata } from "../fakes/data";
 
-describe("SeriesTeamStatsPresenter", () => {
-  const presenter = new SeriesTeamStatsPresenter();
+describe("SeriesTeamStatsFormatter", () => {
+  const presenter = new SeriesTeamStatsFormatter();
 
   describe("getSeriesData", () => {
     it("returns data for each team", () => {

--- a/pages/src/components/stats/total-control-match-stats-presenter.ts
+++ b/pages/src/components/stats/total-control-match-stats-presenter.ts
@@ -1,7 +1,7 @@
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class TotalControlMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class TotalControlMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(): StatsCollection {
     return new Map([]);
   }

--- a/pages/src/components/stats/unknown-match-stats-presenter.ts
+++ b/pages/src/components/stats/unknown-match-stats-presenter.ts
@@ -1,7 +1,7 @@
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class UnknownMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class UnknownMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(): StatsCollection {
     return new Map([]);
   }

--- a/pages/src/components/stats/vip-match-stats-presenter.ts
+++ b/pages/src/components/stats/vip-match-stats-presenter.ts
@@ -1,9 +1,9 @@
 import type { GameVariantCategory, Stats } from "halo-infinite-api";
 import { getVipObjectiveStats } from "@guilty-spark/shared/halo/objective-stats";
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
-import { BaseMatchStatsPresenter } from "./base-match-stats-presenter";
+import { BaseMatchStatsFormatter } from "./base-match-stats-presenter";
 
-export class VIPMatchStatsPresenter extends BaseMatchStatsPresenter {
+export class VIPMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(stats: Stats<GameVariantCategory.MultiplayerVIP>): StatsCollection {
     return new Map(getVipObjectiveStats(stats));
   }


### PR DESCRIPTION
## Summary

- Renames all stateless data transformer classes in `components/stats/` from `*MatchStatsPresenter` → `*MatchStatsFormatter` (19 game-mode variants + base), `SeriesTeamStatsPresenter` → `SeriesTeamStatsFormatter`, `SeriesPlayerStatsPresenter` → `SeriesPlayerStatsFormatter`, `KillMatrixPresenter` → `KillMatrixFormatter`
- Renames factory function `createMatchStatsPresenter` → `createMatchStatsFormatter`
- Updates all consumers: `discord-series-stats-presenter.ts`, `discord-series-stats-view.tsx`, `individual-tracker-overlay-presenter.ts`, `stats-panel.tsx`, `live-tracker/create.tsx`
- Updates all test files to match

**No behaviour changes.** This is PR 1/3 of the StatsController refactor.

## Why

The existing `*Presenter` naming conflicted with the SPC pattern's `Presenter` concept (store orchestrators). These classes are pure stateless data transformers — renaming them to `*Formatter` makes their role unambiguous before they are moved to `controllers/stats/` in PR 2.

## Test plan

- [x] `npm run typecheck:pages` — 0 errors
- [x] `npx vitest run pages/src/components/stats` — 101/101 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)