### PR TITLE
feat(batch-analytics): single auth per batch + resilient fetch in HaloFilmService

### DIFF
--- a/api/routes/stats/batch-analytics.ts
+++ b/api/routes/stats/batch-analytics.ts
@@ -1,5 +1,4 @@
 import { parseQueryParams } from "@guilty-spark/shared/base/request-parsing";
-import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import {
   batchMatchAnalyticsContract,
   batchMatchAnalyticsQuerySchema,
@@ -18,22 +17,9 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
 
     const { matchIds, modules } = queryParams.data;
 
-    const settled = await Promise.allSettled(
-      matchIds.map(async (matchId) => services.analyticsService.getMatchAnalytics(matchId, modules)),
-    );
+    const results = await services.analyticsService.getBatchMatchAnalytics(matchIds, modules);
 
-    const resultsMap = new Map<string, MatchAnalytics | null>();
-    let failureCount = 0;
-    for (const [index, matchId] of matchIds.entries()) {
-      const outcome = settled[index];
-      if (outcome == null || outcome.status === "rejected") {
-        resultsMap.set(matchId, null);
-        failureCount++;
-      } else {
-        resultsMap.set(matchId, outcome.value);
-      }
-    }
-
+    const failureCount = Object.values(results).filter((v) => v === null).length;
     if (failureCount > 0) {
       services.logService.warn(
         `${failureCount.toString()}/${matchIds.length.toString()} match analytics fetches failed`,
@@ -41,6 +27,6 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
       );
     }
 
-    return batchMatchAnalyticsContract.toResponse({ results: Object.fromEntries(resultsMap) }, { noStore: true });
+    return batchMatchAnalyticsContract.toResponse({ results }, { noStore: true });
   });
 };

--- a/api/routes/stats/batch-analytics.ts
+++ b/api/routes/stats/batch-analytics.ts
@@ -15,7 +15,8 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
       return queryParams.response;
     }
 
-    const { matchIds, modules } = queryParams.data;
+    const { matchIds: rawMatchIds, modules } = queryParams.data;
+    const matchIds = [...new Set(rawMatchIds)];
 
     const results = await services.analyticsService.getBatchMatchAnalytics(matchIds, modules);
 

