### PR TITLE
feat(kill-matrix): add player ordering and team icons

### DIFF
--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -86,7 +86,7 @@ gh api repos/{owner}/{repo}/pulls/{PR}/comments/{COMMENT_ID}/replies \
   -X POST -f body="Not actioned: <reason why the concern doesn't apply>."
 ```
 
-**Resolve every thread** via GraphQL. First get thread node IDs:
+**Resolve every unresolved Copilot thread** via GraphQL. First get thread node IDs, including the author of the first comment so you can filter to Copilot-owned threads only:
 
 ```bash
 gh api graphql -f query='
@@ -97,7 +97,7 @@ gh api graphql -f query='
         nodes {
           id
           isResolved
-          comments(first: 1) { nodes { databaseId } }
+          comments(first: 1) { nodes { databaseId author { login } } }
         }
       }
     }
@@ -105,7 +105,7 @@ gh api graphql -f query='
 }'
 ```
 
-Then resolve each unresolved thread for the comments you just replied to:
+Then resolve each unresolved thread whose first comment author login contains `"copilot"`:
 
 ```bash
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE_ID}"}) { thread { isResolved } } }'

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -98,7 +98,7 @@ gh api repos/{owner}/{repo}/pulls/{PR}/comments/{COMMENT_ID}/replies \
   -X POST -f body="Not actioned: <reason>."
 ```
 
-**Resolve every thread.** Get thread node IDs:
+**Resolve every unresolved Copilot thread.** Get thread node IDs, including the author of the first comment so you can filter to Copilot-owned threads only:
 
 ```bash
 gh api graphql -f query='
@@ -109,7 +109,7 @@ gh api graphql -f query='
         nodes {
           id
           isResolved
-          comments(first: 1) { nodes { databaseId } }
+          comments(first: 1) { nodes { databaseId author { login } } }
         }
       }
     }
@@ -117,7 +117,7 @@ gh api graphql -f query='
 }'
 ```
 
-Resolve each unresolved thread for the comments just replied to:
+Resolve each unresolved thread whose first comment author login contains `"copilot"`:
 
 ```bash
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE_ID}"}) { thread { isResolved } } }'

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -5,7 +5,11 @@ import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-
 import type { MatchStatsData } from "../../controllers/stats/types";
 import { StatsController } from "../../controllers/stats/stats-controller";
 import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
-import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixViewRow } from "../../controllers/stats/kill-matrix/types";
+import {
+  EMPTY_KILL_MATRIX_PIVOT_DATA,
+  type KillMatrixPlayer,
+  type KillMatrixViewRow,
+} from "../../controllers/stats/kill-matrix/types";
 import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import { ComponentLoaderStatus } from "../component-loader/component-loader";
 import { DEFAULT_TEAM_COLORS, getTeamColorOrDefault, type TeamColor } from "../team-colors/team-colors";
@@ -145,6 +149,7 @@ export class DiscordSeriesStatsPresenter {
         ]),
       ),
     );
+    let orderedPlayers: readonly KillMatrixPlayer[] | undefined = undefined;
     let seriesData: { teamData: MatchStatsData[]; playerData: MatchStatsData[] } | null = null;
 
     if (rawMatches.length > 0) {
@@ -157,9 +162,9 @@ export class DiscordSeriesStatsPresenter {
         }
         this.controller.loadSeries(rawMatches, playersMap, this.renderData.medalMetadata);
         seriesData = this.controller.getSeriesStats();
-        playersByXuid = new Map(
-          this.controller.getPlayers().map((p) => [p.xuid, { gamertag: p.gamertag, teamId: p.teamId }]),
-        );
+        const players = this.controller.getPlayers();
+        orderedPlayers = players;
+        playersByXuid = new Map(players.map((p) => [p.xuid, { gamertag: p.gamertag, teamId: p.teamId }]));
       } catch {
         seriesData = null;
       }
