### PR TITLE
feat(individual-tracker): improve observability logging throughout the stack

### DIFF
--- a/api/commands/base/base-command.ts
+++ b/api/commands/base/base-command.ts
@@ -103,7 +103,7 @@ export abstract class BaseCommand {
     try {
       return this.handleInteraction(interaction);
     } catch (error) {
-      this.services.logService.error(error as Error);
+      this.services.logService.error(error);
 
       return {
         response: {

--- a/api/commands/maps/maps.ts
+++ b/api/commands/maps/maps.ts
@@ -191,7 +191,7 @@ export class MapsCommand extends BaseCommand {
             await discordService.updateDeferredReply(interaction.token, response);
           }
         } catch (error) {
-          logService.error(error as Error);
+          logService.error(error);
           await discordService.updateDeferredReplyWithError(interaction.token, error);
         }
       },
@@ -247,7 +247,7 @@ export class MapsCommand extends BaseCommand {
 
       await this.services.discordService.createMessage(interaction.channel.id, response);
     } catch (error) {
-      this.services.logService.error(error as Error);
+      this.services.logService.error(error);
       await this.services.discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
@@ -273,7 +273,7 @@ export class MapsCommand extends BaseCommand {
 
       await this.services.discordService.updateDeferredReply(interaction.token, response);
     } catch (error) {
-      this.services.logService.error(error as Error);
+      this.services.logService.error(error);
       await this.services.discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
@@ -298,7 +298,7 @@ export class MapsCommand extends BaseCommand {
 
       await this.services.discordService.updateDeferredReply(interaction.token, response);
     } catch (error) {
-      this.services.logService.error(error as Error);
+      this.services.logService.error(error);
       await this.services.discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
@@ -323,7 +323,7 @@ export class MapsCommand extends BaseCommand {
 
       await this.services.discordService.updateDeferredReply(interaction.token, response);
     } catch (error) {
-      this.services.logService.error(error as Error);
+      this.services.logService.error(error);
       await this.services.discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }

--- a/api/commands/setup/setup.ts
+++ b/api/commands/setup/setup.ts
@@ -1452,7 +1452,7 @@ export class SetupCommand extends BaseCommand {
 
       await discordService.updateDeferredReply(interaction.token, content);
     } catch (error) {
-      this.services.logService.error(error as Error);
+      this.services.logService.error(error);
       await discordService.updateDeferredReply(interaction.token, {
         content: `Failed to fetch configuration: ${error instanceof Error ? error.message : "unknown"}`,
       });

--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -317,7 +317,7 @@ export class StatsCommand extends BaseCommand {
           "Cleaning up previous Guilty Spark messages before computing data",
         );
       } catch (error) {
-        logService.error(error as Error, new Map([["threadChannelId", threadChannelId]]));
+        logService.error(error, new Map([["threadChannelId", threadChannelId]]));
       }
 
       [previousEndUserError] = errorMessages;
@@ -687,7 +687,7 @@ export class StatsCommand extends BaseCommand {
       );
     } catch (error) {
       logService.warn(
-        error as Error,
+        error,
         new Map([
           ["guildId", guildId],
           ["queueNumber", queueNumber.toString()],

--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -32,6 +32,7 @@ import type { GuildConfigRow } from "../../services/database/types/guild_config"
 import { StatsReturnType } from "../../services/database/types/guild_config";
 import { EndUserError } from "../../base/end-user-error";
 import { create } from "../../embeds/stats/create";
+import type { JsonAny } from "../../services/log/types";
 
 export enum InteractionButton {
   Retry = "btn_stats_retry",
@@ -679,18 +680,18 @@ export class StatsCommand extends BaseCommand {
 
       logService.warn(
         `Discord series stats warm request returned non-OK status: ${response.status.toString()}`,
-        new Map([
+        new Map<string, JsonAny>([
           ["guildId", guildId],
-          ["queueNumber", queueNumber.toString()],
-          ["status", response.status.toString()],
+          ["queueNumber", queueNumber],
+          ["status", response.status],
         ]),
       );
     } catch (error) {
       logService.warn(
         error,
-        new Map([
+        new Map<string, JsonAny>([
           ["guildId", guildId],
-          ["queueNumber", queueNumber.toString()],
+          ["queueNumber", queueNumber],
         ]),
       );
     }

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -44,7 +44,7 @@ import { getDurationInSeconds } from "@guilty-spark/shared/halo/duration";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { parseJsonBody } from "@guilty-spark/shared/base/request-parsing";
 import { type IndividualTopBarStatOption } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
-import type { LogService } from "../../services/log/types";
+import type { JsonAny, LogService } from "../../services/log/types";
 import { installServices as installServicesImpl, type Services } from "../../services/install";
 import {
   CloudflareWebSocketHibernationAdapter,
@@ -161,7 +161,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         }
       } catch (error) {
         this.logService.error(error, new Map([["context", "IndividualTrackerDO fetch error"]]));
-        Sentry.captureException(error);
         return new Response("Internal Server Error", { status: 500 });
       }
     });
@@ -187,11 +186,11 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
       this.logService.info(
         "IndividualTracker: alarm triggered",
-        new Map([
+        new Map<string, JsonAny>([
           ["trackerId", trackerState.trackerId],
           ["gamertag", trackerState.gamertag],
-          ["checkCount", trackerState.checkCount.toString()],
-          ["consecutiveErrors", trackerState.errorState.consecutiveErrors.toString()],
+          ["checkCount", trackerState.checkCount],
+          ["consecutiveErrors", trackerState.errorState.consecutiveErrors],
         ]),
       );
 
@@ -206,9 +205,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       if (differenceInHours(new Date(), lastActivity) >= trackerState.idleTimeoutHours) {
         this.logService.info(
           "IndividualTracker: idle timeout reached, stopping tracker",
-          new Map([
+          new Map<string, JsonAny>([
             ["trackerId", trackerState.trackerId],
-            ["idleTimeoutHours", trackerState.idleTimeoutHours.toString()],
+            ["idleTimeoutHours", trackerState.idleTimeoutHours],
           ]),
         );
         trackerState.status = "stopped";
@@ -226,7 +225,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         discoveredNewMatch = await this.poll(trackerState);
       } catch (error) {
         this.logService.error(error, new Map([["context", "IndividualTracker alarm poll failed"]]));
-        Sentry.captureException(error);
         this.handleError(trackerState, error);
       }
 
@@ -350,11 +348,11 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     this.logService.info(
       "IndividualTracker: poll complete",
-      new Map([
+      new Map<string, JsonAny>([
         ["trackerId", trackerState.trackerId],
-        ["newMatches", newlyDiscovered.size.toString()],
-        ["totalMatches", trackerState.matchIds.length.toString()],
-        ["checkCount", trackerState.checkCount.toString()],
+        ["newMatches", newlyDiscovered.size],
+        ["totalMatches", trackerState.matchIds.length],
+        ["checkCount", trackerState.checkCount],
       ]),
     );
 
@@ -638,9 +636,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     this.logService.info(
       "IndividualTracker: match selection updated",
-      new Map([
+      new Map<string, JsonAny>([
         ["trackerId", trackerState.trackerId],
-        ["selectedCount", incoming.length.toString()],
+        ["selectedCount", incoming.length],
       ]),
     );
 
@@ -1071,7 +1069,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return response;
     } catch (error) {
       this.logService.error(error, new Map([["context", "IndividualTracker: failed to establish WebSocket"]]));
-      Sentry.captureException(error);
       return new Response("Failed to establish WebSocket connection", { status: 500 });
     }
   }
@@ -1086,10 +1083,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   webSocketClose(_ws: WebSocket, code: number, reason: string, wasClean: boolean): void {
     this.logService.debug(
       "IndividualTracker: WebSocket client disconnected",
-      new Map([
-        ["code", code.toString()],
+      new Map<string, JsonAny>([
+        ["code", code],
         ["reason", reason],
-        ["wasClean", wasClean.toString()],
+        ["wasClean", wasClean],
       ]),
     );
   }

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -160,7 +160,14 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           }
         }
       } catch (error) {
-        this.logService.error(error, new Map([["context", "IndividualTrackerDO fetch error"]]));
+        this.logService.error(
+          error,
+          new Map([
+            ["context", "IndividualTrackerDO fetch error"],
+            ["action", action ?? "unknown"],
+            ["url", url.pathname],
+          ]),
+        );
         return new Response("Internal Server Error", { status: 500 });
       }
     });

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -109,6 +109,8 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         method: request.method,
       });
 
+      this.logService.debug("IndividualTrackerDO: fetch", new Map([["action", action ?? "unknown"]]));
+
       try {
         switch (action) {
           case "start": {
@@ -158,7 +160,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           }
         }
       } catch (error) {
-        this.logService.error("IndividualTrackerDO fetch error:", new Map([["error", String(error)]]));
+        this.logService.error(error, new Map([["context", "IndividualTrackerDO fetch error"]]));
         Sentry.captureException(error);
         return new Response("Internal Server Error", { status: 500 });
       }
@@ -183,6 +185,16 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         errorCount: trackerState.errorState.consecutiveErrors,
       });
 
+      this.logService.info(
+        "IndividualTracker: alarm triggered",
+        new Map([
+          ["trackerId", trackerState.trackerId],
+          ["gamertag", trackerState.gamertag],
+          ["checkCount", trackerState.checkCount.toString()],
+          ["consecutiveErrors", trackerState.errorState.consecutiveErrors.toString()],
+        ]),
+      );
+
       const lastActivity = new Date(
         Math.max(
           new Date(trackerState.startTime).getTime(),
@@ -192,6 +204,13 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         ),
       );
       if (differenceInHours(new Date(), lastActivity) >= trackerState.idleTimeoutHours) {
+        this.logService.info(
+          "IndividualTracker: idle timeout reached, stopping tracker",
+          new Map([
+            ["trackerId", trackerState.trackerId],
+            ["idleTimeoutHours", trackerState.idleTimeoutHours.toString()],
+          ]),
+        );
         trackerState.status = "stopped";
         trackerState.lastUpdateTime = new Date().toISOString();
         await this.state.storage.deleteAlarm();
@@ -206,7 +225,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       try {
         discoveredNewMatch = await this.poll(trackerState);
       } catch (error) {
-        this.logService.error("IndividualTracker: alarm poll failed", new Map([["error", String(error)]]));
+        this.logService.error(error, new Map([["context", "IndividualTracker alarm poll failed"]]));
         Sentry.captureException(error);
         this.handleError(trackerState, error);
       }
@@ -329,6 +348,16 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.errorState.lastSuccessTime = now;
     trackerState.errorState.lastErrorMessage = undefined;
 
+    this.logService.info(
+      "IndividualTracker: poll complete",
+      new Map([
+        ["trackerId", trackerState.trackerId],
+        ["newMatches", newlyDiscovered.size.toString()],
+        ["totalMatches", trackerState.matchIds.length.toString()],
+        ["checkCount", trackerState.checkCount.toString()],
+      ]),
+    );
+
     return discoveredNewMatch;
   }
 
@@ -342,10 +371,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         throw error;
       }
       this.logService.warn(
-        "IndividualTracker: getMatchStats failed",
+        error,
         new Map([
+          ["context", "IndividualTracker: getMatchStats failed"],
           ["matchId", summary.matchId],
-          ["error", String(error)],
         ]),
       );
       summary.score = "";
@@ -388,10 +417,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           throw error;
         }
         this.logService.warn(
-          "IndividualTracker: recomputeAccumulatedTotals getMatchStats failed",
+          error,
           new Map([
+            ["context", "IndividualTracker: recomputeAccumulatedTotals getMatchStats failed"],
             ["matchId", matchId],
-            ["error", String(error)],
           ]),
         );
         continue;
@@ -407,11 +436,11 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return await this.services.haloService.getMapName(assetId, versionId);
     } catch (error) {
       this.logService.warn(
-        "IndividualTracker: getMapName failed",
+        error,
         new Map([
+          ["context", "IndividualTracker: getMapName failed"],
           ["assetId", assetId],
           ["versionId", versionId],
-          ["error", String(error)],
         ]),
       );
       return "";
@@ -426,10 +455,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       }
     } catch (error) {
       this.logService.warn(
-        "IndividualTracker: failed to mark registry stopped on idle timeout",
+        error,
         new Map([
+          ["context", "IndividualTracker: failed to mark registry stopped on idle timeout"],
           ["trackerId", trackerState.trackerId],
-          ["error", String(error)],
         ]),
       );
     }
@@ -509,6 +538,16 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     await this.setState(trackerState);
     await this.state.storage.setAlarm(addMilliseconds(new Date(), ALARM_INTERVAL_MS).getTime());
 
+    this.logService.info(
+      "IndividualTracker: tracker started",
+      new Map([
+        ["userId", body.userId],
+        ["trackerId", body.trackerId],
+        ["gamertag", body.gamertag],
+        ["searchStartTime", body.searchStartTime],
+      ]),
+    );
+
     return individualTrackerStartContract.toResponse({ success: true, state: this.sanitizeState(trackerState) });
   }
 
@@ -524,6 +563,8 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     await this.state.storage.deleteAlarm();
     await this.setState(trackerState);
     this.broadcastViewState(trackerState);
+
+    this.logService.info("IndividualTracker: tracker paused", new Map([["trackerId", trackerState.trackerId]]));
 
     return individualTrackerPauseContract.toResponse({ success: true, state: this.sanitizeState(trackerState) });
   }
@@ -542,6 +583,8 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     await this.state.storage.setAlarm(addMilliseconds(new Date(), resumeAlarmDelay).getTime());
     this.broadcastViewState(trackerState);
 
+    this.logService.info("IndividualTracker: tracker resumed", new Map([["trackerId", trackerState.trackerId]]));
+
     return individualTrackerResumeContract.toResponse({ success: true, state: this.sanitizeState(trackerState) });
   }
 
@@ -556,6 +599,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       trackerState.lastUpdateTime = new Date().toISOString();
       this.broadcastViewState(trackerState);
       this.closeWebSockets("Tracker stopped");
+      this.logService.info("IndividualTracker: tracker stopped", new Map([["trackerId", trackerState.trackerId]]));
     }
 
     return individualTrackerStopContract.toResponse({ success: true });
@@ -592,6 +636,14 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       await this.state.storage.setAlarm(Date.now());
     }
 
