### PR TITLE
refactor(live-tracker): move view useMemos into LiveTrackerPresenter

### DIFF
--- a/pages/src/components/live-tracker/live-tracker-context.tsx
+++ b/pages/src/components/live-tracker/live-tracker-context.tsx
@@ -4,6 +4,7 @@ import type { MatchStatsData } from "../../controllers/stats/types";
 import type { SeriesMetadata } from "../../controllers/stats/series-metadata";
 import type { LiveTrackerParams } from "./live-tracker-store";
 import type {
+  LiveTrackerAvailablePlayer,
   LiveTrackerViewModel,
   LiveTrackerMatchRenderModel,
   LiveTrackerSubstitutionRenderModel,
@@ -163,11 +164,19 @@ export function useMatchByIndex(index: number): LiveTrackerMatchRenderModel | nu
 }
 
 /**
- * Select substitutions (NeatQueue only)
+ * Select substitutions sorted by timestamp (pre-sorted by presenter)
  */
-export function useSubstitutions(): readonly LiveTrackerSubstitutionRenderModel[] | null {
+export function useSubstitutions(): readonly LiveTrackerSubstitutionRenderModel[] {
   const { model } = useLiveTrackerContext();
-  return useMemo(() => (model.state?.type === "neatqueue" ? model.state.substitutions : null), [model.state]);
+  return useMemo(() => model.sortedSubstitutions, [model.sortedSubstitutions]);
+}
+
+/**
+ * Select available players for settings (pre-computed by presenter)
+ */
+export function useAvailablePlayers(): readonly LiveTrackerAvailablePlayer[] {
+  const { model } = useLiveTrackerContext();
+  return useMemo(() => model.availablePlayers, [model.availablePlayers]);
 }
 
 /**

--- a/pages/src/components/live-tracker/live-tracker-presenter.ts
+++ b/pages/src/components/live-tracker/live-tracker-presenter.ts
@@ -68,13 +68,23 @@ export class LiveTrackerPresenter {
       statusText = initialStatusText;
     }
 
+    const state = lastStateMessage?.type === "state" ? toLiveTrackerStateRenderModel(lastStateMessage) : null;
+    const substitutions = state?.type === "neatqueue" ? state.substitutions : [];
+    const sortedSubstitutions = [...substitutions].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+    const availablePlayers =
+      state?.type === "neatqueue"
+        ? state.teams.flatMap((team) => team.players.map((player) => ({ id: player.id, name: player.displayName })))
+        : [];
+
     return {
       title,
       subtitle,
       statusText,
       statusClassName,
       iconUrl,
-      state: lastStateMessage?.type === "state" ? toLiveTrackerStateRenderModel(lastStateMessage) : null,
+      state,
+      sortedSubstitutions,
+      availablePlayers,
     };
   }
 

--- a/pages/src/components/live-tracker/live-tracker.tsx
+++ b/pages/src/components/live-tracker/live-tracker.tsx
@@ -1,7 +1,6 @@
-import React, { useMemo, useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import ReactTimeAgo from "react-time-ago";
 import classNames from "classnames";
-import { compareAsc } from "date-fns";
 import { MatchStats as MatchStatsView } from "../stats/match-stats";
 import { SeriesStats } from "../stats/series-stats";
 import { Container } from "../container/container";
@@ -22,6 +21,7 @@ import {
   useSeriesStats,
   useHasMatches,
   useSubstitutions,
+  useAvailablePlayers,
 } from "./live-tracker-context";
 import type { LiveTrackerStateRenderModel } from "./types";
 import styles from "./live-tracker.module.css";
@@ -48,9 +48,11 @@ export function LiveTrackerView(): React.ReactElement {
   const trackerInfo = useTrackerInfo();
   const state = useTrackerState();
   const hasMatches = useHasMatches();
-  const sortedSubstitutions = useSubstitutions();
   const allMatchStats = useAllMatchStats();
   const seriesStats = useSeriesStats();
+
+  const sortedSubstitutionsList = useSubstitutions();
+  const availablePlayers = useAvailablePlayers();
 
   const { settings, setSettings } = useStreamerSettings();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -139,44 +141,15 @@ export function LiveTrackerView(): React.ReactElement {
     updateUrl(mode);
   }, []);
 
-  // Apply settings overrides for title and subtitle
-  const displayTitle = useMemo(
-    () =>
-      settings.series.titleOverride !== null && settings.series.titleOverride !== ""
-        ? settings.series.titleOverride
-        : trackerInfo.title,
-    [settings.series.titleOverride, trackerInfo.title],
-  );
+  const displayTitle =
+    settings.series.titleOverride !== null && settings.series.titleOverride !== ""
+      ? settings.series.titleOverride
+      : trackerInfo.title;
 
-  const displaySubtitle = useMemo(
-    () =>
-      settings.series.subtitleOverride !== null && settings.series.subtitleOverride !== ""
-        ? settings.series.subtitleOverride
-        : trackerInfo.subtitle,
-    [settings.series.subtitleOverride, trackerInfo.subtitle],
-  );
-
-  // Sort substitutions by timestamp for rendering between matches (memoized)
-  const sortedSubstitutionsList = useMemo(() => {
-    if (!sortedSubstitutions) {
-      return [];
-    }
-    return [...sortedSubstitutions].sort((a, b) => compareAsc(a.timestamp, b.timestamp));
-  }, [sortedSubstitutions]);
-
-  // Memoize available players for settings dialog
-  const availablePlayers = useMemo(
-    () =>
-      hasState(state)
-        ? state.teams.flatMap((team) =>
-            team.players.map((player) => ({
-              id: player.id,
-              name: player.displayName,
-            })),
-          )
-        : [],
-    [state],
-  );
+  const displaySubtitle =
+    settings.series.subtitleOverride !== null && settings.series.subtitleOverride !== ""
+      ? settings.series.subtitleOverride
+      : trackerInfo.subtitle;
 
   // Set body data attribute for streamer mode styling
   useEffect(() => {

--- a/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay.test.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay.test.tsx
@@ -57,6 +57,8 @@ function aFakeLiveTrackerViewModelWith(overrides?: Partial<LiveTrackerViewModel>
     iconUrl: "data:,",
     statusText: "active",
     statusClassName: "status-active",
+    sortedSubstitutions: [],
+    availablePlayers: [],
     state: {
       type: "neatqueue",
       guildName: "Test Guild",

--- a/pages/src/components/live-tracker/tests/live-tracker-context.test.tsx
+++ b/pages/src/components/live-tracker/tests/live-tracker-context.test.tsx
@@ -31,6 +31,8 @@ function aFakeLiveTrackerViewModelWith(overrides?: Partial<LiveTrackerViewModel>
     iconUrl: "data:,",
     statusText: "active",
     statusClassName: "status-active",
+    sortedSubstitutions: [],
+    availablePlayers: [],
     state: {
       type: "neatqueue",
       guildName: "Test Guild",
@@ -327,25 +329,17 @@ describe("LiveTrackerContext", () => {
   });
 
   it("provides substitutions to hooks", () => {
-    const defaultState = aFakeLiveTrackerViewModelWith().state;
     const model = aFakeLiveTrackerViewModelWith({
-      state:
-        defaultState?.type === "neatqueue"
-          ? {
-              ...defaultState,
-              type: "neatqueue",
-              substitutions: [
-                {
-                  playerInId: "player2",
-                  playerInDisplayName: "Player Two",
-                  playerOutId: "player1",
-                  playerOutDisplayName: "Player One",
-                  teamName: "Team 1",
-                  timestamp: "2025-01-01T00:05:00.000Z",
-                },
-              ],
-            }
-          : defaultState,
+      sortedSubstitutions: [
+        {
+          playerInId: "player2",
+          playerInDisplayName: "Player Two",
+          playerOutId: "player1",
+          playerOutDisplayName: "Player One",
+          teamName: "Team 1",
+          timestamp: "2025-01-01T00:05:00.000Z",
+        },
+      ],
     });
 
     const { result } = renderHook(() => useSubstitutions(), {
@@ -356,8 +350,8 @@ describe("LiveTrackerContext", () => {
       ),
     });
 
-    expect(result.current?.length).toBe(1);
-    expect(result.current?.[0]?.playerInId).toBe("player2");
+    expect(result.current.length).toBe(1);
+    expect(result.current[0]?.playerInId).toBe("player2");
   });
 
   it("provides match count to hooks", () => {

--- a/pages/src/components/live-tracker/types.ts
+++ b/pages/src/components/live-tracker/types.ts
@@ -72,6 +72,11 @@ export interface LiveTrackerNeatQueueStateRenderModel {
   readonly seriesData?: LiveTrackerSeriesDataRenderModel;
 }
 
+export interface LiveTrackerAvailablePlayer {
+  readonly id: string;
+  readonly name: string;
+}
+
 export interface LiveTrackerViewModel {
   readonly title: string;
   readonly subtitle: string;
@@ -79,4 +84,6 @@ export interface LiveTrackerViewModel {
   readonly statusText: string;
   readonly statusClassName: string;
   readonly state: LiveTrackerStateRenderModel | null;
+  readonly sortedSubstitutions: readonly LiveTrackerSubstitutionRenderModel[];
+  readonly availablePlayers: readonly LiveTrackerAvailablePlayer[];
 }


### PR DESCRIPTION
## Summary

- Moves `sortedSubstitutions` (timestamp-sorted substitutions) and `availablePlayers` (flattened teams→players for the settings dialog) out of `live-tracker.tsx` useMemos and into `LiveTrackerPresenter.present()`
- Adds both fields to `LiveTrackerViewModel` and `LiveTrackerAvailablePlayer` type
- Converts `displayTitle` / `displaySubtitle` from `useMemo` to plain variable expressions (trivial conditionals don't need memoization)
- Updates `useSubstitutions()` in context to return the pre-sorted array from `model.sortedSubstitutions` (non-nullable); adds `useAvailablePlayers()` hook
- Updates both context and streamer-overlay test helpers to include the new required fields

## Test plan

- [ ] `npm run done` passes (typecheck + lint + vitest)
- [ ] `live-tracker-context.test.tsx` — substitutions test updated to set `sortedSubstitutions` directly on the model
- [ ] `streamer-overlay.test.tsx` — helper factory updated with new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)