### PR TITLE
feat(stats): add batch match analytics endpoint

### DIFF
--- a/api/routes/stats/batch-analytics.ts
+++ b/api/routes/stats/batch-analytics.ts
@@ -7,7 +7,7 @@ import {
 import type { RoutesRegisterHandler } from "../base/types";
 
 export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installServices) => {
-  router.get("/api/stats/batch-match-analytics", async (request, env: Env) => {
+  router.get("/api/stats/match-analytics", async (request, env: Env) => {
     const services = installServices({ env });
 
     const url = new URL(request.url);
@@ -37,7 +37,7 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
     if (failureCount > 0) {
       services.logService.error(
         new Error(`${failureCount.toString()}/${matchIds.length.toString()} match analytics fetches failed`),
-        new Map([["route", "stats:batch-match-analytics"]]),
+        new Map([["route", "stats:match-analytics-batch"]]),
       );
     }
 

--- a/api/routes/stats/batch-analytics.ts
+++ b/api/routes/stats/batch-analytics.ts
@@ -1,0 +1,46 @@
+import { parseQueryParams } from "@guilty-spark/shared/base/request-parsing";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import {
+  batchMatchAnalyticsContract,
+  batchMatchAnalyticsQuerySchema,
+} from "@guilty-spark/shared/contracts/stats/batch-match-analytics";
+import type { RoutesRegisterHandler } from "../base/types";
+
+export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installServices) => {
+  router.get("/api/stats/batch-match-analytics", async (request, env: Env) => {
+    const services = installServices({ env });
+
+    const url = new URL(request.url);
+    const queryParams = parseQueryParams(url, batchMatchAnalyticsQuerySchema, "Invalid query parameters");
+    if (!queryParams.success) {
+      return queryParams.response;
+    }
+
+    const { matchIds, modules } = queryParams.data;
+
+    const settled = await Promise.allSettled(
+      matchIds.map(async (matchId) => services.analyticsService.getMatchAnalytics(matchId, modules)),
+    );
+
+    const results: Record<string, MatchAnalytics | null> = {};
+    let failureCount = 0;
+    for (const [index, matchId] of matchIds.entries()) {
+      const outcome = settled[index];
+      if (outcome == null || outcome.status === "rejected") {
+        results[matchId] = null;
+        failureCount++;
+      } else {
+        results[matchId] = outcome.value;
+      }
+    }
+
+    if (failureCount > 0) {
+      services.logService.error(
+        new Error(`${String(failureCount)}/${String(matchIds.length)} match analytics fetches failed`),
+        new Map([["route", "stats:batch-match-analytics"]]),
+      );
+    }
+
+    return batchMatchAnalyticsContract.toResponse({ results }, { noStore: true });
+  });
+};

--- a/api/routes/stats/batch-analytics.ts
+++ b/api/routes/stats/batch-analytics.ts
@@ -35,8 +35,8 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
     }
 
     if (failureCount > 0) {
-      services.logService.error(
-        new Error(`${failureCount.toString()}/${matchIds.length.toString()} match analytics fetches failed`),
+      services.logService.warn(
+        `${failureCount.toString()}/${matchIds.length.toString()} match analytics fetches failed`,
         new Map([["route", "stats:match-analytics-batch"]]),
       );
     }

--- a/api/routes/stats/batch-analytics.ts
+++ b/api/routes/stats/batch-analytics.ts
@@ -36,7 +36,7 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
 
     if (failureCount > 0) {
       services.logService.error(
-        new Error(`${String(failureCount)}/${String(matchIds.length)} match analytics fetches failed`),
+        new Error(`${failureCount.toString()}/${matchIds.length.toString()} match analytics fetches failed`),
         new Map([["route", "stats:batch-match-analytics"]]),
       );
     }

--- a/api/routes/stats/batch-analytics.ts
+++ b/api/routes/stats/batch-analytics.ts
@@ -22,15 +22,15 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
       matchIds.map(async (matchId) => services.analyticsService.getMatchAnalytics(matchId, modules)),
     );
 
-    const results: Record<string, MatchAnalytics | null> = {};
+    const resultsMap = new Map<string, MatchAnalytics | null>();
     let failureCount = 0;
     for (const [index, matchId] of matchIds.entries()) {
       const outcome = settled[index];
       if (outcome == null || outcome.status === "rejected") {
-        results[matchId] = null;
+        resultsMap.set(matchId, null);
         failureCount++;
       } else {
-        results[matchId] = outcome.value;
+        resultsMap.set(matchId, outcome.value);
       }
     }
 
@@ -41,6 +41,6 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
       );
     }
 
-    return batchMatchAnalyticsContract.toResponse({ results }, { noStore: true });
+    return batchMatchAnalyticsContract.toResponse({ results: Object.fromEntries(resultsMap) }, { noStore: true });
   });
 };