+    this.logService.info(
+      "IndividualTracker: match selection updated",
+      new Map([
+        ["trackerId", trackerState.trackerId],
+        ["selectedCount", incoming.length.toString()],
+      ]),
+    );
+
     return selectMatchesContract.toResponse({ success: true });
   }
 
@@ -627,6 +679,8 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     await this.setState(trackerState);
     this.broadcastViewState(trackerState);
 
+    this.logService.info("IndividualTracker: series started", new Map([["trackerId", trackerState.trackerId]]));
+
     return startSeriesContract.toResponse({ success: true });
   }
 
@@ -645,6 +699,8 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     await this.setState(trackerState);
     this.broadcastViewState(trackerState);
+
+    this.logService.info("IndividualTracker: series ended", new Map([["trackerId", trackerState.trackerId]]));
 
     return endSeriesContract.toResponse({ success: true });
   }
@@ -704,6 +760,8 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     await this.setState(trackerState);
     this.broadcastViewState(trackerState);
+
+    this.logService.info("IndividualTracker: series resumed", new Map([["trackerId", trackerState.trackerId]]));
 
     return resumeSeriesContract.toResponse({ success: true });
   }
@@ -810,14 +868,26 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         ? this.services.haloService
             .getRankedArenaCsrs([state.xuid])
             .then((m) => m.get(state.xuid) ?? null)
-            .catch(() => {
-              this.logService.warn("IndividualTracker: getRankedArenaCsrs failed", new Map([["xuid", state.xuid]]));
+            .catch((err: unknown) => {
+              this.logService.warn(
+                err,
+                new Map([
+                  ["context", "IndividualTracker: getRankedArenaCsrs failed"],
+                  ["xuid", state.xuid],
+                ]),
+              );
               return null;
             })
         : Promise.resolve(null),
       hasEsraSlot
-        ? this.services.haloService.getPlayerEsra(state.xuid).catch(() => {
-            this.logService.warn("IndividualTracker: getPlayerEsra failed", new Map([["xuid", state.xuid]]));
+        ? this.services.haloService.getPlayerEsra(state.xuid).catch((err: unknown) => {
+            this.logService.warn(
+              err,
+              new Map([
+                ["context", "IndividualTracker: getPlayerEsra failed"],
+                ["xuid", state.xuid],
+              ]),
+            );
             return null;
           })
         : Promise.resolve(null),
@@ -985,13 +1055,22 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
 
     const trackerState = await this.getState();
+    this.logService.info(
+      "IndividualTracker: WebSocket connection requested",
+      new Map([["trackerId", trackerState?.trackerId ?? "unknown"]]),
+    );
     try {
-      return this.webSocketAdapter.upgrade(
+      const response = this.webSocketAdapter.upgrade(
         this.state,
         trackerState != null ? this.viewMessage(trackerState) : undefined,
       );
+      this.logService.info(
+        "IndividualTracker: WebSocket connection established",
+        new Map([["trackerId", trackerState?.trackerId ?? "unknown"]]),
+      );
+      return response;
     } catch (error) {
-      this.logService.error("IndividualTracker: failed to establish WebSocket", new Map([["error", String(error)]]));
+      this.logService.error(error, new Map([["context", "IndividualTracker: failed to establish WebSocket"]]));
       Sentry.captureException(error);
       return new Response("Failed to establish WebSocket connection", { status: 500 });
     }
@@ -1016,7 +1095,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   }
 
   webSocketError(_ws: WebSocket, error: unknown): void {
-    this.logService.warn("IndividualTracker: WebSocket error", new Map([["error", String(error)]]));
+    this.logService.warn(error, new Map([["context", "IndividualTracker: WebSocket error"]]));
   }
 
   private broadcastViewState(state: IndividualTrackerInternalState): void {

--- a/api/routes/auth/logout.ts
+++ b/api/routes/auth/logout.ts
@@ -13,14 +13,14 @@ export const authLogoutRoute: RoutesRegisterHandler = (router, installServices) 
       try {
         await authService.invalidateSession(request);
       } catch (error: unknown) {
-        logService.error(error as Error, new Map([["message", "Failed to invalidate session during logout"]]));
+        logService.error(error, new Map([["message", "Failed to invalidate session during logout"]]));
       }
 
       authService.clearSessionCookie(response);
 
       return response;
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Auth logout error"]]));
+      logService.error(error, new Map([["message", "Auth logout error"]]));
       return errorContract.toResponse({ error: "Logout failed" }, { status: 500, noStore: true });
     }
   });

--- a/api/routes/auth/logout.ts
+++ b/api/routes/auth/logout.ts
@@ -13,14 +13,14 @@ export const authLogoutRoute: RoutesRegisterHandler = (router, installServices) 
       try {
         await authService.invalidateSession(request);
       } catch (error: unknown) {
-        logService.error(error, new Map([["message", "Failed to invalidate session during logout"]]));
+        logService.error(error, new Map([["context", "Failed to invalidate session during logout"]]));
       }
 
       authService.clearSessionCookie(response);
 
       return response;
     } catch (error) {
-      logService.error(error, new Map([["message", "Auth logout error"]]));
+      logService.error(error, new Map([["context", "Auth logout error"]]));
       return errorContract.toResponse({ error: "Logout failed" }, { status: 500, noStore: true });
     }
   });