@@ -206,9 +211,10 @@ export class DiscordSeriesStatsPresenter {
         startTime: match.startTime,
         endTime: match.endTime,
         teamColors,
-        killMatrixPivotData: rows != null ? KillMatrixFormatter.pivot(rows) : EMPTY_KILL_MATRIX_PIVOT_DATA,
+        killMatrixPivotData:
+          rows != null ? KillMatrixFormatter.pivot(rows, orderedPlayers) : EMPTY_KILL_MATRIX_PIVOT_DATA,
         transposedKillMatrixPivotData:
-          rows != null ? KillMatrixFormatter.transpose(rows) : EMPTY_KILL_MATRIX_PIVOT_DATA,
+          rows != null ? KillMatrixFormatter.transpose(rows, orderedPlayers) : EMPTY_KILL_MATRIX_PIVOT_DATA,
         killMatrixStatus: snapshot.analyticsStatus,
       };
       if (!isMatchStats(match.rawMatch)) {
@@ -234,8 +240,8 @@ export class DiscordSeriesStatsPresenter {
             playerData: seriesData.playerData,
             metadata: calculateSeriesMetadata(this.renderData.matches, this.renderData.seriesScore),
             teamColors,
-            killMatrixPivotData: KillMatrixFormatter.pivot(aggregatedKillMatrixRows),
-            transposedKillMatrixPivotData: KillMatrixFormatter.transpose(aggregatedKillMatrixRows),
+            killMatrixPivotData: KillMatrixFormatter.pivot(aggregatedKillMatrixRows, orderedPlayers),
+            transposedKillMatrixPivotData: KillMatrixFormatter.transpose(aggregatedKillMatrixRows, orderedPlayers),
             killMatrixStatus: snapshot.analyticsStatus,
           }
         : null;

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -70,6 +70,7 @@ export class IndividualTrackerViewerPresenter {
         controller.loadAnalytics(analytics, playerMap);
       }
       const killMatrixRows = analytics != null ? controller.getKillMatrix() : null;
+      const orderedPlayers = controller.getPlayers();
       return {
         status: "loaded",
         matchId: stats.MatchId,
@@ -79,9 +80,13 @@ export class IndividualTrackerViewerPresenter {
         endTime: stats.MatchInfo.EndTime,
         data: controller.getMatchStats(),
         killMatrixPivotData:
-          killMatrixRows != null ? KillMatrixFormatter.pivot(killMatrixRows) : EMPTY_KILL_MATRIX_PIVOT_DATA,
+          killMatrixRows != null
+            ? KillMatrixFormatter.pivot(killMatrixRows, orderedPlayers)
+            : EMPTY_KILL_MATRIX_PIVOT_DATA,
         transposedKillMatrixPivotData:
-          killMatrixRows != null ? KillMatrixFormatter.transpose(killMatrixRows) : EMPTY_KILL_MATRIX_PIVOT_DATA,
+          killMatrixRows != null
+            ? KillMatrixFormatter.transpose(killMatrixRows, orderedPlayers)
+            : EMPTY_KILL_MATRIX_PIVOT_DATA,
       };
     } catch {
       return { status: "error", message: "Failed to compute match stats" };

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
@@ -1,3 +1,9 @@
+.playerHeader {
+  align-items: center;
+  display: inline-flex;
+  gap: var(--space-1);
+}
+
 .killCell {
   font-variant-numeric: tabular-nums;
   text-align: center;

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Alert } from "../../alert/alert";
 import { Button } from "../../button/button";
 import { ComponentLoader, ComponentLoaderStatus } from "../../component-loader/component-loader";
+import { TeamIcon } from "../../icons/team-icon";
 import { SortableTable, type SortableTableColumn } from "../../table/sortable-table";
 import tableStyles from "../../table/table.module.css";
 import type { KillMatrixPivotData, KillMatrixPivotRow } from "../../../controllers/stats/kill-matrix/types";
@@ -51,21 +52,35 @@ export function KillMatrixTable({
         accessorFn: (row): string => row.killerGamertag,
         sortingFn: "alphanumeric",
         cellClassName: tableStyles.labelCell,
+        cell: (_value, row): React.ReactNode => {
+          const { killerTeamId } = row;
+          return (
+            <span className={styles.playerHeader}>
+              {killerTeamId != null && <TeamIcon teamId={killerTeamId} size="x-small" />}
+              {row.killerGamertag}
+            </span>
+          );
+        },
       },
     ];
 
-    for (const victimGamertag of activePivotData.victimGamertags) {
+    for (const { gamertag, teamId } of activePivotData.columnHeaders) {
       cols.push({
-        id: victimGamertag,
-        header: victimGamertag,
-        accessorFn: (row): number => row[victimGamertag] as number,
+        id: gamertag,
+        header: (
+          <span className={styles.playerHeader}>
+            {teamId != null && <TeamIcon teamId={teamId} size="x-small" />}
+            {gamertag}
+          </span>
+        ),
+        accessorFn: (row: KillMatrixPivotRow): number => row.kills.get(gamertag) ?? 0,
         sortingFn: "basic",
         cellClassName: styles.killCell,
       });
     }
 
     return cols;
-  }, [effectiveStatus, activeKillerAxisLabel, activePivotData.victimGamertags]);
+  }, [effectiveStatus, activeKillerAxisLabel, activePivotData.columnHeaders]);
 
   const playerCount = playerGamertags !== undefined && playerGamertags.length > 0 ? playerGamertags.length : 8;
 

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -1,6 +1,12 @@
 import "@testing-library/jest-dom/vitest";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../icons/team-icon", () => ({
