### PR TITLE
refactor(discord-series-stats): full SPC pattern

### DIFF
--- a/pages/src/components/discord-series-stats/create.tsx
+++ b/pages/src/components/discord-series-stats/create.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useState, type ReactElement } from "react";
+import { useEffect, useMemo, useSyncExternalStore, type ReactElement } from "react";
 import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
-import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import { StatsController } from "../../controllers/stats/stats-controller";
+import { DiscordSeriesStatsStore } from "./discord-series-stats-store";
 import { DiscordSeriesStatsPresenter } from "./discord-series-stats-presenter";
 import { DiscordSeriesStatsView } from "./discord-series-stats-view";
 
@@ -12,53 +12,27 @@ interface DiscordSeriesStatsProps {
 }
 
 export function DiscordSeriesStats({ data, matchAnalyticsService }: DiscordSeriesStatsProps): ReactElement {
+  const store = useMemo(() => new DiscordSeriesStatsStore(), [data.renderData]);
   const controller = useMemo(() => new StatsController(), [data.renderData]);
   const presenter = useMemo(
-    () => new DiscordSeriesStatsPresenter(data.renderData, controller),
-    [data.renderData, controller],
+    () => new DiscordSeriesStatsPresenter(data.renderData, controller, store, matchAnalyticsService),
+    [data.renderData, controller, store, matchAnalyticsService],
   );
 
-  const model = useMemo(() => presenter.present(), [presenter]);
-
-  const [analyticsByMatchId, setAnalyticsByMatchId] = useState<ReadonlyMap<string, MatchAnalytics>>(new Map());
+  const snapshot = useSyncExternalStore(
+    (listener) => store.subscribe(listener),
+    () => store.getSnapshot(),
+    () => store.getSnapshot(),
+  );
 
   useEffect(() => {
-    let cancelled = false;
-    const { matchIds } = data;
-
-    void Promise.all(
-      matchIds.map(async (matchId) => {
-        try {
-          const analytics = await matchAnalyticsService.getMatchAnalytics(matchId);
-          return { matchId, analytics };
-        } catch {
-          return null;
-        }
-      }),
-    ).then((results) => {
-      if (cancelled) {
-        return;
-      }
-      const map = new Map<string, MatchAnalytics>();
-      for (const result of results) {
-        if (result != null) {
-          map.set(result.matchId, result.analytics);
-        }
-      }
-      setAnalyticsByMatchId(map);
-    });
-
+    presenter.start();
     return (): void => {
-      cancelled = true;
+      presenter.dispose();
     };
-  }, [data.matchIds, matchAnalyticsService]);
+  }, [presenter]);
 
-  return (
-    <DiscordSeriesStatsView
-      renderData={data.renderData}
-      model={model}
-      analyticsByMatchId={analyticsByMatchId}
-      controller={controller}
-    />
-  );
+  const model = useMemo(() => presenter.present(snapshot), [presenter, snapshot]);
+
+  return <DiscordSeriesStatsView renderData={data.renderData} model={model} />;
 }

--- a/pages/src/components/discord-series-stats/create.tsx
+++ b/pages/src/components/discord-series-stats/create.tsx
@@ -34,5 +34,5 @@ export function DiscordSeriesStats({ data, matchAnalyticsService }: DiscordSerie
 
   const model = useMemo(() => presenter.present(snapshot), [presenter, snapshot]);
 
-  return <DiscordSeriesStatsView renderData={data.renderData} model={model} />;
+  return <DiscordSeriesStatsView {...model} />;
 }

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -1,9 +1,14 @@
 import type { MatchStats } from "halo-infinite-api";
 import { differenceInSeconds, isValid, parseISO } from "date-fns";
 import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { MatchStatsData } from "../../controllers/stats/types";
 import { StatsController } from "../../controllers/stats/stats-controller";