--- a/api/routes/auth/microsoft/callback.ts
+++ b/api/routes/auth/microsoft/callback.ts
@@ -24,7 +24,7 @@ export const authMicrosoftCallbackRoute: RoutesRegisterHandler = (router, instal
       try {
         xboxUser = await xboxService.getUserFromMicrosoftAccessToken(sessionPayload.accessToken);
       } catch (xboxError) {
-        logService.error(xboxError as Error, new Map([["message", "Xbox profile required for sign-in"]]));
+        logService.error(xboxError, new Map([["message", "Xbox profile required for sign-in"]]));
         await databaseService.deleteUserSession(sessionPayload.sessionId);
         const rejectUrl = new URL("/login", env.PAGES_URL);
         rejectUrl.searchParams.set("error", "xbox-required");
@@ -61,7 +61,7 @@ export const authMicrosoftCallbackRoute: RoutesRegisterHandler = (router, instal
 
       return response;
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Auth callback error"]]));
+      logService.error(error, new Map([["message", "Auth callback error"]]));
       return errorContract.toResponse({ error: "Authentication failed" }, { status: 400, noStore: true });
     }
   });

--- a/api/routes/auth/microsoft/callback.ts
+++ b/api/routes/auth/microsoft/callback.ts
@@ -24,7 +24,7 @@ export const authMicrosoftCallbackRoute: RoutesRegisterHandler = (router, instal
       try {
         xboxUser = await xboxService.getUserFromMicrosoftAccessToken(sessionPayload.accessToken);
       } catch (xboxError) {
-        logService.error(xboxError, new Map([["message", "Xbox profile required for sign-in"]]));
+        logService.error(xboxError, new Map([["context", "Xbox profile required for sign-in"]]));
         await databaseService.deleteUserSession(sessionPayload.sessionId);
         const rejectUrl = new URL("/login", env.PAGES_URL);
         rejectUrl.searchParams.set("error", "xbox-required");
@@ -61,7 +61,7 @@ export const authMicrosoftCallbackRoute: RoutesRegisterHandler = (router, instal
 
       return response;
     } catch (error) {
-      logService.error(error, new Map([["message", "Auth callback error"]]));
+      logService.error(error, new Map([["context", "Auth callback error"]]));
       return errorContract.toResponse({ error: "Authentication failed" }, { status: 400, noStore: true });
     }
   });

--- a/api/routes/auth/microsoft/start.ts
+++ b/api/routes/auth/microsoft/start.ts
@@ -36,7 +36,7 @@ export const authMicrosoftStartRoute: RoutesRegisterHandler = (router, installSe
 
       return response;
     } catch (error) {
-      services.logService.error(error, new Map([["message", "Auth start error"]]));
+      services.logService.error(error, new Map([["context", "Auth start error"]]));
       return errorContract.toResponse(
         { error: "Failed to generate authorization URL" },
         { status: 500, noStore: true },

--- a/api/routes/auth/microsoft/start.ts
+++ b/api/routes/auth/microsoft/start.ts
@@ -36,7 +36,7 @@ export const authMicrosoftStartRoute: RoutesRegisterHandler = (router, installSe
 
       return response;
     } catch (error) {
-      services.logService.error(error as Error, new Map([["message", "Auth start error"]]));
+      services.logService.error(error, new Map([["message", "Auth start error"]]));
       return errorContract.toResponse(
         { error: "Failed to generate authorization URL" },
         { status: 500, noStore: true },

--- a/api/routes/auth/session.ts
+++ b/api/routes/auth/session.ts
@@ -55,7 +55,7 @@ export const authSessionRoute: RoutesRegisterHandler = (router, installServices)
         { noStore: true },
       );
     } catch (error) {
-      logService.error(error, new Map([["message", "Auth session error"]]));
+      logService.error(error, new Map([["context", "Auth session error"]]));
       return errorContract.toResponse({ error: "Failed to retrieve session" }, { status: 500, noStore: true });
     }
   });

--- a/api/routes/auth/session.ts
+++ b/api/routes/auth/session.ts
@@ -55,7 +55,7 @@ export const authSessionRoute: RoutesRegisterHandler = (router, installServices)
         { noStore: true },
       );
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Auth session error"]]));
+      logService.error(error, new Map([["message", "Auth session error"]]));
       return errorContract.toResponse({ error: "Failed to retrieve session" }, { status: 500, noStore: true });
     }
   });

--- a/api/routes/discord/interactions.ts
+++ b/api/routes/discord/interactions.ts
@@ -30,7 +30,7 @@ export const discordInteractionsRoute: RoutesRegisterHandler = (router, installS
 
       return response;
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Discord interaction error"]]));
+      logService.error(error, new Map([["message", "Discord interaction error"]]));
 
       return new Response("Internal error", { status: 500 });
     }

--- a/api/routes/discord/interactions.ts
+++ b/api/routes/discord/interactions.ts
@@ -30,7 +30,7 @@ export const discordInteractionsRoute: RoutesRegisterHandler = (router, installS
 
       return response;
     } catch (error) {
-      logService.error(error, new Map([["message", "Discord interaction error"]]));
+      logService.error(error, new Map([["context", "Discord interaction error"]]));
 
       return new Response("Internal error", { status: 500 });
     }

--- a/api/routes/individual-tracker/follow.ts
+++ b/api/routes/individual-tracker/follow.ts
@@ -64,7 +64,7 @@ export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router
       const directory = await buildDirectory(env, identity.UserId, services);
       return trackerDirectoryContract.toResponse(directory, { noStore: true });
     } catch (error) {
-      logService.error(error, new Map([["message", "Follow view error"]]));
+      logService.error(error, new Map([["context", "Follow view error"]]));
       return errorContract.toResponse({ error: "Failed to fetch follow directory" }, { status: 500, noStore: true });
     }
   });
@@ -100,7 +100,7 @@ export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       return new Response(null, { status: 101, webSocket: client });
     } catch (error) {
-      logService.error(error, new Map([["message", "Follow WebSocket error"]]));
+      logService.error(error, new Map([["context", "Follow WebSocket error"]]));
       return new Response("Internal Server Error", { status: 500 });
     }
   });

--- a/api/routes/individual-tracker/follow.ts
+++ b/api/routes/individual-tracker/follow.ts
@@ -64,7 +64,7 @@ export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router
       const directory = await buildDirectory(env, identity.UserId, services);
       return trackerDirectoryContract.toResponse(directory, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Follow view error"]]));
+      logService.error(error, new Map([["message", "Follow view error"]]));
       return errorContract.toResponse({ error: "Failed to fetch follow directory" }, { status: 500, noStore: true });
     }
   });
@@ -100,7 +100,7 @@ export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       return new Response(null, { status: 101, webSocket: client });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Follow WebSocket error"]]));
+      logService.error(error, new Map([["message", "Follow WebSocket error"]]));
       return new Response("Internal Server Error", { status: 500 });
     }
   });

--- a/api/routes/individual-tracker/manage.ts
+++ b/api/routes/individual-tracker/manage.ts
@@ -212,9 +212,18 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       const state = await startTrackerDo(env, startRequest);
 
+      logService.info(
+        "Individual tracker started",
+        new Map([
+          ["trackerId", tracker.TrackerId],
+          ["gamertag", tracker.Gamertag],
+          ["userId", auth.session.userId],
+        ]),
+      );
+
       return trackerContract.toResponse({ tracker: toTracker(tracker, state) }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker start error"]]));
+      logService.error(error, new Map([["context", "Individual tracker start error"]]));
       return errorContract.toResponse({ error: "Failed to start tracker" }, { status: 500, noStore: true });
     }
   });
@@ -248,9 +257,11 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
       await stopTrackerDo(env, auth.session.userId, tracker.TrackerId);
       await individualTrackerService.markTrackerStatus(tracker, "stopped");
 
+      logService.info("Individual tracker stopped", new Map([["trackerId", tracker.TrackerId]]));
+
       return stopTrackerContract.toResponse({ success: true }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker stop error"]]));
+      logService.error(error, new Map([["context", "Individual tracker stop error"]]));
       return errorContract.toResponse({ error: "Failed to stop tracker" }, { status: 500, noStore: true });
     }
   });
@@ -284,9 +295,11 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
       const state = await pauseTrackerDo(env, auth.session.userId, tracker.TrackerId);
       const paused = await individualTrackerService.markTrackerStatus(tracker, "paused");
 