--- a/api/routes/stats/stats.ts
+++ b/api/routes/stats/stats.ts
@@ -1,8 +1,10 @@
 import type { RoutesRegisterHandler } from "../base/types";
 import { statsDiscordSeriesRoute } from "./discord-series";
 import { matchAnalyticsRoute } from "./analytics";
+import { batchMatchAnalyticsRoute } from "./batch-analytics";
 
 export const statsRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
   statsDiscordSeriesRoute(router, installServices);
   matchAnalyticsRoute(router, installServices);
+  batchMatchAnalyticsRoute(router, installServices);
 };

--- a/api/routes/stats/tests/batch-analytics.test.ts
+++ b/api/routes/stats/tests/batch-analytics.test.ts
@@ -71,7 +71,7 @@ describe("/api/stats/match-analytics (batch)", () => {
     vi.spyOn(services.analyticsService, "getMatchAnalytics")
       .mockResolvedValueOnce(analytics)
       .mockRejectedValueOnce(new Error("halo api down"));
-    const logErrorSpy: MockInstance<typeof services.logService.error> = vi.spyOn(services.logService, "error");
+    const logWarnSpy: MockInstance<typeof services.logService.warn> = vi.spyOn(services.logService, "warn");
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
     statsRoutesRegisterHandler(router, localInstallServices);
 
@@ -88,9 +88,9 @@ describe("/api/stats/match-analytics (batch)", () => {
         "match-fail": null,
       },
     });
-    expect(logErrorSpy).toHaveBeenCalledOnce();
-    expect(logErrorSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "1/2 match analytics fetches failed" }),
+    expect(logWarnSpy).toHaveBeenCalledOnce();
+    expect(logWarnSpy).toHaveBeenCalledWith(
+      "1/2 match analytics fetches failed",
       new Map([["route", "stats:match-analytics-batch"]]),
     );
   });
