### PR TITLE
refactor(kill-matrix-table): move pivot logic into KillMatrixFormatter

### DIFF
--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -1,72 +1,19 @@
 import React from "react";
-import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { Alert } from "../../alert/alert";
 import { SortableTable, type SortableTableColumn } from "../../table/sortable-table";
 import tableStyles from "../../table/table.module.css";
-import type { KillMatrixViewRow } from "../../../controllers/stats/kill-matrix/types";
+import type { KillMatrixPivotData, KillMatrixPivotRow } from "../../../controllers/stats/kill-matrix/types";
 import styles from "./kill-matrix-table.module.css";
 
 interface KillMatrixTableProps {
-  readonly rows: readonly KillMatrixViewRow[];
+  readonly pivotData: KillMatrixPivotData;
   readonly ariaLabel: string;
   readonly emptyMessage: string;
 }
 
-interface MatrixRow {
-  readonly killerId: string;
-  readonly killerGamertag: string;
-  [victimGamertag: string]: string | number;
-}
-
-export function KillMatrixTable({ rows, ariaLabel, emptyMessage }: KillMatrixTableProps): React.ReactElement {
-  // Build a pivot table structure: killers x victims with kill counts
-  const matrixData = React.useMemo(() => {
-    if (rows.length === 0) {
-      return { tableRows: [], victimGamertags: [] };
-    }
-
-    // Extract unique killers and victims
-    const killersMap = new Map<string, string>();
-    const victimsMap = new Map<string, string>();
-    const killCounts = new Map<string, Map<string, number>>();
-
-    for (const row of rows) {
-      killersMap.set(row.killer.xuid, row.killer.gamertag);
-      victimsMap.set(row.victim.xuid, row.victim.gamertag);
-
-      if (!killCounts.has(row.killer.xuid)) {
-        killCounts.set(row.killer.xuid, new Map());
-      }
-      const victimCounts = Preconditions.checkExists(killCounts.get(row.killer.xuid));
-      victimCounts.set(row.victim.xuid, row.count);
-    }
-
-    // Sort killers and victims alphabetically
-    const sortedKillers = Array.from(killersMap.entries()).sort((a, b) => a[1].localeCompare(b[1]));
-    const sortedVictims = Array.from(victimsMap.entries()).sort((a, b) => a[1].localeCompare(b[1]));
-
-    // Build table rows
-    const tableRows: MatrixRow[] = sortedKillers.map(([killerId, killerGamertag]) => {
-      const row: MatrixRow = {
-        killerId,
-        killerGamertag,
-      };
-
-      const victimCounts = killCounts.get(killerId) ?? new Map();
-      for (const [victimId, victimGamertag] of sortedVictims) {
-        row[victimGamertag] = victimCounts.get(victimId) ?? 0;
-      }
-
-      return row;
-    });
-
-    const victimGamertags = sortedVictims.map(([, gamertag]) => gamertag);
-
-    return { tableRows, victimGamertags };
-  }, [rows]);
-
-  const columns = React.useMemo<SortableTableColumn<MatrixRow>[]>(() => {
-    const cols: SortableTableColumn<MatrixRow>[] = [
+export function KillMatrixTable({ pivotData, ariaLabel, emptyMessage }: KillMatrixTableProps): React.ReactElement {
+  const columns = React.useMemo<SortableTableColumn<KillMatrixPivotRow>[]>(() => {
+    const cols: SortableTableColumn<KillMatrixPivotRow>[] = [
       {
         id: "killer",
         header: "Killer",
@@ -76,8 +23,7 @@ export function KillMatrixTable({ rows, ariaLabel, emptyMessage }: KillMatrixTab
       },
     ];
 
-    // Add a column for each victim
-    for (const victimGamertag of matrixData.victimGamertags) {
+    for (const victimGamertag of pivotData.victimGamertags) {
       cols.push({
         id: victimGamertag,
         header: victimGamertag,
@@ -88,15 +34,15 @@ export function KillMatrixTable({ rows, ariaLabel, emptyMessage }: KillMatrixTab
     }
 
     return cols;
-  }, [matrixData.victimGamertags]);
+  }, [pivotData.victimGamertags]);
 
-  if (matrixData.tableRows.length === 0) {
+  if (pivotData.tableRows.length === 0) {
     return <Alert variant="info">{emptyMessage}</Alert>;
   }
 
   return (
     <SortableTable
-      data={matrixData.tableRows}
+      data={pivotData.tableRows}
       columns={columns}
       getRowKey={(row): string => row.killerId}
       ariaLabel={ariaLabel}

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom/vitest";
 
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
+import { KillMatrixFormatter } from "../../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { KillMatrixTable } from "../kill-matrix-table";
 
 describe("KillMatrixTable", () => {
@@ -10,29 +11,31 @@ describe("KillMatrixTable", () => {
   });
 
   it("renders empty message when there are no rows", () => {
-    render(<KillMatrixTable rows={[]} ariaLabel="Kill matrix" emptyMessage="No kill matrix data." />);
+    render(
+      <KillMatrixTable
+        pivotData={KillMatrixFormatter.pivot([])}
+        ariaLabel="Kill matrix"
+        emptyMessage="No kill matrix data."
+      />,
+    );
 
     expect(screen.getByText("No kill matrix data.")).toBeInTheDocument();
   });
 
   it("renders rows when data exists", () => {
-    render(
-      <KillMatrixTable
-        ariaLabel="Kill matrix"
-        emptyMessage="No kill matrix data."
-        rows={[
-          {
-            key: "111:222",
-            killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
-            victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
-            count: 3,
-            headshotKills: 1,
-            perfects: 0,
-            classification: "enemy-kill",
-          },
-        ]}
-      />,
-    );
+    const pivotData = KillMatrixFormatter.pivot([
+      {
+        key: "111:222",
+        killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+        victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+        count: 3,
+        headshotKills: 1,
+        perfects: 0,
+        classification: "enemy-kill",
+      },
+    ]);
+
+    render(<KillMatrixTable pivotData={pivotData} ariaLabel="Kill matrix" emptyMessage="No kill matrix data." />);
 
     expect(screen.getByLabelText("Kill matrix")).toBeInTheDocument();
     expect(screen.getByText("Alpha")).toBeInTheDocument();

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -9,6 +9,7 @@ import { MedalIcon } from "../icons/medal-icon";
 import type { TeamColor } from "../team-colors/team-colors";
 import { Container } from "../container/container";
 import type { KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
+import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import type { MatchStatsData, MatchStatsPlayerData } from "../../controllers/stats/types";
 import { sortByMedals, getTeamMedalsMap, getPlayerMedalsMap } from "../../controllers/stats/medals-sorting";
 import { KillMatrixTable } from "./kill-matrix/kill-matrix-table";
@@ -267,7 +268,7 @@ export function MatchStats({
             label: "Kill Matrix",
             content: (
               <KillMatrixTable
-                rows={killMatrixRows ?? []}
+                pivotData={KillMatrixFormatter.pivot(killMatrixRows ?? [])}
                 ariaLabel="Match kill matrix"
                 emptyMessage="Kill matrix data is not available for this match yet."
               />

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -8,6 +8,7 @@ import { MedalIcon } from "../icons/medal-icon";
 import type { TeamColor } from "../team-colors/team-colors";
 import { Container } from "../container/container";
 import type { KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
+import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import type { MatchStatsData, MatchStatsPlayerData } from "../../controllers/stats/types";
 import type { SeriesMetadata } from "../../controllers/stats/series-metadata";
 import { sortByMedals, getTeamMedalsMap, getPlayerMedalsMap } from "../../controllers/stats/medals-sorting";
@@ -258,7 +259,7 @@ export function SeriesStats({
               label: "Kill Matrix",
               content: (
                 <KillMatrixTable
-                  rows={killMatrixRows ?? []}
+                  pivotData={KillMatrixFormatter.pivot(killMatrixRows ?? [])}
                   ariaLabel="Series kill matrix"
                   emptyMessage="Kill matrix data is not available for this series yet."
                 />

--- a/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
+++ b/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
@@ -1,5 +1,6 @@
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
-import type { KillMatrixClassification, KillMatrixPlayer, KillMatrixViewRow } from "./types";
+import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import type { KillMatrixClassification, KillMatrixPivotData, KillMatrixPlayer, KillMatrixViewRow } from "./types";
 
 interface KillMatrixFormatterPlayerLookup {
   readonly gamertag: string;
@@ -79,6 +80,48 @@ export class KillMatrixFormatter {
   private parsePairKey(key: string): { killerXuid: string; victimXuid: string } {
     const [killerXuid, victimXuid] = key.split(":");
     return { killerXuid, victimXuid };
+  }
+
+  public static pivot(rows: readonly KillMatrixViewRow[]): KillMatrixPivotData {
+    if (rows.length === 0) {
+      return { tableRows: [], victimGamertags: [] };
+    }
+
+    const killersMap = new Map<string, string>();
+    const victimsMap = new Map<string, string>();
+    const killCounts = new Map<string, Map<string, number>>();
+
+    for (const row of rows) {
+      killersMap.set(row.killer.xuid, row.killer.gamertag);
+      victimsMap.set(row.victim.xuid, row.victim.gamertag);
+
+      if (!killCounts.has(row.killer.xuid)) {
+        killCounts.set(row.killer.xuid, new Map());
+      }
+      const victimCounts = Preconditions.checkExists(killCounts.get(row.killer.xuid));
+      victimCounts.set(row.victim.xuid, row.count);
+    }
+
+    const sortedKillers = Array.from(killersMap.entries()).sort((a, b) => a[1].localeCompare(b[1]));
+    const sortedVictims = Array.from(victimsMap.entries()).sort((a, b) => a[1].localeCompare(b[1]));
+
+    const tableRows = sortedKillers.map(([killerId, killerGamertag]) => {
+      const row: { killerId: string; killerGamertag: string; [key: string]: string | number } = {
+        killerId,
+        killerGamertag,
+      };
+
+      const victimCounts = killCounts.get(killerId) ?? new Map();
+      for (const [victimId, victimGamertag] of sortedVictims) {
+        row[victimGamertag] = victimCounts.get(victimId) ?? 0;
+      }
+
+      return row;
+    });
+
+    const victimGamertags = sortedVictims.map(([, gamertag]) => gamertag);
+
+    return { tableRows, victimGamertags };
   }
 
   public static aggregate(rows: readonly KillMatrixViewRow[]): KillMatrixViewRow[] {

--- a/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
+++ b/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
@@ -47,6 +47,101 @@ describe("KillMatrixFormatter", () => {
     expect(row.classification).toBe("enemy-kill");
   });
 
+  describe("pivot", () => {
+    it("returns empty pivot for no rows", () => {
+      expect(KillMatrixFormatter.pivot([])).toEqual({ tableRows: [], victimGamertags: [] });
+    });
+
+    it("returns a single row with one victim column", () => {
+      const rows: KillMatrixViewRow[] = [
+        {
+          key: "111:222",
+          killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          count: 5,
+          headshotKills: 2,
+          perfects: 0,
+          classification: "enemy-kill",
+        },
+      ];
+
+      const result = KillMatrixFormatter.pivot(rows);
+
+      expect(result.victimGamertags).toEqual(["Bravo"]);
+      expect(result.tableRows).toHaveLength(1);
+      expect(result.tableRows[0]).toMatchObject({ killerId: "111", killerGamertag: "Alpha", Bravo: 5 });
+    });
+
+    it("sorts killers and victims alphabetically and fills zeros for missing kills", () => {
+      const rows: KillMatrixViewRow[] = [
+        {
+          key: "222:111",
+          killer: { xuid: "222", gamertag: "Charlie", teamId: 0 },
+          victim: { xuid: "111", gamertag: "Alpha", teamId: 1 },
+          count: 2,
+          headshotKills: 0,
+          perfects: 0,
+          classification: "enemy-kill",
+        },
+        {
+          key: "333:111",
+          killer: { xuid: "333", gamertag: "Alpha", teamId: 0 },
+          victim: { xuid: "111", gamertag: "Alpha", teamId: 1 },
+          count: 1,
+          headshotKills: 0,
+          perfects: 0,
+          classification: "enemy-kill",
+        },
+        {
+          key: "222:444",
+          killer: { xuid: "222", gamertag: "Charlie", teamId: 0 },
+          victim: { xuid: "444", gamertag: "Bravo", teamId: 1 },
+          count: 3,
+          headshotKills: 0,
+          perfects: 0,
+          classification: "enemy-kill",
+        },
+      ];
+
+      const result = KillMatrixFormatter.pivot(rows);
+
+      expect(result.victimGamertags).toEqual(["Alpha", "Bravo"]);
+      expect(result.tableRows).toHaveLength(2);
+      expect(result.tableRows[0]).toMatchObject({ killerId: "333", killerGamertag: "Alpha", Alpha: 1, Bravo: 0 });
+      expect(result.tableRows[1]).toMatchObject({ killerId: "222", killerGamertag: "Charlie", Alpha: 2, Bravo: 3 });
+    });
+
+    it("correctly handles players who appear as both killer and victim", () => {
+      const rows: KillMatrixViewRow[] = [
+        {
+          key: "111:222",
+          killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          count: 3,
+          headshotKills: 0,
+          perfects: 0,
+          classification: "enemy-kill",
+        },
+        {
+          key: "222:111",
+          killer: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          victim: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          count: 1,
+          headshotKills: 0,
+          perfects: 0,
+          classification: "enemy-kill",
+        },
+      ];
+
+      const result = KillMatrixFormatter.pivot(rows);
+
+      expect(result.victimGamertags).toEqual(["Alpha", "Bravo"]);
+      expect(result.tableRows).toHaveLength(2);
+      expect(result.tableRows[0]).toMatchObject({ killerGamertag: "Alpha", Alpha: 0, Bravo: 3 });
+      expect(result.tableRows[1]).toMatchObject({ killerGamertag: "Bravo", Alpha: 1, Bravo: 0 });
+    });
+  });
+
   describe("aggregate", () => {
     it("sums counts for the same key across multiple rows", () => {
       const rows: KillMatrixViewRow[] = [

--- a/pages/src/controllers/stats/kill-matrix/types.ts
+++ b/pages/src/controllers/stats/kill-matrix/types.ts
@@ -2,6 +2,17 @@ import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-
 
 export type KillMatrixClassification = "enemy-kill" | "betrayal" | "suicide";
 
+export interface KillMatrixPivotRow {
+  readonly killerId: string;
+  readonly killerGamertag: string;
+  readonly [victimGamertag: string]: string | number;
+}
+
+export interface KillMatrixPivotData {
+  readonly tableRows: readonly KillMatrixPivotRow[];
+  readonly victimGamertags: readonly string[];
+}
+
 export interface KillMatrixPlayer {
   readonly xuid: string;
   readonly gamertag: string;


### PR DESCRIPTION
## Summary

- `KillMatrixFormatter.pivot(rows)` static method added — converts `KillMatrixViewRow[]` into a killers × victims pivot table (`KillMatrixPivotData`)
- `KillMatrixPivotRow` and `KillMatrixPivotData` types added to `controllers/stats/kill-matrix/types.ts`
- `KillMatrixTable` now accepts `pivotData: KillMatrixPivotData` instead of `rows: KillMatrixViewRow[]`; removed the data-transformation `useMemo` — only the column-definition `useMemo` (pure view logic) remains
- `match-stats` and `series-stats` call `KillMatrixFormatter.pivot(killMatrixRows ?? [])` before rendering the table; no changes to their public props

## Test plan

- [ ] `kill-matrix-table.test.tsx` — tests updated to pass `KillMatrixFormatter.pivot([...])` as `pivotData` instead of raw `rows`
- [ ] `kill-matrix-formatter.test.ts` — existing tests cover `aggregate()`; pivot behaviour is exercised through the table tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)