### PR TITLE
refactor(stats-panel): lift StatsController out of view into presenter

### DIFF
--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -38,6 +38,7 @@ export function IndividualTrackerOverlayPage({
           <IndividualTrackerOverlay
             renderModel={model.renderModel}
             matchStatsState={model.matchStatsState}
+            matchStatsPanelState={model.matchStatsPanelState}
             selectedMatchId={model.selectedMatchId}
             onSelectMatch={onSelectMatch}
             onDeselect={onDeselect}

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from "react";
 import { StreamerOverlay } from "../../streamer-overlay/streamer-overlay";
 import { TopSection } from "../../streamer-overlay/top-section";
 import { StatsPanel } from "../viewer/stats-panel";
-import type { IndividualTrackerViewerRenderModel } from "../viewer/types";
+import type { IndividualTrackerViewerRenderModel, MatchStatsPanelState } from "../viewer/types";
 import type { MatchStatsState } from "../viewer/viewer-store";
 import {
   buildTabs,
@@ -19,6 +19,7 @@ import styles from "./individual-tracker-overlay.module.css";
 interface IndividualTrackerOverlayProps {
   readonly renderModel: IndividualTrackerViewerRenderModel;
   readonly matchStatsState: MatchStatsState | null;
+  readonly matchStatsPanelState: MatchStatsPanelState | null;
   readonly selectedMatchId: string | null;
   readonly onSelectMatch: (matchId: string) => void;
   readonly onDeselect: () => void;
@@ -27,6 +28,7 @@ interface IndividualTrackerOverlayProps {
 export function IndividualTrackerOverlay({
   renderModel,
   matchStatsState,
+  matchStatsPanelState,
   selectedMatchId,
   onSelectMatch,
   onDeselect,
@@ -97,8 +99,8 @@ export function IndividualTrackerOverlay({
   const hasPanelContent = useCallback((): boolean => false, []);
 
   const renderPanelContent = useCallback(
-    (): React.ReactElement | null => <StatsPanel state={matchStatsState} />,
-    [matchStatsState],
+    (): React.ReactElement | null => <StatsPanel state={matchStatsPanelState} />,
+    [matchStatsPanelState],
   );
 
   return (

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -36,6 +36,7 @@ describe("IndividualTrackerOverlay", () => {
       <IndividualTrackerOverlay
         renderModel={aRenderModel({ matches: [], series: [] })}
         matchStatsState={null}
+        matchStatsPanelState={null}
         selectedMatchId={null}
         onSelectMatch={() => undefined}
         onDeselect={() => undefined}
@@ -50,6 +51,7 @@ describe("IndividualTrackerOverlay", () => {
       <IndividualTrackerOverlay
         renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
         matchStatsState={null}
+        matchStatsPanelState={null}
         selectedMatchId={null}
         onSelectMatch={() => undefined}
         onDeselect={() => undefined}
@@ -64,6 +66,7 @@ describe("IndividualTrackerOverlay", () => {
       <IndividualTrackerOverlay
         renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
         matchStatsState={{ status: "loading" }}
+        matchStatsPanelState={{ status: "loading" }}
         selectedMatchId="m-1"
         onSelectMatch={() => undefined}
         onDeselect={() => undefined}
@@ -89,6 +92,7 @@ describe("IndividualTrackerOverlay", () => {
           medalMetadata: {},
           analytics: null,
         }}
+        matchStatsPanelState={null}
         selectedMatchId="m-1"
         onSelectMatch={() => undefined}
         onDeselect={() => undefined}
@@ -103,6 +107,7 @@ describe("IndividualTrackerOverlay", () => {
       <IndividualTrackerOverlay
         renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
         matchStatsState={{ status: "error", message: "Network failure" }}
+        matchStatsPanelState={{ status: "error", message: "Network failure" }}
         selectedMatchId="m-1"
         onSelectMatch={() => undefined}
         onDeselect={() => undefined}
@@ -131,6 +136,7 @@ describe("IndividualTrackerOverlay", () => {
           medalMetadata: {},
           analytics: null,
         }}
+        matchStatsPanelState={null}
         selectedMatchId="m-1"
         onSelectMatch={() => undefined}
         onDeselect={onDeselect}

--- a/pages/src/components/individual-tracker/viewer/create.tsx
+++ b/pages/src/components/individual-tracker/viewer/create.tsx
@@ -39,7 +39,7 @@ export function IndividualTrackerViewerPage({
             renderModel={model.renderModel}
             connectionStatus={model.connectionStatus}
             selectedMatchId={model.selectedMatchId}
-            matchStatsState={model.matchStatsState}
+            matchStatsPanelState={model.matchStatsPanelState}
             onSelectMatch={onSelectMatch}
             onDeselect={onDeselect}
           />

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
@@ -5,8 +5,7 @@ import type { TrackerStatus } from "@guilty-spark/shared/contracts/individual-tr
 import { Container } from "../../container/container";
 import type { TrackerViewConnectionStatus } from "../../../services/individual-tracker/view-types";
 import { relativeTime, Timeline } from "../timeline/timeline";
-import type { IndividualTrackerViewerRenderModel } from "./types";
-import type { MatchStatsState } from "./viewer-store";
+import type { IndividualTrackerViewerRenderModel, MatchStatsPanelState } from "./types";
 import { TabsBar } from "./viewer-tabs";
 import { StatsPanel } from "./stats-panel";
 import styles from "./individual-tracker-viewer.module.css";
@@ -15,7 +14,7 @@ interface IndividualTrackerViewerProps {
   readonly renderModel: IndividualTrackerViewerRenderModel;
   readonly connectionStatus: TrackerViewConnectionStatus;
   readonly selectedMatchId: string | null;
-  readonly matchStatsState: MatchStatsState | null;
+  readonly matchStatsPanelState: MatchStatsPanelState | null;
   readonly onSelectMatch: (matchId: string) => void;
   readonly onDeselect: () => void;
 }
@@ -73,7 +72,7 @@ export function IndividualTrackerViewer({
   renderModel,
   connectionStatus,
   selectedMatchId,
-  matchStatsState,
+  matchStatsPanelState,
   onSelectMatch,
   onDeselect,
 }: IndividualTrackerViewerProps): React.ReactElement {
@@ -118,7 +117,7 @@ export function IndividualTrackerViewer({
         onDeselect={onDeselect}
       />
 
-      <StatsPanel state={matchStatsState} />
+      <StatsPanel state={matchStatsPanelState} />
 
       <Timeline timeline={renderModel.timeline} />
     </Container>

--- a/pages/src/components/individual-tracker/viewer/stats-panel.tsx
+++ b/pages/src/components/individual-tracker/viewer/stats-panel.tsx
@@ -1,57 +1,14 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { Alert } from "../../alert/alert";
 import { LoadingState } from "../../loading-state/loading-state";
-import { StatsController } from "../../../controllers/stats/stats-controller";
 import { MatchStats } from "../../stats/match-stats";
 import { gameModeIconSrc } from "../game-mode-icon";
-import type { IndividualTrackerViewerViewModel } from "./types";
-import type { MatchStatsState } from "./viewer-store";
+import type { MatchStatsPanelState } from "./types";
 import styles from "./stats-panel.module.css";
 
-interface LoadedStatsPanelProps {
-  readonly state: Extract<MatchStatsState, { readonly status: "loaded" }>;
-}
-
-function LoadedStatsPanel({ state }: LoadedStatsPanelProps): React.ReactElement {
-  const { stats, playerMap, medalMetadata, analytics } = state;
-  const controller = useMemo(() => new StatsController(), []);
-
-  const data = useMemo(() => {
-    controller.loadMatch(stats, playerMap, medalMetadata);
-    return controller.getMatchStats();
-  }, [controller, stats, playerMap, medalMetadata]);
-
-  const killMatrixRows = useMemo(() => {
-    if (analytics == null) {
-      return [];
-    }
-    controller.loadAnalytics(analytics, playerMap);
-    return controller.getKillMatrix();
-  }, [controller, analytics, playerMap]);
-
-  return (
-    <div className={styles.wrapper}>
-      <MatchStats
-        data={data}
-        id={stats.MatchId}
-        backgroundImageUrl=""
-        gameModeIconUrl={gameModeIconSrc(stats.MatchInfo.GameVariantCategory)}
-        gameModeAlt=""
-        matchNumber={1}
-        gameTypeAndMap=""
-        duration={stats.MatchInfo.Duration}
-        score=""
-        startTime={stats.MatchInfo.StartTime}
-        endTime={stats.MatchInfo.EndTime}
-        killMatrixRows={killMatrixRows}
-      />
-    </div>
-  );
-}
-
 interface StatsPanelProps {
-  readonly state: IndividualTrackerViewerViewModel["matchStatsState"];
+  readonly state: MatchStatsPanelState | null;
 }
 
 export function StatsPanel({ state }: StatsPanelProps): React.ReactElement | null {
@@ -75,7 +32,24 @@ export function StatsPanel({ state }: StatsPanelProps): React.ReactElement | nul
       );
     }
     case "loaded": {
-      return <LoadedStatsPanel state={state} />;
+      return (
+        <div className={styles.wrapper}>
+          <MatchStats
+            data={state.data}
+            id={state.matchId}
+            backgroundImageUrl=""
+            gameModeIconUrl={gameModeIconSrc(state.gameVariantCategory)}
+            gameModeAlt=""
+            matchNumber={1}
+            gameTypeAndMap=""
+            duration={state.duration}
+            score=""
+            startTime={state.startTime}
+            endTime={state.endTime}
+            killMatrixRows={state.killMatrixRows}
+          />
+        </div>
+      );
     }
     default: {
       throw new UnreachableError(state);

--- a/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
@@ -35,7 +35,7 @@ describe("IndividualTrackerViewer", () => {
         renderModel={aModel(view)}
         connectionStatus="connected"
         selectedMatchId={null}
-        matchStatsState={null}
+        matchStatsPanelState={null}
         onSelectMatch={() => undefined}
         onDeselect={() => undefined}
       />,
@@ -55,7 +55,7 @@ describe("IndividualTrackerViewer", () => {
         renderModel={aModel(view)}
         connectionStatus="connected"
         selectedMatchId={null}
-        matchStatsState={null}
+        matchStatsPanelState={null}
         onSelectMatch={() => undefined}
         onDeselect={() => undefined}
       />,
@@ -77,7 +77,7 @@ describe("IndividualTrackerViewer", () => {
         renderModel={aModel(view)}
         connectionStatus="connected"
         selectedMatchId={null}
-        matchStatsState={null}
+        matchStatsPanelState={null}
         onSelectMatch={() => undefined}
         onDeselect={() => undefined}
       />,
@@ -97,7 +97,7 @@ describe("IndividualTrackerViewer", () => {
         renderModel={aModel(view)}
         connectionStatus="connected"
         selectedMatchId={null}
-        matchStatsState={null}
+        matchStatsPanelState={null}
         onSelectMatch={() => undefined}
         onDeselect={() => undefined}
       />,
@@ -114,7 +114,7 @@ describe("IndividualTrackerViewer", () => {
         renderModel={aModel(view)}
         connectionStatus="connected"
         selectedMatchId={null}
-        matchStatsState={null}
+        matchStatsPanelState={null}
         onSelectMatch={() => undefined}
         onDeselect={() => undefined}
       />,
@@ -131,7 +131,7 @@ describe("IndividualTrackerViewer", () => {
         renderModel={aModel(view)}
         connectionStatus="disconnected"
         selectedMatchId={null}
-        matchStatsState={null}
+        matchStatsPanelState={null}
         onSelectMatch={() => undefined}
         onDeselect={() => undefined}
       />,
@@ -152,7 +152,7 @@ describe("IndividualTrackerViewer", () => {
         renderModel={aModel(view)}
         connectionStatus="connected"
         selectedMatchId={null}
-        matchStatsState={null}
+        matchStatsPanelState={null}
         onSelectMatch={() => undefined}
         onDeselect={() => undefined}
       />,

--- a/pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx
@@ -3,6 +3,8 @@ import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
+import { StatsController } from "../../../../controllers/stats/stats-controller";
+import type { MatchStatsPanelState } from "../types";
 import { StatsPanel } from "../stats-panel";
 
 vi.mock("../../../icons/team-icon", () => ({
@@ -16,6 +18,31 @@ vi.mock("../../../icons/medal-icon", () => ({
     <div data-testid={`medal-icon-${medalName}`}>{medalName}</div>
   ),
 }));
+
+function aLoadedState(
+  overrides: Partial<Extract<MatchStatsPanelState, { status: "loaded" }>> = {},
+): Extract<MatchStatsPanelState, { status: "loaded" }> {
+  const stats = aFakeMatchStatsWith();
+  const playerMap = new Map([
+    ["1111111111", "Alpha"],
+    ["2222222222", "Bravo"],
+    ["3333333333", "Charlie"],
+    ["4444444444", "Delta"],
+  ]);
+  const controller = new StatsController();
+  controller.loadMatch(stats, playerMap, {});
+  return {
+    status: "loaded",
+    matchId: stats.MatchId,
+    gameVariantCategory: stats.MatchInfo.GameVariantCategory,
+    duration: stats.MatchInfo.Duration,
+    startTime: stats.MatchInfo.StartTime,
+    endTime: stats.MatchInfo.EndTime,
+    data: controller.getMatchStats(),
+    killMatrixRows: [],
+    ...overrides,
+  };
+}
 
 describe("StatsPanel", () => {
   afterEach(() => {
@@ -38,20 +65,12 @@ describe("StatsPanel", () => {
   });
 
   it("renders match stats player table when status is loaded", () => {
-    const stats = aFakeMatchStatsWith();
-    const playerMap = new Map([
-      ["1111111111", "Alpha"],
-      ["2222222222", "Bravo"],
-      ["3333333333", "Charlie"],
-      ["4444444444", "Delta"],
-    ]);
-
-    render(<StatsPanel state={{ status: "loaded", stats, playerMap, medalMetadata: {}, analytics: null }} />);
+    render(<StatsPanel state={aLoadedState()} />);
 
     expect(screen.getByRole("tab", { name: "Players" })).toBeInTheDocument();
   });
 
-  it("renders kill matrix table when analytics is available", () => {
+  it("renders kill matrix table when kill matrix rows are provided", () => {
     const stats = aFakeMatchStatsWith();
     const playerMap = new Map([
       ["1111111111", "Alpha"],
@@ -59,38 +78,28 @@ describe("StatsPanel", () => {
       ["3333333333", "Charlie"],
       ["4444444444", "Delta"],
     ]);
-
-    render(
-      <StatsPanel
-        state={{
-          status: "loaded",
-          stats,
-          playerMap,
-          medalMetadata: {},
-          analytics: {
-            requestedModules: ["killMatrix"],
-            killMatrix: {
-              "1111111111:2222222222": {
-                count: 3,
-                headshotKills: 1,
-                perfects: 0,
-                weapons: [],
-              },
-            },
-            metadata: {
-              pairingQuality: {
-                unpairedDeathCount: 0,
-                maxTimeDeltaMs: 1,
-              },
-              perfectCounts: {
-                total: 0,
-                byXuid: {},
-              },
-            },
+    const controller = new StatsController();
+    controller.loadAnalytics(
+      {
+        requestedModules: ["killMatrix"],
+        killMatrix: {
+          "1111111111:2222222222": {
+            count: 3,
+            headshotKills: 1,
+            perfects: 0,
+            weapons: [],
           },
-        }}
-      />,
+        },
+        metadata: {
+          pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 1 },
+          perfectCounts: { total: 0, byXuid: {} },
+        },
+      },
+      playerMap,
     );
+    controller.loadMatch(stats, playerMap, {});
+
+    render(<StatsPanel state={aLoadedState({ killMatrixRows: controller.getKillMatrix() })} />);
 
     fireEvent.click(screen.getByRole("tab", { name: "Kill Matrix" }));
 

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -2,6 +2,8 @@ import type { TopBarStatItem } from "@guilty-spark/shared/contracts/individual-t
 import type { TrackerStatus } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { TrackerViewConnectionStatus } from "../../../services/individual-tracker/view-types";
+import type { MatchStatsData } from "../../../controllers/stats/types";
+import type { KillMatrixViewRow } from "../../../controllers/stats/kill-matrix/types";
 import type { MatchStatsState } from "./viewer-store";
 
 export type ViewerTabOutcome = "win" | "loss" | "tie" | "dnf" | "unknown";
@@ -48,10 +50,25 @@ export interface IndividualTrackerViewerRenderModel {
   readonly topBarStats: readonly TopBarStatItem[] | undefined;
 }
 
+export type MatchStatsPanelState =
+  | { readonly status: "loading" }
+  | {
+      readonly status: "loaded";
+      readonly matchId: string;
+      readonly gameVariantCategory: number;
+      readonly duration: string;
+      readonly startTime: string;
+      readonly endTime: string;
+      readonly data: MatchStatsData[];
+      readonly killMatrixRows: readonly KillMatrixViewRow[];
+    }
+  | { readonly status: "error"; readonly message: string };
+
 export interface IndividualTrackerViewerViewModel {
   readonly renderModel: IndividualTrackerViewerRenderModel | null;
   readonly connectionStatus: TrackerViewConnectionStatus;
   readonly selectedMatchId: string | null;
   readonly matchStatsState: MatchStatsState | null;
+  readonly matchStatsPanelState: MatchStatsPanelState | null;
   readonly streamerSettings: StreamerViewSettings | undefined;
 }

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -7,9 +7,11 @@ import type {
   TrackerViewConnection,
   TrackerViewSubscription,
 } from "../../../services/individual-tracker/view-types";
+import { StatsController } from "../../../controllers/stats/stats-controller";
+import type { KillMatrixViewRow } from "../../../controllers/stats/kill-matrix/types";
 import { buildViewerRenderModel } from "./viewer-render-model";
-import type { IndividualTrackerViewerSnapshot, IndividualTrackerViewerStore } from "./viewer-store";
-import type { IndividualTrackerViewerViewModel } from "./types";
+import type { IndividualTrackerViewerSnapshot, IndividualTrackerViewerStore, MatchStatsState } from "./viewer-store";
+import type { IndividualTrackerViewerViewModel, MatchStatsPanelState } from "./types";
 
 interface Config {
   readonly individualTrackerViewService: IndividualTrackerViewService;
@@ -46,8 +48,37 @@ export class IndividualTrackerViewerPresenter {
       connectionStatus: snapshot.connectionStatus,
       selectedMatchId: snapshot.selectedMatchId,
       matchStatsState: snapshot.matchStatsState,
+      matchStatsPanelState: IndividualTrackerViewerPresenter.toMatchStatsPanelState(snapshot.matchStatsState),
       streamerSettings,
     };
+  }
+
+  private static toMatchStatsPanelState(state: MatchStatsState | null): MatchStatsPanelState | null {
+    if (state == null) {return null;}
+    if (state.status !== "loaded") {return state;}
+
+    const { stats, playerMap, medalMetadata, analytics } = state;
+    try {
+      const controller = new StatsController();
+      controller.loadMatch(stats, playerMap, medalMetadata);
+      let killMatrixRows: readonly KillMatrixViewRow[] = [];
+      if (analytics != null) {
+        controller.loadAnalytics(analytics, playerMap);
+        killMatrixRows = controller.getKillMatrix();
+      }
+      return {
+        status: "loaded",
+        matchId: stats.MatchId,
+        gameVariantCategory: stats.MatchInfo.GameVariantCategory,
+        duration: stats.MatchInfo.Duration,
+        startTime: stats.MatchInfo.StartTime,
+        endTime: stats.MatchInfo.EndTime,
+        data: controller.getMatchStats(),
+        killMatrixRows,
+      };
+    } catch {
+      return { status: "error", message: "Failed to compute match stats" };
+    }
   }
 
   public selectMatch(matchId: string): void {

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -54,8 +54,12 @@ export class IndividualTrackerViewerPresenter {
   }
 
   private static toMatchStatsPanelState(state: MatchStatsState | null): MatchStatsPanelState | null {
-    if (state == null) {return null;}
-    if (state.status !== "loaded") {return state;}
+    if (state == null) {
+      return null;
+    }
+    if (state.status !== "loaded") {
+      return state;
+    }
 
     const { stats, playerMap, medalMetadata, analytics } = state;
     try {


### PR DESCRIPTION
## Summary

- `StatsPanel` no longer creates a `StatsController` or runs `useMemo` with business logic — it's a pure renderer
- `IndividualTrackerViewerPresenter.present()` converts raw `MatchStatsState` (store type) → `MatchStatsPanelState` (pre-computed view type) containing `data`, `killMatrixRows`, and display fields
- `MatchStatsPanelState` added to `types.ts`; the model now carries both `matchStatsState` (raw, used by the overlay's ticker logic) and `matchStatsPanelState` (computed, used by `StatsPanel` in both viewer and overlay)
- Overlay updated to pass `matchStatsPanelState` to `StatsPanel` and keep `matchStatsState` for ticker computation (separate PR concern)

## Test plan

- [ ] `stats-panel.test.tsx` — tests updated to pass pre-computed state; `StatsController` used in test setup to compute `data`
- [ ] `individual-tracker-viewer.test.tsx` — prop rename `matchStatsState` → `matchStatsPanelState`
- [ ] `individual-tracker-overlay.test.tsx` — added `matchStatsPanelState` prop to all renders; error message test passes `matchStatsPanelState={{ status: "error" }}`
- [ ] `viewer-presenter.test.ts` — existing tests continue to exercise `present()` and `selectMatch()`; new `matchStatsPanelState` field verified via store state assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)