+      logService.info("Individual tracker paused", new Map([["trackerId", tracker.TrackerId]]));
+
       return trackerContract.toResponse({ tracker: toTracker(paused, state) }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker pause error"]]));
+      logService.error(error, new Map([["context", "Individual tracker pause error"]]));
       return errorContract.toResponse({ error: "Failed to pause tracker" }, { status: 500, noStore: true });
     }
   });
@@ -320,9 +333,11 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
       const state = await resumeTrackerDo(env, auth.session.userId, tracker.TrackerId);
       const resumed = await individualTrackerService.markTrackerStatus(tracker, "active");
 
+      logService.info("Individual tracker resumed", new Map([["trackerId", tracker.TrackerId]]));
+
       return trackerContract.toResponse({ tracker: toTracker(resumed, state) }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker resume error"]]));
+      logService.error(error, new Map([["context", "Individual tracker resume error"]]));
       return errorContract.toResponse({ error: "Failed to resume tracker" }, { status: 500, noStore: true });
     }
   });
@@ -360,7 +375,7 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       return trackerContract.toResponse({ tracker: toTracker(tracker, state) }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker select active error"]]));
+      logService.error(error, new Map([["context", "Individual tracker select active error"]]));
       return errorContract.toResponse({ error: "Failed to select active tracker" }, { status: 500, noStore: true });
     }
   });
@@ -385,7 +400,7 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       return trackersContract.toResponse({ trackers }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker list error"]]));
+      logService.error(error, new Map([["context", "Individual tracker list error"]]));
       return errorContract.toResponse({ error: "Failed to list trackers" }, { status: 500, noStore: true });
     }
   });
@@ -420,7 +435,7 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       return trackerContract.toResponse({ tracker: toTracker(tracker, state) }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker status error"]]));
+      logService.error(error, new Map([["context", "Individual tracker status error"]]));
       return errorContract.toResponse({ error: "Failed to fetch tracker status" }, { status: 500, noStore: true });
     }
   });
@@ -459,7 +474,7 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       return selectMatchesContract.toResponse({ success: true }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker select matches error"]]));
+      logService.error(error, new Map([["context", "Individual tracker select matches error"]]));
       return errorContract.toResponse({ error: "Failed to update match selection" }, { status: 500, noStore: true });
     }
   });
@@ -506,7 +521,7 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       return startSeriesContract.toResponse({ success: true }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker start series error"]]));
+      logService.error(error, new Map([["context", "Individual tracker start series error"]]));
       return errorContract.toResponse({ error: "Failed to start series" }, { status: 500, noStore: true });
     }
   });
@@ -542,7 +557,7 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       return endSeriesContract.toResponse({ success: true }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker end series error"]]));
+      logService.error(error, new Map([["context", "Individual tracker end series error"]]));
       return errorContract.toResponse({ error: "Failed to end series" }, { status: 500, noStore: true });
     }
   });
@@ -593,7 +608,7 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       return editSeriesContract.toResponse({ success: true }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker edit series error"]]));
+      logService.error(error, new Map([["context", "Individual tracker edit series error"]]));
       return errorContract.toResponse({ error: "Failed to edit series" }, { status: 500, noStore: true });
     }
   });
@@ -635,7 +650,7 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       return resumeSeriesContract.toResponse({ success: true }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker resume series error"]]));
+      logService.error(error, new Map([["context", "Individual tracker resume series error"]]));
       return errorContract.toResponse({ error: "Failed to resume series" }, { status: 500, noStore: true });
     }
   });
@@ -669,7 +684,7 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       return deleteTrackerContract.toResponse({ success: true }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker delete error"]]));
+      logService.error(error, new Map([["context", "Individual tracker delete error"]]));
       return errorContract.toResponse({ error: "Failed to delete tracker" }, { status: 500, noStore: true });
     }
   });

--- a/api/routes/individual-tracker/profile.ts
+++ b/api/routes/individual-tracker/profile.ts
@@ -25,7 +25,7 @@ export const trackerProfileRoutesRegisterHandler: RoutesRegisterHandler = (route
 
       return trackerProfileContract.toResponse({ profile: toTrackerProfile(profile) }, { noStore: true });
     } catch (error) {
-      logService.error(error, new Map([["message", "Individual tracker profile get error"]]));
+      logService.error(error, new Map([["context", "Individual tracker profile get error"]]));
       return errorContract.toResponse({ error: "Failed to fetch profile" }, { status: 500, noStore: true });
     }
   });
@@ -69,7 +69,7 @@ export const trackerProfileRoutesRegisterHandler: RoutesRegisterHandler = (route
         throw error;
       }
     } catch (error) {
-      logService.error(error, new Map([["message", "Individual tracker profile update error"]]));
+      logService.error(error, new Map([["context", "Individual tracker profile update error"]]));
       return errorContract.toResponse({ error: "Failed to update profile" }, { status: 500, noStore: true });
     }
   });

--- a/api/routes/individual-tracker/profile.ts
+++ b/api/routes/individual-tracker/profile.ts
@@ -25,7 +25,7 @@ export const trackerProfileRoutesRegisterHandler: RoutesRegisterHandler = (route
 
       return trackerProfileContract.toResponse({ profile: toTrackerProfile(profile) }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker profile get error"]]));
+      logService.error(error, new Map([["message", "Individual tracker profile get error"]]));
       return errorContract.toResponse({ error: "Failed to fetch profile" }, { status: 500, noStore: true });
     }
   });
@@ -69,7 +69,7 @@ export const trackerProfileRoutesRegisterHandler: RoutesRegisterHandler = (route
         throw error;
       }
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker profile update error"]]));
+      logService.error(error, new Map([["message", "Individual tracker profile update error"]]));
       return errorContract.toResponse({ error: "Failed to update profile" }, { status: 500, noStore: true });
     }
   });

--- a/api/routes/individual-tracker/settings.ts
+++ b/api/routes/individual-tracker/settings.ts
@@ -19,7 +19,7 @@ export const trackerSettingsRoutesRegisterHandler: RoutesRegisterHandler = (rout
 
       return settingsContract.toResponse({ settings }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker settings get error"]]));
+      logService.error(error, new Map([["message", "Individual tracker settings get error"]]));
       return errorContract.toResponse({ error: "Failed to fetch settings" }, { status: 500, noStore: true });
     }
   });
@@ -43,7 +43,7 @@ export const trackerSettingsRoutesRegisterHandler: RoutesRegisterHandler = (rout
 
       return settingsContract.toResponse({ settings }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker settings update error"]]));
+      logService.error(error, new Map([["message", "Individual tracker settings update error"]]));
       return errorContract.toResponse({ error: "Failed to update settings" }, { status: 500, noStore: true });
     }
   });

--- a/api/routes/individual-tracker/settings.ts
+++ b/api/routes/individual-tracker/settings.ts
@@ -19,7 +19,7 @@ export const trackerSettingsRoutesRegisterHandler: RoutesRegisterHandler = (rout
 
       return settingsContract.toResponse({ settings }, { noStore: true });
     } catch (error) {
-      logService.error(error, new Map([["message", "Individual tracker settings get error"]]));
+      logService.error(error, new Map([["context", "Individual tracker settings get error"]]));
       return errorContract.toResponse({ error: "Failed to fetch settings" }, { status: 500, noStore: true });
     }
   });
@@ -43,7 +43,7 @@ export const trackerSettingsRoutesRegisterHandler: RoutesRegisterHandler = (rout
 
       return settingsContract.toResponse({ settings }, { noStore: true });
     } catch (error) {
-      logService.error(error, new Map([["message", "Individual tracker settings update error"]]));
+      logService.error(error, new Map([["context", "Individual tracker settings update error"]]));
       return errorContract.toResponse({ error: "Failed to update settings" }, { status: 500, noStore: true });
     }
   });

--- a/api/routes/individual-tracker/view.ts
+++ b/api/routes/individual-tracker/view.ts
@@ -28,7 +28,7 @@ export const trackerViewRoutesRegisterHandler: RoutesRegisterHandler = (router, 
 
       return trackerViewContract.toResponse({ view: toTrackerView(row, doState, streamerSettings) }, { noStore: true });
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker view error"]]));
+      logService.error(error, new Map([["context", "Individual tracker view error"]]));
       return errorContract.toResponse({ error: "Failed to fetch tracker view" }, { status: 500, noStore: true });
     }
   });
@@ -61,7 +61,7 @@ export const trackerViewRoutesRegisterHandler: RoutesRegisterHandler = (router, 
 
       return await stub.fetch(new Request(forwardedUrl.toString(), { headers: request.headers }));
     } catch (error) {
-      logService.error(error as Error, new Map([["message", "Individual tracker WebSocket error"]]));
+      logService.error(error, new Map([["context", "Individual tracker WebSocket error"]]));
       return new Response("Internal Server Error", { status: 500 });
     }
   });

--- a/api/routes/stats/discord-series.ts
+++ b/api/routes/stats/discord-series.ts
@@ -554,7 +554,7 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
         return discordSeriesStatsContract.toResponse(getForbiddenResponseData(guildId, queueNumber), { status: 403 });
       }
 
-      logService.error(error, new Map([["message", "Failed to resolve discord series stats route"]]));
+      logService.error(error, new Map([["context", "Failed to resolve discord series stats route"]]));
       return errorContract.toResponse(
         { error: "Failed to resolve discord series stats" },
         { status: 500, noStore: true },
@@ -612,7 +612,7 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
         return toLookupResponse(getForbiddenResponseData(guildId, queueNumber));
       }
 
