### PR TITLE
feat(kill-matrix): add pivot toggle button to swap kills/deaths axis

### DIFF
--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -207,7 +207,8 @@ export class DiscordSeriesStatsPresenter {
         endTime: match.endTime,
         teamColors,
         killMatrixPivotData: rows != null ? KillMatrixFormatter.pivot(rows) : EMPTY_KILL_MATRIX_PIVOT_DATA,
-        transposedKillMatrixPivotData: rows != null ? KillMatrixFormatter.transpose(rows) : EMPTY_KILL_MATRIX_PIVOT_DATA,
+        transposedKillMatrixPivotData:
+          rows != null ? KillMatrixFormatter.transpose(rows) : EMPTY_KILL_MATRIX_PIVOT_DATA,
         killMatrixStatus: snapshot.analyticsStatus,
       };
       if (!isMatchStats(match.rawMatch)) {

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -207,6 +207,7 @@ export class DiscordSeriesStatsPresenter {
         endTime: match.endTime,
         teamColors,
         killMatrixPivotData: rows != null ? KillMatrixFormatter.pivot(rows) : EMPTY_KILL_MATRIX_PIVOT_DATA,
+        transposedKillMatrixPivotData: rows != null ? KillMatrixFormatter.transpose(rows) : EMPTY_KILL_MATRIX_PIVOT_DATA,
         killMatrixStatus: snapshot.analyticsStatus,
       };
       if (!isMatchStats(match.rawMatch)) {
@@ -222,6 +223,9 @@ export class DiscordSeriesStatsPresenter {
       }
     });
 
