### PR TITLE
refactor(stats): migrate all consumers to StatsController (PR 3/3)

### DIFF
--- a/pages/src/components/discord-series-stats/create.tsx
+++ b/pages/src/components/discord-series-stats/create.tsx
@@ -12,8 +12,11 @@ interface DiscordSeriesStatsProps {
 }
 
 export function DiscordSeriesStats({ data, matchAnalyticsService }: DiscordSeriesStatsProps): ReactElement {
-  const controller = useMemo(() => new StatsController(), [data]);
-  const presenter = useMemo(() => new DiscordSeriesStatsPresenter(data.renderData, controller), [data, controller]);
+  const controller = useMemo(() => new StatsController(), [data.renderData]);
+  const presenter = useMemo(
+    () => new DiscordSeriesStatsPresenter(data.renderData, controller),
+    [data.renderData, controller],
+  );
 
   const model = useMemo(() => presenter.present(), [presenter]);
 

--- a/pages/src/components/discord-series-stats/create.tsx
+++ b/pages/src/components/discord-series-stats/create.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, type ReactElement } from "react";
 import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
+import { StatsController } from "../../controllers/stats/stats-controller";
 import { DiscordSeriesStatsPresenter } from "./discord-series-stats-presenter";
 import { DiscordSeriesStatsView } from "./discord-series-stats-view";
 
@@ -11,7 +12,8 @@ interface DiscordSeriesStatsProps {
 }
 
 export function DiscordSeriesStats({ data, matchAnalyticsService }: DiscordSeriesStatsProps): ReactElement {
-  const presenter = useMemo(() => new DiscordSeriesStatsPresenter(data.renderData), [data]);
+  const controller = useMemo(() => new StatsController(), [data]);
+  const presenter = useMemo(() => new DiscordSeriesStatsPresenter(data.renderData, controller), [data, controller]);
 
   const model = useMemo(() => presenter.present(), [presenter]);
 
@@ -48,5 +50,12 @@ export function DiscordSeriesStats({ data, matchAnalyticsService }: DiscordSerie
     };
   }, [data.matchIds, matchAnalyticsService]);
 
-  return <DiscordSeriesStatsView renderData={data.renderData} model={model} analyticsByMatchId={analyticsByMatchId} />;
+  return (
+    <DiscordSeriesStatsView
+      renderData={data.renderData}
+      model={model}
+      analyticsByMatchId={analyticsByMatchId}
+      controller={controller}
+    />
+  );
 }

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -2,9 +2,8 @@ import type { MatchStats } from "halo-infinite-api";
 import { differenceInSeconds, isValid, parseISO } from "date-fns";
 import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
 import { createMatchStatsFormatter } from "../../controllers/stats/create";
-import { SeriesTeamStatsFormatter } from "../../controllers/stats/series-team-stats-formatter";
-import { SeriesPlayerStatsFormatter } from "../../controllers/stats/series-player-stats-formatter";
 import type { MatchStatsData } from "../../controllers/stats/types";
+import type { StatsController } from "../../controllers/stats/stats-controller";
 import { DEFAULT_TEAM_COLORS, getTeamColorOrDefault, type TeamColor } from "../team-colors/team-colors";
 
 const WIN_OUTCOME = 2;
