### PR TITLE
feat(kill-matrix): move pivot to presenters, add loading shimmer and axis labels

### DIFF
--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -5,7 +5,7 @@ import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-
 import type { MatchStatsData } from "../../controllers/stats/types";
 import { StatsController } from "../../controllers/stats/stats-controller";
 import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
-import type { KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
+import type { KillMatrixPivotData, KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
 import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import { DEFAULT_TEAM_COLORS, getTeamColorOrDefault, type TeamColor } from "../team-colors/team-colors";
 import { gameModeIconSrc } from "../individual-tracker/game-mode-icon";
@@ -94,6 +94,7 @@ export class DiscordSeriesStatsPresenter {
 
   start(): void {
     this.cancelled = false;
+    this.store.update({ analyticsLoading: true });
     void this.fetchAnalytics();
   }
 
@@ -104,6 +105,7 @@ export class DiscordSeriesStatsPresenter {
   private async fetchAnalytics(): Promise<void> {
     const matchIds = this.renderData.matches.map((m) => m.matchId);
     if (matchIds.length === 0) {
+      this.store.update({ analyticsLoading: false });
       return;
     }
     try {
@@ -117,9 +119,9 @@ export class DiscordSeriesStatsPresenter {
           map.set(matchId, analytics);
         }
       }
-      this.store.update({ analyticsByMatchId: map });
+      this.store.update({ analyticsByMatchId: map, analyticsLoading: false });
     } catch {
-      // analytics are best-effort; store retains empty map
+      this.store.update({ analyticsLoading: false });
     }
   }
 
@@ -167,6 +169,7 @@ export class DiscordSeriesStatsPresenter {
         matchKillMatrixRows.set(match.matchId, killMatrixFormatter.present({ analytics, playersByXuid }));
       }
     }
+    const emptyPivot: KillMatrixPivotData = { tableRows: [], victimGamertags: [] };
 
     const matchSummaries: DiscordSeriesMatchSummary[] = this.renderData.matches.map((match) => ({
       matchId: match.matchId,
@@ -188,7 +191,7 @@ export class DiscordSeriesStatsPresenter {
     });
 
     const matchDetails: DiscordSeriesMatchDetail[] = this.renderData.matches.map((match, index) => {
-      const killMatrixRows = matchKillMatrixRows.get(match.matchId) ?? ([] as readonly KillMatrixViewRow[]);
+      const rows = matchKillMatrixRows.get(match.matchId);
       const base = {
         matchId: match.matchId,
         gameMapThumbnailUrl: match.gameMapThumbnailUrl,
@@ -201,7 +204,8 @@ export class DiscordSeriesStatsPresenter {
         startTime: match.startTime,
         endTime: match.endTime,
         teamColors,
-        killMatrixRows,
+        killMatrixPivotData: rows != null ? KillMatrixFormatter.pivot(rows) : emptyPivot,
+        killMatrixLoading: snapshot.analyticsLoading,
       };
       if (!isMatchStats(match.rawMatch)) {
         return { ...base, data: null };
@@ -223,9 +227,10 @@ export class DiscordSeriesStatsPresenter {
             playerData: seriesData.playerData,
             metadata: calculateSeriesMetadata(this.renderData.matches, this.renderData.seriesScore),
             teamColors,
-            killMatrixRows: KillMatrixFormatter.aggregate(
-              [...matchKillMatrixRows.values()].flatMap((rows) => [...rows]),
+            killMatrixPivotData: KillMatrixFormatter.pivot(
+              KillMatrixFormatter.aggregate([...matchKillMatrixRows.values()].flatMap((rows) => [...rows])),
             ),
+            killMatrixLoading: snapshot.analyticsLoading,
           }
         : null;
 

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -230,7 +230,7 @@ export class DiscordSeriesStatsPresenter {
             metadata: calculateSeriesMetadata(this.renderData.matches, this.renderData.seriesScore),
             teamColors,
             killMatrixPivotData: KillMatrixFormatter.pivot(
-              KillMatrixFormatter.aggregate([...matchKillMatrixRows.values()].flatMap((rows) => [...rows])),
+              KillMatrixFormatter.aggregate([...matchKillMatrixRows.values()].flatMap((rows) => rows)),
             ),
             killMatrixStatus: snapshot.analyticsStatus,
           }

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -7,6 +7,7 @@ import { StatsController } from "../../controllers/stats/stats-controller";
 import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
 import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
+import { ComponentLoaderStatus } from "../component-loader/component-loader";
 import { DEFAULT_TEAM_COLORS, getTeamColorOrDefault, type TeamColor } from "../team-colors/team-colors";
 import { gameModeIconSrc } from "../individual-tracker/game-mode-icon";
 import type { DiscordSeriesStatsSnapshot, DiscordSeriesStatsStore } from "./discord-series-stats-store";
@@ -94,7 +95,7 @@ export class DiscordSeriesStatsPresenter {
 
   start(): void {
     this.cancelled = false;
-    this.store.update({ analyticsLoading: true });
+    this.store.update({ analyticsStatus: ComponentLoaderStatus.LOADING });
     void this.fetchAnalytics();
   }
 
@@ -105,7 +106,7 @@ export class DiscordSeriesStatsPresenter {
   private async fetchAnalytics(): Promise<void> {
     const matchIds = this.renderData.matches.map((m) => m.matchId);
     if (matchIds.length === 0) {
-      this.store.update({ analyticsLoading: false });
+      this.store.update({ analyticsStatus: ComponentLoaderStatus.LOADED });
       return;
     }
     try {
@@ -119,9 +120,12 @@ export class DiscordSeriesStatsPresenter {
           map.set(matchId, analytics);
         }
       }
-      this.store.update({ analyticsByMatchId: map, analyticsLoading: false });
+      this.store.update({ analyticsByMatchId: map, analyticsStatus: ComponentLoaderStatus.LOADED });
     } catch {
-      this.store.update({ analyticsLoading: false });
+      if (this.cancelled) {
+        return;
+      }
+      this.store.update({ analyticsStatus: ComponentLoaderStatus.ERROR });
     }
   }
 
@@ -203,7 +207,7 @@ export class DiscordSeriesStatsPresenter {
         endTime: match.endTime,
         teamColors,
         killMatrixPivotData: rows != null ? KillMatrixFormatter.pivot(rows) : EMPTY_KILL_MATRIX_PIVOT_DATA,
-        killMatrixLoading: snapshot.analyticsLoading,
+        killMatrixStatus: snapshot.analyticsStatus,
       };
       if (!isMatchStats(match.rawMatch)) {
         return { ...base, data: null };
@@ -228,7 +232,7 @@ export class DiscordSeriesStatsPresenter {
             killMatrixPivotData: KillMatrixFormatter.pivot(
               KillMatrixFormatter.aggregate([...matchKillMatrixRows.values()].flatMap((rows) => [...rows])),
             ),
-            killMatrixLoading: snapshot.analyticsLoading,
+            killMatrixStatus: snapshot.analyticsStatus,
           }
         : null;
 

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -5,7 +5,7 @@ import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-
 import type { MatchStatsData } from "../../controllers/stats/types";
 import { StatsController } from "../../controllers/stats/stats-controller";
 import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
-import type { KillMatrixPivotData, KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
+import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
 import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import { DEFAULT_TEAM_COLORS, getTeamColorOrDefault, type TeamColor } from "../team-colors/team-colors";
 import { gameModeIconSrc } from "../individual-tracker/game-mode-icon";
@@ -169,8 +169,6 @@ export class DiscordSeriesStatsPresenter {
         matchKillMatrixRows.set(match.matchId, killMatrixFormatter.present({ analytics, playersByXuid }));
       }
     }
-    const emptyPivot: KillMatrixPivotData = { tableRows: [], victimGamertags: [] };
-
     const matchSummaries: DiscordSeriesMatchSummary[] = this.renderData.matches.map((match) => ({
       matchId: match.matchId,
       gameMapThumbnailUrl: match.gameMapThumbnailUrl,
@@ -204,7 +202,7 @@ export class DiscordSeriesStatsPresenter {
         startTime: match.startTime,
         endTime: match.endTime,
         teamColors,
-        killMatrixPivotData: rows != null ? KillMatrixFormatter.pivot(rows) : emptyPivot,
+        killMatrixPivotData: rows != null ? KillMatrixFormatter.pivot(rows) : EMPTY_KILL_MATRIX_PIVOT_DATA,
         killMatrixLoading: snapshot.analyticsLoading,
       };
       if (!isMatchStats(match.rawMatch)) {

--- a/pages/src/components/discord-series-stats/discord-series-stats-store.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-store.ts
@@ -11,7 +11,7 @@ export class DiscordSeriesStatsStore {
   private readonly subscribers = new Set<() => void>();
 
   constructor() {
-    this.snapshot = { analyticsByMatchId: new Map(), analyticsStatus: ComponentLoaderStatus.LOADING };
+    this.snapshot = { analyticsByMatchId: new Map(), analyticsStatus: ComponentLoaderStatus.PENDING };
   }
 
   subscribe(listener: () => void): () => void {

--- a/pages/src/components/discord-series-stats/discord-series-stats-store.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-store.ts
@@ -1,8 +1,9 @@
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import { ComponentLoaderStatus } from "../component-loader/component-loader";
 
 export interface DiscordSeriesStatsSnapshot {
   readonly analyticsByMatchId: ReadonlyMap<string, MatchAnalytics>;
-  readonly analyticsLoading: boolean;
+  readonly analyticsStatus: ComponentLoaderStatus;
 }
 
 export class DiscordSeriesStatsStore {
@@ -10,7 +11,7 @@ export class DiscordSeriesStatsStore {
   private readonly subscribers = new Set<() => void>();
 
   constructor() {
-    this.snapshot = { analyticsByMatchId: new Map(), analyticsLoading: true };
+    this.snapshot = { analyticsByMatchId: new Map(), analyticsStatus: ComponentLoaderStatus.LOADING };
   }
 
   subscribe(listener: () => void): () => void {

--- a/pages/src/components/discord-series-stats/discord-series-stats-store.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-store.ts
@@ -2,6 +2,7 @@ import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-
 
 export interface DiscordSeriesStatsSnapshot {
   readonly analyticsByMatchId: ReadonlyMap<string, MatchAnalytics>;
+  readonly analyticsLoading: boolean;
 }
 
 export class DiscordSeriesStatsStore {
@@ -9,7 +10,7 @@ export class DiscordSeriesStatsStore {
   private readonly subscribers = new Set<() => void>();
 
   constructor() {
-    this.snapshot = { analyticsByMatchId: new Map() };
+    this.snapshot = { analyticsByMatchId: new Map(), analyticsLoading: true };
   }
 
   subscribe(listener: () => void): () => void {

--- a/pages/src/components/discord-series-stats/discord-series-stats.tsx
+++ b/pages/src/components/discord-series-stats/discord-series-stats.tsx
@@ -83,7 +83,8 @@ function MatchDetailSection({ detail, contentWidthClass }: MatchDetailSectionPro
           startTime={detail.startTime}
           endTime={detail.endTime}
           teamColors={detail.teamColors}
-          killMatrixRows={detail.killMatrixRows}
+          killMatrixPivotData={detail.killMatrixPivotData}
+          killMatrixLoading={detail.killMatrixLoading}
         />
       ) : (
         <Alert variant="warning">Failed to load detailed stats for match {detail.matchId}.</Alert>
@@ -165,7 +166,8 @@ export function DiscordSeriesStatsView({
               title="Series Totals"
               metadata={seriesStats.metadata}
               teamColors={seriesStats.teamColors}
-              killMatrixRows={seriesStats.killMatrixRows}
+              killMatrixPivotData={seriesStats.killMatrixPivotData}
+              killMatrixLoading={seriesStats.killMatrixLoading}
             />
           </Container>
         )}

--- a/pages/src/components/discord-series-stats/discord-series-stats.tsx
+++ b/pages/src/components/discord-series-stats/discord-series-stats.tsx
@@ -84,7 +84,7 @@ function MatchDetailSection({ detail, contentWidthClass }: MatchDetailSectionPro
           endTime={detail.endTime}
           teamColors={detail.teamColors}
           killMatrixPivotData={detail.killMatrixPivotData}
-          killMatrixLoading={detail.killMatrixLoading}
+          killMatrixStatus={detail.killMatrixStatus}
         />
       ) : (
         <Alert variant="warning">Failed to load detailed stats for match {detail.matchId}.</Alert>
@@ -167,7 +167,7 @@ export function DiscordSeriesStatsView({
               metadata={seriesStats.metadata}
               teamColors={seriesStats.teamColors}
               killMatrixPivotData={seriesStats.killMatrixPivotData}
-              killMatrixLoading={seriesStats.killMatrixLoading}
+              killMatrixStatus={seriesStats.killMatrixStatus}
             />
           </Container>
         )}

--- a/pages/src/components/discord-series-stats/types.ts
+++ b/pages/src/components/discord-series-stats/types.ts
@@ -1,5 +1,5 @@
 import type { MatchStatsData } from "../../controllers/stats/types";
-import type { KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
+import type { KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
 import type { TeamColor } from "../team-colors/team-colors";
 
 export interface DiscordSeriesMatchSummary {
@@ -32,7 +32,8 @@ export interface DiscordSeriesMatchDetail {
   readonly startTime: string;
   readonly endTime: string;
   readonly teamColors: readonly TeamColor[];
-  readonly killMatrixRows: readonly KillMatrixViewRow[];
+  readonly killMatrixPivotData: KillMatrixPivotData;
+  readonly killMatrixLoading: boolean;
 }
 
 interface DiscordSeriesSeriesStats {
@@ -45,7 +46,8 @@ interface DiscordSeriesSeriesStats {
     readonly endTime: string;
   } | null;
   readonly teamColors: readonly TeamColor[];
-  readonly killMatrixRows: readonly KillMatrixViewRow[];
+  readonly killMatrixPivotData: KillMatrixPivotData;
+  readonly killMatrixLoading: boolean;
 }
 
 export interface DiscordSeriesStatsViewModel {

--- a/pages/src/components/discord-series-stats/types.ts
+++ b/pages/src/components/discord-series-stats/types.ts
@@ -1,6 +1,7 @@
 import type { MatchStatsData } from "../../controllers/stats/types";
 import type { KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
 import type { TeamColor } from "../team-colors/team-colors";
+import type { ComponentLoaderStatus } from "../component-loader/component-loader";
 
 export interface DiscordSeriesMatchSummary {
   readonly matchId: string;
@@ -33,7 +34,7 @@ export interface DiscordSeriesMatchDetail {
   readonly endTime: string;
   readonly teamColors: readonly TeamColor[];
   readonly killMatrixPivotData: KillMatrixPivotData;
-  readonly killMatrixLoading: boolean;
+  readonly killMatrixStatus: ComponentLoaderStatus;
 }
 
 interface DiscordSeriesSeriesStats {
@@ -47,7 +48,7 @@ interface DiscordSeriesSeriesStats {
   } | null;
   readonly teamColors: readonly TeamColor[];
   readonly killMatrixPivotData: KillMatrixPivotData;
-  readonly killMatrixLoading: boolean;
+  readonly killMatrixStatus: ComponentLoaderStatus;
 }
 
 export interface DiscordSeriesStatsViewModel {

--- a/pages/src/components/individual-tracker/viewer/stats-panel.tsx
+++ b/pages/src/components/individual-tracker/viewer/stats-panel.tsx
@@ -46,7 +46,7 @@ export function StatsPanel({ state }: StatsPanelProps): React.ReactElement | nul
             score=""
             startTime={state.startTime}
             endTime={state.endTime}
-            killMatrixRows={state.killMatrixRows}
+            killMatrixPivotData={state.killMatrixPivotData}
           />
         </div>
       );

--- a/pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 import { StatsController } from "../../../../controllers/stats/stats-controller";
+import { KillMatrixFormatter } from "../../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import type { MatchStatsPanelState } from "../types";
 import { StatsPanel } from "../stats-panel";
 
@@ -39,7 +40,7 @@ function aLoadedState(
     startTime: stats.MatchInfo.StartTime,
     endTime: stats.MatchInfo.EndTime,
     data: controller.getMatchStats(),
-    killMatrixRows: [],
+    killMatrixPivotData: { tableRows: [], victimGamertags: [] },
     ...overrides,
   };
 }
@@ -99,7 +100,11 @@ describe("StatsPanel", () => {
     );
     controller.loadMatch(stats, playerMap, {});
 
-    render(<StatsPanel state={aLoadedState({ killMatrixRows: controller.getKillMatrix() })} />);
+    render(
+      <StatsPanel
+        state={aLoadedState({ killMatrixPivotData: KillMatrixFormatter.pivot(controller.getKillMatrix()) })}
+      />,
+    );
 
     fireEvent.click(screen.getByRole("tab", { name: "Kill Matrix" }));
 

--- a/pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx
@@ -5,6 +5,8 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 import { StatsController } from "../../../../controllers/stats/stats-controller";
 import { KillMatrixFormatter } from "../../../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import { aFakeMatchAnalyticsWith } from "../../../../controllers/stats/kill-matrix/fakes/match-analytics.fake";
+import { EMPTY_KILL_MATRIX_PIVOT_DATA } from "../../../../controllers/stats/kill-matrix/types";
 import type { MatchStatsPanelState } from "../types";
 import { StatsPanel } from "../stats-panel";
 
@@ -40,7 +42,7 @@ function aLoadedState(
     startTime: stats.MatchInfo.StartTime,
     endTime: stats.MatchInfo.EndTime,
     data: controller.getMatchStats(),
-    killMatrixPivotData: { tableRows: [], victimGamertags: [] },
+    killMatrixPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
     ...overrides,
   };
 }
@@ -81,8 +83,7 @@ describe("StatsPanel", () => {
     ]);
     const controller = new StatsController();
     controller.loadAnalytics(
-      {
-        requestedModules: ["killMatrix"],
+      aFakeMatchAnalyticsWith({
         killMatrix: {
           "1111111111:2222222222": {
             count: 3,
@@ -91,11 +92,7 @@ describe("StatsPanel", () => {
             weapons: [],
           },
         },
-        metadata: {
-          pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 1 },
-          perfectCounts: { total: 0, byXuid: {} },
-        },
-      },
+      }),
       playerMap,
     );
     controller.loadMatch(stats, playerMap, {});

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -3,7 +3,7 @@ import type { TrackerStatus } from "@guilty-spark/shared/contracts/individual-tr
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { TrackerViewConnectionStatus } from "../../../services/individual-tracker/view-types";
 import type { MatchStatsData } from "../../../controllers/stats/types";
-import type { KillMatrixViewRow } from "../../../controllers/stats/kill-matrix/types";
+import type { KillMatrixPivotData } from "../../../controllers/stats/kill-matrix/types";
 import type { MatchStatsState } from "./viewer-store";
 
 export type ViewerTabOutcome = "win" | "loss" | "tie" | "dnf" | "unknown";
@@ -60,7 +60,7 @@ export type MatchStatsPanelState =
       readonly startTime: string;
       readonly endTime: string;
       readonly data: MatchStatsData[];
-      readonly killMatrixRows: readonly KillMatrixViewRow[];
+      readonly killMatrixPivotData: KillMatrixPivotData;
     }
   | { readonly status: "error"; readonly message: string };
 

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../../services/individual-tracker/view-types";
 import { StatsController } from "../../../controllers/stats/stats-controller";
 import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import { EMPTY_KILL_MATRIX_PIVOT_DATA } from "../../../controllers/stats/kill-matrix/types";
 import { buildViewerRenderModel } from "./viewer-render-model";
 import type { IndividualTrackerViewerSnapshot, IndividualTrackerViewerStore, MatchStatsState } from "./viewer-store";
 import type { IndividualTrackerViewerViewModel, MatchStatsPanelState } from "./types";
@@ -68,7 +69,6 @@ export class IndividualTrackerViewerPresenter {
       if (analytics != null) {
         controller.loadAnalytics(analytics, playerMap);
       }
-      const killMatrixRows = analytics != null ? controller.getKillMatrix() : [];
       return {
         status: "loaded",
         matchId: stats.MatchId,
@@ -77,7 +77,8 @@ export class IndividualTrackerViewerPresenter {
         startTime: stats.MatchInfo.StartTime,
         endTime: stats.MatchInfo.EndTime,
         data: controller.getMatchStats(),
-        killMatrixPivotData: KillMatrixFormatter.pivot(killMatrixRows),
+        killMatrixPivotData:
+          analytics != null ? KillMatrixFormatter.pivot(controller.getKillMatrix()) : EMPTY_KILL_MATRIX_PIVOT_DATA,
       };
     } catch {
       return { status: "error", message: "Failed to compute match stats" };

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -8,7 +8,7 @@ import type {
   TrackerViewSubscription,
 } from "../../../services/individual-tracker/view-types";
 import { StatsController } from "../../../controllers/stats/stats-controller";
-import type { KillMatrixViewRow } from "../../../controllers/stats/kill-matrix/types";
+import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { buildViewerRenderModel } from "./viewer-render-model";
 import type { IndividualTrackerViewerSnapshot, IndividualTrackerViewerStore, MatchStatsState } from "./viewer-store";
 import type { IndividualTrackerViewerViewModel, MatchStatsPanelState } from "./types";
@@ -65,11 +65,10 @@ export class IndividualTrackerViewerPresenter {
     try {
       const controller = new StatsController();
       controller.loadMatch(stats, playerMap, medalMetadata);
-      let killMatrixRows: readonly KillMatrixViewRow[] = [];
       if (analytics != null) {
         controller.loadAnalytics(analytics, playerMap);
-        killMatrixRows = controller.getKillMatrix();
       }
+      const killMatrixRows = analytics != null ? controller.getKillMatrix() : [];
       return {
         status: "loaded",
         matchId: stats.MatchId,
@@ -78,7 +77,7 @@ export class IndividualTrackerViewerPresenter {
         startTime: stats.MatchInfo.StartTime,
         endTime: stats.MatchInfo.EndTime,
         data: controller.getMatchStats(),
-        killMatrixRows,
+        killMatrixPivotData: KillMatrixFormatter.pivot(killMatrixRows),
       };
     } catch {
       return { status: "error", message: "Failed to compute match stats" };

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
@@ -18,11 +18,15 @@
 }
 
 .shimmerRow {
+  align-items: center;
   animation: shimmer 1.5s ease-in-out infinite;
   background: linear-gradient(90deg, var(--halo-bg-card) 25%, var(--halo-teal-darker) 50%, var(--halo-bg-card) 75%);
   background-size: 200% 100%;
   border-radius: 4px;
+  display: flex;
+  font-size: var(--text-sm);
   height: 2rem;
+  padding-left: var(--space-2);
   width: 85%;
 }
 

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
@@ -11,31 +11,33 @@
 }
 
 .shimmerContainer {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
+  display: grid;
+  gap: var(--space-1);
+  grid-template-columns: auto repeat(var(--shimmer-cols, 8), minmax(3rem, 1fr));
+  overflow-x: auto;
   padding: var(--space-4) 0;
 }
 
-.shimmerRow {
+.shimmerHeaderCell {
+  color: var(--halo-gray);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-1) var(--space-2);
+}
+
+.shimmerLabelCell {
   align-items: center;
+  display: flex;
+  font-size: var(--text-sm);
+  padding: var(--space-1) var(--space-2);
+}
+
+.shimmerCell {
   animation: shimmer 1.5s ease-in-out infinite;
   background: linear-gradient(90deg, var(--halo-bg-card) 25%, var(--halo-teal-darker) 50%, var(--halo-bg-card) 75%);
   background-size: 200% 100%;
   border-radius: 4px;
-  display: flex;
-  font-size: var(--text-sm);
   height: 2rem;
-  padding-left: var(--space-2);
-  width: 85%;
-}
-
-.shimmerRow:nth-child(3n + 2) {
-  width: 90%;
-}
-
-.shimmerRow:nth-child(3n + 3) {
-  width: 95%;
 }
 
 @keyframes shimmer {

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
@@ -23,6 +23,15 @@
   background-size: 200% 100%;
   border-radius: 4px;
   height: 2rem;
+  width: 85%;
+}
+
+.shimmerRow:nth-child(3n + 2) {
+  width: 90%;
+}
+
+.shimmerRow:nth-child(3n + 3) {
+  width: 95%;
 }
 
 @keyframes shimmer {

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
@@ -2,3 +2,35 @@
   font-variant-numeric: tabular-nums;
   text-align: center;
 }
+
+.victimAxisLabel {
+  color: var(--halo-gray);
+  font-size: var(--text-sm);
+  padding-bottom: var(--space-1);
+  text-align: right;
+}
+
+.shimmerContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4) 0;
+}
+
+.shimmerRow {
+  animation: shimmer 1.5s ease-in-out infinite;
+  background: linear-gradient(90deg, var(--halo-bg-card) 25%, var(--halo-teal-darker) 50%, var(--halo-bg-card) 75%);
+  background-size: 200% 100%;
+  border-radius: 4px;
+  height: 2rem;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% center;
+  }
+
+  100% {
+    background-position: -200% center;
+  }
+}

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -9,14 +9,24 @@ interface KillMatrixTableProps {
   readonly pivotData: KillMatrixPivotData;
   readonly ariaLabel: string;
   readonly emptyMessage: string;
+  readonly loading?: boolean;
+  readonly killerAxisLabel?: string;
+  readonly victimAxisLabel?: string;
 }
 
-export function KillMatrixTable({ pivotData, ariaLabel, emptyMessage }: KillMatrixTableProps): React.ReactElement {
+export function KillMatrixTable({
+  pivotData,
+  ariaLabel,
+  emptyMessage,
+  loading,
+  killerAxisLabel = "Kills",
+  victimAxisLabel = "Deaths",
+}: KillMatrixTableProps): React.ReactElement {
   const columns = React.useMemo<SortableTableColumn<KillMatrixPivotRow>[]>(() => {
     const cols: SortableTableColumn<KillMatrixPivotRow>[] = [
       {
         id: "killer",
-        header: "Killer",
+        header: killerAxisLabel,
         accessorFn: (row): string => row.killerGamertag,
         sortingFn: "alphanumeric",
         cellClassName: tableStyles.labelCell,
@@ -34,18 +44,31 @@ export function KillMatrixTable({ pivotData, ariaLabel, emptyMessage }: KillMatr
     }
 
     return cols;
-  }, [pivotData.victimGamertags]);
+  }, [killerAxisLabel, pivotData.victimGamertags]);
+
+  if (loading === true) {
+    return (
+      <div className={styles.shimmerContainer} aria-busy="true" aria-label={ariaLabel}>
+        {Array.from({ length: 5 }, (_, i) => (
+          <div key={i} className={styles.shimmerRow} style={{ width: `${(85 + (i % 3) * 5).toString()}%` }} />
+        ))}
+      </div>
+    );
+  }
 
   if (pivotData.tableRows.length === 0) {
     return <Alert variant="info">{emptyMessage}</Alert>;
   }
 
   return (
-    <SortableTable
-      data={pivotData.tableRows}
-      columns={columns}
-      getRowKey={(row): string => row.killerId}
-      ariaLabel={ariaLabel}
-    />
+    <div>
+      <div className={styles.victimAxisLabel}>{victimAxisLabel} →</div>
+      <SortableTable
+        data={pivotData.tableRows}
+        columns={columns}
+        getRowKey={(row): string => row.killerId}
+        ariaLabel={ariaLabel}
+      />
+    </div>
   );
 }

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Alert } from "../../alert/alert";
+import { ComponentLoaderStatus } from "../../component-loader/component-loader";
 import { SortableTable, type SortableTableColumn } from "../../table/sortable-table";
 import tableStyles from "../../table/table.module.css";
 import type { KillMatrixPivotData, KillMatrixPivotRow } from "../../../controllers/stats/kill-matrix/types";
@@ -9,20 +10,29 @@ interface KillMatrixTableProps {
   readonly pivotData: KillMatrixPivotData;
   readonly ariaLabel: string;
   readonly emptyMessage: string;
-  readonly loading?: boolean;
+  readonly status?: ComponentLoaderStatus;
   readonly killerAxisLabel?: string;
   readonly victimAxisLabel?: string;
+  readonly playerGamertags?: readonly string[];
 }
 
 export function KillMatrixTable({
   pivotData,
   ariaLabel,
   emptyMessage,
-  loading,
+  status,
   killerAxisLabel = "Killer",
   victimAxisLabel = "Deaths",
+  playerGamertags,
 }: KillMatrixTableProps): React.ReactElement {
+  const isLoading = status === ComponentLoaderStatus.LOADING || status === ComponentLoaderStatus.PENDING;
+  const isError = status === ComponentLoaderStatus.ERROR;
+
   const columns = React.useMemo<SortableTableColumn<KillMatrixPivotRow>[]>(() => {
+    if (isLoading) {
+      return [];
+    }
+
     const cols: SortableTableColumn<KillMatrixPivotRow>[] = [
       {
         id: "killer",
@@ -44,16 +54,26 @@ export function KillMatrixTable({
     }
 
     return cols;
-  }, [killerAxisLabel, pivotData.victimGamertags]);
+  }, [isLoading, killerAxisLabel, pivotData.victimGamertags]);
 
-  if (loading === true) {
+  if (isLoading) {
+    const rowCount = playerGamertags?.length ?? 5;
     return (
       <div className={styles.shimmerContainer} aria-busy="true" aria-label={ariaLabel}>
-        {Array.from({ length: 5 }, (_, i) => (
-          <div key={i} className={styles.shimmerRow} />
-        ))}
+        {Array.from({ length: rowCount }, (_, i) => {
+          const gamertag = playerGamertags?.[i];
+          return (
+            <div key={gamertag ?? i} className={styles.shimmerRow}>
+              {gamertag}
+            </div>
+          );
+        })}
       </div>
     );
+  }
+
+  if (isError) {
+    return <Alert variant="warning">{emptyMessage}</Alert>;
   }
 
   if (pivotData.tableRows.length === 0) {

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -19,7 +19,7 @@ export function KillMatrixTable({
   ariaLabel,
   emptyMessage,
   loading,
-  killerAxisLabel = "Kills",
+  killerAxisLabel = "Killer",
   victimAxisLabel = "Deaths",
 }: KillMatrixTableProps): React.ReactElement {
   const columns = React.useMemo<SortableTableColumn<KillMatrixPivotRow>[]>(() => {

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -65,7 +65,7 @@ export function KillMatrixTable({
         {Array.from({ length: rowCount }, (_, i) => {
           const gamertag = playerGamertags?.[i];
           return (
-            <div key={gamertag ?? i} className={styles.shimmerRow}>
+            <div key={i} className={styles.shimmerRow}>
               {gamertag}
             </div>
           );

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -59,7 +59,7 @@ export function KillMatrixTable({
   }, [isLoading, killerAxisLabel, pivotData.victimGamertags]);
 
   if (isLoading) {
-    const rowCount = playerGamertags !== undefined && playerGamertags.length > 0 ? playerGamertags.length : 5;
+    const rowCount = playerGamertags !== undefined && playerGamertags.length > 0 ? playerGamertags.length : 8;
     return (
       <div role="region" className={styles.shimmerContainer} aria-busy="true" aria-label={ariaLabel}>
         {Array.from({ length: rowCount }, (_, i) => {

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -10,6 +10,7 @@ interface KillMatrixTableProps {
   readonly pivotData: KillMatrixPivotData;
   readonly ariaLabel: string;
   readonly emptyMessage: string;
+  readonly errorMessage?: string;
   readonly status?: ComponentLoaderStatus;
   readonly killerAxisLabel?: string;
   readonly victimAxisLabel?: string;
@@ -20,6 +21,7 @@ export function KillMatrixTable({
   pivotData,
   ariaLabel,
   emptyMessage,
+  errorMessage,
   status,
   killerAxisLabel = "Killer",
   victimAxisLabel = "Deaths",
@@ -59,7 +61,7 @@ export function KillMatrixTable({
   if (isLoading) {
     const rowCount = playerGamertags?.length ?? 5;
     return (
-      <div className={styles.shimmerContainer} aria-busy="true" aria-label={ariaLabel}>
+      <div role="region" className={styles.shimmerContainer} aria-busy="true" aria-label={ariaLabel}>
         {Array.from({ length: rowCount }, (_, i) => {
           const gamertag = playerGamertags?.[i];
           return (
@@ -73,7 +75,7 @@ export function KillMatrixTable({
   }
 
   if (isError) {
-    return <Alert variant="warning">{emptyMessage}</Alert>;
+    return <Alert variant="warning">{errorMessage ?? emptyMessage}</Alert>;
   }
 
   if (pivotData.tableRows.length === 0) {

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -50,7 +50,7 @@ export function KillMatrixTable({
     return (
       <div className={styles.shimmerContainer} aria-busy="true" aria-label={ariaLabel}>
         {Array.from({ length: 5 }, (_, i) => (
-          <div key={i} className={styles.shimmerRow} style={{ width: `${(85 + (i % 3) * 5).toString()}%` }} />
+          <div key={i} className={styles.shimmerRow} />
         ))}
       </div>
     );

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -59,7 +59,7 @@ export function KillMatrixTable({
   }, [isLoading, killerAxisLabel, pivotData.victimGamertags]);
 
   if (isLoading) {
-    const rowCount = playerGamertags?.length ?? 5;
+    const rowCount = playerGamertags !== undefined && playerGamertags.length > 0 ? playerGamertags.length : 5;
     return (
       <div role="region" className={styles.shimmerContainer} aria-busy="true" aria-label={ariaLabel}>
         {Array.from({ length: rowCount }, (_, i) => {

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Alert } from "../../alert/alert";
-import { ComponentLoaderStatus } from "../../component-loader/component-loader";
+import { ComponentLoader, ComponentLoaderStatus } from "../../component-loader/component-loader";
 import { SortableTable, type SortableTableColumn } from "../../table/sortable-table";
 import tableStyles from "../../table/table.module.css";
 import type { KillMatrixPivotData, KillMatrixPivotRow } from "../../../controllers/stats/kill-matrix/types";
@@ -27,11 +27,10 @@ export function KillMatrixTable({
   victimAxisLabel = "Deaths",
   playerGamertags,
 }: KillMatrixTableProps): React.ReactElement {
-  const isLoading = status === ComponentLoaderStatus.LOADING || status === ComponentLoaderStatus.PENDING;
-  const isError = status === ComponentLoaderStatus.ERROR;
+  const effectiveStatus = status ?? ComponentLoaderStatus.LOADED;
 
   const columns = React.useMemo<SortableTableColumn<KillMatrixPivotRow>[]>(() => {
-    if (isLoading) {
+    if (effectiveStatus !== ComponentLoaderStatus.LOADED) {
       return [];
     }
 
@@ -56,41 +55,56 @@ export function KillMatrixTable({
     }
 
     return cols;
-  }, [isLoading, killerAxisLabel, pivotData.victimGamertags]);
+  }, [effectiveStatus, killerAxisLabel, pivotData.victimGamertags]);
 
-  if (isLoading) {
-    const rowCount = playerGamertags !== undefined && playerGamertags.length > 0 ? playerGamertags.length : 8;
-    return (
-      <div role="region" className={styles.shimmerContainer} aria-busy="true" aria-label={ariaLabel}>
-        {Array.from({ length: rowCount }, (_, i) => {
-          const gamertag = playerGamertags?.[i];
-          return (
-            <div key={i} className={styles.shimmerRow}>
-              {gamertag}
-            </div>
-          );
-        })}
+  const playerCount = playerGamertags !== undefined && playerGamertags.length > 0 ? playerGamertags.length : 8;
+
+  const shimmer = (
+    <div
+      role="region"
+      className={styles.shimmerContainer}
+      style={{ "--shimmer-cols": playerCount } as React.CSSProperties}
+      aria-busy="true"
+      aria-label={ariaLabel}
+    >
+      <div className={styles.shimmerHeaderCell}>{killerAxisLabel}</div>
+      {Array.from({ length: playerCount }, (_, i) => (
+        <div key={i} className={styles.shimmerHeaderCell}>
+          {playerGamertags?.[i]}
+        </div>
+      ))}
+      {Array.from({ length: playerCount }, (_, row) => (
+        <React.Fragment key={row}>
+          <div className={styles.shimmerLabelCell}>{playerGamertags?.[row]}</div>
+          {Array.from({ length: playerCount }, (_col, col) => (
+            <div key={col} className={styles.shimmerCell} />
+          ))}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+
+  const loaded =
+    pivotData.tableRows.length === 0 ? (
+      <Alert variant="info">{emptyMessage}</Alert>
+    ) : (
+      <div>
+        <div className={styles.victimAxisLabel}>{victimAxisLabel} →</div>
+        <SortableTable
+          data={pivotData.tableRows}
+          columns={columns}
+          getRowKey={(row): string => row.killerId}
+          ariaLabel={ariaLabel}
+        />
       </div>
     );
-  }
-
-  if (isError) {
-    return <Alert variant="warning">{errorMessage ?? emptyMessage}</Alert>;
-  }
-
-  if (pivotData.tableRows.length === 0) {
-    return <Alert variant="info">{emptyMessage}</Alert>;
-  }
 
   return (
-    <div>
-      <div className={styles.victimAxisLabel}>{victimAxisLabel} →</div>
-      <SortableTable
-        data={pivotData.tableRows}
-        columns={columns}
-        getRowKey={(row): string => row.killerId}
-        ariaLabel={ariaLabel}
-      />
-    </div>
+    <ComponentLoader
+      status={effectiveStatus}
+      loading={shimmer}
+      error={<Alert variant="warning">{errorMessage ?? emptyMessage}</Alert>}
+      loaded={loaded}
+    />
   );
 }

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -61,7 +61,7 @@ describe("KillMatrixTable", () => {
     expect(screen.queryByText("No kill matrix data.")).not.toBeInTheDocument();
   });
 
-  it("shows 8 shimmer rows when playerGamertags is an empty array", () => {
+  it("shows NxN shimmer grid using default 8 players when playerGamertags is an empty array", () => {
     render(
       <KillMatrixTable
         pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
@@ -74,10 +74,11 @@ describe("KillMatrixTable", () => {
 
     const shimmer = screen.getByRole("region", { name: "Kill matrix" });
     expect(shimmer).toHaveAttribute("aria-busy", "true");
-    expect(shimmer.children).toHaveLength(8);
+    // (N+1)^2 cells: 1 killer header + N victim headers + N rows × (1 label + N cells)
+    expect(shimmer.children).toHaveLength(81);
   });
 
-  it("shows shimmer rows using playerGamertags when provided", () => {
+  it("shows NxN shimmer grid using playerGamertags when provided", () => {
     render(
       <KillMatrixTable
         pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
@@ -90,9 +91,11 @@ describe("KillMatrixTable", () => {
 
     const shimmer = screen.getByRole("region", { name: "Kill matrix" });
     expect(shimmer).toHaveAttribute("aria-busy", "true");
-    expect(screen.getByText("Alpha")).toBeInTheDocument();
-    expect(screen.getByText("Bravo")).toBeInTheDocument();
-    expect(screen.getByText("Charlie")).toBeInTheDocument();
+    // 3 players: (3+1)^2 = 16 cells; each name appears in header row + row label
+    expect(shimmer.children).toHaveLength(16);
+    expect(screen.getAllByText("Alpha")).toHaveLength(2);
+    expect(screen.getAllByText("Bravo")).toHaveLength(2);
+    expect(screen.getAllByText("Charlie")).toHaveLength(2);
   });
 
   it("shows emptyMessage when status is error and no errorMessage is provided", () => {

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -74,7 +74,7 @@ describe("KillMatrixTable", () => {
 
     const shimmer = screen.getByRole("region", { name: "Kill matrix" });
     expect(shimmer).toHaveAttribute("aria-busy", "true");
-    expect(shimmer.children).toHaveLength(5);
+    expect(shimmer.children).toHaveLength(8);
   });
 
   it("shows shimmer rows using playerGamertags when provided", () => {

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom/vitest";
 
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
+import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import { KillMatrixFormatter } from "../../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { EMPTY_KILL_MATRIX_PIVOT_DATA } from "../../../../controllers/stats/kill-matrix/types";
 import { KillMatrixTable } from "../kill-matrix-table";
@@ -45,13 +46,13 @@ describe("KillMatrixTable", () => {
     expect(screen.getByText("Deaths →")).toBeInTheDocument();
   });
 
-  it("shows shimmer skeleton when loading", () => {
+  it("shows shimmer skeleton when status is loading", () => {
     render(
       <KillMatrixTable
         pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
         ariaLabel="Kill matrix"
         emptyMessage="No kill matrix data."
-        loading={true}
+        status={ComponentLoaderStatus.LOADING}
       />,
     );
 
@@ -59,13 +60,43 @@ describe("KillMatrixTable", () => {
     expect(screen.queryByText("No kill matrix data.")).not.toBeInTheDocument();
   });
 
-  it("shows empty message when not loading and no data", () => {
+  it("shows shimmer rows using playerGamertags when provided", () => {
     render(
       <KillMatrixTable
         pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
         ariaLabel="Kill matrix"
         emptyMessage="No kill matrix data."
-        loading={false}
+        status={ComponentLoaderStatus.LOADING}
+        playerGamertags={["Alpha", "Bravo", "Charlie"]}
+      />,
+    );
+
+    expect(screen.getByLabelText("Kill matrix")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Bravo")).toBeInTheDocument();
+    expect(screen.getByText("Charlie")).toBeInTheDocument();
+  });
+
+  it("shows error message when status is error", () => {
+    render(
+      <KillMatrixTable
+        pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
+        ariaLabel="Kill matrix"
+        emptyMessage="Kill matrix data is not available."
+        status={ComponentLoaderStatus.ERROR}
+      />,
+    );
+
+    expect(screen.getByText("Kill matrix data is not available.")).toBeInTheDocument();
+  });
+
+  it("shows empty message when status is loaded and no data", () => {
+    render(
+      <KillMatrixTable
+        pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
+        ariaLabel="Kill matrix"
+        emptyMessage="No kill matrix data."
+        status={ComponentLoaderStatus.LOADED}
       />,
     );
 

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -56,7 +56,8 @@ describe("KillMatrixTable", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Kill matrix")).toHaveAttribute("aria-busy", "true");
+    const shimmer = screen.getByRole("region", { name: "Kill matrix" });
+    expect(shimmer).toHaveAttribute("aria-busy", "true");
     expect(screen.queryByText("No kill matrix data.")).not.toBeInTheDocument();
   });
 
@@ -71,13 +72,14 @@ describe("KillMatrixTable", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Kill matrix")).toHaveAttribute("aria-busy", "true");
+    const shimmer = screen.getByRole("region", { name: "Kill matrix" });
+    expect(shimmer).toHaveAttribute("aria-busy", "true");
     expect(screen.getByText("Alpha")).toBeInTheDocument();
     expect(screen.getByText("Bravo")).toBeInTheDocument();
     expect(screen.getByText("Charlie")).toBeInTheDocument();
   });
 
-  it("shows error message when status is error", () => {
+  it("shows emptyMessage when status is error and no errorMessage is provided", () => {
     render(
       <KillMatrixTable
         pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
@@ -88,6 +90,21 @@ describe("KillMatrixTable", () => {
     );
 
     expect(screen.getByText("Kill matrix data is not available.")).toBeInTheDocument();
+  });
+
+  it("shows errorMessage instead of emptyMessage when status is error and errorMessage is provided", () => {
+    render(
+      <KillMatrixTable
+        pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
+        ariaLabel="Kill matrix"
+        emptyMessage="Kill matrix data is not available."
+        errorMessage="Failed to load kill matrix data."
+        status={ComponentLoaderStatus.ERROR}
+      />,
+    );
+
+    expect(screen.getByText("Failed to load kill matrix data.")).toBeInTheDocument();
+    expect(screen.queryByText("Kill matrix data is not available.")).not.toBeInTheDocument();
   });
 
   it("shows empty message when status is loaded and no data", () => {

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -22,7 +22,7 @@ describe("KillMatrixTable", () => {
     expect(screen.getByText("No kill matrix data.")).toBeInTheDocument();
   });
 
-  it("renders rows when data exists", () => {
+  it("renders rows when data exists with axis labels", () => {
     const pivotData = KillMatrixFormatter.pivot([
       {
         key: "111:222",
@@ -40,5 +40,34 @@ describe("KillMatrixTable", () => {
     expect(screen.getByLabelText("Kill matrix")).toBeInTheDocument();
     expect(screen.getByText("Alpha")).toBeInTheDocument();
     expect(screen.getByText("Bravo")).toBeInTheDocument();
+    expect(screen.getByText("Kills")).toBeInTheDocument();
+    expect(screen.getByText("Deaths →")).toBeInTheDocument();
+  });
+
+  it("shows shimmer skeleton when loading", () => {
+    render(
+      <KillMatrixTable
+        pivotData={{ tableRows: [], victimGamertags: [] }}
+        ariaLabel="Kill matrix"
+        emptyMessage="No kill matrix data."
+        loading={true}
+      />,
+    );
+
+    expect(screen.getByLabelText("Kill matrix")).toHaveAttribute("aria-busy", "true");
+    expect(screen.queryByText("No kill matrix data.")).not.toBeInTheDocument();
+  });
+
+  it("shows empty message when not loading and no data", () => {
+    render(
+      <KillMatrixTable
+        pivotData={{ tableRows: [], victimGamertags: [] }}
+        ariaLabel="Kill matrix"
+        emptyMessage="No kill matrix data."
+        loading={false}
+      />,
+    );
+
+    expect(screen.getByText("No kill matrix data.")).toBeInTheDocument();
   });
 });

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -40,7 +40,7 @@ describe("KillMatrixTable", () => {
     expect(screen.getByLabelText("Kill matrix")).toBeInTheDocument();
     expect(screen.getByText("Alpha")).toBeInTheDocument();
     expect(screen.getByText("Bravo")).toBeInTheDocument();
-    expect(screen.getByText("Kills")).toBeInTheDocument();
+    expect(screen.getByText("Killer")).toBeInTheDocument();
     expect(screen.getByText("Deaths →")).toBeInTheDocument();
   });
 

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -61,6 +61,22 @@ describe("KillMatrixTable", () => {
     expect(screen.queryByText("No kill matrix data.")).not.toBeInTheDocument();
   });
 
+  it("shows 5 shimmer rows when playerGamertags is an empty array", () => {
+    render(
+      <KillMatrixTable
+        pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
+        ariaLabel="Kill matrix"
+        emptyMessage="No kill matrix data."
+        status={ComponentLoaderStatus.LOADING}
+        playerGamertags={[]}
+      />,
+    );
+
+    const shimmer = screen.getByRole("region", { name: "Kill matrix" });
+    expect(shimmer).toHaveAttribute("aria-busy", "true");
+    expect(shimmer.children).toHaveLength(5);
+  });
+
   it("shows shimmer rows using playerGamertags when provided", () => {
     render(
       <KillMatrixTable

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -61,7 +61,7 @@ describe("KillMatrixTable", () => {
     expect(screen.queryByText("No kill matrix data.")).not.toBeInTheDocument();
   });
 
-  it("shows 5 shimmer rows when playerGamertags is an empty array", () => {
+  it("shows 8 shimmer rows when playerGamertags is an empty array", () => {
     render(
       <KillMatrixTable
         pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { KillMatrixFormatter } from "../../../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import { EMPTY_KILL_MATRIX_PIVOT_DATA } from "../../../../controllers/stats/kill-matrix/types";
 import { KillMatrixTable } from "../kill-matrix-table";
 
 describe("KillMatrixTable", () => {
@@ -47,7 +48,7 @@ describe("KillMatrixTable", () => {
   it("shows shimmer skeleton when loading", () => {
     render(
       <KillMatrixTable
-        pivotData={{ tableRows: [], victimGamertags: [] }}
+        pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
         ariaLabel="Kill matrix"
         emptyMessage="No kill matrix data."
         loading={true}
@@ -61,7 +62,7 @@ describe("KillMatrixTable", () => {
   it("shows empty message when not loading and no data", () => {
     render(
       <KillMatrixTable
-        pivotData={{ tableRows: [], victimGamertags: [] }}
+        pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
         ariaLabel="Kill matrix"
         emptyMessage="No kill matrix data."
         loading={false}

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -275,6 +275,7 @@ export function MatchStats({
                 pivotData={killMatrixPivotData ?? EMPTY_KILL_MATRIX_PIVOT_DATA}
                 ariaLabel="Match kill matrix"
                 emptyMessage="Kill matrix data is not available for this match yet."
+                errorMessage="Failed to load kill matrix data for this match."
                 status={killMatrixStatus}
                 playerGamertags={playerGamertags}
               />

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -8,7 +8,7 @@ import { TeamIcon } from "../icons/team-icon";
 import { MedalIcon } from "../icons/medal-icon";
 import type { TeamColor } from "../team-colors/team-colors";
 import { Container } from "../container/container";
-import type { KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
+import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
 import type { MatchStatsData, MatchStatsPlayerData } from "../../controllers/stats/types";
 import { sortByMedals, getTeamMedalsMap, getPlayerMedalsMap } from "../../controllers/stats/medals-sorting";
 import { KillMatrixTable } from "./kill-matrix/kill-matrix-table";
@@ -269,7 +269,7 @@ export function MatchStats({
             label: "Kill Matrix",
             content: (
               <KillMatrixTable
-                pivotData={killMatrixPivotData ?? { tableRows: [], victimGamertags: [] }}
+                pivotData={killMatrixPivotData ?? EMPTY_KILL_MATRIX_PIVOT_DATA}
                 loading={killMatrixLoading}
                 ariaLabel="Match kill matrix"
                 emptyMessage="Kill matrix data is not available for this match yet."

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -1,6 +1,7 @@
 import type { MatchStats } from "halo-infinite-api";
 import React from "react";
 import classNames from "classnames";
+import type { ComponentLoaderStatus } from "../component-loader/component-loader";
 import { SortableTable, type SortableTableColumn } from "../table/sortable-table";
 import tableStyles from "../table/table.module.css";
 import { TabbedSection } from "../tabbed-section/tabbed-section";
@@ -28,7 +29,7 @@ interface MatchStatsProps {
   readonly endTime: string;
   readonly teamColors?: readonly TeamColor[];
   readonly killMatrixPivotData?: KillMatrixPivotData;
-  readonly killMatrixLoading?: boolean;
+  readonly killMatrixStatus?: ComponentLoaderStatus;
 }
 
 type MatchStatsRow = MatchStatsData & { player: MatchStatsPlayerData };
@@ -47,7 +48,7 @@ export function MatchStats({
   endTime,
   teamColors,
   killMatrixPivotData,
-  killMatrixLoading,
+  killMatrixStatus,
 }: MatchStatsProps): React.ReactElement {
   const [activeTab, setActiveTab] = React.useState<"players" | "kill-matrix">("players");
   const hasTeamStats = data.length > 0 && data[0].teamStats.length > 0;
@@ -173,6 +174,8 @@ export function MatchStats({
     ];
   }, [data]);
 
+  const playerGamertags = React.useMemo(() => data.flatMap((d) => d.players).map((p) => p.name), [data]);
+
   // Flatten player data for table
   const playerData = React.useMemo(
     () =>
@@ -270,9 +273,10 @@ export function MatchStats({
             content: (
               <KillMatrixTable
                 pivotData={killMatrixPivotData ?? EMPTY_KILL_MATRIX_PIVOT_DATA}
-                loading={killMatrixLoading}
                 ariaLabel="Match kill matrix"
                 emptyMessage="Kill matrix data is not available for this match yet."
+                status={killMatrixStatus}
+                playerGamertags={playerGamertags}
               />
             ),
           },

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -8,8 +8,7 @@ import { TeamIcon } from "../icons/team-icon";
 import { MedalIcon } from "../icons/medal-icon";
 import type { TeamColor } from "../team-colors/team-colors";
 import { Container } from "../container/container";
-import type { KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
-import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import type { KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
 import type { MatchStatsData, MatchStatsPlayerData } from "../../controllers/stats/types";
 import { sortByMedals, getTeamMedalsMap, getPlayerMedalsMap } from "../../controllers/stats/medals-sorting";
 import { KillMatrixTable } from "./kill-matrix/kill-matrix-table";
@@ -28,7 +27,8 @@ interface MatchStatsProps {
   readonly startTime: string;
   readonly endTime: string;
   readonly teamColors?: readonly TeamColor[];
-  readonly killMatrixRows?: readonly KillMatrixViewRow[];
+  readonly killMatrixPivotData?: KillMatrixPivotData;
+  readonly killMatrixLoading?: boolean;
 }
 
 type MatchStatsRow = MatchStatsData & { player: MatchStatsPlayerData };
@@ -46,7 +46,8 @@ export function MatchStats({
   startTime,
   endTime,
   teamColors,
-  killMatrixRows,
+  killMatrixPivotData,
+  killMatrixLoading,
 }: MatchStatsProps): React.ReactElement {
   const [activeTab, setActiveTab] = React.useState<"players" | "kill-matrix">("players");
   const hasTeamStats = data.length > 0 && data[0].teamStats.length > 0;
@@ -268,7 +269,8 @@ export function MatchStats({
             label: "Kill Matrix",
             content: (
               <KillMatrixTable
-                pivotData={KillMatrixFormatter.pivot(killMatrixRows ?? [])}
+                pivotData={killMatrixPivotData ?? { tableRows: [], victimGamertags: [] }}
+                loading={killMatrixLoading}
                 ariaLabel="Match kill matrix"
                 emptyMessage="Kill matrix data is not available for this match yet."
               />

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -7,7 +7,7 @@ import { TeamIcon } from "../icons/team-icon";
 import { MedalIcon } from "../icons/medal-icon";
 import type { TeamColor } from "../team-colors/team-colors";
 import { Container } from "../container/container";
-import type { KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
+import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
 import type { MatchStatsData, MatchStatsPlayerData } from "../../controllers/stats/types";
 import type { SeriesMetadata } from "../../controllers/stats/series-metadata";
 import { sortByMedals, getTeamMedalsMap, getPlayerMedalsMap } from "../../controllers/stats/medals-sorting";
@@ -260,7 +260,7 @@ export function SeriesStats({
               label: "Kill Matrix",
               content: (
                 <KillMatrixTable
-                  pivotData={killMatrixPivotData ?? { tableRows: [], victimGamertags: [] }}
+                  pivotData={killMatrixPivotData ?? EMPTY_KILL_MATRIX_PIVOT_DATA}
                   loading={killMatrixLoading}
                   ariaLabel="Series kill matrix"
                   emptyMessage="Kill matrix data is not available for this series yet."

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -7,8 +7,7 @@ import { TeamIcon } from "../icons/team-icon";
 import { MedalIcon } from "../icons/medal-icon";
 import type { TeamColor } from "../team-colors/team-colors";
 import { Container } from "../container/container";
-import type { KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
-import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import type { KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
 import type { MatchStatsData, MatchStatsPlayerData } from "../../controllers/stats/types";
 import type { SeriesMetadata } from "../../controllers/stats/series-metadata";
 import { sortByMedals, getTeamMedalsMap, getPlayerMedalsMap } from "../../controllers/stats/medals-sorting";
@@ -21,7 +20,8 @@ interface SeriesStatsProps {
   readonly title: string;
   readonly metadata: SeriesMetadata | null;
   readonly teamColors?: readonly TeamColor[];
-  readonly killMatrixRows?: readonly KillMatrixViewRow[];
+  readonly killMatrixPivotData?: KillMatrixPivotData;
+  readonly killMatrixLoading?: boolean;
 }
 
 type MatchStatsRow = MatchStatsData & { player: MatchStatsPlayerData };
@@ -32,7 +32,8 @@ export function SeriesStats({
   title,
   metadata,
   teamColors,
-  killMatrixRows,
+  killMatrixPivotData,
+  killMatrixLoading,
 }: SeriesStatsProps): React.ReactElement {
   const [activeTab, setActiveTab] = React.useState<"accumulated" | "kill-matrix">("accumulated");
   const hasTeamStats = teamData.length > 0 && teamData[0].teamStats.length > 0;
@@ -259,7 +260,8 @@ export function SeriesStats({
               label: "Kill Matrix",
               content: (
                 <KillMatrixTable
-                  pivotData={KillMatrixFormatter.pivot(killMatrixRows ?? [])}
+                  pivotData={killMatrixPivotData ?? { tableRows: [], victimGamertags: [] }}
+                  loading={killMatrixLoading}
                   ariaLabel="Series kill matrix"
                   emptyMessage="Kill matrix data is not available for this series yet."
                 />

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -266,6 +266,7 @@ export function SeriesStats({
                   pivotData={killMatrixPivotData ?? EMPTY_KILL_MATRIX_PIVOT_DATA}
                   ariaLabel="Series kill matrix"
                   emptyMessage="Kill matrix data is not available for this series yet."
+                  errorMessage="Failed to load kill matrix data for this series."
                   status={killMatrixStatus}
                   playerGamertags={playerGamertags}
                 />

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import classNames from "classnames";
+import type { ComponentLoaderStatus } from "../component-loader/component-loader";
 import { SortableTable, type SortableTableColumn } from "../table/sortable-table";
 import tableStyles from "../table/table.module.css";
 import { TabbedSection } from "../tabbed-section/tabbed-section";
@@ -21,7 +22,7 @@ interface SeriesStatsProps {
   readonly metadata: SeriesMetadata | null;
   readonly teamColors?: readonly TeamColor[];
   readonly killMatrixPivotData?: KillMatrixPivotData;
-  readonly killMatrixLoading?: boolean;
+  readonly killMatrixStatus?: ComponentLoaderStatus;
 }
 
 type MatchStatsRow = MatchStatsData & { player: MatchStatsPlayerData };
@@ -33,7 +34,7 @@ export function SeriesStats({
   metadata,
   teamColors,
   killMatrixPivotData,
-  killMatrixLoading,
+  killMatrixStatus,
 }: SeriesStatsProps): React.ReactElement {
   const [activeTab, setActiveTab] = React.useState<"accumulated" | "kill-matrix">("accumulated");
   const hasTeamStats = teamData.length > 0 && teamData[0].teamStats.length > 0;
@@ -164,6 +165,8 @@ export function SeriesStats({
     ];
   }, [playerData, hasPlayerStats]);
 
+  const playerGamertags = React.useMemo(() => playerData.flatMap((d) => d.players).map((p) => p.name), [playerData]);
+
   // Flatten player data for table
   const flattenedPlayerData = React.useMemo<MatchStatsRow[]>(
     () =>
@@ -261,9 +264,10 @@ export function SeriesStats({
               content: (
                 <KillMatrixTable
                   pivotData={killMatrixPivotData ?? EMPTY_KILL_MATRIX_PIVOT_DATA}
-                  loading={killMatrixLoading}
                   ariaLabel="Series kill matrix"
                   emptyMessage="Kill matrix data is not available for this series yet."
+                  status={killMatrixStatus}
+                  playerGamertags={playerGamertags}
                 />
               ),
             },

--- a/pages/src/controllers/stats/kill-matrix/types.ts
+++ b/pages/src/controllers/stats/kill-matrix/types.ts
@@ -13,6 +13,8 @@ export interface KillMatrixPivotData {
   readonly victimGamertags: readonly string[];
 }
 
+export const EMPTY_KILL_MATRIX_PIVOT_DATA: KillMatrixPivotData = { tableRows: [], victimGamertags: [] };
+
 export interface KillMatrixPlayer {
   readonly xuid: string;
   readonly gamertag: string;


### PR DESCRIPTION
## Summary

- Moves \`KillMatrixFormatter.pivot()\` calls out of view components (\`SeriesStats\`, \`MatchStats\`) into presenters (\`DiscordSeriesStatsPresenter\`, \`ViewerPresenter\`), following the SPC pattern where presenters own business logic
- Adds a loading shimmer skeleton to \`KillMatrixTable\` — 8 rows by default (matching a typical 4v4), or exactly the player count when \`playerGamertags\` is provided — with \`role="region"\`, \`aria-busy="true"\`, and CSS nth-child width variation
- Adds \`killerAxisLabel\`/\`victimAxisLabel\` props to \`KillMatrixTable\` (defaults: \`"Killer"\`/\`"Deaths"\`) with the victim axis rendered as \`"Deaths →"\` above the table
- Adds \`status\` prop (\`ComponentLoaderStatus\`) to \`KillMatrixTable\`, replacing the old \`loading: boolean\`; \`PENDING\` and \`LOADING\` both show the shimmer, \`ERROR\` shows the \`errorMessage\`, \`LOADED\` shows data or empty state
- Adds separate \`errorMessage\` prop to \`KillMatrixTable\` so fetch failures and no-data states can show distinct copy; falls back to \`emptyMessage\` when not provided
- Initialises \`DiscordSeriesStatsStore.analyticsStatus\` to \`PENDING\` (not \`LOADING\`) since loading hasn't started until \`presenter.start()\` runs
- Exports \`EMPTY_KILL_MATRIX_PIVOT_DATA\` from \`kill-matrix/types.ts\` to replace three identical inline literals

## Test plan

- [ ] \`kill-matrix-table.test.tsx\` — shimmer renders with \`role="region"\` and \`aria-busy="true"\`; empty array falls back to 8-row skeleton; named gamertags shown in shimmer rows; error state uses \`errorMessage\` over \`emptyMessage\`; axis labels present
- [ ] \`stats-panel.test.tsx\` — \`killMatrixPivotData\` passed through correctly
- [ ] \`discord-series-stats/tests/create.test.tsx\` — presenter integration
- [ ] All changed-file tests pass via \`npm run done\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)