@@ -99,10 +99,7 @@ describe("/api/stats/match-analytics (batch)", () => {
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => installFakeServicesWith({ env }));
     statsRoutesRegisterHandler(router, localInstallServices);
 
-    const response = (await router.fetch(
-      new Request("http://localhost/api/stats/match-analytics"),
-      env,
-    )) as Response;
+    const response = (await router.fetch(new Request("http://localhost/api/stats/match-analytics"), env)) as Response;
 
     expect(response.status).toBe(400);
     const body = await response.json();

--- a/api/routes/stats/tests/batch-analytics.test.ts
+++ b/api/routes/stats/tests/batch-analytics.test.ts
@@ -64,13 +64,14 @@ describe("/api/stats/batch-match-analytics", () => {
     expect(getMatchAnalyticsSpy).toHaveBeenCalledWith("match-2", ["killMatrix"]);
   });
 
-  it("returns null for matchIds that fail, successful ones with data", async () => {
+  it("returns null for matchIds that fail, successful ones with data, and logs the failure count", async () => {
     const analytics = aFakeAnalytics();
 
     const services = installFakeServicesWith({ env });
     vi.spyOn(services.analyticsService, "getMatchAnalytics")
       .mockResolvedValueOnce(analytics)
       .mockRejectedValueOnce(new Error("halo api down"));
+    const logErrorSpy: MockInstance<typeof services.logService.error> = vi.spyOn(services.logService, "error");
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
     statsRoutesRegisterHandler(router, localInstallServices);
 
@@ -87,6 +88,11 @@ describe("/api/stats/batch-match-analytics", () => {
         "match-fail": null,
       },
     });
+    expect(logErrorSpy).toHaveBeenCalledOnce();
+    expect(logErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "1/2 match analytics fetches failed" }),
+      new Map([["route", "stats:batch-match-analytics"]]),
+    );
   });
 
   it("returns 400 when matchIds param is missing", async () => {

--- a/api/routes/stats/tests/batch-analytics.test.ts
+++ b/api/routes/stats/tests/batch-analytics.test.ts
@@ -23,7 +23,7 @@ const aFakeAnalytics = (): MatchAnalytics => ({
   },
 });
 
-describe("/api/stats/batch-match-analytics", () => {
+describe("/api/stats/match-analytics (batch)", () => {
   let env: Env;
   let router: AutoRouterType;
 
@@ -45,7 +45,7 @@ describe("/api/stats/batch-match-analytics", () => {
     statsRoutesRegisterHandler(router, localInstallServices);
 
     const response = (await router.fetch(
-      new Request("http://localhost/api/stats/batch-match-analytics?matchIds=match-1,match-2&modules=killMatrix"),
+      new Request("http://localhost/api/stats/match-analytics?matchIds=match-1,match-2&modules=killMatrix"),
       env,
     )) as Response;
 
@@ -76,7 +76,7 @@ describe("/api/stats/batch-match-analytics", () => {
     statsRoutesRegisterHandler(router, localInstallServices);
 
     const response = (await router.fetch(
-      new Request("http://localhost/api/stats/batch-match-analytics?matchIds=match-ok,match-fail"),
+      new Request("http://localhost/api/stats/match-analytics?matchIds=match-ok,match-fail"),
       env,
     )) as Response;
 
@@ -91,7 +91,7 @@ describe("/api/stats/batch-match-analytics", () => {
     expect(logErrorSpy).toHaveBeenCalledOnce();
     expect(logErrorSpy).toHaveBeenCalledWith(
       expect.objectContaining({ message: "1/2 match analytics fetches failed" }),
-      new Map([["route", "stats:batch-match-analytics"]]),
+      new Map([["route", "stats:match-analytics-batch"]]),
     );
   });
 
@@ -100,7 +100,7 @@ describe("/api/stats/batch-match-analytics", () => {
     statsRoutesRegisterHandler(router, localInstallServices);
 
     const response = (await router.fetch(
-      new Request("http://localhost/api/stats/batch-match-analytics"),
+      new Request("http://localhost/api/stats/match-analytics"),
       env,
     )) as Response;
 
@@ -114,7 +114,7 @@ describe("/api/stats/batch-match-analytics", () => {
     statsRoutesRegisterHandler(router, localInstallServices);
 
     const response = (await router.fetch(
-      new Request("http://localhost/api/stats/batch-match-analytics?matchIds=match-1&modules=scoreProgression"),
+      new Request("http://localhost/api/stats/match-analytics?matchIds=match-1&modules=scoreProgression"),
       env,
     )) as Response;
 
@@ -129,7 +129,7 @@ describe("/api/stats/batch-match-analytics", () => {
     statsRoutesRegisterHandler(router, localInstallServices);
 
     const response = (await router.fetch(
-      new Request(`http://localhost/api/stats/batch-match-analytics?matchIds=${matchIds}`),
+      new Request(`http://localhost/api/stats/match-analytics?matchIds=${matchIds}`),
       env,
     )) as Response;
 

--- a/api/routes/stats/tests/batch-analytics.test.ts
+++ b/api/routes/stats/tests/batch-analytics.test.ts
@@ -1,27 +1,13 @@
 import type { AutoRouterType } from "itty-router";
 import type { MockInstance } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import type { LogService } from "../../../services/log/types";
 import { createApiRouter } from "../../../base/router";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
+import type { AnalyticsService } from "../../../services/analytics/analytics";
+import { aFakeMatchAnalyticsWith } from "../../../services/analytics/fakes/analytics.fake";
 import { installFakeServicesWith } from "../../../services/fakes/services";
 import { statsRoutesRegisterHandler } from "../stats";
-
-const aFakeAnalytics = (): MatchAnalytics => ({
-  requestedModules: ["killMatrix"],
-  killMatrix: {
-    "2533274844642438:2533274881185517": {
-      count: 3,
-      headshotKills: 1,
-      perfects: 0,
-      weapons: [],
-    },
-  },
-  metadata: {
-    pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 1 },
-    perfectCounts: { total: 0, byXuid: {} },
-  },
-});
 
 describe("/api/stats/match-analytics (batch)", () => {
   let env: Env;
@@ -33,10 +19,10 @@ describe("/api/stats/match-analytics (batch)", () => {
   });
 
   it("returns results keyed by matchId with no-store cache header", async () => {
-    const analytics = aFakeAnalytics();
+    const analytics = aFakeMatchAnalyticsWith();
 
     const services = installFakeServicesWith({ env });
-    const getMatchAnalyticsSpy: MockInstance<typeof services.analyticsService.getMatchAnalytics> = vi.spyOn(
+    const getMatchAnalyticsSpy: MockInstance<AnalyticsService["getMatchAnalytics"]> = vi.spyOn(
       services.analyticsService,
       "getMatchAnalytics",
     );
@@ -65,13 +51,13 @@ describe("/api/stats/match-analytics (batch)", () => {
   });
 
   it("returns null for matchIds that fail, successful ones with data, and logs the failure count", async () => {
-    const analytics = aFakeAnalytics();
+    const analytics = aFakeMatchAnalyticsWith();
 
     const services = installFakeServicesWith({ env });
     vi.spyOn(services.analyticsService, "getMatchAnalytics")
       .mockResolvedValueOnce(analytics)
       .mockRejectedValueOnce(new Error("halo api down"));
-    const logWarnSpy: MockInstance<typeof services.logService.warn> = vi.spyOn(services.logService, "warn");
+    const logWarnSpy: MockInstance<LogService["warn"]> = vi.spyOn(services.logService, "warn");
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
     statsRoutesRegisterHandler(router, localInstallServices);
 

--- a/api/routes/stats/tests/batch-analytics.test.ts
+++ b/api/routes/stats/tests/batch-analytics.test.ts
@@ -1,0 +1,134 @@
+import type { AutoRouterType } from "itty-router";
+import type { MockInstance } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import { createApiRouter } from "../../../base/router";
+import { aFakeEnvWith } from "../../../base/fakes/env.fake";
+import { installFakeServicesWith } from "../../../services/fakes/services";
+import { statsRoutesRegisterHandler } from "../stats";
+
+const aFakeAnalytics = (): MatchAnalytics => ({
+  requestedModules: ["killMatrix"],
+  killMatrix: {
+    "2533274844642438:2533274881185517": {
+      count: 3,
+      headshotKills: 1,
+      perfects: 0,
+      weapons: [],
+    },
+  },
+  metadata: {
+    pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 1 },
+    perfectCounts: { total: 0, byXuid: {} },
+  },
+});
+
+describe("/api/stats/batch-match-analytics", () => {
+  let env: Env;
+  let router: AutoRouterType;
+
+  beforeEach(() => {
+    env = aFakeEnvWith();
+    router = createApiRouter();
+  });
+
+  it("returns results keyed by matchId with no-store cache header", async () => {
+    const analytics = aFakeAnalytics();
+
+    const services = installFakeServicesWith({ env });
+    const getMatchAnalyticsSpy: MockInstance<typeof services.analyticsService.getMatchAnalytics> = vi.spyOn(
+      services.analyticsService,
+      "getMatchAnalytics",
+    );
+    getMatchAnalyticsSpy.mockResolvedValue(analytics);
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request("http://localhost/api/stats/batch-match-analytics?matchIds=match-1,match-2&modules=killMatrix"),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+
+    const body = await response.json();
+    expect(body).toEqual({
+      results: {
+        "match-1": analytics,
+        "match-2": analytics,
+      },
+    });
+    expect(getMatchAnalyticsSpy).toHaveBeenCalledTimes(2);
+    expect(getMatchAnalyticsSpy).toHaveBeenCalledWith("match-1", ["killMatrix"]);
+    expect(getMatchAnalyticsSpy).toHaveBeenCalledWith("match-2", ["killMatrix"]);
+  });
+
+  it("returns null for matchIds that fail, successful ones with data", async () => {
+    const analytics = aFakeAnalytics();
+
+    const services = installFakeServicesWith({ env });
+    vi.spyOn(services.analyticsService, "getMatchAnalytics")
+      .mockResolvedValueOnce(analytics)
+      .mockRejectedValueOnce(new Error("halo api down"));
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request("http://localhost/api/stats/batch-match-analytics?matchIds=match-ok,match-fail"),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({
+      results: {
+        "match-ok": analytics,
+        "match-fail": null,
+      },
+    });
+  });
+
+  it("returns 400 when matchIds param is missing", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => installFakeServicesWith({ env }));
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request("http://localhost/api/stats/batch-match-analytics"),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body).toEqual({ error: "Invalid query parameters" });
+  });
+
+  it("returns 400 for unsupported modules", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => installFakeServicesWith({ env }));
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request("http://localhost/api/stats/batch-match-analytics?matchIds=match-1&modules=scoreProgression"),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body).toEqual({ error: "Invalid query parameters" });
+  });
+
+  it("returns 400 when more than 30 matchIds are provided", async () => {
+    const matchIds = Array.from({ length: 31 }, (_, i) => `match-${i.toString()}`).join(",");
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => installFakeServicesWith({ env }));
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request(`http://localhost/api/stats/batch-match-analytics?matchIds=${matchIds}`),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body).toEqual({ error: "Invalid query parameters" });
+  });
+});

--- a/api/services/analytics/fakes/analytics.fake.ts
+++ b/api/services/analytics/fakes/analytics.fake.ts
@@ -1,7 +1,27 @@
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { aFakeHaloServiceWith } from "../../halo/fakes/halo.fake";
 import { aFakeHaloFilmServiceWith } from "../../halo/fakes/halo-film.fake";
 import type { AnalyticsServiceOpts } from "../analytics";
 import { AnalyticsService } from "../analytics";
+
+export function aFakeMatchAnalyticsWith(overrides: Partial<MatchAnalytics> = {}): MatchAnalytics {
+  return {
+    requestedModules: ["killMatrix"],
+    killMatrix: {
+      "2533274844642438:2533274881185517": {
+        count: 3,
+        headshotKills: 1,
+        perfects: 0,
+        weapons: [],
+      },
+    },
+    metadata: {
+      pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 1 },
+      perfectCounts: { total: 0, byXuid: {} },
+    },
+    ...overrides,
+  };
+}
 
 export function aFakeAnalyticsServiceWith(opts: Partial<AnalyticsServiceOpts> = {}): AnalyticsService {
   const haloService = opts.haloService ?? aFakeHaloServiceWith();

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -103,6 +103,9 @@ export class DiscordSeriesStatsPresenter {
 
   private async fetchAnalytics(): Promise<void> {
     const matchIds = this.renderData.matches.map((m) => m.matchId);
+    if (matchIds.length === 0) {
+      return;
+    }
     try {
       const batchResults = await this.matchAnalyticsService.getBatchMatchAnalytics(matchIds);
       if (this.cancelled) {

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -94,29 +94,30 @@ export class DiscordSeriesStatsPresenter {
 
   start(): void {
     this.cancelled = false;
-    const matchIds = this.renderData.matches.map((m) => m.matchId);
-
-    void this.matchAnalyticsService
-      .getBatchMatchAnalytics(matchIds)
-      .then((batchResults) => {
-        if (this.cancelled) {
-          return;
-        }
-        const map = new Map<string, MatchAnalytics>();
-        for (const [matchId, analytics] of Object.entries(batchResults)) {
-          if (analytics != null) {
-            map.set(matchId, analytics);
-          }
-        }
-        this.store.update({ analyticsByMatchId: map });
-      })
-      .catch(() => {
-        // batch fetch failed; store retains empty map
-      });
+    void this.fetchAnalytics();
   }
 
   dispose(): void {
     this.cancelled = true;
+  }
+
+  private async fetchAnalytics(): Promise<void> {
+    const matchIds = this.renderData.matches.map((m) => m.matchId);
+    try {
+      const batchResults = await this.matchAnalyticsService.getBatchMatchAnalytics(matchIds);
+      if (this.cancelled) {
+        return;
+      }
+      const map = new Map<string, MatchAnalytics>();
+      for (const [matchId, analytics] of Object.entries(batchResults)) {
+        if (analytics != null) {
+          map.set(matchId, analytics);
+        }
+      }
+      this.store.update({ analyticsByMatchId: map });
+    } catch {
+      // analytics are best-effort; store retains empty map
+    }
   }
 
   present(snapshot: DiscordSeriesStatsSnapshot): DiscordSeriesStatsViewModel {

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -96,27 +96,23 @@ export class DiscordSeriesStatsPresenter {
     this.cancelled = false;
     const matchIds = this.renderData.matches.map((m) => m.matchId);
 
-    void Promise.all(
-      matchIds.map(async (matchId) => {
-        try {
-          const analytics = await this.matchAnalyticsService.getMatchAnalytics(matchId);
-          return { matchId, analytics };
-        } catch {
-          return null;
+    void this.matchAnalyticsService
+      .getBatchMatchAnalytics(matchIds)
+      .then((batchResults) => {
+        if (this.cancelled) {
+          return;
         }
-      }),
-    ).then((results) => {
-      if (this.cancelled) {
-        return;
-      }
-      const map = new Map<string, MatchAnalytics>();
-      for (const result of results) {
-        if (result != null) {
-          map.set(result.matchId, result.analytics);
+        const map = new Map<string, MatchAnalytics>();
+        for (const [matchId, analytics] of Object.entries(batchResults)) {
+          if (analytics != null) {
+            map.set(matchId, analytics);
+          }
         }
-      }
-      this.store.update({ analyticsByMatchId: map });
-    });
+        this.store.update({ analyticsByMatchId: map });
+      })
+      .catch(() => {
+        // batch fetch failed; store retains empty map
+      });
   }
 
   dispose(): void {

--- a/pages/src/components/discord-series-stats/tests/create.test.tsx
+++ b/pages/src/components/discord-series-stats/tests/create.test.tsx
@@ -106,9 +106,9 @@ describe("DiscordSeriesStats", () => {
     expect(screen.getByRole("button", { name: "Switch to standard view" })).toBeInTheDocument();
   });
 
-  it("fetches match analytics for each match in renderData", async () => {
+  it("fetches batch match analytics for all matches in renderData", async () => {
     const matchAnalyticsService = aFakeMatchAnalyticsServiceWith();
-    const getMatchAnalyticsSpy = vi.spyOn(matchAnalyticsService, "getMatchAnalytics");
+    const getBatchMatchAnalyticsSpy = vi.spyOn(matchAnalyticsService, "getBatchMatchAnalytics");
     const base = aFakeResolvedDataWith();
     const secondMatch = { ...base.renderData.matches[0], matchId: "match-2" };
 
@@ -123,10 +123,9 @@ describe("DiscordSeriesStats", () => {
     );
 
     await waitFor(() => {
-      expect(getMatchAnalyticsSpy).toHaveBeenCalledTimes(2);
+      expect(getBatchMatchAnalyticsSpy).toHaveBeenCalledTimes(1);
     });
 
-    expect(getMatchAnalyticsSpy).toHaveBeenCalledWith("match-1");
-    expect(getMatchAnalyticsSpy).toHaveBeenCalledWith("match-2");
+    expect(getBatchMatchAnalyticsSpy).toHaveBeenCalledWith(["match-1", "match-2"]);
   });
 });

--- a/pages/src/services/stats/fakes/match-analytics.fake.ts
+++ b/pages/src/services/stats/fakes/match-analytics.fake.ts
@@ -28,19 +28,34 @@ function aFakeMatchAnalyticsWith(overrides: Partial<MatchAnalytics> = {}): Match
 
 interface FakeMatchAnalyticsServiceOptions {
   readonly analytics: MatchAnalytics;
+  readonly failMatchIds: readonly string[];
 }
 
 export class FakeMatchAnalyticsService implements MatchAnalyticsService {
   private readonly analytics: MatchAnalytics;
+  private readonly failMatchIds: ReadonlySet<string>;
 
   constructor(options: Partial<FakeMatchAnalyticsServiceOptions> = {}) {
     this.analytics = options.analytics ?? aFakeMatchAnalyticsWith();
+    this.failMatchIds = new Set(options.failMatchIds ?? []);
   }
 
   async getMatchAnalytics(matchId: string, modules?: readonly AnalyticsModule[]): Promise<MatchAnalytics> {
     void matchId;
     void modules;
     return Promise.resolve(this.analytics);
+  }
+
+  async getBatchMatchAnalytics(
+    matchIds: readonly string[],
+    modules?: readonly AnalyticsModule[],
+  ): Promise<Record<string, MatchAnalytics | null>> {
+    void modules;
+    const results: Record<string, MatchAnalytics | null> = {};
+    for (const matchId of matchIds) {
+      results[matchId] = this.failMatchIds.has(matchId) ? null : this.analytics;
+    }
+    return Promise.resolve(results);
   }
 }
 

--- a/pages/src/services/stats/fakes/match-analytics.fake.ts
+++ b/pages/src/services/stats/fakes/match-analytics.fake.ts
@@ -41,8 +41,10 @@ export class FakeMatchAnalyticsService implements MatchAnalyticsService {
   }
 
   async getMatchAnalytics(matchId: string, modules?: readonly AnalyticsModule[]): Promise<MatchAnalytics> {
-    void matchId;
     void modules;
+    if (this.failMatchIds.has(matchId)) {
+      return Promise.reject(new Error(`Analytics fetch failed for ${matchId}`));
+    }
     return Promise.resolve(this.analytics);
   }
 

--- a/pages/src/services/stats/fakes/match-analytics.fake.ts
+++ b/pages/src/services/stats/fakes/match-analytics.fake.ts
@@ -53,11 +53,10 @@ export class FakeMatchAnalyticsService implements MatchAnalyticsService {
     modules?: readonly AnalyticsModule[],
   ): Promise<Record<string, MatchAnalytics | null>> {
     void modules;
-    const results: Record<string, MatchAnalytics | null> = {};
-    for (const matchId of matchIds) {
-      results[matchId] = this.failMatchIds.has(matchId) ? null : this.analytics;
-    }
-    return Promise.resolve(results);
+    const resultsMap = new Map<string, MatchAnalytics | null>(
+      matchIds.map((matchId) => [matchId, this.failMatchIds.has(matchId) ? null : this.analytics]),
+    );
+    return Promise.resolve(Object.fromEntries(resultsMap));
   }
 }
 

--- a/pages/src/services/stats/match-analytics-types.ts
+++ b/pages/src/services/stats/match-analytics-types.ts
@@ -2,4 +2,8 @@ import type { AnalyticsModule, MatchAnalytics } from "@guilty-spark/shared/contr
 
 export interface MatchAnalyticsService {
   getMatchAnalytics(matchId: string, modules?: readonly AnalyticsModule[]): Promise<MatchAnalytics>;
+  getBatchMatchAnalytics(
+    matchIds: readonly string[],
+    modules?: readonly AnalyticsModule[],
+  ): Promise<Record<string, MatchAnalytics | null>>;
 }

--- a/pages/src/services/stats/match-analytics.ts
+++ b/pages/src/services/stats/match-analytics.ts
@@ -46,7 +46,7 @@ export class RealMatchAnalyticsService implements MatchAnalyticsService {
       matchIds: matchIds.join(","),
       modules: buildModulesQuery(normalizedModules),
     });
-    const response = await fetch(`${this.apiHost}/api/stats/batch-match-analytics?${query.toString()}`, {
+    const response = await fetch(`${this.apiHost}/api/stats/match-analytics?${query.toString()}`, {
       credentials: "include",
     });
     const parsed = await batchMatchAnalyticsContract.fromResponse(response);

--- a/pages/src/services/stats/match-analytics.ts
+++ b/pages/src/services/stats/match-analytics.ts
@@ -3,6 +3,7 @@ import {
   type AnalyticsModule,
   matchAnalyticsContract,
 } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import { batchMatchAnalyticsContract } from "@guilty-spark/shared/contracts/stats/batch-match-analytics";
 import type { MatchAnalyticsService } from "./match-analytics-types";
 
 interface RealMatchAnalyticsServiceOptions {
@@ -34,5 +35,21 @@ export class RealMatchAnalyticsService implements MatchAnalyticsService {
     });
     const parsed = await matchAnalyticsContract.fromResponse(response);
     return parsed.analytics;
+  }
+
+  async getBatchMatchAnalytics(
+    matchIds: readonly string[],
+    modules: readonly AnalyticsModule[] = DEFAULT_MODULES,
+  ): Promise<Record<string, MatchAnalytics | null>> {
+    const normalizedModules = modules.length === 0 ? DEFAULT_MODULES : modules;
+    const query = new URLSearchParams({
+      matchIds: matchIds.join(","),
+      modules: buildModulesQuery(normalizedModules),
+    });
+    const response = await fetch(`${this.apiHost}/api/stats/batch-match-analytics?${query.toString()}`, {
+      credentials: "include",
+    });
+    const parsed = await batchMatchAnalyticsContract.fromResponse(response);
+    return parsed.results;
   }
 }

--- a/pages/src/services/stats/tests/match-analytics.test.ts
+++ b/pages/src/services/stats/tests/match-analytics.test.ts
@@ -131,7 +131,7 @@ describe("RealMatchAnalyticsService.getBatchMatchAnalytics", () => {
 
     expect(result).toEqual({ "match-1": analytics, "match-2": analytics });
     expect(fetchSpy).toHaveBeenCalledWith(
-      "https://api.example.com/api/stats/batch-match-analytics?matchIds=match-1%2Cmatch-2&modules=killMatrix",
+      "https://api.example.com/api/stats/match-analytics?matchIds=match-1%2Cmatch-2&modules=killMatrix",
       { credentials: "include" },
     );
   });
@@ -148,7 +148,7 @@ describe("RealMatchAnalyticsService.getBatchMatchAnalytics", () => {
     await service.getBatchMatchAnalytics(["match-1"], ["killMatrix"]);
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      "https://api.example.com/api/stats/batch-match-analytics?matchIds=match-1&modules=killMatrix",
+      "https://api.example.com/api/stats/match-analytics?matchIds=match-1&modules=killMatrix",
       { credentials: "include" },
     );
   });

--- a/pages/src/services/stats/tests/match-analytics.test.ts
+++ b/pages/src/services/stats/tests/match-analytics.test.ts
@@ -99,3 +99,76 @@ describe("RealMatchAnalyticsService", () => {
     );
   });
 });
+
+describe("RealMatchAnalyticsService.getBatchMatchAnalytics", () => {
+  let fetchSpy: MockInstance<typeof globalThis.fetch>;
+  let service: RealMatchAnalyticsService;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    service = new RealMatchAnalyticsService({ apiHost: "https://api.example.com" });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("fetches batch analytics and returns results record", async () => {
+    const analytics = aFakeAnalyticsResponseWith();
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          results: {
+            "match-1": analytics,
+            "match-2": analytics,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await service.getBatchMatchAnalytics(["match-1", "match-2"]);
+
+    expect(result).toEqual({ "match-1": analytics, "match-2": analytics });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/stats/batch-match-analytics?matchIds=match-1%2Cmatch-2&modules=killMatrix",
+      { credentials: "include" },
+    );
+  });
+
+  it("passes explicit modules in the query", async () => {
+    const analytics = aFakeAnalyticsResponseWith();
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ results: { "match-1": analytics } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await service.getBatchMatchAnalytics(["match-1"], ["killMatrix"]);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/stats/batch-match-analytics?matchIds=match-1&modules=killMatrix",
+      { credentials: "include" },
+    );
+  });
+
+  it("preserves null results for failed matchIds", async () => {
+    const analytics = aFakeAnalyticsResponseWith();
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          results: {
+            "match-ok": analytics,
+            "match-fail": null,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await service.getBatchMatchAnalytics(["match-ok", "match-fail"]);
+
+    expect(result).toEqual({ "match-ok": analytics, "match-fail": null });
+  });
+});

--- a/shared/src/contracts/stats/batch-match-analytics.ts
+++ b/shared/src/contracts/stats/batch-match-analytics.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { defineContract } from "../base";
+import { matchAnalyticsSchema, requestedModulesQuerySchema } from "./match-analytics";
+
+const matchIdsQuerySchema = z
+  .string()
+  .transform((raw) => {
+    return raw
+      .split(",")
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0);
+  })
+  .pipe(z.array(z.string()).min(1).max(30));
+
+export const batchMatchAnalyticsQuerySchema = z.object({
+  matchIds: matchIdsQuerySchema,
+  modules: requestedModulesQuerySchema,
+});
+
+export type BatchMatchAnalyticsQuery = z.infer<typeof batchMatchAnalyticsQuerySchema>;
+
+export const batchMatchAnalyticsContract = defineContract(
+  z.object({
+    results: z.record(z.string(), matchAnalyticsSchema.nullable()),
+  }),
+);
+
+export type BatchMatchAnalyticsResult = z.infer<typeof batchMatchAnalyticsContract.schema>;

--- a/shared/src/contracts/stats/match-analytics.ts
+++ b/shared/src/contracts/stats/match-analytics.ts
@@ -24,7 +24,7 @@ export const matchAnalyticsParamsSchema = z.object({
 });
 export type MatchAnalyticsParams = z.infer<typeof matchAnalyticsParamsSchema>;
 
-const requestedModulesQuerySchema = z
+export const requestedModulesQuerySchema = z
   .string()
   .optional()
   .default("killMatrix")

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from "node:path";
 import { coverageConfigDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@guilty-spark/shared": path.resolve(import.meta.dirname, "shared/src"),
+    },
+  },
   test: {
     mockReset: true,
     restoreMocks: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,6 @@
-import path from "node:path";
 import { coverageConfigDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
-  resolve: {
-    alias: {
-      "@guilty-spark/shared": path.resolve(import.meta.dirname, "shared/src"),
-    },
-  },
   test: {
     mockReset: true,
     restoreMocks: true,


### PR DESCRIPTION
## Summary

- Adds \`GET /api/stats/match-analytics?matchIds=id1,id2,...\` endpoint — fetches multiple match analytics in one request using \`Promise.allSettled\` so partial failures return null rather than failing the whole batch. This colocates with the existing \`GET /api/stats/match-analytics/:matchId\` route; the router differentiates by the presence/absence of a path segment, allowing the old endpoint to be retired independently in a later PR.
- Adds shared \`batchMatchAnalyticsContract\` and \`batchMatchAnalyticsQuerySchema\` (reuses \`requestedModulesQuerySchema\` from the existing single-match contract)
- Extends \`MatchAnalyticsService\` with \`getBatchMatchAnalytics\` and updates \`RealMatchAnalyticsService\` and \`FakeMatchAnalyticsService\` accordingly
- Updates \`DiscordSeriesStatsPresenter\` to use the batch endpoint instead of N parallel single-match calls

## Test plan

- [ ] \`api/routes/stats/tests/batch-analytics.test.ts\` — happy path, partial failure, >30 matchIds → 400, missing matchIds → 400
- [ ] \`pages/src/services/stats/tests/match-analytics.test.ts\` — new \`getBatchMatchAnalytics\` tests
- [ ] \`pages/src/components/discord-series-stats/tests/create.test.tsx\` — updated to assert one batch call instead of N individual calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)