--- a/api/routes/stats/tests/batch-analytics.test.ts
+++ b/api/routes/stats/tests/batch-analytics.test.ts
@@ -22,11 +22,11 @@ describe("/api/stats/match-analytics (batch)", () => {
     const analytics = aFakeMatchAnalyticsWith();
 
     const services = installFakeServicesWith({ env });
-    const getMatchAnalyticsSpy: MockInstance<AnalyticsService["getMatchAnalytics"]> = vi.spyOn(
+    const getBatchMatchAnalyticsSpy: MockInstance<AnalyticsService["getBatchMatchAnalytics"]> = vi.spyOn(
       services.analyticsService,
-      "getMatchAnalytics",
+      "getBatchMatchAnalytics",
     );
-    getMatchAnalyticsSpy.mockResolvedValue(analytics);
+    getBatchMatchAnalyticsSpy.mockResolvedValue({ "match-1": analytics, "match-2": analytics });
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
     statsRoutesRegisterHandler(router, localInstallServices);
 
@@ -45,18 +45,18 @@ describe("/api/stats/match-analytics (batch)", () => {
         "match-2": analytics,
       },
     });
-    expect(getMatchAnalyticsSpy).toHaveBeenCalledTimes(2);
-    expect(getMatchAnalyticsSpy).toHaveBeenCalledWith("match-1", ["killMatrix"]);
-    expect(getMatchAnalyticsSpy).toHaveBeenCalledWith("match-2", ["killMatrix"]);
+    expect(getBatchMatchAnalyticsSpy).toHaveBeenCalledOnce();
+    expect(getBatchMatchAnalyticsSpy).toHaveBeenCalledWith(["match-1", "match-2"], ["killMatrix"]);
   });
 
   it("returns null for matchIds that fail, successful ones with data, and logs the failure count", async () => {
     const analytics = aFakeMatchAnalyticsWith();
 
     const services = installFakeServicesWith({ env });
-    vi.spyOn(services.analyticsService, "getMatchAnalytics")
-      .mockResolvedValueOnce(analytics)
-      .mockRejectedValueOnce(new Error("halo api down"));
+    vi.spyOn(services.analyticsService, "getBatchMatchAnalytics").mockResolvedValue({
+      "match-ok": analytics,
+      "match-fail": null,
+    });
     const logWarnSpy: MockInstance<LogService["warn"]> = vi.spyOn(services.logService, "warn");
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
     statsRoutesRegisterHandler(router, localInstallServices);

--- a/api/services/analytics/analytics.ts
+++ b/api/services/analytics/analytics.ts
@@ -7,10 +7,12 @@ import {
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import type { HaloService } from "../halo/halo";
 import type { HaloFilmService } from "../halo/halo-film";
+import type { LogService } from "../log/types";
 
 export interface AnalyticsServiceOpts {
   haloService: HaloService;
   haloFilmService: HaloFilmService;
+  logService: LogService;
 }
 
 const supportedAnalyticsModuleSet = new Set<string>(SUPPORTED_ANALYTICS_MODULES);
@@ -39,10 +41,12 @@ function toContractKillMatrix(
 export class AnalyticsService {
   private readonly haloService: HaloService;
   private readonly haloFilmService: HaloFilmService;
+  private readonly logService: LogService;
 
-  constructor({ haloService, haloFilmService }: AnalyticsServiceOpts) {
+  constructor({ haloService, haloFilmService, logService }: AnalyticsServiceOpts) {
     this.haloService = haloService;
     this.haloFilmService = haloFilmService;
+    this.logService = logService;
   }
 
   async getMatchAnalytics(matchId: string, modules: string[]): Promise<MatchAnalytics> {
@@ -67,8 +71,8 @@ export class AnalyticsService {
   async getBatchMatchAnalytics(matchIds: string[], modules: string[]): Promise<Record<string, MatchAnalytics | null>> {
     try {
       await this.haloFilmService.resolveAuthContext();
-    } catch {
-      // pre-warm failed; per-match calls will handle auth individually
+    } catch (error) {
+      this.logService.warn(error, new Map([["context", "resolveAuthContext pre-warm"]]));
     }
 
     const settled = await Promise.allSettled(matchIds.map(async (matchId) => this.getMatchAnalytics(matchId, modules)));

--- a/api/services/analytics/analytics.ts
+++ b/api/services/analytics/analytics.ts
@@ -63,4 +63,17 @@ export class AnalyticsService {
       },
     };
   }
+
+  async getBatchMatchAnalytics(matchIds: string[], modules: string[]): Promise<Record<string, MatchAnalytics | null>> {
+    await this.haloFilmService.resolveAuthContext();
+
+    const settled = await Promise.allSettled(matchIds.map(async (matchId) => this.getMatchAnalytics(matchId, modules)));
+
+    const results: Record<string, MatchAnalytics | null> = {};
+    for (const [index, matchId] of matchIds.entries()) {
+      const outcome = settled[index];
+      results[matchId] = outcome?.status === "fulfilled" ? outcome.value : null;
+    }
+    return results;
+  }
 }

--- a/api/services/analytics/analytics.ts
+++ b/api/services/analytics/analytics.ts
@@ -70,9 +70,9 @@ export class AnalyticsService {
 
   async getBatchMatchAnalytics(matchIds: string[], modules: string[]): Promise<Record<string, MatchAnalytics | null>> {
     try {
-      await this.haloFilmService.resolveAuthContext();
+      await this.haloFilmService.warmAuthCache();
     } catch (error) {
-      this.logService.warn(error, new Map([["context", "resolveAuthContext pre-warm"]]));
+      this.logService.warn(error, new Map([["context", "warmAuthCache pre-warm"]]));
     }
 
     const settled = await Promise.allSettled(matchIds.map(async (matchId) => this.getMatchAnalytics(matchId, modules)));

--- a/api/services/analytics/analytics.ts
+++ b/api/services/analytics/analytics.ts
@@ -65,14 +65,18 @@ export class AnalyticsService {
   }
 
   async getBatchMatchAnalytics(matchIds: string[], modules: string[]): Promise<Record<string, MatchAnalytics | null>> {
-    await this.haloFilmService.resolveAuthContext();
+    try {
+      await this.haloFilmService.resolveAuthContext();
+    } catch {
+      // pre-warm failed; per-match calls will handle auth individually
+    }
 
     const settled = await Promise.allSettled(matchIds.map(async (matchId) => this.getMatchAnalytics(matchId, modules)));
 
     const results: Record<string, MatchAnalytics | null> = {};
     for (const [index, matchId] of matchIds.entries()) {
-      const outcome = settled[index];
-      results[matchId] = outcome?.status === "fulfilled" ? outcome.value : null;
+      const outcome = Preconditions.checkExists(settled[index]);
+      results[matchId] = outcome.status === "fulfilled" ? outcome.value : null;
     }
     return results;
   }

--- a/api/services/analytics/fakes/analytics.fake.ts
+++ b/api/services/analytics/fakes/analytics.fake.ts
@@ -1,6 +1,7 @@
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { aFakeHaloServiceWith } from "../../halo/fakes/halo.fake";
 import { aFakeHaloFilmServiceWith } from "../../halo/fakes/halo-film.fake";
+import { aFakeLogServiceWith } from "../../log/fakes/log.fake";
 import type { AnalyticsServiceOpts } from "../analytics";
 import { AnalyticsService } from "../analytics";
 
@@ -26,6 +27,7 @@ export function aFakeMatchAnalyticsWith(overrides: Partial<MatchAnalytics> = {})
 export function aFakeAnalyticsServiceWith(opts: Partial<AnalyticsServiceOpts> = {}): AnalyticsService {
   const haloService = opts.haloService ?? aFakeHaloServiceWith();
   const haloFilmService = opts.haloFilmService ?? aFakeHaloFilmServiceWith();
+  const logService = opts.logService ?? aFakeLogServiceWith();
 
-  return new AnalyticsService({ haloService, haloFilmService });
+  return new AnalyticsService({ haloService, haloFilmService, logService });
 }

--- a/api/services/analytics/tests/analytics.test.ts
+++ b/api/services/analytics/tests/analytics.test.ts
@@ -133,12 +133,13 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
     const logService = aFakeLogServiceWith();
     const logWarnSpy = vi.spyOn(logService, "warn");
     vi.spyOn(haloFilmService, "warmAuthCache").mockRejectedValue(new Error("auth down"));
-    vi.spyOn(haloService, "getMatchDetails").mockRejectedValue(new Error("auth down"));
+    const getMatchDetailsSpy = vi.spyOn(haloService, "getMatchDetails").mockRejectedValue(new Error("auth down"));
 
     const service = new AnalyticsService({ haloService, haloFilmService, logService });
     const results = await service.getBatchMatchAnalytics(["match-1"], ["killMatrix"]);
 
     expect(logWarnSpy).toHaveBeenCalledOnce();
+    expect(getMatchDetailsSpy).toHaveBeenCalledOnce();
     expect(results["match-1"]).toBeNull();
   });
 });

--- a/api/services/analytics/tests/analytics.test.ts
+++ b/api/services/analytics/tests/analytics.test.ts
@@ -76,3 +76,54 @@ describe("AnalyticsService", () => {
     );
   });
 });
+
+describe("AnalyticsService.getBatchMatchAnalytics", () => {
+  it("resolves auth once then returns results keyed by matchId", async () => {
+    const env = aFakeEnvWith();
+    const haloService = aFakeHaloServiceWith({ env });
+    const haloFilmService = aFakeHaloFilmServiceWith({ env });
+    const resolveAuthSpy = vi.spyOn(haloFilmService, "resolveAuthContext").mockResolvedValue({
+      spartanToken: "spartan-token",
+      clearanceToken: "clearance-token",
+    });
+    const matchStats = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+    vi.spyOn(haloService, "getMatchDetails").mockResolvedValue([matchStats]);
+    vi.spyOn(haloFilmService, "buildKillMatrixAnalytics").mockResolvedValue({
+      entries: [],
+      pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 0 },
+      perfectCounts: { total: 0, byXuid: {} },
+    });
+
+    const service = new AnalyticsService({ haloService, haloFilmService });
+    const results = await service.getBatchMatchAnalytics(["match-1", "match-2"], ["killMatrix"]);
+
+    expect(resolveAuthSpy).toHaveBeenCalledOnce();
+    expect(results["match-1"]).not.toBeNull();
+    expect(results["match-2"]).not.toBeNull();
+  });
+
+  it("returns null for failed matches without affecting successful ones", async () => {
+    const env = aFakeEnvWith();
+    const haloService = aFakeHaloServiceWith({ env });
+    const haloFilmService = aFakeHaloFilmServiceWith({ env });
+    vi.spyOn(haloFilmService, "resolveAuthContext").mockResolvedValue({
+      spartanToken: "spartan-token",
+      clearanceToken: "clearance-token",
+    });
+    const matchStats = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+    vi.spyOn(haloService, "getMatchDetails")
+      .mockResolvedValueOnce([matchStats])
+      .mockRejectedValueOnce(new Error("halo api down"));
+    vi.spyOn(haloFilmService, "buildKillMatrixAnalytics").mockResolvedValue({
+      entries: [],
+      pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 0 },
+      perfectCounts: { total: 0, byXuid: {} },
+    });
+
+    const service = new AnalyticsService({ haloService, haloFilmService });
+    const results = await service.getBatchMatchAnalytics(["match-ok", "match-fail"], ["killMatrix"]);
+
+    expect(results["match-ok"]).not.toBeNull();
+    expect(results["match-fail"]).toBeNull();
+  });
+});