-      logService.error(error, new Map([["message", "Failed to resolve discord series stats lookup route"]]));
+      logService.error(error, new Map([["context", "Failed to resolve discord series stats lookup route"]]));
       return errorContract.toResponse(
         { error: "Failed to resolve discord series stats lookup" },
         { status: 500, noStore: true },

--- a/api/routes/stats/discord-series.ts
+++ b/api/routes/stats/discord-series.ts
@@ -554,7 +554,7 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
         return discordSeriesStatsContract.toResponse(getForbiddenResponseData(guildId, queueNumber), { status: 403 });
       }
 
-      logService.error(error as Error, new Map([["message", "Failed to resolve discord series stats route"]]));
+      logService.error(error, new Map([["message", "Failed to resolve discord series stats route"]]));
       return errorContract.toResponse(
         { error: "Failed to resolve discord series stats" },
         { status: 500, noStore: true },
@@ -612,7 +612,7 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
         return toLookupResponse(getForbiddenResponseData(guildId, queueNumber));
       }
 
-      logService.error(error as Error, new Map([["message", "Failed to resolve discord series stats lookup route"]]));
+      logService.error(error, new Map([["message", "Failed to resolve discord series stats lookup route"]]));
       return errorContract.toResponse(
         { error: "Failed to resolve discord series stats lookup" },
         { status: 500, noStore: true },

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -160,7 +160,7 @@ export class DiscordService {
       const parsedInteraction = JSON.parse(body) as APIInteraction;
       return { interaction: parsedInteraction, isValid: true, rawBody: body };
     } catch (error) {
-      this.logService.error(error as Error, new Map([["body", body]]));
+      this.logService.error(error, new Map([["body", body]]));
 
       return { isValid: false, error: "Invalid JSON", rawBody: body };
     }
@@ -704,7 +704,7 @@ export class DiscordService {
 
       return { hasAll: missing.length === 0, missing };
     } catch (error) {
-      this.logService.warn(error as Error);
+      this.logService.warn(error);
       return { hasAll: false, missing: requiredPermissions };
     }
   }

--- a/api/services/halo/halo.ts
+++ b/api/services/halo/halo.ts
@@ -499,7 +499,7 @@ export class HaloService {
 
       return { esra: averageEsra, lastRankedGamePlayed };
     } catch (error) {
-      this.logService.error(error as Error, new Map([["context", `Failed to fetch ESRA for xuid ${xuid}`]]));
+      this.logService.error(error, new Map([["context", `Failed to fetch ESRA for xuid ${xuid}`]]));
       throw error;
     }
   }
@@ -555,7 +555,7 @@ export class HaloService {
     try {
       return await this.getPlayerMatches(user.xuid, matchType, count, 0);
     } catch (error) {
-      this.logService.error(error as Error);
+      this.logService.error(error);
 
       throw new EndUserError("Unable to retrieve match history");
     }
@@ -868,7 +868,7 @@ export class HaloService {
       return null;
     } catch (error) {
       this.logService.warn(
-        error as Error,
+        error,
         new Map([["context", `Failed to fetch map thumbnail for assetId ${assetId}, versionId ${versionId}`]]),
       );
       return null;
@@ -1135,10 +1135,7 @@ export class HaloService {
         try {
           result = await fallbackFetch();
         } catch (xboxError) {
-          this.logService.info(
-            xboxError as Error,
-            new Map([["context", `Xbox Live API also failed for ${identifier}`]]),
-          );
+          this.logService.info(xboxError, new Map([["context", `Xbox Live API also failed for ${identifier}`]]));
         }
       }
     }
@@ -1478,7 +1475,7 @@ export class HaloService {
           xboxGamertagMap.set(user.xuid, user.gamertag);
         }
       } catch (error) {
-        this.logService.warn(`Failed to fetch Xbox gamertags for fuzzy matching: ${(error as Error).message}`);
+        this.logService.warn(error, new Map([["context", "Failed to fetch Xbox gamertags for fuzzy matching"]]));
       }
     }
 

--- a/api/services/halo/resilient-fetch.ts
+++ b/api/services/halo/resilient-fetch.ts
@@ -309,7 +309,7 @@ export function createResilientFetch({ env, logService, proxyUrl }: ResilientFet
     try {
       return await fetchWithRetry();
     } catch (error) {
-      logService.error(error as Error, new Map([["url", url]]));
+      logService.error(error, new Map([["url", url]]));
       throw error;
     }
   };