+    const aggregatedKillMatrixRows = KillMatrixFormatter.aggregate(
+      [...matchKillMatrixRows.values()].flatMap((rows) => rows),
+    );
     const seriesStats: DiscordSeriesStatsViewModel["seriesStats"] =
       seriesData != null
         ? {
@@ -229,9 +233,8 @@ export class DiscordSeriesStatsPresenter {
             playerData: seriesData.playerData,
             metadata: calculateSeriesMetadata(this.renderData.matches, this.renderData.seriesScore),
             teamColors,
-            killMatrixPivotData: KillMatrixFormatter.pivot(
-              KillMatrixFormatter.aggregate([...matchKillMatrixRows.values()].flatMap((rows) => rows)),
-            ),
+            killMatrixPivotData: KillMatrixFormatter.pivot(aggregatedKillMatrixRows),
+            transposedKillMatrixPivotData: KillMatrixFormatter.transpose(aggregatedKillMatrixRows),
             killMatrixStatus: snapshot.analyticsStatus,
           }
         : null;

--- a/pages/src/components/discord-series-stats/discord-series-stats.tsx
+++ b/pages/src/components/discord-series-stats/discord-series-stats.tsx
@@ -84,6 +84,7 @@ function MatchDetailSection({ detail, contentWidthClass }: MatchDetailSectionPro
           endTime={detail.endTime}
           teamColors={detail.teamColors}
           killMatrixPivotData={detail.killMatrixPivotData}
+          transposedKillMatrixPivotData={detail.transposedKillMatrixPivotData}
           killMatrixStatus={detail.killMatrixStatus}
         />
       ) : (
@@ -167,6 +168,7 @@ export function DiscordSeriesStatsView({
               metadata={seriesStats.metadata}
               teamColors={seriesStats.teamColors}
               killMatrixPivotData={seriesStats.killMatrixPivotData}
+              transposedKillMatrixPivotData={seriesStats.transposedKillMatrixPivotData}
               killMatrixStatus={seriesStats.killMatrixStatus}
             />
           </Container>

--- a/pages/src/components/discord-series-stats/types.ts
+++ b/pages/src/components/discord-series-stats/types.ts
@@ -34,6 +34,7 @@ export interface DiscordSeriesMatchDetail {
   readonly endTime: string;
   readonly teamColors: readonly TeamColor[];
   readonly killMatrixPivotData: KillMatrixPivotData;
+  readonly transposedKillMatrixPivotData: KillMatrixPivotData;
   readonly killMatrixStatus: ComponentLoaderStatus;
 }
 
@@ -48,6 +49,7 @@ interface DiscordSeriesSeriesStats {
   } | null;
   readonly teamColors: readonly TeamColor[];
   readonly killMatrixPivotData: KillMatrixPivotData;
+  readonly transposedKillMatrixPivotData: KillMatrixPivotData;
   readonly killMatrixStatus: ComponentLoaderStatus;
 }
 

--- a/pages/src/components/individual-tracker/viewer/stats-panel.tsx
+++ b/pages/src/components/individual-tracker/viewer/stats-panel.tsx
@@ -47,6 +47,7 @@ export function StatsPanel({ state }: StatsPanelProps): React.ReactElement | nul
             startTime={state.startTime}
             endTime={state.endTime}
             killMatrixPivotData={state.killMatrixPivotData}
+            transposedKillMatrixPivotData={state.transposedKillMatrixPivotData}
           />
         </div>
       );

--- a/pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/stats-panel.test.tsx
@@ -43,6 +43,7 @@ function aLoadedState(
     endTime: stats.MatchInfo.EndTime,
     data: controller.getMatchStats(),
     killMatrixPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
+    transposedKillMatrixPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
     ...overrides,
   };
 }

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -61,6 +61,7 @@ export type MatchStatsPanelState =
       readonly endTime: string;
       readonly data: MatchStatsData[];
       readonly killMatrixPivotData: KillMatrixPivotData;
+      readonly transposedKillMatrixPivotData: KillMatrixPivotData;
     }
   | { readonly status: "error"; readonly message: string };
 

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -69,6 +69,7 @@ export class IndividualTrackerViewerPresenter {
       if (analytics != null) {
         controller.loadAnalytics(analytics, playerMap);
       }
+      const killMatrixRows = analytics != null ? controller.getKillMatrix() : null;
       return {
         status: "loaded",
         matchId: stats.MatchId,
@@ -78,7 +79,9 @@ export class IndividualTrackerViewerPresenter {
         endTime: stats.MatchInfo.EndTime,
         data: controller.getMatchStats(),
         killMatrixPivotData:
-          analytics != null ? KillMatrixFormatter.pivot(controller.getKillMatrix()) : EMPTY_KILL_MATRIX_PIVOT_DATA,
+          killMatrixRows != null ? KillMatrixFormatter.pivot(killMatrixRows) : EMPTY_KILL_MATRIX_PIVOT_DATA,
+        transposedKillMatrixPivotData:
+          killMatrixRows != null ? KillMatrixFormatter.transpose(killMatrixRows) : EMPTY_KILL_MATRIX_PIVOT_DATA,
       };
     } catch {
       return { status: "error", message: "Failed to compute match stats" };

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
@@ -47,14 +47,6 @@
   width: 85%;
 }
 
-.shimmerRow:nth-child(3n + 2) {
-  width: 90%;
-}
-
-.shimmerRow:nth-child(3n + 3) {
-  width: 95%;
-}
-
 @keyframes shimmer {
   0% {
     background-position: 200% center;

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
@@ -38,6 +38,15 @@
   background-size: 200% 100%;
   border-radius: 4px;
   height: 2rem;
+  width: 85%;
+}
+
+.shimmerRow:nth-child(3n + 2) {
+  width: 90%;
+}
+
+.shimmerRow:nth-child(3n + 3) {
+  width: 95%;
 }
 
 @keyframes shimmer {

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
@@ -3,10 +3,16 @@
   text-align: center;
 }
 
+.tableHeader {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: var(--space-1);
+}
+
 .victimAxisLabel {
   color: var(--halo-gray);
   font-size: var(--text-sm);
-  padding-bottom: var(--space-1);
   text-align: right;
 }
 

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -109,7 +109,7 @@ export function KillMatrixTable({
                 setIsTransposed((prev) => !prev);
               }}
             >
-              {isTransposed ? "View Kills" : "View Deaths"}
+              {isTransposed ? "Switch to Kills view" : "Switch to Deaths view"}
             </Button>
           )}
         </div>

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -34,9 +34,10 @@ export function KillMatrixTable({
 
   const [isTransposed, setIsTransposed] = React.useState(false);
 
-  const activePivotData = isTransposed && transposedPivotData != null ? transposedPivotData : pivotData;
-  const activeKillerAxisLabel = isTransposed ? "Victim" : killerAxisLabel;
-  const activeVictimAxisLabel = isTransposed ? "Kills" : victimAxisLabel;
+  const isTransposedActive = isTransposed && transposedPivotData != null;
+  const activePivotData = isTransposedActive ? transposedPivotData : pivotData;
+  const activeKillerAxisLabel = isTransposedActive ? "Victim" : killerAxisLabel;
+  const activeVictimAxisLabel = isTransposedActive ? "Kills" : victimAxisLabel;
 
   const columns = React.useMemo<SortableTableColumn<KillMatrixPivotRow>[]>(() => {
     if (effectiveStatus !== ComponentLoaderStatus.LOADED) {
@@ -66,8 +67,7 @@ export function KillMatrixTable({
     return cols;
   }, [effectiveStatus, activeKillerAxisLabel, activePivotData.victimGamertags]);
 
-  const playerCount =
-    playerGamertags !== undefined && playerGamertags.length > 0 ? playerGamertags.length : 8;
+  const playerCount = playerGamertags !== undefined && playerGamertags.length > 0 ? playerGamertags.length : 8;
 
   const shimmer = (
     <div
@@ -109,7 +109,7 @@ export function KillMatrixTable({
                 setIsTransposed((prev) => !prev);
               }}
             >
-              {isTransposed ? "Switch to Kills view" : "Switch to Deaths view"}
+              {isTransposedActive ? "Switch to Kills view" : "Switch to Deaths view"}
             </Button>
           )}
         </div>

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Alert } from "../../alert/alert";
+import { Button } from "../../button/button";
 import { ComponentLoader, ComponentLoaderStatus } from "../../component-loader/component-loader";
 import { SortableTable, type SortableTableColumn } from "../../table/sortable-table";
 import tableStyles from "../../table/table.module.css";
@@ -8,6 +9,7 @@ import styles from "./kill-matrix-table.module.css";
 
 interface KillMatrixTableProps {
   readonly pivotData: KillMatrixPivotData;
+  readonly transposedPivotData?: KillMatrixPivotData;
   readonly ariaLabel: string;
   readonly emptyMessage: string;
   readonly errorMessage?: string;
@@ -19,6 +21,7 @@ interface KillMatrixTableProps {
 
 export function KillMatrixTable({
   pivotData,
+  transposedPivotData,
   ariaLabel,
   emptyMessage,
   errorMessage,
@@ -29,6 +32,12 @@ export function KillMatrixTable({
 }: KillMatrixTableProps): React.ReactElement {
   const effectiveStatus = status ?? ComponentLoaderStatus.LOADED;
 
+  const [isTransposed, setIsTransposed] = React.useState(false);
+
+  const activePivotData = isTransposed && transposedPivotData != null ? transposedPivotData : pivotData;
+  const activeKillerAxisLabel = isTransposed ? "Victim" : killerAxisLabel;
+  const activeVictimAxisLabel = isTransposed ? "Kills" : victimAxisLabel;
+
   const columns = React.useMemo<SortableTableColumn<KillMatrixPivotRow>[]>(() => {
     if (effectiveStatus !== ComponentLoaderStatus.LOADED) {
       return [];
@@ -37,14 +46,14 @@ export function KillMatrixTable({
     const cols: SortableTableColumn<KillMatrixPivotRow>[] = [
       {
         id: "killer",
-        header: killerAxisLabel,
+        header: activeKillerAxisLabel,
         accessorFn: (row): string => row.killerGamertag,
         sortingFn: "alphanumeric",
         cellClassName: tableStyles.labelCell,
       },
     ];
 
-    for (const victimGamertag of pivotData.victimGamertags) {
+    for (const victimGamertag of activePivotData.victimGamertags) {
       cols.push({
         id: victimGamertag,
         header: victimGamertag,
@@ -55,9 +64,10 @@ export function KillMatrixTable({
     }
 
     return cols;
-  }, [effectiveStatus, killerAxisLabel, pivotData.victimGamertags]);
+  }, [effectiveStatus, activeKillerAxisLabel, activePivotData.victimGamertags]);
 
-  const playerCount = playerGamertags !== undefined && playerGamertags.length > 0 ? playerGamertags.length : 8;
+  const playerCount =
+    playerGamertags !== undefined && playerGamertags.length > 0 ? playerGamertags.length : 8;
 
   const shimmer = (
     <div
@@ -85,13 +95,26 @@ export function KillMatrixTable({
   );
 
   const loaded =
-    pivotData.tableRows.length === 0 ? (
+    activePivotData.tableRows.length === 0 ? (
       <Alert variant="info">{emptyMessage}</Alert>
     ) : (
       <div>
-        <div className={styles.victimAxisLabel}>{victimAxisLabel} →</div>
+        <div className={styles.tableHeader}>
+          <div className={styles.victimAxisLabel}>{activeVictimAxisLabel} →</div>
+          {transposedPivotData != null && (
+            <Button
+              size="small"
+              variant="secondary"
+              onClick={(): void => {
+                setIsTransposed((prev) => !prev);
+              }}
+            >
+              {isTransposed ? "View Kills" : "View Deaths"}
+            </Button>
+          )}
+        </div>
         <SortableTable
-          data={pivotData.tableRows}
+          data={activePivotData.tableRows}
           columns={columns}
           getRowKey={(row): string => row.killerId}
           ariaLabel={ariaLabel}

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -9,7 +9,6 @@ import styles from "./kill-matrix-table.module.css";
 
 interface KillMatrixTableProps {
   readonly pivotData: KillMatrixPivotData;
-  readonly transposedPivotData?: KillMatrixPivotData;
   readonly ariaLabel: string;
   readonly emptyMessage: string;
   readonly errorMessage?: string;
@@ -17,11 +16,11 @@ interface KillMatrixTableProps {
   readonly killerAxisLabel?: string;
   readonly victimAxisLabel?: string;
   readonly playerGamertags?: readonly string[];
+  readonly transposedPivotData?: KillMatrixPivotData;
 }
 
 export function KillMatrixTable({
   pivotData,
-  transposedPivotData,
   ariaLabel,
   emptyMessage,
   errorMessage,
@@ -29,6 +28,7 @@ export function KillMatrixTable({
   killerAxisLabel = "Killer",
   victimAxisLabel = "Deaths",
   playerGamertags,
+  transposedPivotData,
 }: KillMatrixTableProps): React.ReactElement {
   const effectiveStatus = status ?? ComponentLoaderStatus.LOADED;
 

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -154,8 +154,8 @@ describe("KillMatrixTable", () => {
 
     render(<KillMatrixTable pivotData={pivotData} ariaLabel="Kill matrix" emptyMessage="No kill matrix data." />);
 
-    expect(screen.queryByText("View Deaths")).not.toBeInTheDocument();
-    expect(screen.queryByText("View Kills")).not.toBeInTheDocument();
+    expect(screen.queryByText("Switch to Deaths view")).not.toBeInTheDocument();
+    expect(screen.queryByText("Switch to Kills view")).not.toBeInTheDocument();
   });
 
   it("toggles between kills and deaths view when toggle button is clicked", () => {
@@ -183,14 +183,16 @@ describe("KillMatrixTable", () => {
     );
 
     expect(screen.getByText("Deaths →")).toBeInTheDocument();
-    expect(screen.getByText("View Deaths")).toBeInTheDocument();
+    expect(screen.getByText("Killer")).toBeInTheDocument();
+    expect(screen.getByText("Switch to Deaths view")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("View Deaths"));
+    fireEvent.click(screen.getByText("Switch to Deaths view"));
 
     expect(screen.getByText("Kills →")).toBeInTheDocument();
-    expect(screen.getByText("View Kills")).toBeInTheDocument();
+    expect(screen.getByText("Victim")).toBeInTheDocument();
+    expect(screen.getByText("Switch to Kills view")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("View Kills"));
+    fireEvent.click(screen.getByText("Switch to Kills view"));
 
     expect(screen.getByText("Deaths →")).toBeInTheDocument();
   });

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -176,9 +176,9 @@ describe("KillMatrixTable", () => {
     render(
       <KillMatrixTable
         pivotData={pivotData}
-        transposedPivotData={transposedPivotData}
         ariaLabel="Kill matrix"
         emptyMessage="No kill matrix data."
+        transposedPivotData={transposedPivotData}
       />,
     );
 

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 
 import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import { KillMatrixFormatter } from "../../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { EMPTY_KILL_MATRIX_PIVOT_DATA } from "../../../../controllers/stats/kill-matrix/types";
@@ -137,5 +137,61 @@ describe("KillMatrixTable", () => {
     );
 
     expect(screen.getByText("No kill matrix data.")).toBeInTheDocument();
+  });
+
+  it("does not render toggle button when transposedPivotData is not provided", () => {
+    const pivotData = KillMatrixFormatter.pivot([
+      {
+        key: "111:222",
+        killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+        victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+        count: 3,
+        headshotKills: 1,
+        perfects: 0,
+        classification: "enemy-kill",
+      },
+    ]);
+
+    render(<KillMatrixTable pivotData={pivotData} ariaLabel="Kill matrix" emptyMessage="No kill matrix data." />);
+
+    expect(screen.queryByText("View Deaths")).not.toBeInTheDocument();
+    expect(screen.queryByText("View Kills")).not.toBeInTheDocument();
+  });
+
+  it("toggles between kills and deaths view when toggle button is clicked", () => {
+    const rows = [
+      {
+        key: "111:222",
+        killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+        victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+        count: 3,
+        headshotKills: 1,
+        perfects: 0,
+        classification: "enemy-kill" as const,
+      },
+    ];
+    const pivotData = KillMatrixFormatter.pivot(rows);
+    const transposedPivotData = KillMatrixFormatter.transpose(rows);
+
+    render(
+      <KillMatrixTable
+        pivotData={pivotData}
+        transposedPivotData={transposedPivotData}
+        ariaLabel="Kill matrix"
+        emptyMessage="No kill matrix data."
+      />,
+    );
+
+    expect(screen.getByText("Deaths →")).toBeInTheDocument();
+    expect(screen.getByText("View Deaths")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("View Deaths"));
+
+    expect(screen.getByText("Kills →")).toBeInTheDocument();
+    expect(screen.getByText("View Kills")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("View Kills"));
+
+    expect(screen.getByText("Deaths →")).toBeInTheDocument();
   });
 });

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -1,7 +1,8 @@
 import "@testing-library/jest-dom/vitest";
 
 import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import { KillMatrixFormatter } from "../../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { EMPTY_KILL_MATRIX_PIVOT_DATA } from "../../../../controllers/stats/kill-matrix/types";
@@ -158,7 +159,8 @@ describe("KillMatrixTable", () => {
     expect(screen.queryByText("Switch to Kills view")).not.toBeInTheDocument();
   });
 
-  it("toggles between kills and deaths view when toggle button is clicked", () => {
+  it("toggles between kills and deaths view when toggle button is clicked", async () => {
+    const user = userEvent.setup();
     const rows = [
       {
         key: "111:222",
@@ -186,13 +188,13 @@ describe("KillMatrixTable", () => {
     expect(screen.getByText("Killer")).toBeInTheDocument();
     expect(screen.getByText("Switch to Deaths view")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("Switch to Deaths view"));
+    await user.click(screen.getByText("Switch to Deaths view"));
 
     expect(screen.getByText("Kills →")).toBeInTheDocument();
     expect(screen.getByText("Victim")).toBeInTheDocument();
     expect(screen.getByText("Switch to Kills view")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("Switch to Kills view"));
+    await user.click(screen.getByText("Switch to Kills view"));
 
     expect(screen.getByText("Deaths →")).toBeInTheDocument();
   });

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -29,6 +29,7 @@ interface MatchStatsProps {
   readonly endTime: string;
   readonly teamColors?: readonly TeamColor[];
   readonly killMatrixPivotData?: KillMatrixPivotData;
+  readonly transposedKillMatrixPivotData?: KillMatrixPivotData;
   readonly killMatrixStatus?: ComponentLoaderStatus;
 }
 
@@ -48,6 +49,7 @@ export function MatchStats({
   endTime,
   teamColors,
   killMatrixPivotData,
+  transposedKillMatrixPivotData,
   killMatrixStatus,
 }: MatchStatsProps): React.ReactElement {
   const [activeTab, setActiveTab] = React.useState<"players" | "kill-matrix">("players");
@@ -273,6 +275,7 @@ export function MatchStats({
             content: (
               <KillMatrixTable
                 pivotData={killMatrixPivotData ?? EMPTY_KILL_MATRIX_PIVOT_DATA}
+                transposedPivotData={transposedKillMatrixPivotData}
                 ariaLabel="Match kill matrix"
                 emptyMessage="Kill matrix data is not available for this match yet."
                 errorMessage="Failed to load kill matrix data for this match."

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -22,6 +22,7 @@ interface SeriesStatsProps {
   readonly metadata: SeriesMetadata | null;
   readonly teamColors?: readonly TeamColor[];
   readonly killMatrixPivotData?: KillMatrixPivotData;
+  readonly transposedKillMatrixPivotData?: KillMatrixPivotData;
   readonly killMatrixStatus?: ComponentLoaderStatus;
 }
 
@@ -34,6 +35,7 @@ export function SeriesStats({
   metadata,
   teamColors,
   killMatrixPivotData,
+  transposedKillMatrixPivotData,
   killMatrixStatus,
 }: SeriesStatsProps): React.ReactElement {
   const [activeTab, setActiveTab] = React.useState<"accumulated" | "kill-matrix">("accumulated");
@@ -264,6 +266,7 @@ export function SeriesStats({
               content: (
                 <KillMatrixTable
                   pivotData={killMatrixPivotData ?? EMPTY_KILL_MATRIX_PIVOT_DATA}
+                  transposedPivotData={transposedKillMatrixPivotData}
                   ariaLabel="Series kill matrix"
                   emptyMessage="Kill matrix data is not available for this series yet."
                   errorMessage="Failed to load kill matrix data for this series."

--- a/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
+++ b/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
@@ -124,6 +124,10 @@ export class KillMatrixFormatter {
     return { tableRows, victimGamertags };
   }
 
+  public static transpose(rows: readonly KillMatrixViewRow[]): KillMatrixPivotData {
+    return KillMatrixFormatter.pivot(rows.map((row) => ({ ...row, killer: row.victim, victim: row.killer })));
+  }
+
   public static aggregate(rows: readonly KillMatrixViewRow[]): KillMatrixViewRow[] {
     const merged = new Map<string, KillMatrixViewRow>();
 

--- a/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
+++ b/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
@@ -202,4 +202,30 @@ describe("KillMatrixFormatter", () => {
       expect(KillMatrixFormatter.aggregate([])).toEqual([]);
     });
   });
+
+  describe("transpose", () => {
+    it("returns empty pivot for no rows", () => {
+      expect(KillMatrixFormatter.transpose([])).toEqual({ tableRows: [], victimGamertags: [] });
+    });
+
+    it("swaps killers and victims so rows become victims and columns become killers", () => {
+      const rows: KillMatrixViewRow[] = [
+        {
+          key: "111:222",
+          killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          count: 5,
+          headshotKills: 2,
+          perfects: 0,
+          classification: "enemy-kill",
+        },
+      ];
+
+      const result = KillMatrixFormatter.transpose(rows);
+
+      expect(result.victimGamertags).toEqual(["Alpha"]);
+      expect(result.tableRows).toHaveLength(1);
+      expect(result.tableRows[0]).toMatchObject({ killerId: "222", killerGamertag: "Bravo", Alpha: 5 });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `KillMatrixFormatter.transpose()` — swaps killer/victim roles on rows before pivoting, producing the transposed kill matrix
- Adds `transposedKillMatrixPivotData` through the presenter/type/view chain (`DiscordSeriesStatsPresenter`, `IndividualTrackerViewerPresenter`, `DiscordSeriesMatchDetail`, `DiscordSeriesSeriesStats`, `MatchStatsPanelState`, `SeriesStats`, `MatchStats`)
- Adds "Switch to Deaths view" / "Switch to Kills view" toggle button in `KillMatrixTable` — only rendered when `transposedPivotData` is provided; axis labels update accordingly ("Deaths →" ↔ "Kills →", "Killer" ↔ "Victim")

## Test plan

- [ ] `kill-matrix-formatter.test.ts` — `transpose()` swaps rows/columns correctly
- [ ] `kill-matrix-table.test.tsx` — toggle button absent without `transposedPivotData`; toggle changes axis labels and column headers
- [ ] All 39 changed-file tests pass via `npm run done`

🤖 Generated with [Claude Code](https://claude.com/claude-code)