--- a/api/services/analytics/tests/analytics.test.ts
+++ b/api/services/analytics/tests/analytics.test.ts
@@ -4,6 +4,7 @@ import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import { getMatchStats } from "../../halo/fakes/data";
 import { aFakeHaloFilmServiceWith } from "../../halo/fakes/halo-film.fake";
 import { aFakeHaloServiceWith } from "../../halo/fakes/halo.fake";
+import { aFakeLogServiceWith } from "../../log/fakes/log.fake";
 import { AnalyticsService } from "../analytics";
 
 describe("AnalyticsService", () => {
@@ -11,6 +12,7 @@ describe("AnalyticsService", () => {
     const env = aFakeEnvWith();
     const haloService = aFakeHaloServiceWith({ env });
     const haloFilmService = aFakeHaloFilmServiceWith({ env });
+    const logService = aFakeLogServiceWith();
 
     vi.spyOn(haloService, "getMatchDetails").mockResolvedValue([
       Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer")),
@@ -38,7 +40,7 @@ describe("AnalyticsService", () => {
       },
     });
 
-    const service = new AnalyticsService({ haloService, haloFilmService });
+    const service = new AnalyticsService({ haloService, haloFilmService, logService });
 
     const analytics = await service.getMatchAnalytics("match-123", ["killMatrix"]);
 
@@ -69,7 +71,8 @@ describe("AnalyticsService", () => {
     const env = aFakeEnvWith();
     const haloService = aFakeHaloServiceWith({ env });
     const haloFilmService = aFakeHaloFilmServiceWith({ env });
-    const service = new AnalyticsService({ haloService, haloFilmService });
+    const logService = aFakeLogServiceWith();
+    const service = new AnalyticsService({ haloService, haloFilmService, logService });
 
     await expect(service.getMatchAnalytics("match-123", ["scoreProgression"])).rejects.toThrow(
       "No supported analytics modules requested",
@@ -82,6 +85,7 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
     const env = aFakeEnvWith();
     const haloService = aFakeHaloServiceWith({ env });
     const haloFilmService = aFakeHaloFilmServiceWith({ env });
+    const logService = aFakeLogServiceWith();
     const resolveAuthSpy = vi.spyOn(haloFilmService, "resolveAuthContext").mockResolvedValue({
       spartanToken: "spartan-token",
       clearanceToken: "clearance-token",
@@ -94,7 +98,7 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
       perfectCounts: { total: 0, byXuid: {} },
     });
 
-    const service = new AnalyticsService({ haloService, haloFilmService });
+    const service = new AnalyticsService({ haloService, haloFilmService, logService });
     const results = await service.getBatchMatchAnalytics(["match-1", "match-2"], ["killMatrix"]);
 
     expect(resolveAuthSpy).toHaveBeenCalledOnce();
@@ -106,6 +110,7 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
     const env = aFakeEnvWith();
     const haloService = aFakeHaloServiceWith({ env });
     const haloFilmService = aFakeHaloFilmServiceWith({ env });
+    const logService = aFakeLogServiceWith();
     vi.spyOn(haloFilmService, "resolveAuthContext").mockResolvedValue({
       spartanToken: "spartan-token",
       clearanceToken: "clearance-token",
@@ -120,10 +125,26 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
       perfectCounts: { total: 0, byXuid: {} },
     });
 
-    const service = new AnalyticsService({ haloService, haloFilmService });
+    const service = new AnalyticsService({ haloService, haloFilmService, logService });
     const results = await service.getBatchMatchAnalytics(["match-ok", "match-fail"], ["killMatrix"]);
 
     expect(results["match-ok"]).not.toBeNull();
     expect(results["match-fail"]).toBeNull();
+  });
+
+  it("logs a warning when auth pre-warm fails", async () => {
+    const env = aFakeEnvWith();
+    const haloService = aFakeHaloServiceWith({ env });
+    const haloFilmService = aFakeHaloFilmServiceWith({ env });
+    const logService = aFakeLogServiceWith();
+    const logWarnSpy = vi.spyOn(logService, "warn");
+    vi.spyOn(haloFilmService, "resolveAuthContext").mockRejectedValue(new Error("auth down"));
+    vi.spyOn(haloService, "getMatchDetails").mockRejectedValue(new Error("auth down"));
+
+    const service = new AnalyticsService({ haloService, haloFilmService, logService });
+    const results = await service.getBatchMatchAnalytics(["match-1"], ["killMatrix"]);
+
+    expect(logWarnSpy).toHaveBeenCalledOnce();
+    expect(results["match-1"]).toBeNull();
   });
 });

--- a/api/services/analytics/tests/analytics.test.ts
+++ b/api/services/analytics/tests/analytics.test.ts
@@ -86,10 +86,7 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
     const haloService = aFakeHaloServiceWith({ env });
     const haloFilmService = aFakeHaloFilmServiceWith({ env });
     const logService = aFakeLogServiceWith();
-    const resolveAuthSpy = vi.spyOn(haloFilmService, "resolveAuthContext").mockResolvedValue({
-      spartanToken: "spartan-token",
-      clearanceToken: "clearance-token",
-    });
+    const warmAuthCacheSpy = vi.spyOn(haloFilmService, "warmAuthCache").mockResolvedValue(undefined);
     const matchStats = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
     vi.spyOn(haloService, "getMatchDetails").mockResolvedValue([matchStats]);
     vi.spyOn(haloFilmService, "buildKillMatrixAnalytics").mockResolvedValue({
@@ -101,7 +98,7 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
     const service = new AnalyticsService({ haloService, haloFilmService, logService });
     const results = await service.getBatchMatchAnalytics(["match-1", "match-2"], ["killMatrix"]);
 
-    expect(resolveAuthSpy).toHaveBeenCalledOnce();
+    expect(warmAuthCacheSpy).toHaveBeenCalledOnce();
     expect(results["match-1"]).not.toBeNull();
     expect(results["match-2"]).not.toBeNull();
   });
@@ -111,10 +108,7 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
     const haloService = aFakeHaloServiceWith({ env });
     const haloFilmService = aFakeHaloFilmServiceWith({ env });
     const logService = aFakeLogServiceWith();
-    vi.spyOn(haloFilmService, "resolveAuthContext").mockResolvedValue({
-      spartanToken: "spartan-token",
-      clearanceToken: "clearance-token",
-    });
+    vi.spyOn(haloFilmService, "warmAuthCache").mockResolvedValue(undefined);
     const matchStats = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
     vi.spyOn(haloService, "getMatchDetails")
       .mockResolvedValueOnce([matchStats])
@@ -132,13 +126,13 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
     expect(results["match-fail"]).toBeNull();
   });
 
-  it("logs a warning when auth pre-warm fails", async () => {
+  it("logs a warning and returns null for all matches when auth pre-warm fails", async () => {
     const env = aFakeEnvWith();
     const haloService = aFakeHaloServiceWith({ env });
     const haloFilmService = aFakeHaloFilmServiceWith({ env });
     const logService = aFakeLogServiceWith();
     const logWarnSpy = vi.spyOn(logService, "warn");
-    vi.spyOn(haloFilmService, "resolveAuthContext").mockRejectedValue(new Error("auth down"));
+    vi.spyOn(haloFilmService, "warmAuthCache").mockRejectedValue(new Error("auth down"));
     vi.spyOn(haloService, "getMatchDetails").mockRejectedValue(new Error("auth down"));
 
     const service = new AnalyticsService({ haloService, haloFilmService, logService });

--- a/api/services/fakes/services.ts
+++ b/api/services/fakes/services.ts
@@ -28,7 +28,8 @@ export function installFakeServicesWith(opts: Partial<Services & { env: Env }> =
     opts.haloFilmService ??
     aFakeHaloFilmServiceWith({ env, spartanTokenProvider: new CustomSpartanTokenProvider({ env, xboxService }) });
   const userTokenProvider = opts.userTokenProvider ?? aFakeUserTokenProviderWith({ authService, xboxService });
-  const analyticsService = opts.analyticsService ?? aFakeAnalyticsServiceWith({ haloService, haloFilmService });
+  const analyticsService =
+    opts.analyticsService ?? aFakeAnalyticsServiceWith({ haloService, haloFilmService, logService });
   const liveTrackerService =
     opts.liveTrackerService ?? aFakeLiveTrackerServiceWith({ logService, discordService, env });
   const neatQueueService =

--- a/api/services/halo/fakes/halo-film.fake.ts
+++ b/api/services/halo/fakes/halo-film.fake.ts
@@ -13,5 +13,5 @@ export function aFakeHaloFilmServiceWith(opts: Partial<HaloFilmServiceOpts> = {}
       xboxService: aFakeXboxServiceWith({ env }),
     });
 
-  return new HaloFilmService({ env, spartanTokenProvider });
+  return new HaloFilmService({ env, spartanTokenProvider, ...(opts.fetch != null ? { fetch: opts.fetch } : {}) });
 }

--- a/api/services/halo/halo-film.ts
+++ b/api/services/halo/halo-film.ts
@@ -33,10 +33,16 @@ export class HaloFilmService {
 
   private readonly env: Env;
   private readonly spartanTokenProvider: CustomSpartanTokenProvider;
+  private readonly fetchFn: typeof globalThis.fetch | undefined;
 
-  constructor({ env, spartanTokenProvider }: HaloFilmServiceOpts) {
+  constructor({ env, spartanTokenProvider, fetch: fetchFn }: HaloFilmServiceOpts) {
     this.env = env;
     this.spartanTokenProvider = spartanTokenProvider;
+    this.fetchFn = fetchFn;
+  }
+
+  private async callFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    return this.fetchFn != null ? this.fetchFn(input, init) : fetch(input, init);
   }
 
   async getHighlightEventsForMatch(matchId: string): Promise<ParsedHighlightEvent[]> {
@@ -277,7 +283,7 @@ export class HaloFilmService {
   }
 
   private async fetchJson<T>(url: string, spartanToken: string, clearanceToken?: string): Promise<T> {
-    const response = await fetch(url, {
+    const response = await this.callFetch(url, {
       method: "GET",
       headers: this.createHeaders(spartanToken, clearanceToken),
     });
@@ -290,7 +296,7 @@ export class HaloFilmService {
   }
 
   private async fetchBinary(url: string, spartanToken: string, clearanceToken: string): Promise<Uint8Array> {
-    const response = await fetch(url, {
+    const response = await this.callFetch(url, {
       method: "GET",
       headers: this.createHeaders(spartanToken, clearanceToken, "*/*"),
     });
@@ -302,7 +308,7 @@ export class HaloFilmService {
     return new Uint8Array(await response.arrayBuffer());
   }
 
-  private async resolveAuthContext(): Promise<{ spartanToken: string; clearanceToken: string }> {
+  async resolveAuthContext(): Promise<{ spartanToken: string; clearanceToken: string }> {
     const spartanToken = await this.spartanTokenProvider.getSpartanToken();
 
     const cachedClearance = await this.env.APP_DATA.get(HaloFilmService.CLEARANCE_CACHE_KEY);

--- a/api/services/halo/halo-film.ts
+++ b/api/services/halo/halo-film.ts
@@ -308,7 +308,11 @@ export class HaloFilmService {
     return new Uint8Array(await response.arrayBuffer());
   }
 
-  async resolveAuthContext(): Promise<{ spartanToken: string; clearanceToken: string }> {
+  async warmAuthCache(): Promise<void> {
+    await this.resolveAuthContext();
+  }
+
+  private async resolveAuthContext(): Promise<{ spartanToken: string; clearanceToken: string }> {
     const spartanToken = await this.spartanTokenProvider.getSpartanToken();
 
     const cachedClearance = await this.env.APP_DATA.get(HaloFilmService.CLEARANCE_CACHE_KEY);

--- a/api/services/halo/resilient-fetch.ts
+++ b/api/services/halo/resilient-fetch.ts
@@ -14,6 +14,7 @@ interface ResilientFetchOptions {
   env: Env;
   logService: LogService;
   proxyUrl: string;
+  kvKeyNamespace?: string;
 }
 
 interface DebounceEntry {
@@ -44,9 +45,9 @@ function detectProxyType(proxyUrl: string): ProxyType {
   return ProxyType.JSON_RPC;
 }
 
-function getErrorWindowKey(): string {
+function getErrorWindowKey(baseKey: string): string {
   const windowStart = Math.floor(Date.now() / CIRCUIT_BREAKER_CONFIG.ERROR_WINDOW_MS);
-  return `${KV_KEYS.ERROR_WINDOW}:${windowStart.toString()}`;
+  return `${baseKey}:${windowStart.toString()}`;
 }
 
 function filterHeadersForProxy(headers: Headers): Headers {
@@ -80,12 +81,20 @@ function transformUrlForProxy(originalUrl: string, proxyBaseUrl: string): string
   return `${proxyBase}${pathWithDomain}`;
 }
 
-export function createResilientFetch({ env, logService, proxyUrl }: ResilientFetchOptions): typeof fetch {
+export function createResilientFetch({
+  env,
+  logService,
+  proxyUrl,
+  kvKeyNamespace,
+}: ResilientFetchOptions): typeof fetch {
   const proxyConfig: ProxyConfig = {
     type: detectProxyType(proxyUrl),
     baseUrl: proxyUrl,
     enabled: isValidUrl(proxyUrl),
   };
+
+  const circuitBreakerKey = kvKeyNamespace != null ? `${kvKeyNamespace}:circuit_breaker` : KV_KEYS.CIRCUIT_BREAKER;
+  const errorWindowKey = kvKeyNamespace != null ? `${kvKeyNamespace}:errors` : KV_KEYS.ERROR_WINDOW;
 
   const kvDebounceMap = new Map<string, DebounceEntry>();
 
@@ -95,7 +104,7 @@ export function createResilientFetch({ env, logService, proxyUrl }: ResilientFet
   }
 
   async function getCircuitBreakerState(): Promise<CircuitBreakerState | null> {
-    return await env.APP_DATA.get<CircuitBreakerState>(KV_KEYS.CIRCUIT_BREAKER, "json");
+    return await env.APP_DATA.get<CircuitBreakerState>(circuitBreakerKey, "json");
   }
 
   function logCacheStatus(response: Response, url: string, viaProxy = false): void {
@@ -147,7 +156,7 @@ export function createResilientFetch({ env, logService, proxyUrl }: ResilientFet
 
     const ttlSeconds = differenceInSeconds(expiresAt, now);
 
-    scheduleKvWrite(KV_KEYS.CIRCUIT_BREAKER, JSON.stringify(state), ttlSeconds);
+    scheduleKvWrite(circuitBreakerKey, JSON.stringify(state), ttlSeconds);
 
     logService.warn(
       `Circuit breaker activated: ${reason}`,
@@ -160,7 +169,7 @@ export function createResilientFetch({ env, logService, proxyUrl }: ResilientFet
   }
 
   async function trackError(statusCode: number, url: string): Promise<void> {
-    const windowKey = getErrorWindowKey();
+    const windowKey = getErrorWindowKey(errorWindowKey);
     const now = Date.now();
 
     const existingWindow = await env.APP_DATA.get<ErrorWindow>(windowKey, "json");

--- a/api/services/halo/tests/resilient-fetch.test.ts
+++ b/api/services/halo/tests/resilient-fetch.test.ts
@@ -617,7 +617,9 @@ describe("createResilientFetch", () => {
   describe("kvKeyNamespace", () => {
     it("reads circuit-breaker state from namespaced key when kvKeyNamespace is provided", async () => {
       kvGetSpy.mockImplementation(async (key) => {
-        if (key === KV_KEYS.PROXY_ENABLED) {return Promise.resolve("true");}
+        if (key === KV_KEYS.PROXY_ENABLED) {
+          return Promise.resolve("true");
+        }
         return Promise.resolve(null);
       });
       fetchSpy.mockResolvedValue(aFakeResponseWith({ status: 200 }));
@@ -638,7 +640,9 @@ describe("createResilientFetch", () => {
     it("writes circuit-breaker and error-window state to namespaced keys when kvKeyNamespace is provided", async () => {
       const errorWindow = aFakeErrorWindowWith({ errorCount: 2 });
       kvGetSpy.mockImplementation(async (key: string) => {
-        if (key.startsWith("halo:film:errors")) {return Promise.resolve(errorWindow);}
+        if (key.startsWith("halo:film:errors")) {
+          return Promise.resolve(errorWindow);
+        }
         return Promise.resolve(null);
       });
 

--- a/api/services/halo/tests/resilient-fetch.test.ts
+++ b/api/services/halo/tests/resilient-fetch.test.ts
@@ -614,6 +614,62 @@ describe("createResilientFetch", () => {
     });
   });
 
+  describe("kvKeyNamespace", () => {
+    it("reads circuit-breaker state from namespaced key when kvKeyNamespace is provided", async () => {
+      kvGetSpy.mockImplementation(async (key) => {
+        if (key === KV_KEYS.PROXY_ENABLED) {return Promise.resolve("true");}
+        return Promise.resolve(null);
+      });
+      fetchSpy.mockResolvedValue(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+        kvKeyNamespace: "halo:film",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      expect(kvGetSpy).toHaveBeenCalledWith("halo:film:circuit_breaker", "json");
+      expect(kvGetSpy).not.toHaveBeenCalledWith(KV_KEYS.CIRCUIT_BREAKER, "json");
+    });
+
+    it("writes circuit-breaker and error-window state to namespaced keys when kvKeyNamespace is provided", async () => {
+      const errorWindow = aFakeErrorWindowWith({ errorCount: 2 });
+      kvGetSpy.mockImplementation(async (key: string) => {
+        if (key.startsWith("halo:film:errors")) {return Promise.resolve(errorWindow);}
+        return Promise.resolve(null);
+      });
+
+      fetchSpy
+        .mockResolvedValueOnce(aFakeResponseWith({ status: 526 }))
+        .mockResolvedValueOnce(aFakeResponseWith({ status: 200 }));
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "https://haloquery.com/proxy",
+        kvKeyNamespace: "halo:film",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(kvPutSpy).toHaveBeenCalledWith(
+        expect.stringContaining("halo:film:errors"),
+        expect.any(String),
+        expect.objectContaining({ expirationTtl: CIRCUIT_BREAKER_CONFIG.ERROR_TRACKING_TTL_SECONDS }),
+      );
+      expect(kvPutSpy).toHaveBeenCalledWith(
+        "halo:film:circuit_breaker",
+        expect.any(String),
+        expect.objectContaining({ expirationTtl: expect.any(Number) as number }),
+      );
+      expect(kvPutSpy).not.toHaveBeenCalledWith(KV_KEYS.CIRCUIT_BREAKER, expect.anything(), expect.anything());
+    });
+  });
+
   describe("cache status logging", () => {
     it("logs cache HIT status for direct requests", async () => {
       kvGetSpy.mockResolvedValue(null);

--- a/api/services/halo/types.ts
+++ b/api/services/halo/types.ts
@@ -201,4 +201,5 @@ export interface KillMatrixAnalytics {
 export interface HaloFilmServiceOpts {
   env: Env;
   spartanTokenProvider: CustomSpartanTokenProvider;
+  fetch?: typeof globalThis.fetch;
 }

--- a/api/services/install.ts
+++ b/api/services/install.ts
@@ -94,6 +94,11 @@ export function installServices({ env }: InstallServicesOpts): Services {
   const haloFilmService = new HaloFilmService({
     env,
     spartanTokenProvider,
+    fetch: createResilientFetch({
+      env,
+      logService,
+      proxyUrl: env.PROXY_WORKER_URL,
+    }),
   });
   const analyticsService = new AnalyticsService({ haloService, haloFilmService });
   const liveTrackerService = new LiveTrackerService({ env, logService, discordService });

--- a/api/services/install.ts
+++ b/api/services/install.ts
@@ -98,6 +98,7 @@ export function installServices({ env }: InstallServicesOpts): Services {
       env,
       logService,
       proxyUrl: env.PROXY_WORKER_URL,
+      kvKeyNamespace: "halo:film",
     }),
   });
   const analyticsService = new AnalyticsService({ haloService, haloFilmService });

--- a/api/services/install.ts
+++ b/api/services/install.ts
@@ -101,7 +101,7 @@ export function installServices({ env }: InstallServicesOpts): Services {
       kvKeyNamespace: "halo:film",
     }),
   });
-  const analyticsService = new AnalyticsService({ haloService, haloFilmService });
+  const analyticsService = new AnalyticsService({ haloService, haloFilmService, logService });
   const liveTrackerService = new LiveTrackerService({ env, logService, discordService });
   const individualTrackerService = new IndividualTrackerService({ env, logService, databaseService });
   const neatQueueService = new NeatQueueService({


### PR DESCRIPTION
## Summary

- **Resilient fetch in `HaloFilmService`**: Added optional `fetch` to `HaloFilmServiceOpts` and a private `callFetch` method that lazily falls back to the global `fetch` (preserves `vi.spyOn(globalThis, "fetch")` test compatibility). `install.ts` now passes `createResilientFetch(...)` so all Waypoint HTTP calls (film metadata, clearance token, chunk downloads) get circuit-breaker / proxy fallback / 429-retry automatically.
- **Isolated circuit-breaker KV keys**: `createResilientFetch` accepts a `kvKeyNamespace` option. `halo:film` and the existing stats proxy now use separate keys (`halo:film:circuit_breaker`, `halo:film:errors`) so a rate-limit storm on film endpoints cannot trip the stats circuit-breaker.
- **Single auth pre-warm per batch**: `getBatchMatchAnalytics` calls `haloFilmService.warmAuthCache()` once before `Promise.allSettled` fan-out. On a cold start, this ensures the clearance token is in KV before all N concurrent per-match calls read it, preventing N concurrent Waypoint writes to the same key. Pre-warm failure is caught, logged via `logService.warn`, and execution continues so per-match errors are surfaced independently.
- **`warmAuthCache()` public API**: `HaloFilmService` exposes `warmAuthCache(): Promise<void>` as the public pre-warm surface, keeping `resolveAuthContext()` (which returns the raw token tuple) private.
- **`LogService` on `AnalyticsService`**: Added to support logging auth pre-warm failures directly from the service rather than requiring the route layer to instrument them.
- **Batch route simplified**: Route delegates fan-out and per-match error isolation to `getBatchMatchAnalytics`; failure-count logging remains in the route where the `logService` context lives.

## Test plan

- [ ] `AnalyticsService.getBatchMatchAnalytics` — resolves auth once, returns results keyed by matchId
- [ ] `AnalyticsService.getBatchMatchAnalytics` — returns `null` for failed matches without affecting successful ones
- [ ] `AnalyticsService.getBatchMatchAnalytics` — logs a warning and returns null for all matches when auth pre-warm fails
- [ ] Batch route — delegates to `getBatchMatchAnalytics`, correct response shape with no-store header
- [ ] Batch route — logs failure count when results contain nulls

🤖 Generated with [Claude Code](https://claude.com/claude-code)