--- a/api/services/individual-tracker/individual-tracker.ts
+++ b/api/services/individual-tracker/individual-tracker.ts
@@ -188,7 +188,7 @@ export class IndividualTrackerService {
           }
         } catch (error) {
           this.logService.warn(
-            error as Error,
+            error,
             new Map([
               ["reason", "nudgeTrackers: failed to nudge tracker"],
               ["trackerId", tracker.TrackerId],

--- a/api/services/log/aggregator-client.ts
+++ b/api/services/log/aggregator-client.ts
@@ -7,33 +7,33 @@ export class AggregatorClient implements LogService {
     this.clients = clients;
   }
 
-  debug(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void {
+  debug(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void {
     for (const client of this.clients) {
-      client.debug(error, extra);
+      client.debug(message, extra);
     }
   }
 
-  info(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void {
+  info(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void {
     for (const client of this.clients) {
-      client.info(error, extra);
+      client.info(message, extra);
     }
   }
 
-  warn(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void {
+  warn(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void {
     for (const client of this.clients) {
-      client.warn(error, extra);
+      client.warn(message, extra);
     }
   }
 
-  error(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void {
+  error(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void {
     for (const client of this.clients) {
-      client.error(error, extra);
+      client.error(message, extra);
     }
   }
 
-  fatal(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void {
+  fatal(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void {
     for (const client of this.clients) {
-      client.fatal(error, extra);
+      client.fatal(message, extra);
     }
   }
 }

--- a/api/services/log/base-log-service.ts
+++ b/api/services/log/base-log-service.ts
@@ -1,13 +1,13 @@
 import type { JsonAny, LogService } from "./types";
 
 export abstract class BaseLogService implements LogService {
-  abstract debug(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void;
+  abstract debug(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void;
 
-  abstract info(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void;
+  abstract info(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void;
 
-  abstract warn(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void;
+  abstract warn(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void;
 
-  abstract error(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void;
+  abstract error(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void;
 
-  abstract fatal(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void;
+  abstract fatal(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void;
 }

--- a/api/services/log/console-log-client.ts
+++ b/api/services/log/console-log-client.ts
@@ -2,36 +2,50 @@ import type { LogService, JsonAny } from "./types";
 
 export class ConsoleLogClient implements LogService {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  debug(_error: Error | string, _extra?: ReadonlyMap<string, JsonAny>): void {
-    // console.debug(error, extra ? JSON.stringify([...extra], null, 2) : undefined);
+  debug(_message: unknown, _extra?: ReadonlyMap<string, JsonAny>): void {
+    // no-op
   }
 
-  info(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void {
-    console.info(this.format(error, extra));
+  info(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void {
+    console.info(this.format(message, extra, this.captureCallSiteStack()));
   }
 
-  warn(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void {
-    console.warn(this.format(error, extra));
+  warn(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void {
+    console.warn(this.format(message, extra, this.captureCallSiteStack()));
   }
 
-  error(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void {
-    console.error(this.format(error, extra));
+  error(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void {
+    console.error(this.format(message, extra, this.captureCallSiteStack()));
   }
 
-  fatal(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void {
-    console.error("FATAL:", this.format(error, extra));
+  fatal(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void {
+    console.error("FATAL:", this.format(message, extra, this.captureCallSiteStack()));
   }
 
-  private format(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): string {
-    const content: Record<string, JsonAny> = {
-      message: typeof error === "string" ? error : error.message,
-    };
+  private captureCallSiteStack(): string {
+    const lines = new Error().stack?.split("\n") ?? [];
+    return lines
+      .filter((line) => line !== "Error" && !line.includes("console-log-client") && !line.includes("aggregator-client"))
+      .join("\n");
+  }
 
-    if (typeof error !== "string") {
-      content["stack"] = error.stack;
+  private format(message: unknown, extra?: ReadonlyMap<string, JsonAny>, callStack?: string): string {
+    const content: Record<string, JsonAny> = {};
+
+    if (message instanceof Error) {
+      content["message"] = message.message;
+      if (message.stack != null) {
+        content["stack"] = message.stack;
+      }
+    } else {
+      content["message"] = typeof message === "string" ? message : String(message);
     }
 
-    if (extra) {
+    if (callStack != null && callStack.length > 0) {
+      content["callStack"] = callStack;
+    }
+
+    if (extra != null) {
       for (const [key, value] of extra) {
         content[key] = value;
       }

--- a/api/services/log/console-log-client.ts
+++ b/api/services/log/console-log-client.ts
@@ -22,6 +22,20 @@ export class ConsoleLogClient implements LogService {
     console.error("FATAL:", this.format(message, extra, this.captureCallSiteStack()));
   }
 
+  private toJsonSafe(value: unknown): string {
+    if (typeof value === "string") {
+      return value;
+    }
+    if (value === undefined) {
+      return "undefined";
+    }
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "[unserializable]";
+    }
+  }
+
   private captureCallSiteStack(): string {
     const lines = new Error().stack?.split("\n") ?? [];
     return lines
@@ -51,7 +65,7 @@ export class ConsoleLogClient implements LogService {
         content["stack"] = message.stack;
       }
     } else {
-      content["message"] = typeof message === "string" ? message : String(message);
+      content["message"] = this.toJsonSafe(message);
     }
 
     if (callStack != null && callStack.length > 0) {

--- a/api/services/log/console-log-client.ts
+++ b/api/services/log/console-log-client.ts
@@ -7,7 +7,7 @@ export class ConsoleLogClient implements LogService {
   }
 
   info(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void {
-    console.info(this.format(message, extra, this.captureCallSiteStack()));
+    console.info(this.format(message, extra));
   }
 
   warn(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void {

--- a/api/services/log/console-log-client.ts
+++ b/api/services/log/console-log-client.ts
@@ -25,7 +25,14 @@ export class ConsoleLogClient implements LogService {
   private captureCallSiteStack(): string {
     const lines = new Error().stack?.split("\n") ?? [];
     return lines
-      .filter((line) => line !== "Error" && !line.includes("console-log-client") && !line.includes("aggregator-client"))
+      .filter(
+        (line) =>
+          line !== "Error" &&
+          !line.startsWith("Error") &&
+          !line.includes("console-log-client") &&
+          !line.includes("aggregator-client"),
+      )
+      .slice(0, 10)
       .join("\n");
   }
 

--- a/api/services/log/console-log-client.ts
+++ b/api/services/log/console-log-client.ts
@@ -26,8 +26,8 @@ export class ConsoleLogClient implements LogService {
     if (typeof value === "string") {
       return value;
     }
-    if (value === undefined) {
-      return "undefined";
+    if (value === undefined || typeof value === "function" || typeof value === "symbol") {
+      return String(value);
     }
     try {
       return JSON.stringify(value);

--- a/api/services/log/console-log-client.ts
+++ b/api/services/log/console-log-client.ts
@@ -39,6 +39,12 @@ export class ConsoleLogClient implements LogService {
   private format(message: unknown, extra?: ReadonlyMap<string, JsonAny>, callStack?: string): string {
     const content: Record<string, JsonAny> = {};
 
+    if (extra != null) {
+      for (const [key, value] of extra) {
+        content[key] = value;
+      }
+    }
+
     if (message instanceof Error) {
       content["message"] = message.message;
       if (message.stack != null) {
@@ -50,12 +56,6 @@ export class ConsoleLogClient implements LogService {
 
     if (callStack != null && callStack.length > 0) {
       content["callStack"] = callStack;
-    }
-
-    if (extra != null) {
-      for (const [key, value] of extra) {
-        content[key] = value;
-      }
     }
 
     return JSON.stringify(content, null, 2);

--- a/api/services/log/fakes/log.fake.ts
+++ b/api/services/log/fakes/log.fake.ts
@@ -4,19 +4,19 @@ import type { BaseLogService } from "../base-log-service";
 import type { JsonAny, LogService } from "../types";
 
 export class FakeLogService implements BaseLogService {
-  debug(_error: Error | string, _extra?: ReadonlyMap<string, JsonAny>): void {
+  debug(_message: unknown, _extra?: ReadonlyMap<string, JsonAny>): void {
     // no-op
   }
-  info(_error: Error | string, _extra?: ReadonlyMap<string, JsonAny>): void {
+  info(_message: unknown, _extra?: ReadonlyMap<string, JsonAny>): void {
     // no-op
   }
-  warn(_error: Error | string, _extra?: ReadonlyMap<string, JsonAny>): void {
+  warn(_message: unknown, _extra?: ReadonlyMap<string, JsonAny>): void {
     // no-op
   }
-  error(_error: Error | string, _extra?: ReadonlyMap<string, JsonAny>): void {
+  error(_message: unknown, _extra?: ReadonlyMap<string, JsonAny>): void {
     // no-op
   }
-  fatal(_error: Error | string, _extra?: ReadonlyMap<string, JsonAny>): void {
+  fatal(_message: unknown, _extra?: ReadonlyMap<string, JsonAny>): void {
     // no-op
   }
 }

--- a/api/services/log/sentry-log-client.ts
+++ b/api/services/log/sentry-log-client.ts
@@ -12,83 +12,92 @@ export class SentryLogClient implements LogService {
     this.shouldLog = mode === "production";
   }
 
-  debug(error: Error | string, extra: ReadonlyMap<string, JsonAny> = new Map()): void {
+  private toMessage(message: unknown): string {
+    if (message instanceof Error) {
+      return message.message;
+    }
+    if (typeof message === "string") {
+      return message;
+    }
+    return String(message);
+  }
+
+  debug(message: unknown, extra: ReadonlyMap<string, JsonAny> = new Map()): void {
     if (!this.shouldLog) {
       return;
     }
 
     addBreadcrumb({
       category: "debug",
-      message: error instanceof Error ? error.message : error,
+      message: this.toMessage(message),
       level: "debug",
       data: Object.fromEntries(extra),
     });
   }
 
-  info(error: Error | string, extra: ReadonlyMap<string, JsonAny> = new Map()): void {
+  info(message: unknown, extra: ReadonlyMap<string, JsonAny> = new Map()): void {
     if (!this.shouldLog) {
       return;
     }
 
     addBreadcrumb({
       category: "info",
-      message: error instanceof Error ? error.message : error,
+      message: this.toMessage(message),
       level: "info",
       data: Object.fromEntries(extra),
     });
   }
 
-  warn(error: Error | string, extra: ReadonlyMap<string, JsonAny> = new Map()): void {
+  warn(message: unknown, extra: ReadonlyMap<string, JsonAny> = new Map()): void {
     if (!this.shouldLog) {
       return;
     }
 
-    // For warnings, use breadcrumbs unless it's an actual Error object that needs tracking
-    if (error instanceof Error) {
-      captureException(error, {
+    if (message instanceof Error) {
+      captureException(message, {
         level: "warning",
         extra: Object.fromEntries(extra),
       });
     } else {
       addBreadcrumb({
         category: "warning",
-        message: error,
+        message: this.toMessage(message),
         level: "warning",
         data: Object.fromEntries(extra),
       });
     }
   }
 
-  error(error: Error | string, extra: ReadonlyMap<string, JsonAny> = new Map()): void {
+  error(message: unknown, extra: ReadonlyMap<string, JsonAny> = new Map()): void {
     if (!this.shouldLog) {
       return;
     }
 
-    if (error instanceof Error) {
-      captureException(error, {
+    if (message instanceof Error) {
+      captureException(message, {
         level: "error",
         extra: Object.fromEntries(extra),
       });
     } else {
-      captureMessage(error, {
+      captureMessage(this.toMessage(message), {
         level: "error",
         extra: Object.fromEntries(extra),
       });
     }
   }
 
-  fatal(error: Error | string, extra: ReadonlyMap<string, JsonAny> = new Map()): void {
+  fatal(message: unknown, extra: ReadonlyMap<string, JsonAny> = new Map()): void {
     if (!this.shouldLog) {
       return;
     }
 
-    if (error instanceof Error) {
-      captureException(error, {
+    if (message instanceof Error) {
+      captureException(message, {
         level: "fatal",
         extra: Object.fromEntries(extra),
       });
     } else {
-      captureMessage(error, {
+      captureMessage(this.toMessage(message), {
         level: "fatal",
         extra: Object.fromEntries(extra),
       });

--- a/api/services/log/sentry-log-client.ts
+++ b/api/services/log/sentry-log-client.ts
@@ -19,7 +19,14 @@ export class SentryLogClient implements LogService {
     if (typeof message === "string") {
       return message;
     }
-    return String(message);
+    if (message === undefined) {
+      return "undefined";
+    }
+    try {
+      return JSON.stringify(message);
+    } catch {
+      return "[unserializable]";
+    }
   }
 
   debug(message: unknown, extra: ReadonlyMap<string, JsonAny> = new Map()): void {

--- a/api/services/log/sentry-log-client.ts
+++ b/api/services/log/sentry-log-client.ts
@@ -19,8 +19,8 @@ export class SentryLogClient implements LogService {
     if (typeof message === "string") {
       return message;
     }
-    if (message === undefined) {
-      return "undefined";
+    if (message === undefined || typeof message === "function" || typeof message === "symbol") {
+      return String(message);
     }
     try {
       return JSON.stringify(message);

--- a/api/services/log/tests/console-log-client.test.ts
+++ b/api/services/log/tests/console-log-client.test.ts
@@ -89,11 +89,18 @@ describe("ConsoleLogClient", () => {
       expect(logged["callStack"]).toBeUndefined();
     });
 
-    it("logs unknown values as strings", () => {
+    it("logs numbers as JSON strings", () => {
       logClient.info(42);
 
       const logged = parseLogged(consoleSpy.info);
       expect(logged).toMatchObject({ message: "42" });
+    });
+
+    it("logs plain objects as JSON", () => {
+      logClient.info({ key: "value", count: 1 });
+
+      const logged = parseLogged(consoleSpy.info);
+      expect(logged).toMatchObject({ message: '{"key":"value","count":1}' });
     });
   });
 

--- a/api/services/log/tests/console-log-client.test.ts
+++ b/api/services/log/tests/console-log-client.test.ts
@@ -2,8 +2,27 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { MockInstance } from "vitest";
 import { ConsoleLogClient } from "../console-log-client";
 
-function stringifyContent(content: Record<string, unknown>): string {
-  return JSON.stringify(content, null, 2);
+function parseLogged(
+  spy: MockInstance<typeof console.info | typeof console.warn | typeof console.error>,
+): Record<string, unknown> {
+  expect(spy).toHaveBeenCalledTimes(1);
+  const [call] = spy.mock.calls;
+  if (call == null) {
+    throw new Error("Expected spy to have been called");
+  }
+  const [firstArg] = call;
+  return JSON.parse(firstArg as string) as Record<string, unknown>;
+}
+
+function parseFatalLogged(spy: MockInstance<typeof console.error>): Record<string, unknown> {
+  expect(spy).toHaveBeenCalledTimes(1);
+  const [call] = spy.mock.calls;
+  if (call == null) {
+    throw new Error("Expected spy to have been called");
+  }
+  const [prefix, secondArg] = call as [string, string];
+  expect(prefix).toBe("FATAL:");
+  return JSON.parse(secondArg) as Record<string, unknown>;
 }
 
 describe("ConsoleLogClient", () => {
@@ -45,11 +64,9 @@ describe("ConsoleLogClient", () => {
     it("logs info message without extra data", () => {
       logClient.info("test info message");
 
-      expect(consoleSpy.info).toHaveBeenCalledWith(
-        stringifyContent({
-          message: "test info message",
-        }),
-      );
+      const logged = parseLogged(consoleSpy.info);
+      expect(logged).toMatchObject({ message: "test info message" });
+      expect(logged["callStack"]).toBeTypeOf("string");
     });
 
     it("logs info message with extra data", () => {
@@ -57,25 +74,26 @@ describe("ConsoleLogClient", () => {
 
       logClient.info("test info", extra);
 
-      expect(consoleSpy.info).toHaveBeenCalledWith(
-        stringifyContent({
-          message: "test info",
-          key: "value",
-        }),
-      );
+      const logged = parseLogged(consoleSpy.info);
+      expect(logged).toMatchObject({ message: "test info", key: "value" });
+      expect(logged["callStack"]).toBeTypeOf("string");
     });
 
-    it("logs Error objects", () => {
+    it("logs Error objects with message and stack from the error", () => {
       const error = new Error("test error");
 
       logClient.info(error);
 
-      expect(consoleSpy.info).toHaveBeenCalledWith(
-        stringifyContent({
-          message: "test error",
-          stack: error.stack,
-        }),
-      );
+      const logged = parseLogged(consoleSpy.info);
+      expect(logged).toMatchObject({ message: "test error", stack: error.stack });
+      expect(logged["callStack"]).toBeTypeOf("string");
+    });
+
+    it("logs unknown values as strings", () => {
+      logClient.info(42);
+
+      const logged = parseLogged(consoleSpy.info);
+      expect(logged).toMatchObject({ message: "42" });
     });
   });
 
@@ -83,11 +101,9 @@ describe("ConsoleLogClient", () => {
     it("logs warn message without extra data", () => {
       logClient.warn("test warning");
 
-      expect(consoleSpy.warn).toHaveBeenCalledWith(
-        stringifyContent({
-          message: "test warning",
-        }),
-      );
+      const logged = parseLogged(consoleSpy.warn);
+      expect(logged).toMatchObject({ message: "test warning" });
+      expect(logged["callStack"]).toBeTypeOf("string");
     });
 
     it("logs warn message with extra data", () => {
@@ -95,12 +111,18 @@ describe("ConsoleLogClient", () => {
 
       logClient.warn("test warning", extra);
 
-      expect(consoleSpy.warn).toHaveBeenCalledWith(
-        stringifyContent({
-          message: "test warning",
-          context: "data",
-        }),
-      );
+      const logged = parseLogged(consoleSpy.warn);
+      expect(logged).toMatchObject({ message: "test warning", context: "data" });
+    });
+
+    it("logs Error objects with message and stack from the error", () => {
+      const error = new Error("test warn error");
+
+      logClient.warn(error);
+
+      const logged = parseLogged(consoleSpy.warn);
+      expect(logged).toMatchObject({ message: "test warn error", stack: error.stack });
+      expect(logged["callStack"]).toBeTypeOf("string");
     });
   });
 
@@ -108,11 +130,9 @@ describe("ConsoleLogClient", () => {
     it("logs error message without extra data", () => {
       logClient.error("test error");
 
-      expect(consoleSpy.error).toHaveBeenCalledWith(
-        stringifyContent({
-          message: "test error",
-        }),
-      );
+      const logged = parseLogged(consoleSpy.error);
+      expect(logged).toMatchObject({ message: "test error" });
+      expect(logged["callStack"]).toBeTypeOf("string");
     });
 
     it("logs error message with extra data", () => {
@@ -120,12 +140,18 @@ describe("ConsoleLogClient", () => {
 
       logClient.error("test error", extra);
 
-      expect(consoleSpy.error).toHaveBeenCalledWith(
-        stringifyContent({
-          message: "test error",
-          details: "info",
-        }),
-      );
+      const logged = parseLogged(consoleSpy.error);
+      expect(logged).toMatchObject({ message: "test error", details: "info" });
+    });
+
+    it("logs Error objects with message and stack from the error", () => {
+      const error = new Error("test error object");
+
+      logClient.error(error);
+
+      const logged = parseLogged(consoleSpy.error);
+      expect(logged).toMatchObject({ message: "test error object", stack: error.stack });
+      expect(logged["callStack"]).toBeTypeOf("string");
     });
   });
 
@@ -133,12 +159,9 @@ describe("ConsoleLogClient", () => {
     it("logs fatal message with FATAL prefix without extra data", () => {
       logClient.fatal("critical failure");
 
-      expect(consoleSpy.error).toHaveBeenCalledWith(
-        "FATAL:",
-        stringifyContent({
-          message: "critical failure",
-        }),
-      );
+      const logged = parseFatalLogged(consoleSpy.error);
+      expect(logged).toMatchObject({ message: "critical failure" });
+      expect(logged["callStack"]).toBeTypeOf("string");
     });
 
     it("logs fatal message with FATAL prefix with extra data", () => {
@@ -146,13 +169,8 @@ describe("ConsoleLogClient", () => {
 
       logClient.fatal("critical failure", extra);
 
-      expect(consoleSpy.error).toHaveBeenCalledWith(
-        "FATAL:",
-        stringifyContent({
-          message: "critical failure",
-          crash: "data",
-        }),
-      );
+      const logged = parseFatalLogged(consoleSpy.error);
+      expect(logged).toMatchObject({ message: "critical failure", crash: "data" });
     });
   });
 });

--- a/api/services/log/tests/console-log-client.test.ts
+++ b/api/services/log/tests/console-log-client.test.ts
@@ -11,7 +11,10 @@ function parseLogged(
     throw new Error("Expected spy to have been called");
   }
   const [firstArg] = call;
-  return JSON.parse(firstArg as string) as Record<string, unknown>;
+  if (typeof firstArg !== "string") {
+    throw new Error(`Expected first console argument to be a string, got ${typeof firstArg}`);
+  }
+  return JSON.parse(firstArg) as Record<string, unknown>;
 }
 
 function parseFatalLogged(spy: MockInstance<typeof console.error>): Record<string, unknown> {
@@ -20,7 +23,13 @@ function parseFatalLogged(spy: MockInstance<typeof console.error>): Record<strin
   if (call == null) {
     throw new Error("Expected spy to have been called");
   }
-  const [prefix, secondArg] = call as [string, string];
+  const [prefix, secondArg] = call as unknown[];
+  if (typeof prefix !== "string") {
+    throw new Error(`Expected first console argument to be a string, got ${typeof prefix}`);
+  }
+  if (typeof secondArg !== "string") {
+    throw new Error(`Expected second console argument to be a string, got ${typeof secondArg}`);
+  }
   expect(prefix).toBe("FATAL:");
   return JSON.parse(secondArg) as Record<string, unknown>;
 }

--- a/api/services/log/tests/console-log-client.test.ts
+++ b/api/services/log/tests/console-log-client.test.ts
@@ -66,7 +66,7 @@ describe("ConsoleLogClient", () => {
 
       const logged = parseLogged(consoleSpy.info);
       expect(logged).toMatchObject({ message: "test info message" });
-      expect(logged["callStack"]).toBeTypeOf("string");
+      expect(logged["callStack"]).toBeUndefined();
     });
 
     it("logs info message with extra data", () => {
@@ -76,7 +76,7 @@ describe("ConsoleLogClient", () => {
 
       const logged = parseLogged(consoleSpy.info);
       expect(logged).toMatchObject({ message: "test info", key: "value" });
-      expect(logged["callStack"]).toBeTypeOf("string");
+      expect(logged["callStack"]).toBeUndefined();
     });
 
     it("logs Error objects with message and stack from the error", () => {
@@ -86,7 +86,7 @@ describe("ConsoleLogClient", () => {
 
       const logged = parseLogged(consoleSpy.info);
       expect(logged).toMatchObject({ message: "test error", stack: error.stack });
-      expect(logged["callStack"]).toBeTypeOf("string");
+      expect(logged["callStack"]).toBeUndefined();
     });
 
     it("logs unknown values as strings", () => {

--- a/api/services/log/types.ts
+++ b/api/services/log/types.ts
@@ -1,13 +1,13 @@
 export type JsonAny = boolean | number | string | null | undefined | JsonAny[] | { [key: string]: JsonAny };
 
 export interface LogService {
-  debug(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void;
+  debug(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void;
 
-  info(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void;
+  info(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void;
 
-  warn(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void;
+  warn(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void;
 
-  error(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void;
+  error(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void;
 
-  fatal(error: Error | string, extra?: ReadonlyMap<string, JsonAny>): void;
+  fatal(message: unknown, extra?: ReadonlyMap<string, JsonAny>): void;
 }

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -126,7 +126,7 @@ export class NeatQueueService {
 
       return { isValid: true, rawBody, interaction: body, neatQueueConfig };
     } catch (error) {
-      this.logService.error(error as Error);
+      this.logService.error(error);
 
       return { isValid: false, rawBody, error: "Invalid JSON" };
     }
@@ -309,7 +309,7 @@ export class NeatQueueService {
             }
           }
         } catch (error) {
-          this.logService.error(error as Error, new Map([["reason", "Failed to process substitution"]]));
+          this.logService.error(error, new Map([["reason", "Failed to process substitution"]]));
           if (series.length === 0) {
             throw error;
           }
@@ -324,7 +324,7 @@ export class NeatQueueService {
         });
         series.unshift(...startData);
       } catch (error) {
-        this.logService.error(error as Error, new Map([["reason", "Failed to get series data from Discord queue"]]));
+        this.logService.error(error, new Map([["reason", "Failed to get series data from Discord queue"]]));
         if (series.length === 0) {
           throw error;
         }
@@ -388,7 +388,7 @@ export class NeatQueueService {
         return;
       }
 
-      this.logService.error(error as Error, new Map([["reason", "Unhandled error during retry"]]));
+      this.logService.error(error, new Map([["reason", "Unhandled error during retry"]]));
       const endUserError = new EndUserError("An unexpected error occurred while retrying the neat queue job", {
         actions: ["retry"],
       });
@@ -441,7 +441,7 @@ export class NeatQueueService {
 
       await this.discordService.editMessage(channelId, messageId, playersPostMessage);
     } catch (error) {
-      this.logService.error(error as Error, new Map([["reason", "Failed to update players embed"]]));
+      this.logService.error(error, new Map([["reason", "Failed to update players embed"]]));
     }
   }
 
@@ -543,7 +543,7 @@ export class NeatQueueService {
         });
       }
     } catch (error) {
-      logService.warn(error as Error, new Map([["reason", "Failed to post players message or maps button"]]));
+      logService.warn(error, new Map([["reason", "Failed to post players message or maps button"]]));
 
       if ((error instanceof DiscordError && error.restError.code === 50001) || error === insufficientPermissionsError) {
         await databaseService.updateGuildConfig(request.guild, {
@@ -888,7 +888,7 @@ export class NeatQueueService {
         await discordService.deleteMessage(request.channel, oldMessageId, "Updating players list after substitution");
       } catch (error) {
         logService.warn(
-          error as Error,
+          error,
           new Map([
             ["reason", "Failed to delete old players message"],
             ["messageId", oldMessageId],
@@ -906,7 +906,7 @@ export class NeatQueueService {
         ]),
       );
     } catch (error) {
-      logService.warn(error as Error, new Map([["reason", "Failed to update players embed for substitution"]]));
+      logService.warn(error, new Map([["reason", "Failed to update players embed for substitution"]]));
 
       if (error instanceof DiscordError && error.restError.code === 50001) {
         await databaseService.updateGuildConfig(request.guild, {
@@ -1004,7 +1004,7 @@ export class NeatQueueService {
         (await this.resolveSeriesFromLiveTracker(request)) ??
         (await this.getSeriesDataFromTimeline(timeline, neatQueueConfig));
     } catch (error) {
-      this.logService.info(error as Error, new Map([["reason", "Failed to get series data from timeline"]]));
+      this.logService.info(error, new Map([["reason", "Failed to get series data from timeline"]]));
       errorOccurred = true;
 
       const opts = { request, neatQueueConfig, handledError: error as Error, timeline };
@@ -1202,7 +1202,7 @@ export class NeatQueueService {
       this.queueStateCache.set(cacheKey, defaultState);
       return defaultState;
     } catch (error) {
-      this.logService.warn(error as Error);
+      this.logService.warn(error);
       this.queueStateCache.set(cacheKey, defaultState);
       return defaultState;
     }
@@ -1531,7 +1531,7 @@ export class NeatQueueService {
             series.push(...subSeries);
           } catch (error) {
             // don't fail if its just a substitution
-            this.logService.info(error as Error, new Map([["reason", "No series data from substitution"]]));
+            this.logService.info(error, new Map([["reason", "No series data from substitution"]]));
             this.haloService.clearUserCache();
           }
 
@@ -1690,7 +1690,7 @@ export class NeatQueueService {
 
       await this.postSeriesDetailsToChannel(thread.id, request.guild, series);
     } catch (error) {
-      this.logService.warn(error as Error, new Map([["reason", "Failed to post series data to thread"]]));
+      this.logService.warn(error, new Map([["reason", "Failed to post series data to thread"]]));
 
       if (!foundResultsMessage) {
         return;
@@ -1747,7 +1747,7 @@ export class NeatQueueService {
         components: endUserError.discordActions,
       });
     } catch (error) {
-      this.logService.warn(error as Error, new Map([["reason", "Failed to post error to thread"]]));
+      this.logService.warn(error, new Map([["reason", "Failed to post error to thread"]]));
 
       if (useFallback) {
         this.logService.info("Attempting to post direct to channel");
@@ -1804,7 +1804,7 @@ export class NeatQueueService {
       channelId = thread.id;
       await this.postSeriesDetailsToChannel(channelId, request.guild, series);
     } catch (error) {
-      this.logService.error(error as Error, new Map([["reason", "Failed to post series data direct to channel"]]));
+      this.logService.error(error, new Map([["reason", "Failed to post series data direct to channel"]]));
 
       const endUserError = this.getEndUserErrorEmbed(error as Error, request, neatQueueConfig, timeline);
       await discordService.createMessage(channelId, {
@@ -1862,7 +1862,7 @@ export class NeatQueueService {
         components: endUserError.discordActions,
       });
     } catch (error) {
-      this.logService.error(error as Error, new Map([["reason", "Failed to post error direct to channel"]]));
+      this.logService.error(error, new Map([["reason", "Failed to post error direct to channel"]]));
     }
   }
 

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -1007,7 +1007,8 @@ export class NeatQueueService {
       this.logService.info(error, new Map([["reason", "Failed to get series data from timeline"]]));
       errorOccurred = true;
 
-      const opts = { request, neatQueueConfig, handledError: error as Error, timeline };
+      const handledError = error instanceof Error ? error : new Error(String(error));
+      const opts = { request, neatQueueConfig, handledError, timeline };
       await this.handlePostSeriesError(neatQueueConfig.PostSeriesMode, opts);
     }
 
@@ -1703,7 +1704,8 @@ export class NeatQueueService {
       } else if (thread != null) {
         this.logService.info("Attempting to post error to thread");
 
-        const endUserError = this.getEndUserErrorEmbed(error as Error, request, neatQueueConfig, timeline);
+        const normalizedError = error instanceof Error ? error : new Error(String(error));
+        const endUserError = this.getEndUserErrorEmbed(normalizedError, request, neatQueueConfig, timeline);
         await discordService.createMessage(thread.id, {
           embeds: [endUserError.discordEmbed],
           components: endUserError.discordActions,
@@ -1806,7 +1808,8 @@ export class NeatQueueService {
     } catch (error) {
       this.logService.error(error, new Map([["reason", "Failed to post series data direct to channel"]]));
 
-      const endUserError = this.getEndUserErrorEmbed(error as Error, request, neatQueueConfig, timeline);
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
+      const endUserError = this.getEndUserErrorEmbed(normalizedError, request, neatQueueConfig, timeline);
       await discordService.createMessage(channelId, {
         embeds: [endUserError.discordEmbed],
         components: endUserError.discordActions,


### PR DESCRIPTION
## Summary

- **Widen \`LogService\` message type to \`unknown\`** — removes the need for forced \`error as Error\` casts at every call site; \`SentryLogClient\`, \`ConsoleLogClient\`, \`AggregatorClient\`, \`BaseLogService\`, and the fake all updated in lock-step.
- **\`ConsoleLogClient\`: call-site stack traces on warn/error/fatal** — captures \`new Error().stack\` at call time for \`warn\`, \`error\`, and \`fatal\` (not \`info\` — it's too high-frequency to allocate on every call), strips internal log-service frames, truncates to 10 frames, and includes it as \`callStack\` in the structured JSON output.
- **Remove \`error as Error\` casts across the codebase** — ~25 call sites in commands, routes, and services no longer need to force-cast now that the interface accepts \`unknown\`.
- **Individual tracker observability** — structured info/warn/error logs added throughout the full request path: DO lifecycle events (start, pause, resume, stop, series management, match selection), alarm poll results (newMatches, totalMatches, checkCount, consecutiveErrors), and WebSocket connection events. Helps diagnose issues like a tracker showing "started" with no updates flowing to the frontend.

## Test plan

- [ ] \`npm run done\` passes (types, lint, 13 tests green)
- [ ] Start an individual tracker in the browser and verify Cloudflare logs show the expected lifecycle events
- [ ] Confirm error paths (network failure, bad state) surface structured log entries with \`callStack\` field in Cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)