@@ -76,14 +75,17 @@ function calculateSeriesMetadata(
 
   return {
     score: seriesScore,
-    duration: `${totalMinutes.toString()}m ${remainingSeconds.toString().padStart(2, "0")}s`,
+    duration: `${String(totalMinutes)}m ${String(remainingSeconds).padStart(2, "0")}s`,
     startTime: firstMatch.startTime,
     endTime: lastMatch.endTime,
   };
 }
 
 export class DiscordSeriesStatsPresenter {
-  constructor(readonly renderData: DiscordSeriesStatsResolved["renderData"]) {}
+  constructor(
+    readonly renderData: DiscordSeriesStatsResolved["renderData"],
+    private readonly controller: StatsController,
+  ) {}
 
   private static readonly modelByRenderData = new WeakMap<
     DiscordSeriesStatsResolved["renderData"],
@@ -125,19 +127,19 @@ export class DiscordSeriesStatsPresenter {
 
     if (rawMatches.length > 0) {
       try {
-        const teamFormatter = new SeriesTeamStatsFormatter();
-        const playerFormatter = new SeriesPlayerStatsFormatter();
         const playersMap = new Map<string, string>();
-
         for (const match of this.renderData.matches) {
           for (const [xuid, gamertag] of Object.entries(match.playerXuidToGametag)) {
             playersMap.set(xuid, gamertag);
           }
         }
 
+        this.controller.loadSeries(rawMatches, playersMap, this.renderData.medalMetadata);
+        const { teamData, playerData } = this.controller.getSeriesStats();
+
         seriesStats = {
-          teamData: teamFormatter.getSeriesData(rawMatches, playersMap, this.renderData.medalMetadata),
-          playerData: playerFormatter.getSeriesData(rawMatches, playersMap, this.renderData.medalMetadata),
+          teamData,
+          playerData,
           metadata: calculateSeriesMetadata(this.renderData.matches, this.renderData.seriesScore),
         };
       } catch {

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -1,9 +1,8 @@
 import type { MatchStats } from "halo-infinite-api";
 import { differenceInSeconds, isValid, parseISO } from "date-fns";
 import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
-import { createMatchStatsFormatter } from "../../controllers/stats/create";
 import type { MatchStatsData } from "../../controllers/stats/types";
-import type { StatsController } from "../../controllers/stats/stats-controller";
+import { StatsController } from "../../controllers/stats/stats-controller";
 import { DEFAULT_TEAM_COLORS, getTeamColorOrDefault, type TeamColor } from "../team-colors/team-colors";
 
 const WIN_OUTCOME = 2;
@@ -104,12 +103,10 @@ export class DiscordSeriesStatsPresenter {
       }
 
       try {
-        const formatter = createMatchStatsFormatter(match.rawMatch.MatchInfo.GameVariantCategory);
+        const matchController = new StatsController();
         const playerMap = new Map<string, string>(Object.entries(match.playerXuidToGametag));
-        return {
-          matchId: match.matchId,
-          data: formatter.getData(match.rawMatch, playerMap, this.renderData.medalMetadata),
-        };
+        matchController.loadMatch(match.rawMatch, playerMap, this.renderData.medalMetadata);
+        return { matchId: match.matchId, data: matchController.getMatchStats() };
       } catch {
         return { matchId: match.matchId, data: null };
       }

--- a/pages/src/components/discord-series-stats/discord-series-stats-view.tsx
+++ b/pages/src/components/discord-series-stats/discord-series-stats-view.tsx
@@ -7,6 +7,7 @@ import { MatchStats as MatchStatsView } from "../stats/match-stats";
 import { SeriesStats } from "../stats/series-stats";
 import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import type { KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
+import type { StatsController } from "../../controllers/stats/stats-controller";
 import { Container } from "../container/container";
 import { Alert } from "../alert/alert";
 import { getTeamColorOrDefault } from "../team-colors/team-colors";
@@ -22,12 +23,14 @@ interface DiscordSeriesStatsViewProps {
   readonly renderData: DiscordSeriesStatsResolved["renderData"];
   readonly model: DiscordSeriesStatsViewModel;
   readonly analyticsByMatchId: ReadonlyMap<string, MatchAnalytics>;
+  readonly controller: StatsController;
 }
 
 export function DiscordSeriesStatsView({
   renderData,
   model,
   analyticsByMatchId,
+  controller,
 }: DiscordSeriesStatsViewProps): ReactElement {
   const [viewMode, setViewMode] = useState<DiscordSeriesViewMode>("standard");
   const contentWidthClass = viewMode === "wide" ? styles.wide : undefined;
@@ -35,6 +38,21 @@ export function DiscordSeriesStatsView({
     setViewMode((current) => (current === "standard" ? "wide" : "standard"));
   }, []);
   const killMatrixPresenter = useMemo(() => new KillMatrixFormatter(), []);
+
+  const playersByXuid = useMemo((): ReadonlyMap<string, { gamertag: string; teamId: number | null }> => {
+    try {
+      return new Map(controller.getPlayers().map((p) => [p.xuid, { gamertag: p.gamertag, teamId: p.teamId }]));
+    } catch {
+      return new Map(
+        renderData.matches.flatMap((match) =>
+          Object.entries(match.playerXuidToGametag).map(([xuid, gamertag]) => [
+            xuid,
+            { gamertag, teamId: null as number | null },
+          ]),
+        ),
+      );
+    }
+  }, [controller, renderData.matches]);
 
   const allMatchKillMatrixRows = useMemo<ReadonlyMap<string, KillMatrixViewRow[]>>(
     () =>
@@ -44,13 +62,10 @@ export function DiscordSeriesStatsView({
           if (analytics == null) {
             return [];
           }
-          const playersByXuid = new Map(
-            Object.entries(match.playerXuidToGametag).map(([xuid, gamertag]) => [xuid, { gamertag, teamId: null }]),
-          );
           return [[match.matchId, killMatrixPresenter.present({ analytics, playersByXuid })]];
         }),
       ),
-    [analyticsByMatchId, killMatrixPresenter, renderData.matches],
+    [analyticsByMatchId, killMatrixPresenter, playersByXuid, renderData.matches],
   );
 
   const seriesKillMatrixRows = useMemo<KillMatrixViewRow[]>(

--- a/pages/src/components/discord-series-stats/discord-series-stats-view.tsx
+++ b/pages/src/components/discord-series-stats/discord-series-stats-view.tsx
@@ -40,19 +40,18 @@ export function DiscordSeriesStatsView({
   const killMatrixPresenter = useMemo(() => new KillMatrixFormatter(), []);
 
   const playersByXuid = useMemo((): ReadonlyMap<string, { gamertag: string; teamId: number | null }> => {
-    try {
+    if (model.seriesStats != null) {
       return new Map(controller.getPlayers().map((p) => [p.xuid, { gamertag: p.gamertag, teamId: p.teamId }]));
-    } catch {
-      return new Map(
-        renderData.matches.flatMap((match) =>
-          Object.entries(match.playerXuidToGametag).map(([xuid, gamertag]) => [
-            xuid,
-            { gamertag, teamId: null as number | null },
-          ]),
-        ),
-      );
     }
-  }, [controller, renderData.matches]);
+    return new Map(
+      renderData.matches.flatMap((match) =>
+        Object.entries(match.playerXuidToGametag).map(([xuid, gamertag]) => [
+          xuid,
+          { gamertag, teamId: null as number | null },
+        ]),
+      ),
+    );
+  }, [controller, model.seriesStats, renderData.matches]);
 
   const allMatchKillMatrixRows = useMemo<ReadonlyMap<string, KillMatrixViewRow[]>>(
     () =>

--- a/pages/src/components/individual-tracker/viewer/stats-panel.tsx
+++ b/pages/src/components/individual-tracker/viewer/stats-panel.tsx
@@ -1,11 +1,9 @@
 import React, { useMemo } from "react";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
-import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { Alert } from "../../alert/alert";
 import { LoadingState } from "../../loading-state/loading-state";
-import { createMatchStatsFormatter } from "../../../controllers/stats/create";
+import { StatsController } from "../../../controllers/stats/stats-controller";
 import { MatchStats } from "../../stats/match-stats";
-import type { MatchStatsData } from "../../../controllers/stats/types";
 import { gameModeIconSrc } from "../game-mode-icon";
 import type { IndividualTrackerViewerViewModel } from "./types";
 import type { MatchStatsState } from "./viewer-store";
@@ -17,23 +15,20 @@ interface LoadedStatsPanelProps {
 
 function LoadedStatsPanel({ state }: LoadedStatsPanelProps): React.ReactElement {
   const { stats, playerMap, medalMetadata, analytics } = state;
-  const killMatrixPresenter = useMemo(() => new KillMatrixFormatter(), []);
-  const data = useMemo<MatchStatsData[]>(() => {
-    const formatter = createMatchStatsFormatter(stats.MatchInfo.GameVariantCategory);
-    return formatter.getData(stats, playerMap, medalMetadata);
-  }, [stats, playerMap, medalMetadata]);
+  const controller = useMemo(() => new StatsController(), []);
+
+  const data = useMemo(() => {
+    controller.loadMatch(stats, playerMap, medalMetadata);
+    return controller.getMatchStats();
+  }, [controller, stats, playerMap, medalMetadata]);
 
   const killMatrixRows = useMemo(() => {
     if (analytics == null) {
       return [];
     }
-
-    const playersByXuid = new Map(
-      [...playerMap.entries()].map(([xuid, gamertag]) => [xuid, { gamertag, teamId: null }]),
-    );
-
-    return killMatrixPresenter.present({ analytics, playersByXuid });
-  }, [analytics, killMatrixPresenter, playerMap]);
+    controller.loadAnalytics(analytics, playerMap);
+    return controller.getKillMatrix();
+  }, [controller, analytics, playerMap]);
 
   return (
     <div className={styles.wrapper}>

--- a/pages/src/components/live-tracker/create.tsx
+++ b/pages/src/components/live-tracker/create.tsx
@@ -2,10 +2,8 @@ import React, { useEffect, useMemo, useSyncExternalStore, useRef } from "react";
 import { ComponentLoader, ComponentLoaderStatus } from "../component-loader/component-loader";
 import { ErrorState } from "../error-state/error-state";
 import { LoadingState } from "../loading-state/loading-state";
-import { createMatchStatsFormatter } from "../../controllers/stats/create";
 import type { MatchStatsData } from "../../controllers/stats/types";
-import { SeriesTeamStatsFormatter } from "../../controllers/stats/series-team-stats-formatter";
-import { SeriesPlayerStatsFormatter } from "../../controllers/stats/series-player-stats-formatter";
+import { StatsController } from "../../controllers/stats/stats-controller";
 import { calculateSeriesMetadata, type SeriesMetadata } from "../../controllers/stats/series-metadata";
 import type { LiveTrackerService } from "../../services/live-tracker/types";
 import { LiveTrackerPresenter } from "./live-tracker-presenter";
@@ -110,12 +108,10 @@ export function LiveTracker({ liveTrackerService }: LiveTrackerProps): React.Rea
 
       try {
         const matchStats = match.rawMatchStats;
-        const matchStatsFormatter = createMatchStatsFormatter(matchStats.MatchInfo.GameVariantCategory);
+        const controller = new StatsController();
         const playerMap = new Map<string, string>(Object.entries(match.playerXuidToGametag));
-        return {
-          matchId: match.matchId,
-          data: matchStatsFormatter.getData(matchStats, playerMap, medalMetadata),
-        };
+        controller.loadMatch(matchStats, playerMap, medalMetadata);
+        return { matchId: match.matchId, data: controller.getMatchStats() };
       } catch (error) {
         console.error("Error processing match stats:", error);
         return { matchId: match.matchId, data: null };
@@ -142,9 +138,6 @@ export function LiveTracker({ liveTrackerService }: LiveTrackerProps): React.Rea
     }
 
     try {
-      const teamFormatter = new SeriesTeamStatsFormatter();
-      const playerFormatter = new SeriesPlayerStatsFormatter();
-
       const allPlayerXuidToGametag = new Map<string, string>();
       for (const match of model.state.matches) {
         for (const [xuid, gamertag] of Object.entries(match.playerXuidToGametag)) {
@@ -152,13 +145,12 @@ export function LiveTracker({ liveTrackerService }: LiveTrackerProps): React.Rea
         }
       }
 
+      const controller = new StatsController();
+      controller.loadSeries(rawMatchStats, allPlayerXuidToGametag, model.state.medalMetadata);
+      const { teamData, playerData } = controller.getSeriesStats();
       const metadata = calculateSeriesMetadata(model.state.matches, model.state.seriesScore);
 
-      return {
-        teamData: teamFormatter.getSeriesData(rawMatchStats, allPlayerXuidToGametag, model.state.medalMetadata),
-        playerData: playerFormatter.getSeriesData(rawMatchStats, allPlayerXuidToGametag, model.state.medalMetadata),
-        metadata,
-      };
+      return { teamData, playerData, metadata };
     } catch (error) {
       console.error("Error processing series stats:", error);
       return null;


### PR DESCRIPTION
## Summary

- Migrates the remaining 3 consumer sites (`stats-panel.tsx`, `live-tracker/create.tsx`, `discord-series-stats`) to use `StatsController` via constructor injection, completing the refactor started in [#566](https://github.com/davidhouweling/guilty-spark/pull/566)
- `DiscordSeriesStatsPresenter` now accepts a `StatsController` and uses `loadSeries()`/`getSeriesStats()` instead of calling `SeriesTeamStatsFormatter`/`SeriesPlayerStatsFormatter` directly
- `DiscordSeriesStatsView` now accepts a `controller` prop and builds an enriched `playersByXuid` map (with real team IDs) via `controller.getPlayers()` for kill matrix rendering
- Per-match stats in `live-tracker/create.tsx` and `discord-series-stats-presenter.ts` each create their own `StatsController` instance (since `loadMatch()` overwrites state, one controller per match is the right model)

## Test plan

- [ ] All 2570 tests pass (`npx vitest run`)
- [ ] TypeScript clean (`npx tsc --noEmit`)
- [ ] Linting/formatting clean (`npm run done` format + lint steps)
- [ ] `discord-series-stats/tests/create.test.tsx` — 6 tests pass with updated presenter constructor

🤖 Generated with [Claude Code](https://claude.com/claude-code)