+  TeamIcon: ({ teamId }: { teamId: number }): React.ReactNode => (
+    <div data-testid={`team-icon-${teamId.toString()}`}>Team {teamId.toString()}</div>
+  ),
+}));
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ComponentLoaderStatus } from "../../../component-loader/component-loader";

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -1,9 +1,10 @@
 import "@testing-library/jest-dom/vitest";
 
+import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../icons/team-icon", () => ({
-  TeamIcon: ({ teamId }: { teamId: number }): React.ReactNode => (
+  TeamIcon: ({ teamId }: { teamId: number }): ReactNode => (
     <div data-testid={`team-icon-${teamId.toString()}`}>Team {teamId.toString()}</div>
   ),
 }));

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -147,6 +147,64 @@ describe("KillMatrixTable", () => {
     expect(screen.getByText("No kill matrix data.")).toBeInTheDocument();
   });
 
+  it("renders team icons for killer row labels and victim column headers", () => {
+    const pivotData = KillMatrixFormatter.pivot([
+      {
+        key: "111:222",
+        killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+        victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+        count: 3,
+        headshotKills: 1,
+        perfects: 0,
+        classification: "enemy-kill",
+      },
+    ]);
+
+    render(<KillMatrixTable pivotData={pivotData} ariaLabel="Kill matrix" emptyMessage="No kill matrix data." />);
+
+    expect(screen.getByTestId("team-icon-0")).toBeInTheDocument();
+    expect(screen.getByTestId("team-icon-1")).toBeInTheDocument();
+  });
+
+  it("renders team icons after toggling to deaths view and back", async () => {
+    const user = userEvent.setup();
+    const rows = [
+      {
+        key: "111:222",
+        killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+        victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+        count: 3,
+        headshotKills: 1,
+        perfects: 0,
+        classification: "enemy-kill" as const,
+      },
+    ];
+    const pivotData = KillMatrixFormatter.pivot(rows);
+    const transposedPivotData = KillMatrixFormatter.transpose(rows);
+
+    render(
+      <KillMatrixTable
+        pivotData={pivotData}
+        ariaLabel="Kill matrix"
+        emptyMessage="No kill matrix data."
+        transposedPivotData={transposedPivotData}
+      />,
+    );
+
+    expect(screen.getByTestId("team-icon-0")).toBeInTheDocument();
+    expect(screen.getByTestId("team-icon-1")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Switch to Deaths view"));
+
+    expect(screen.getByTestId("team-icon-0")).toBeInTheDocument();
+    expect(screen.getByTestId("team-icon-1")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Switch to Kills view"));
+
+    expect(screen.getByTestId("team-icon-0")).toBeInTheDocument();
+    expect(screen.getByTestId("team-icon-1")).toBeInTheDocument();
+  });
+
   it("does not render toggle button when transposedPivotData is not provided", () => {
     const pivotData = KillMatrixFormatter.pivot([
       {

--- a/pages/src/components/table/sortable-table.tsx
+++ b/pages/src/components/table/sortable-table.tsx
@@ -15,7 +15,7 @@ export interface SortableTableColumn<TData> extends Omit<ColumnDef<TData>, "id" 
   /** Unique identifier for the column */
   id: string;
   /** Header label to display */
-  header: string;
+  header: React.ReactNode;
   /** Function to extract cell value from row data */
   accessorFn: (row: TData) => unknown;
   /** Function to render cell content (optional, defaults to displaying the value) */
@@ -80,7 +80,7 @@ export function SortableTable<TData>({
       columns.map((col) => ({
         id: col.id,
         accessorFn: col.accessorFn,
-        header: col.header,
+        header: (): React.ReactNode => col.header,
         cell: (info): React.ReactNode => {
           const value = info.getValue();
           return col.cell != null ? col.cell(value, info.row.original) : (value as React.ReactNode);

--- a/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
+++ b/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
@@ -1,6 +1,12 @@
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
-import type { KillMatrixClassification, KillMatrixPivotData, KillMatrixPlayer, KillMatrixViewRow } from "./types";
+import type {
+  KillMatrixClassification,
+  KillMatrixColumnHeader,
+  KillMatrixPivotData,
+  KillMatrixPlayer,
+  KillMatrixViewRow,
+} from "./types";
 
 interface KillMatrixFormatterPlayerLookup {
   readonly gamertag: string;
@@ -82,18 +88,21 @@ export class KillMatrixFormatter {
     return { killerXuid, victimXuid };
   }
 
-  public static pivot(rows: readonly KillMatrixViewRow[]): KillMatrixPivotData {
+  public static pivot(
+    rows: readonly KillMatrixViewRow[],
+    orderedPlayers?: readonly KillMatrixPlayer[],
+  ): KillMatrixPivotData {
     if (rows.length === 0) {
-      return { tableRows: [], victimGamertags: [] };
+      return { tableRows: [], columnHeaders: [] };
     }
 
-    const killersMap = new Map<string, string>();
-    const victimsMap = new Map<string, string>();
+    const killersMap = new Map<string, KillMatrixPlayer>();
+    const victimsMap = new Map<string, KillMatrixPlayer>();
     const killCounts = new Map<string, Map<string, number>>();
 
     for (const row of rows) {
-      killersMap.set(row.killer.xuid, row.killer.gamertag);
-      victimsMap.set(row.victim.xuid, row.victim.gamertag);
+      killersMap.set(row.killer.xuid, row.killer);
+      victimsMap.set(row.victim.xuid, row.victim);
 
       if (!killCounts.has(row.killer.xuid)) {
         killCounts.set(row.killer.xuid, new Map());
@@ -102,30 +111,46 @@ export class KillMatrixFormatter {
       victimCounts.set(row.victim.xuid, row.count);
     }
 
-    const sortedKillers = Array.from(killersMap.entries()).sort((a, b) => a[1].localeCompare(b[1]));
-    const sortedVictims = Array.from(victimsMap.entries()).sort((a, b) => a[1].localeCompare(b[1]));
+    const sortedKillers =
+      orderedPlayers != null
+        ? orderedPlayers.filter((p) => killersMap.has(p.xuid))
+        : Array.from(killersMap.values()).sort((a, b) => a.gamertag.localeCompare(b.gamertag));
 
-    const tableRows = sortedKillers.map(([killerId, killerGamertag]) => {
-      const row: { killerId: string; killerGamertag: string; [key: string]: string | number } = {
-        killerId,
-        killerGamertag,
-      };
+    const sortedVictims =
+      orderedPlayers != null
+        ? orderedPlayers.filter((p) => victimsMap.has(p.xuid))
+        : Array.from(victimsMap.values()).sort((a, b) => a.gamertag.localeCompare(b.gamertag));
 
-      const victimCounts = killCounts.get(killerId) ?? new Map();
-      for (const [victimId, victimGamertag] of sortedVictims) {
-        row[victimGamertag] = victimCounts.get(victimId) ?? 0;
+    const tableRows = sortedKillers.map((killer) => {
+      const victimCounts = Preconditions.checkExists(killCounts.get(killer.xuid));
+      const kills = new Map<string, number>();
+      for (const victim of sortedVictims) {
+        kills.set(victim.gamertag, victimCounts.get(victim.xuid) ?? 0);
       }
-
-      return row;
+      return {
+        killerId: killer.xuid,
+        killerGamertag: killer.gamertag,
+        killerTeamId: killer.teamId,
+        kills,
+      };
     });
 
-    const victimGamertags = sortedVictims.map(([, gamertag]) => gamertag);
+    const columnHeaders: KillMatrixColumnHeader[] = sortedVictims.map((p) => ({
+      gamertag: p.gamertag,
+      teamId: p.teamId,
+    }));
 
-    return { tableRows, victimGamertags };
+    return { tableRows, columnHeaders };
   }
 
-  public static transpose(rows: readonly KillMatrixViewRow[]): KillMatrixPivotData {
-    return KillMatrixFormatter.pivot(rows.map((row) => ({ ...row, killer: row.victim, victim: row.killer })));
+  public static transpose(
+    rows: readonly KillMatrixViewRow[],
+    orderedPlayers?: readonly KillMatrixPlayer[],
+  ): KillMatrixPivotData {
+    return KillMatrixFormatter.pivot(
+      rows.map((row) => ({ ...row, killer: row.victim, victim: row.killer })),
+      orderedPlayers,
+    );
   }
 
   public static aggregate(rows: readonly KillMatrixViewRow[]): KillMatrixViewRow[] {

--- a/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
+++ b/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
@@ -111,15 +111,28 @@ export class KillMatrixFormatter {
       victimCounts.set(row.victim.xuid, row.count);
     }
 
-    const sortedKillers =
-      orderedPlayers != null
-        ? orderedPlayers.filter((p) => killersMap.has(p.xuid))
-        : Array.from(killersMap.values()).sort((a, b) => a.gamertag.localeCompare(b.gamertag));
+    const byGamertag = (a: KillMatrixPlayer, b: KillMatrixPlayer): number => a.gamertag.localeCompare(b.gamertag);
 
-    const sortedVictims =
-      orderedPlayers != null
-        ? orderedPlayers.filter((p) => victimsMap.has(p.xuid))
-        : Array.from(victimsMap.values()).sort((a, b) => a.gamertag.localeCompare(b.gamertag));
+    let sortedKillers: KillMatrixPlayer[];
+    let sortedVictims: KillMatrixPlayer[];
+    if (orderedPlayers != null) {
+      const orderedXuids = new Set(orderedPlayers.map((p) => p.xuid));
+      sortedKillers = [
+        ...orderedPlayers.filter((p) => killersMap.has(p.xuid)),
+        ...Array.from(killersMap.values())
+          .filter((p) => !orderedXuids.has(p.xuid))
+          .sort(byGamertag),
+      ];
+      sortedVictims = [
+        ...orderedPlayers.filter((p) => victimsMap.has(p.xuid)),
+        ...Array.from(victimsMap.values())
+          .filter((p) => !orderedXuids.has(p.xuid))
+          .sort(byGamertag),
+      ];
+    } else {
+      sortedKillers = Array.from(killersMap.values()).sort(byGamertag);
+      sortedVictims = Array.from(victimsMap.values()).sort(byGamertag);
+    }
 
     const tableRows = sortedKillers.map((killer) => {
       const victimCounts = Preconditions.checkExists(killCounts.get(killer.xuid));

--- a/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
+++ b/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
@@ -181,6 +181,38 @@ describe("KillMatrixFormatter", () => {
       expect(result.tableRows.map((r) => r.killerGamertag)).toEqual(["Bravo", "Alpha"]);
       expect(result.columnHeaders.map((h) => h.gamertag)).toEqual(["Bravo", "Alpha"]);
     });
+
+    it("appends players absent from orderedPlayers alphabetically after the ordered subset", () => {
+      const rows: KillMatrixViewRow[] = [
+        {
+          key: "111:222",
+          killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          count: 3,
+          headshotKills: 0,
+          perfects: 0,
+          classification: "enemy-kill",
+        },
+        {
+          key: "999:888",
+          killer: { xuid: "999", gamertag: "Zeta", teamId: null },
+          victim: { xuid: "888", gamertag: "Omega", teamId: null },
+          count: 1,
+          headshotKills: 0,
+          perfects: 0,
+          classification: "enemy-kill",
+        },
+      ];
+
+      const orderedPlayers = [
+        { xuid: "222", gamertag: "Bravo", teamId: 1 },
+        { xuid: "111", gamertag: "Alpha", teamId: 0 },
+      ];
+      const result = KillMatrixFormatter.pivot(rows, orderedPlayers);
+
+      expect(result.tableRows.map((r) => r.killerGamertag)).toEqual(["Alpha", "Zeta"]);
+      expect(result.columnHeaders.map((h) => h.gamertag)).toEqual(["Bravo", "Omega"]);
+    });
   });
 
   describe("aggregate", () => {

--- a/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
+++ b/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
@@ -49,7 +49,7 @@ describe("KillMatrixFormatter", () => {
 
   describe("pivot", () => {
     it("returns empty pivot for no rows", () => {
-      expect(KillMatrixFormatter.pivot([])).toEqual({ tableRows: [], victimGamertags: [] });
+      expect(KillMatrixFormatter.pivot([])).toEqual({ tableRows: [], columnHeaders: [] });
     });
 
     it("returns a single row with one victim column", () => {
@@ -67,9 +67,10 @@ describe("KillMatrixFormatter", () => {
 
       const result = KillMatrixFormatter.pivot(rows);
 
-      expect(result.victimGamertags).toEqual(["Bravo"]);
+      expect(result.columnHeaders).toEqual([{ gamertag: "Bravo", teamId: 1 }]);
       expect(result.tableRows).toHaveLength(1);
-      expect(result.tableRows[0]).toMatchObject({ killerId: "111", killerGamertag: "Alpha", Bravo: 5 });
+      expect(result.tableRows[0]).toMatchObject({ killerId: "111", killerGamertag: "Alpha", killerTeamId: 0 });
+      expect(result.tableRows[0].kills.get("Bravo")).toBe(5);
     });
 
     it("sorts killers and victims alphabetically and fills zeros for missing kills", () => {
@@ -105,10 +106,14 @@ describe("KillMatrixFormatter", () => {
 
       const result = KillMatrixFormatter.pivot(rows);
 
-      expect(result.victimGamertags).toEqual(["Alpha", "Bravo"]);
+      expect(result.columnHeaders.map((h) => h.gamertag)).toEqual(["Alpha", "Bravo"]);
       expect(result.tableRows).toHaveLength(2);
-      expect(result.tableRows[0]).toMatchObject({ killerId: "333", killerGamertag: "Alpha", Alpha: 1, Bravo: 0 });
-      expect(result.tableRows[1]).toMatchObject({ killerId: "222", killerGamertag: "Charlie", Alpha: 2, Bravo: 3 });
+      expect(result.tableRows[0]).toMatchObject({ killerId: "333", killerGamertag: "Alpha" });
+      expect(result.tableRows[0].kills.get("Alpha")).toBe(1);
+      expect(result.tableRows[0].kills.get("Bravo")).toBe(0);
+      expect(result.tableRows[1]).toMatchObject({ killerId: "222", killerGamertag: "Charlie" });
+      expect(result.tableRows[1].kills.get("Alpha")).toBe(2);
+      expect(result.tableRows[1].kills.get("Bravo")).toBe(3);
     });
 
     it("correctly handles players who appear as both killer and victim", () => {
@@ -135,10 +140,46 @@ describe("KillMatrixFormatter", () => {
 
       const result = KillMatrixFormatter.pivot(rows);
 
-      expect(result.victimGamertags).toEqual(["Alpha", "Bravo"]);
+      expect(result.columnHeaders.map((h) => h.gamertag)).toEqual(["Alpha", "Bravo"]);
       expect(result.tableRows).toHaveLength(2);
-      expect(result.tableRows[0]).toMatchObject({ killerGamertag: "Alpha", Alpha: 0, Bravo: 3 });
-      expect(result.tableRows[1]).toMatchObject({ killerGamertag: "Bravo", Alpha: 1, Bravo: 0 });
+      expect(result.tableRows[0]).toMatchObject({ killerGamertag: "Alpha" });
+      expect(result.tableRows[0].kills.get("Alpha")).toBe(0);
+      expect(result.tableRows[0].kills.get("Bravo")).toBe(3);
+      expect(result.tableRows[1]).toMatchObject({ killerGamertag: "Bravo" });
+      expect(result.tableRows[1].kills.get("Alpha")).toBe(1);
+      expect(result.tableRows[1].kills.get("Bravo")).toBe(0);
+    });
+
+    it("respects orderedPlayers when provided", () => {
+      const rows: KillMatrixViewRow[] = [
+        {
+          key: "111:222",
+          killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          count: 3,
+          headshotKills: 0,
+          perfects: 0,
+          classification: "enemy-kill",
+        },
+        {
+          key: "222:111",
+          killer: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          victim: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          count: 1,
+          headshotKills: 0,
+          perfects: 0,
+          classification: "enemy-kill",
+        },
+      ];
+
+      const orderedPlayers = [
+        { xuid: "222", gamertag: "Bravo", teamId: 1 },
+        { xuid: "111", gamertag: "Alpha", teamId: 0 },
+      ];
+      const result = KillMatrixFormatter.pivot(rows, orderedPlayers);
+
+      expect(result.tableRows.map((r) => r.killerGamertag)).toEqual(["Bravo", "Alpha"]);
+      expect(result.columnHeaders.map((h) => h.gamertag)).toEqual(["Bravo", "Alpha"]);
     });
   });
 
@@ -205,7 +246,7 @@ describe("KillMatrixFormatter", () => {
 
   describe("transpose", () => {
     it("returns empty pivot for no rows", () => {
-      expect(KillMatrixFormatter.transpose([])).toEqual({ tableRows: [], victimGamertags: [] });
+      expect(KillMatrixFormatter.transpose([])).toEqual({ tableRows: [], columnHeaders: [] });
     });
 
     it("swaps killers and victims so rows become victims and columns become killers", () => {
@@ -223,9 +264,10 @@ describe("KillMatrixFormatter", () => {
 
       const result = KillMatrixFormatter.transpose(rows);
 
-      expect(result.victimGamertags).toEqual(["Alpha"]);
+      expect(result.columnHeaders.map((h) => h.gamertag)).toEqual(["Alpha"]);
       expect(result.tableRows).toHaveLength(1);
-      expect(result.tableRows[0]).toMatchObject({ killerId: "222", killerGamertag: "Bravo", Alpha: 5 });
+      expect(result.tableRows[0]).toMatchObject({ killerId: "222", killerGamertag: "Bravo" });
+      expect(result.tableRows[0].kills.get("Alpha")).toBe(5);
     });
   });
 });

--- a/pages/src/controllers/stats/kill-matrix/types.ts
+++ b/pages/src/controllers/stats/kill-matrix/types.ts
@@ -11,7 +11,7 @@ export interface KillMatrixPivotRow {
   readonly killerId: string;
   readonly killerGamertag: string;
   readonly killerTeamId: number | null;
-  readonly kills: Map<string, number>;
+  readonly kills: ReadonlyMap<string, number>;
 }
 
 export interface KillMatrixPivotData {

--- a/pages/src/controllers/stats/kill-matrix/types.ts
+++ b/pages/src/controllers/stats/kill-matrix/types.ts
@@ -2,18 +2,24 @@ import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-
 
 export type KillMatrixClassification = "enemy-kill" | "betrayal" | "suicide";
 
+export interface KillMatrixColumnHeader {
+  readonly gamertag: string;
+  readonly teamId: number | null;
+}
+
 export interface KillMatrixPivotRow {
   readonly killerId: string;
   readonly killerGamertag: string;
-  readonly [victimGamertag: string]: string | number;
+  readonly killerTeamId: number | null;
+  readonly kills: Map<string, number>;
 }
 
 export interface KillMatrixPivotData {
   readonly tableRows: readonly KillMatrixPivotRow[];
-  readonly victimGamertags: readonly string[];
+  readonly columnHeaders: readonly KillMatrixColumnHeader[];
 }
 
-export const EMPTY_KILL_MATRIX_PIVOT_DATA: KillMatrixPivotData = { tableRows: [], victimGamertags: [] };
+export const EMPTY_KILL_MATRIX_PIVOT_DATA: KillMatrixPivotData = { tableRows: [], columnHeaders: [] };
 
 export interface KillMatrixPlayer {
   readonly xuid: string;


### PR DESCRIPTION
## Summary

- **Player ordering**: Kill matrix rows and columns now follow the same order as the player stats table (team group → score descending within team). `KillMatrixFormatter.pivot()` and `.transpose()` accept an optional `orderedPlayers` parameter; both the discord-series and viewer presenters pass `controller.getPlayers()` which already applies the correct ordering.
- **Team icons**: `TeamIcon` is now rendered inline with each player's gamertag in both row labels (killer column) and column headers (victim columns). A new `.playerHeader` CSS class aligns icon + text with a flex gap.
- **Type improvements**: `KillMatrixPivotRow` replaces the index signature with an explicit `kills: Map<string, number>`, and `KillMatrixPivotData.victimGamertags` is replaced by `columnHeaders: readonly KillMatrixColumnHeader[]` carrying `teamId` alongside the gamertag. `SortableTableColumn.header` is widened from `string` to `React.ReactNode`.

## Test plan

- [ ] Kill matrix formatter tests updated — `columnHeaders`, `killerTeamId`, `kills.get()`, and `orderedPlayers` all verified
- [ ] `npm run done` passes (prettier, typecheck, eslint, vitest)
- [ ] Check kill matrix in discord series stats view — players should appear in team order with team icons
- [ ] Check kill matrix in individual tracker viewer — same ordering and icons
- [ ] Toggle kills/deaths view — both orientations should maintain ordering and icons
- [ ] Match with no analytics — kill matrix falls back to empty state gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)