+import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import type { KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
+import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import { DEFAULT_TEAM_COLORS, getTeamColorOrDefault, type TeamColor } from "../team-colors/team-colors";
+import type { DiscordSeriesStatsSnapshot, DiscordSeriesStatsStore } from "./discord-series-stats-store";
 
 const WIN_OUTCOME = 2;
 
@@ -16,11 +21,17 @@ interface SeriesMetadata {
 
 export interface DiscordSeriesStatsViewModel {
   readonly teamColors: readonly TeamColor[];
-  readonly allMatchStats: { matchId: string; data: MatchStatsData[] | null }[];
+  readonly allMatchStats: {
+    readonly matchId: string;
+    readonly data: MatchStatsData[] | null;
+    readonly winningTeamColorHex: string | null;
+    readonly killMatrixRows: readonly KillMatrixViewRow[];
+  }[];
   readonly seriesStats: {
     readonly teamData: MatchStatsData[];
     readonly playerData: MatchStatsData[];
     readonly metadata: SeriesMetadata | null;
+    readonly killMatrixRows: readonly KillMatrixViewRow[];
   } | null;
 }
 
@@ -81,46 +92,63 @@ function calculateSeriesMetadata(
 }
 
 export class DiscordSeriesStatsPresenter {
+  private cancelled = false;
+
   constructor(
     readonly renderData: DiscordSeriesStatsResolved["renderData"],
     private readonly controller: StatsController,
+    private readonly store: DiscordSeriesStatsStore,
+    private readonly matchAnalyticsService: MatchAnalyticsService,
   ) {}
 
-  private static readonly modelByRenderData = new WeakMap<
-    DiscordSeriesStatsResolved["renderData"],
-    DiscordSeriesStatsViewModel
-  >();
+  start(): void {
+    this.cancelled = false;
+    const matchIds = this.renderData.matches.map((m) => m.matchId);
 
-  present(): DiscordSeriesStatsViewModel {
-    const cached = DiscordSeriesStatsPresenter.modelByRenderData.get(this.renderData);
-    if (cached != null) {
-      return cached;
-    }
-
-    const allMatchStats = this.renderData.matches.map((match) => {
-      if (!isMatchStats(match.rawMatch)) {
-        return { matchId: match.matchId, data: null };
+    void Promise.all(
+      matchIds.map(async (matchId) => {
+        try {
+          const analytics = await this.matchAnalyticsService.getMatchAnalytics(matchId);
+          return { matchId, analytics };
+        } catch {
+          return null;
+        }
+      }),
+    ).then((results) => {
+      if (this.cancelled) {
+        return;
       }
-
-      try {
-        const matchController = new StatsController();
-        const playerMap = new Map<string, string>(Object.entries(match.playerXuidToGametag));
-        matchController.loadMatch(match.rawMatch, playerMap, this.renderData.medalMetadata);
-        return { matchId: match.matchId, data: matchController.getMatchStats() };
-      } catch {
-        return { matchId: match.matchId, data: null };
+      const map = new Map<string, MatchAnalytics>();
+      for (const result of results) {
+        if (result != null) {
+          map.set(result.matchId, result.analytics);
+        }
       }
+      this.store.update({ analyticsByMatchId: map });
     });
+  }
 
-    const rawMatches = this.renderData.matches
-      .map((match) => match.rawMatch)
-      .filter((match): match is MatchStats => isMatchStats(match));
+  dispose(): void {
+    this.cancelled = true;
+  }
 
-    let seriesStats: DiscordSeriesStatsViewModel["seriesStats"] = null;
+  present(snapshot: DiscordSeriesStatsSnapshot): DiscordSeriesStatsViewModel {
     const teamColors = [
       getTeamColorOrDefault(DEFAULT_TEAM_COLORS[0], 0),
       getTeamColorOrDefault(DEFAULT_TEAM_COLORS[1], 1),
     ];
+
+    const rawMatches = this.renderData.matches.map((m) => m.rawMatch).filter((m): m is MatchStats => isMatchStats(m));
+
+    let playersByXuid: ReadonlyMap<string, { gamertag: string; teamId: number | null }> = new Map(
+      this.renderData.matches.flatMap((match) =>
+        Object.entries(match.playerXuidToGametag).map(([xuid, gamertag]) => [
+          xuid,
+          { gamertag, teamId: null as number | null },
+        ]),
+      ),
+    );
+    let seriesData: { teamData: MatchStatsData[]; playerData: MatchStatsData[] } | null = null;
 
     if (rawMatches.length > 0) {
       try {
@@ -130,27 +158,67 @@ export class DiscordSeriesStatsPresenter {
             playersMap.set(xuid, gamertag);
           }
         }
-
         this.controller.loadSeries(rawMatches, playersMap, this.renderData.medalMetadata);
-        const { teamData, playerData } = this.controller.getSeriesStats();
-
-        seriesStats = {
-          teamData,
-          playerData,
-          metadata: calculateSeriesMetadata(this.renderData.matches, this.renderData.seriesScore),
-        };
+        seriesData = this.controller.getSeriesStats();
+        playersByXuid = new Map(
+          this.controller.getPlayers().map((p) => [p.xuid, { gamertag: p.gamertag, teamId: p.teamId }]),
+        );
       } catch {
-        seriesStats = null;
+        seriesData = null;
       }
     }
 
-    const model = {
-      teamColors,
-      allMatchStats,
-      seriesStats,
-    };
-    DiscordSeriesStatsPresenter.modelByRenderData.set(this.renderData, model);
-    return model;
+    const killMatrixFormatter = new KillMatrixFormatter();
+    const matchKillMatrixRows = new Map<string, readonly KillMatrixViewRow[]>();
+    for (const match of this.renderData.matches) {
+      const analytics = snapshot.analyticsByMatchId.get(match.matchId);
+      if (analytics != null) {
+        matchKillMatrixRows.set(match.matchId, killMatrixFormatter.present({ analytics, playersByXuid }));
+      }
+    }
+
+    const allMatchStats = this.renderData.matches.map((match) => {
+      if (!isMatchStats(match.rawMatch)) {
+        return {
+          matchId: match.matchId,
+          data: null,
+          winningTeamColorHex: null,
+          killMatrixRows: [] as readonly KillMatrixViewRow[],
+        };
+      }
+      try {
+        const matchController = new StatsController();
+        const playerMap = new Map<string, string>(Object.entries(match.playerXuidToGametag));
+        matchController.loadMatch(match.rawMatch, playerMap, this.renderData.medalMetadata);
+        return {
+          matchId: match.matchId,
+          data: matchController.getMatchStats(),
+          winningTeamColorHex: DiscordSeriesStatsPresenter.getWinningTeamColor(match.rawMatch, teamColors)?.hex ?? null,
+          killMatrixRows: matchKillMatrixRows.get(match.matchId) ?? ([] as readonly KillMatrixViewRow[]),
+        };
+      } catch {
+        return {
+          matchId: match.matchId,
+          data: null,
+          winningTeamColorHex: null,
+          killMatrixRows: [] as readonly KillMatrixViewRow[],
+        };
+      }
+    });
+
+    const seriesStats: DiscordSeriesStatsViewModel["seriesStats"] =
+      seriesData != null
+        ? {
+            teamData: seriesData.teamData,
+            playerData: seriesData.playerData,
+            metadata: calculateSeriesMetadata(this.renderData.matches, this.renderData.seriesScore),
+            killMatrixRows: KillMatrixFormatter.aggregate(
+              [...matchKillMatrixRows.values()].flatMap((rows) => [...rows]),
+            ),
+          }
+        : null;
+
+    return { teamColors, allMatchStats, seriesStats };
   }
 
   static getWinningTeamColor(rawMatch: unknown, teamColors: readonly TeamColor[]): TeamColor | null {

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -8,7 +8,14 @@ import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-ma
 import type { KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
 import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import { DEFAULT_TEAM_COLORS, getTeamColorOrDefault, type TeamColor } from "../team-colors/team-colors";
+import { gameModeIconSrc } from "../individual-tracker/game-mode-icon";
 import type { DiscordSeriesStatsSnapshot, DiscordSeriesStatsStore } from "./discord-series-stats-store";
+import type {
+  DiscordSeriesMatchDetail,
+  DiscordSeriesMatchSummary,
+  DiscordSeriesStatsViewModel,
+  DiscordSeriesTeamCard,
+} from "./types";
 
 const WIN_OUTCOME = 2;
 
@@ -17,22 +24,6 @@ interface SeriesMetadata {
   readonly duration: string;
   readonly startTime: string;
   readonly endTime: string;
-}
-
-export interface DiscordSeriesStatsViewModel {
-  readonly teamColors: readonly TeamColor[];
-  readonly allMatchStats: {
-    readonly matchId: string;
-    readonly data: MatchStatsData[] | null;
-    readonly winningTeamColorHex: string | null;
-    readonly killMatrixRows: readonly KillMatrixViewRow[];
-  }[];
-  readonly seriesStats: {
-    readonly teamData: MatchStatsData[];
-    readonly playerData: MatchStatsData[];
-    readonly metadata: SeriesMetadata | null;
-    readonly killMatrixRows: readonly KillMatrixViewRow[];
-  } | null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -177,32 +168,51 @@ export class DiscordSeriesStatsPresenter {
       }
     }
 
-    const allMatchStats = this.renderData.matches.map((match) => {
+    const matchSummaries: DiscordSeriesMatchSummary[] = this.renderData.matches.map((match) => ({
+      matchId: match.matchId,
+      gameMapThumbnailUrl: match.gameMapThumbnailUrl,
+      gameModeIconUrl: gameModeIconSrc(match.gameVariantCategory),
+      gameModeAlt: match.gameType,
+      gameScore: match.gameScore,
+      gameSubScore: match.gameSubScore ?? null,
+      gameMap: match.gameMap,
+      winningTeamColorHex: DiscordSeriesStatsPresenter.getWinningTeamColor(match.rawMatch, teamColors)?.hex ?? null,
+    }));
+
+    const teams: DiscordSeriesTeamCard[] = this.renderData.teams.map((team, teamIndex) => {
+      const teamColor =
+        teamIndex < 2
+          ? (teamColors[teamIndex] ?? getTeamColorOrDefault(undefined, teamIndex))
+          : getTeamColorOrDefault(undefined, teamIndex);
+      return { name: team.name, players: team.players, teamColorHex: teamColor.hex };
+    });
+
+    const matchDetails: DiscordSeriesMatchDetail[] = this.renderData.matches.map((match, index) => {
+      const killMatrixRows = matchKillMatrixRows.get(match.matchId) ?? ([] as readonly KillMatrixViewRow[]);
+      const base = {
+        matchId: match.matchId,
+        gameMapThumbnailUrl: match.gameMapThumbnailUrl,
+        gameModeIconUrl: gameModeIconSrc(match.gameVariantCategory),
+        gameModeAlt: match.gameType,
+        matchNumber: index + 1,
+        gameTypeAndMap: match.gameTypeAndMap,
+        duration: match.duration,
+        score: match.gameSubScore != null ? `${match.gameScore} (${match.gameSubScore})` : match.gameScore,
+        startTime: match.startTime,
+        endTime: match.endTime,
+        teamColors,
+        killMatrixRows,
+      };
       if (!isMatchStats(match.rawMatch)) {
-        return {
-          matchId: match.matchId,
-          data: null,
-          winningTeamColorHex: null,
-          killMatrixRows: [] as readonly KillMatrixViewRow[],
-        };
+        return { ...base, data: null };
       }
       try {
         const matchController = new StatsController();
         const playerMap = new Map<string, string>(Object.entries(match.playerXuidToGametag));
         matchController.loadMatch(match.rawMatch, playerMap, this.renderData.medalMetadata);
-        return {
-          matchId: match.matchId,
-          data: matchController.getMatchStats(),
-          winningTeamColorHex: DiscordSeriesStatsPresenter.getWinningTeamColor(match.rawMatch, teamColors)?.hex ?? null,
-          killMatrixRows: matchKillMatrixRows.get(match.matchId) ?? ([] as readonly KillMatrixViewRow[]),
-        };
+        return { ...base, data: matchController.getMatchStats() };
       } catch {
-        return {
-          matchId: match.matchId,
-          data: null,
-          winningTeamColorHex: null,
-          killMatrixRows: [] as readonly KillMatrixViewRow[],
-        };
+        return { ...base, data: null };
       }
     });
 
@@ -212,13 +222,22 @@ export class DiscordSeriesStatsPresenter {
             teamData: seriesData.teamData,
             playerData: seriesData.playerData,
             metadata: calculateSeriesMetadata(this.renderData.matches, this.renderData.seriesScore),
+            teamColors,
             killMatrixRows: KillMatrixFormatter.aggregate(
               [...matchKillMatrixRows.values()].flatMap((rows) => [...rows]),
             ),
           }
         : null;
 
-    return { teamColors, allMatchStats, seriesStats };
+    return {
+      title: this.renderData.title,
+      subtitle: this.renderData.subtitle,
+      seriesScore: this.renderData.seriesScore,
+      matchSummaries,
+      teams,
+      seriesStats,
+      matchDetails,
+    };
   }
 
   static getWinningTeamColor(rawMatch: unknown, teamColors: readonly TeamColor[]): TeamColor | null {

--- a/pages/src/components/discord-series-stats/discord-series-stats-store.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-store.ts
@@ -1,0 +1,32 @@
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+
+export interface DiscordSeriesStatsSnapshot {
+  readonly analyticsByMatchId: ReadonlyMap<string, MatchAnalytics>;
+}
+
+export class DiscordSeriesStatsStore {
+  private snapshot: DiscordSeriesStatsSnapshot;
+  private readonly subscribers = new Set<() => void>();
+
+  constructor() {
+    this.snapshot = { analyticsByMatchId: new Map() };
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.subscribers.add(listener);
+    return (): void => {
+      this.subscribers.delete(listener);
+    };
+  }
+
+  getSnapshot(): DiscordSeriesStatsSnapshot {
+    return this.snapshot;
+  }
+
+  update(partial: Partial<DiscordSeriesStatsSnapshot>): void {
+    this.snapshot = { ...this.snapshot, ...partial };
+    for (const subscriber of this.subscribers) {
+      subscriber();
+    }
+  }
+}

--- a/pages/src/components/discord-series-stats/discord-series-stats-view.tsx
+++ b/pages/src/components/discord-series-stats/discord-series-stats-view.tsx
@@ -1,25 +1,108 @@
 import { useCallback, useState, type CSSProperties, type ReactElement } from "react";
 import classNames from "classnames";
-import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
-import { gameModeIconSrc } from "../individual-tracker/game-mode-icon";
 import { MatchStats as MatchStatsView } from "../stats/match-stats";
 import { SeriesStats } from "../stats/series-stats";
 import { Container } from "../container/container";
 import { Alert } from "../alert/alert";
-import { getTeamColorOrDefault } from "../team-colors/team-colors";
 import styles from "../live-tracker/live-tracker.module.css";
 import { Button } from "../button/button";
 import localStyles from "./discord-series-stats.module.css";
-import type { DiscordSeriesStatsViewModel } from "./discord-series-stats-presenter";
+import type {
+  DiscordSeriesMatchDetail,
+  DiscordSeriesMatchSummary,
+  DiscordSeriesStatsViewModel,
+  DiscordSeriesTeamCard,
+} from "./types";
 
 export type DiscordSeriesViewMode = "standard" | "wide";
 
-interface DiscordSeriesStatsViewProps {
-  readonly renderData: DiscordSeriesStatsResolved["renderData"];
-  readonly model: DiscordSeriesStatsViewModel;
+interface MatchSummaryItemProps {
+  readonly summary: DiscordSeriesMatchSummary;
 }
 
-export function DiscordSeriesStatsView({ renderData, model }: DiscordSeriesStatsViewProps): ReactElement {
+function MatchSummaryItem({ summary }: MatchSummaryItemProps): ReactElement {
+  return (
+    <li
+      className={styles.seriesScore}
+      style={
+        {
+          "--series-score-bg": `url(${summary.gameMapThumbnailUrl})`,
+          "--team-color": summary.winningTeamColorHex ?? "transparent",
+        } as CSSProperties
+      }
+    >
+      <a href={`#${summary.matchId}`} className={classNames(styles.seriesScoreLink, localStyles.seriesScoreLink)}>
+        <img src={summary.gameModeIconUrl} alt={summary.gameModeAlt} className={styles.gameTypeIcon} />
+        {summary.gameScore}
+        {summary.gameSubScore != null ? <span className={styles.seriesSubScore}>({summary.gameSubScore})</span> : null}
+        <span className={styles.gameTypeAndMap}>{summary.gameMap}</span>
+      </a>
+    </li>
+  );
+}
+
+interface TeamCardSectionProps {
+  readonly team: DiscordSeriesTeamCard;
+}
+
+function TeamCardSection({ team }: TeamCardSectionProps): ReactElement {
+  return (
+    <section
+      className={classNames(styles.teamCard, localStyles.teamCard)}
+      style={{ "--team-color": team.teamColorHex } as CSSProperties}
+    >
+      <h3 className={styles.teamName}>{team.name}</h3>
+      <ul className={classNames(styles.playerList, localStyles.playerList)}>
+        {team.players.map((player, playerIndex) => (
+          <li key={`${team.name}:${player}:${playerIndex.toString()}`}>{player}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+interface MatchDetailSectionProps {
+  readonly detail: DiscordSeriesMatchDetail;
+  readonly contentWidthClass: string | undefined;
+}
+
+function MatchDetailSection({ detail, contentWidthClass }: MatchDetailSectionProps): ReactElement {
+  return (
+    <Container mobileDown="0" className={classNames(styles.contentContainer, contentWidthClass)}>
+      {detail.data != null ? (
+        <MatchStatsView
+          data={detail.data}
+          id={detail.matchId}
+          backgroundImageUrl={detail.gameMapThumbnailUrl}
+          gameModeIconUrl={detail.gameModeIconUrl}
+          gameModeAlt={detail.gameModeAlt}
+          matchNumber={detail.matchNumber}
+          gameTypeAndMap={detail.gameTypeAndMap}
+          duration={detail.duration}
+          score={detail.score}
+          startTime={detail.startTime}
+          endTime={detail.endTime}
+          teamColors={detail.teamColors}
+          killMatrixRows={detail.killMatrixRows}
+        />
+      ) : (
+        <Alert variant="warning">Failed to load detailed stats for match {detail.matchId}.</Alert>
+      )}
+    </Container>
+  );
+}
+
+type DiscordSeriesStatsViewProps = DiscordSeriesStatsViewModel;
+
+export function DiscordSeriesStatsView({
+  title,
+  subtitle,
+  seriesScore,
+  matchSummaries,
+  teams,
+  seriesStats,
+  matchDetails,
+}: DiscordSeriesStatsViewProps): ReactElement {
   const [viewMode, setViewMode] = useState<DiscordSeriesViewMode>("standard");
   const contentWidthClass = viewMode === "wide" ? styles.wide : undefined;
   const handleToggleViewMode = useCallback((): void => {
@@ -31,8 +114,8 @@ export function DiscordSeriesStatsView({ renderData, model }: DiscordSeriesStats
       <Container>
         <div className={styles.headerBar}>
           <div className={styles.headerLeft}>
-            <h1 className={styles.headerTitle}>{renderData.title}</h1>
-            <div className={styles.headerSubtitle}>{renderData.subtitle}</div>
+            <h1 className={styles.headerTitle}>{title}</h1>
+            <div className={styles.headerSubtitle}>{subtitle}</div>
           </div>
           <div className={styles.headerRight}>
             <Button
@@ -58,78 +141,31 @@ export function DiscordSeriesStatsView({ renderData, model }: DiscordSeriesStats
             <div className={styles.seriesOverview}>
               <section className={styles.seriesScores}>
                 <h3 className={styles.seriesScoresHeader} aria-label="Series scores">
-                  {renderData.seriesScore}
+                  {seriesScore}
                 </h3>
                 <ul className={styles.seriesScoresList}>
-                  {renderData.matches.map((match, index) => {
-                    const matchStats = model.allMatchStats[index];
-
-                    return (
-                      <li
-                        key={match.matchId}
-                        className={styles.seriesScore}
-                        style={
-                          {
-                            "--series-score-bg": `url(${match.gameMapThumbnailUrl})`,
-                            "--team-color": matchStats.winningTeamColorHex ?? "transparent",
-                          } as CSSProperties
-                        }
-                      >
-                        <a
-                          href={`#${match.matchId}`}
-                          className={classNames(styles.seriesScoreLink, localStyles.seriesScoreLink)}
-                        >
-                          <img
-                            src={gameModeIconSrc(match.gameVariantCategory)}
-                            alt={match.gameType}
-                            className={styles.gameTypeIcon}
-                          />
-                          {match.gameScore}
-                          {match.gameSubScore != null ? (
-                            <span className={styles.seriesSubScore}>({match.gameSubScore})</span>
-                          ) : null}
-                          <span className={styles.gameTypeAndMap}>{match.gameMap}</span>
-                        </a>
-                      </li>
-                    );
-                  })}
+                  {matchSummaries.map((summary) => (
+                    <MatchSummaryItem key={summary.matchId} summary={summary} />
+                  ))}
                 </ul>
               </section>
 
-              {renderData.teams.map((team, teamIndex) => {
-                const teamColor =
-                  teamIndex < 2 && model.teamColors.length > teamIndex
-                    ? (model.teamColors[teamIndex] ?? getTeamColorOrDefault(undefined, teamIndex))
-                    : getTeamColorOrDefault(undefined, teamIndex);
-
-                return (
-                  <section
-                    key={team.name}
-                    className={classNames(styles.teamCard, localStyles.teamCard)}
-                    style={{ "--team-color": teamColor.hex } as CSSProperties}
-                  >
-                    <h3 className={styles.teamName}>{team.name}</h3>
-                    <ul className={classNames(styles.playerList, localStyles.playerList)}>
-                      {team.players.map((player, playerIndex) => (
-                        <li key={`${team.name}:${player}:${playerIndex.toString()}`}>{player}</li>
-                      ))}
-                    </ul>
-                  </section>
-                );
-              })}
+              {teams.map((team) => (
+                <TeamCardSection key={team.name} team={team} />
+              ))}
             </div>
           </div>
         </Container>
 
-        {model.seriesStats != null && (
+        {seriesStats != null && (
           <Container mobileDown="0" className={classNames(styles.contentContainer, contentWidthClass)}>
             <SeriesStats
-              teamData={model.seriesStats.teamData}
-              playerData={model.seriesStats.playerData}
+              teamData={seriesStats.teamData}
+              playerData={seriesStats.playerData}
               title="Series Totals"
-              metadata={model.seriesStats.metadata}
-              teamColors={model.teamColors}
-              killMatrixRows={model.seriesStats.killMatrixRows}
+              metadata={seriesStats.metadata}
+              teamColors={seriesStats.teamColors}
+              killMatrixRows={seriesStats.killMatrixRows}
             />
           </Container>
         )}
@@ -138,37 +174,9 @@ export function DiscordSeriesStatsView({ renderData, model }: DiscordSeriesStats
           <h2 className={styles.sectionTitle}>Matches</h2>
         </Container>
 
-        {renderData.matches.map((match, index) => {
-          const matchStats = model.allMatchStats[index];
-
-          return (
-            <Container
-              key={match.matchId}
-              mobileDown="0"
-              className={classNames(styles.contentContainer, contentWidthClass)}
-            >
-              {matchStats.data != null ? (
-                <MatchStatsView
-                  data={matchStats.data}
-                  id={match.matchId}
-                  backgroundImageUrl={match.gameMapThumbnailUrl}
-                  gameModeIconUrl={gameModeIconSrc(match.gameVariantCategory)}
-                  gameModeAlt={match.gameType}
-                  matchNumber={index + 1}
-                  gameTypeAndMap={match.gameTypeAndMap}
-                  duration={match.duration}
-                  score={match.gameSubScore != null ? `${match.gameScore} (${match.gameSubScore})` : match.gameScore}
-                  startTime={match.startTime}
-                  endTime={match.endTime}
-                  teamColors={model.teamColors}
-                  killMatrixRows={matchStats.killMatrixRows}
-                />
-              ) : (
-                <Alert variant="warning">Failed to load detailed stats for match {match.matchId}.</Alert>
-              )}
-            </Container>
-          );
-        })}
+        {matchDetails.map((detail) => (
+          <MatchDetailSection key={detail.matchId} detail={detail} contentWidthClass={contentWidthClass} />
+        ))}
       </Container>
     </>
   );

--- a/pages/src/components/discord-series-stats/discord-series-stats-view.tsx
+++ b/pages/src/components/discord-series-stats/discord-series-stats-view.tsx
@@ -1,20 +1,15 @@
-import { useCallback, useMemo, useState, type CSSProperties, type ReactElement } from "react";
+import { useCallback, useState, type CSSProperties, type ReactElement } from "react";
 import classNames from "classnames";
 import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
-import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { gameModeIconSrc } from "../individual-tracker/game-mode-icon";
 import { MatchStats as MatchStatsView } from "../stats/match-stats";
 import { SeriesStats } from "../stats/series-stats";
-import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
-import type { KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
-import type { StatsController } from "../../controllers/stats/stats-controller";
 import { Container } from "../container/container";
 import { Alert } from "../alert/alert";
 import { getTeamColorOrDefault } from "../team-colors/team-colors";
 import styles from "../live-tracker/live-tracker.module.css";
 import { Button } from "../button/button";
 import localStyles from "./discord-series-stats.module.css";
-import { DiscordSeriesStatsPresenter } from "./discord-series-stats-presenter";
 import type { DiscordSeriesStatsViewModel } from "./discord-series-stats-presenter";
 
 export type DiscordSeriesViewMode = "standard" | "wide";
@@ -22,55 +17,14 @@ export type DiscordSeriesViewMode = "standard" | "wide";
 interface DiscordSeriesStatsViewProps {
   readonly renderData: DiscordSeriesStatsResolved["renderData"];
   readonly model: DiscordSeriesStatsViewModel;
-  readonly analyticsByMatchId: ReadonlyMap<string, MatchAnalytics>;
-  readonly controller: StatsController;
 }
 
-export function DiscordSeriesStatsView({
-  renderData,
-  model,
-  analyticsByMatchId,
-  controller,
-}: DiscordSeriesStatsViewProps): ReactElement {
+export function DiscordSeriesStatsView({ renderData, model }: DiscordSeriesStatsViewProps): ReactElement {
   const [viewMode, setViewMode] = useState<DiscordSeriesViewMode>("standard");
   const contentWidthClass = viewMode === "wide" ? styles.wide : undefined;
   const handleToggleViewMode = useCallback((): void => {
     setViewMode((current) => (current === "standard" ? "wide" : "standard"));
   }, []);
-  const killMatrixPresenter = useMemo(() => new KillMatrixFormatter(), []);
-
-  const playersByXuid = useMemo((): ReadonlyMap<string, { gamertag: string; teamId: number | null }> => {
-    if (model.seriesStats != null) {
-      return new Map(controller.getPlayers().map((p) => [p.xuid, { gamertag: p.gamertag, teamId: p.teamId }]));
-    }
-    return new Map(
-      renderData.matches.flatMap((match) =>
-        Object.entries(match.playerXuidToGametag).map(([xuid, gamertag]) => [
-          xuid,
-          { gamertag, teamId: null as number | null },
-        ]),
-      ),
-    );
-  }, [controller, model.seriesStats, renderData.matches]);
-
-  const allMatchKillMatrixRows = useMemo<ReadonlyMap<string, KillMatrixViewRow[]>>(
-    () =>
-      new Map(
-        renderData.matches.flatMap((match) => {
-          const analytics = analyticsByMatchId.get(match.matchId);
-          if (analytics == null) {
-            return [];
-          }
-          return [[match.matchId, killMatrixPresenter.present({ analytics, playersByXuid })]];
-        }),
-      ),
-    [analyticsByMatchId, killMatrixPresenter, playersByXuid, renderData.matches],
-  );
-
-  const seriesKillMatrixRows = useMemo<KillMatrixViewRow[]>(
-    () => KillMatrixFormatter.aggregate([...allMatchKillMatrixRows.values()].flat()),
-    [allMatchKillMatrixRows],
-  );
 
   return (
     <>
@@ -107,8 +61,8 @@ export function DiscordSeriesStatsView({
                   {renderData.seriesScore}
                 </h3>
                 <ul className={styles.seriesScoresList}>
-                  {renderData.matches.map((match) => {
-                    const teamColor = DiscordSeriesStatsPresenter.getWinningTeamColor(match.rawMatch, model.teamColors);
+                  {renderData.matches.map((match, index) => {
+                    const matchStats = model.allMatchStats[index];
 
                     return (
                       <li
@@ -117,7 +71,7 @@ export function DiscordSeriesStatsView({
                         style={
                           {
                             "--series-score-bg": `url(${match.gameMapThumbnailUrl})`,
-                            "--team-color": teamColor?.hex ?? "transparent",
+                            "--team-color": matchStats.winningTeamColorHex ?? "transparent",
                           } as CSSProperties
                         }
                       >
@@ -166,6 +120,7 @@ export function DiscordSeriesStatsView({
             </div>
           </div>
         </Container>
+
         {model.seriesStats != null && (
           <Container mobileDown="0" className={classNames(styles.contentContainer, contentWidthClass)}>
             <SeriesStats
@@ -174,7 +129,7 @@ export function DiscordSeriesStatsView({
               title="Series Totals"
               metadata={model.seriesStats.metadata}
               teamColors={model.teamColors}
-              killMatrixRows={seriesKillMatrixRows}
+              killMatrixRows={model.seriesStats.killMatrixRows}
             />
           </Container>
         )}
@@ -206,7 +161,7 @@ export function DiscordSeriesStatsView({
                   startTime={match.startTime}
                   endTime={match.endTime}
                   teamColors={model.teamColors}
-                  killMatrixRows={allMatchKillMatrixRows.get(match.matchId)}
+                  killMatrixRows={matchStats.killMatrixRows}
                 />
               ) : (
                 <Alert variant="warning">Failed to load detailed stats for match {match.matchId}.</Alert>

--- a/pages/src/components/discord-series-stats/tests/create.test.tsx
+++ b/pages/src/components/discord-series-stats/tests/create.test.tsx
@@ -106,13 +106,18 @@ describe("DiscordSeriesStats", () => {
     expect(screen.getByRole("button", { name: "Switch to standard view" })).toBeInTheDocument();
   });
 
-  it("fetches match analytics for each match id", async () => {
+  it("fetches match analytics for each match in renderData", async () => {
     const matchAnalyticsService = aFakeMatchAnalyticsServiceWith();
     const getMatchAnalyticsSpy = vi.spyOn(matchAnalyticsService, "getMatchAnalytics");
+    const base = aFakeResolvedDataWith();
+    const secondMatch = { ...base.renderData.matches[0], matchId: "match-2" };
 
     render(
       <DiscordSeriesStats
-        data={aFakeResolvedDataWith({ matchIds: ["match-1", "match-2"] })}
+        data={aFakeResolvedDataWith({
+          matchIds: ["match-1", "match-2"],
+          renderData: { ...base.renderData, matches: [...base.renderData.matches, secondMatch] },
+        })}
         matchAnalyticsService={matchAnalyticsService}
       />,
     );

--- a/pages/src/components/discord-series-stats/types.ts
+++ b/pages/src/components/discord-series-stats/types.ts
@@ -1,0 +1,59 @@
+import type { MatchStatsData } from "../../controllers/stats/types";
+import type { KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
+import type { TeamColor } from "../team-colors/team-colors";
+
+export interface DiscordSeriesMatchSummary {
+  readonly matchId: string;
+  readonly gameMapThumbnailUrl: string;
+  readonly gameModeIconUrl: string;
+  readonly gameModeAlt: string;
+  readonly gameScore: string;
+  readonly gameSubScore: string | null;
+  readonly gameMap: string;
+  readonly winningTeamColorHex: string | null;
+}
+
+export interface DiscordSeriesTeamCard {
+  readonly name: string;
+  readonly players: readonly string[];
+  readonly teamColorHex: string;
+}
+
+export interface DiscordSeriesMatchDetail {
+  readonly matchId: string;
+  readonly data: MatchStatsData[] | null;
+  readonly gameMapThumbnailUrl: string;
+  readonly gameModeIconUrl: string;
+  readonly gameModeAlt: string;
+  readonly matchNumber: number;
+  readonly gameTypeAndMap: string;
+  readonly duration: string;
+  readonly score: string;
+  readonly startTime: string;
+  readonly endTime: string;
+  readonly teamColors: readonly TeamColor[];
+  readonly killMatrixRows: readonly KillMatrixViewRow[];
+}
+
+interface DiscordSeriesSeriesStats {
+  readonly teamData: MatchStatsData[];
+  readonly playerData: MatchStatsData[];
+  readonly metadata: {
+    readonly score: string;
+    readonly duration: string;
+    readonly startTime: string;
+    readonly endTime: string;
+  } | null;
+  readonly teamColors: readonly TeamColor[];
+  readonly killMatrixRows: readonly KillMatrixViewRow[];
+}
+
+export interface DiscordSeriesStatsViewModel {
+  readonly title: string;
+  readonly subtitle: string;
+  readonly seriesScore: string;
+  readonly matchSummaries: readonly DiscordSeriesMatchSummary[];
+  readonly teams: readonly DiscordSeriesTeamCard[];
+  readonly seriesStats: DiscordSeriesSeriesStats | null;
+  readonly matchDetails: readonly DiscordSeriesMatchDetail[];
+}


### PR DESCRIPTION
## Summary

- Introduces `DiscordSeriesStatsStore` — pure state holder (`analyticsByMatchId`, subscribe/getSnapshot/update pattern matching `MatchHistoryStore`)
- Presenter now owns the analytics fetch (`start()`/`dispose()`) and all computation: match stats, series stats, kill matrix rows per match, aggregated series kill matrix, winning team color hex
- `DiscordSeriesStatsViewModel` extended with `winningTeamColorHex` and `killMatrixRows` on each match entry and on `seriesStats`
- `create.tsx` reduced to pure plumbing: store → controller → presenter → `useSyncExternalStore` → `useEffect(start/dispose)` → `present(snapshot)` → view
- `DiscordSeriesStatsView` now has zero `useMemo` and zero business logic — receives `renderData` (static display) and `model` (all computed data)

## Test plan

- [ ] All 2570 tests pass
- [ ] TypeScript clean
- [ ] Linting/formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)