### PR TITLE
fix(kill-matrix): order players by team/rank instead of API order

### DIFF
--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -163,7 +163,10 @@ export class DiscordSeriesStatsPresenter {
         this.controller.loadSeries(rawMatches, playersMap, this.renderData.medalMetadata);
         seriesData = this.controller.getSeriesStats();
         const players = this.controller.getPlayers();
-        orderedPlayers = players;
+        const playersByGamertag = new Map(players.map((p) => [p.gamertag, p]));
+        orderedPlayers = seriesData.playerData
+          .flatMap((teamData) => teamData.players.map((p) => playersByGamertag.get(p.name)))
+          .filter((p): p is KillMatrixPlayer => p != null);
         playersByXuid = new Map(players.map((p) => [p.xuid, { gamertag: p.gamertag, teamId: p.teamId }]));
       } catch {
         seriesData = null;

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -165,11 +165,12 @@ export class DiscordSeriesStatsPresenter {
         const players = this.controller.getPlayers();
         const playersByGamertag = new Map(players.map((p) => [p.gamertag, p]));
         const GAMES_SUFFIX_RE = /\s+\(\d+\/\d+ games\)$/;
-        orderedPlayers = seriesData.playerData
+        const resolvedPlayers = seriesData.playerData
           .flatMap((teamData) =>
             teamData.players.map((p) => playersByGamertag.get(p.name.replace(GAMES_SUFFIX_RE, ""))),
           )
           .filter((p): p is KillMatrixPlayer => p != null);
+        orderedPlayers = resolvedPlayers.length === players.length ? resolvedPlayers : players;
         playersByXuid = new Map(players.map((p) => [p.xuid, { gamertag: p.gamertag, teamId: p.teamId }]));
       } catch {
         seriesData = null;

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -164,8 +164,11 @@ export class DiscordSeriesStatsPresenter {
         seriesData = this.controller.getSeriesStats();
         const players = this.controller.getPlayers();
         const playersByGamertag = new Map(players.map((p) => [p.gamertag, p]));
+        const GAMES_SUFFIX_RE = /\s+\(\d+\/\d+ games\)$/;
         orderedPlayers = seriesData.playerData
-          .flatMap((teamData) => teamData.players.map((p) => playersByGamertag.get(p.name)))
+          .flatMap((teamData) =>
+            teamData.players.map((p) => playersByGamertag.get(p.name.replace(GAMES_SUFFIX_RE, ""))),
+          )
           .filter((p): p is KillMatrixPlayer => p != null);
         playersByXuid = new Map(players.map((p) => [p.xuid, { gamertag: p.gamertag, teamId: p.teamId }]));
       } catch {

--- a/pages/src/components/discord-series-stats/tests/discord-series-stats-presenter.test.ts
+++ b/pages/src/components/discord-series-stats/tests/discord-series-stats-presenter.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import { ComponentLoaderStatus } from "../../component-loader/component-loader";
+import { StatsController } from "../../../controllers/stats/stats-controller";
+import { aFakeCoreStatsWith, aFakeMatchStatsWith, aFakePlayerWith } from "../../../controllers/stats/fakes/data";
+import { aFakeMatchAnalyticsServiceWith } from "../../../services/stats/fakes/match-analytics.fake";
+import { DiscordSeriesStatsPresenter } from "../discord-series-stats-presenter";
+import { DiscordSeriesStatsStore } from "../discord-series-stats-store";
+
+describe("DiscordSeriesStatsPresenter.present", () => {
+  it("orders kill matrix players correctly when some players have a games-played suffix", () => {
+    // Match A: all 4 players present
+    const matchA = aFakeMatchStatsWith({ MatchId: "match-a" });
+
+    // Match B: player 1111111111 is absent — they will get a "(1/2 games)" suffix in series stats
+    const matchB = aFakeMatchStatsWith({
+      MatchId: "match-b",
+      Players: [
+        aFakePlayerWith({
+          PlayerId: "xuid(2222222222)",
+          LastTeamId: 0,
+          Rank: 4,
+          PlayerTeamStats: [
+            {
+              TeamId: 0,
+              Stats: {
+                CoreStats: aFakeCoreStatsWith({ Kills: 8, Deaths: 12, Assists: 3, PersonalScore: 1200 }),
+                PvpStats: { Kills: 8, Deaths: 12, Assists: 3, KDA: 0.92 },
+              },
+            },
+          ],
+        }),
+        aFakePlayerWith({
+          PlayerId: "xuid(3333333333)",
+          LastTeamId: 1,
+          Rank: 1,
+          PlayerTeamStats: [
+            {
+              TeamId: 1,
+              Stats: {
+                CoreStats: aFakeCoreStatsWith({ Kills: 25, Deaths: 10, Assists: 15, PersonalScore: 4000 }),
+                PvpStats: { Kills: 25, Deaths: 10, Assists: 15, KDA: 4 },
+              },
+            },
+          ],
+        }),
+        aFakePlayerWith({
+          PlayerId: "xuid(4444444444)",
+          LastTeamId: 1,
+          Rank: 2,
+          PlayerTeamStats: [
+            {
+              TeamId: 1,
+              Stats: {
+                CoreStats: aFakeCoreStatsWith({ Kills: 20, Deaths: 11, Assists: 12, PersonalScore: 3200 }),
+                PvpStats: { Kills: 20, Deaths: 11, Assists: 12, KDA: 2.91 },
+              },
+            },
+          ],
+        }),
+      ],
+    });
+
+    const playerXuidToGametag = {
+      "1111111111": "1111111111",
+      "2222222222": "2222222222",
+      "3333333333": "3333333333",
+      "4444444444": "4444444444",
+    };
+
+    const renderData: DiscordSeriesStatsPresenter["renderData"] = {
+      title: "Series",
+      subtitle: "Test",
+      seriesScore: "1:1",
+      medalMetadata: {},
+      teams: [
+        { name: "Eagle", players: ["1111111111", "2222222222"] },
+        { name: "Cobra", players: ["3333333333", "4444444444"] },
+      ],
+      matches: [
+        {
+          matchId: "match-a",
+          gameTypeAndMap: "Slayer: Live Fire",
+          gameVariantCategory: 9,
+          gameType: "Slayer",
+          gameMap: "Live Fire",
+          gameMapThumbnailUrl: "data:,",
+          duration: "10m 00s",
+          gameScore: "50:45",
+          gameSubScore: null,
+          startTime: "2026-01-01T00:00:00.000Z",
+          endTime: "2026-01-01T00:10:00.000Z",
+          playerXuidToGametag,
+          rawMatch: matchA,
+        },
+        {
+          matchId: "match-b",
+          gameTypeAndMap: "Slayer: Live Fire",
+          gameVariantCategory: 9,
+          gameType: "Slayer",
+          gameMap: "Live Fire",
+          gameMapThumbnailUrl: "data:,",
+          duration: "10m 00s",
+          gameScore: "45:50",
+          gameSubScore: null,
+          startTime: "2026-01-01T00:15:00.000Z",
+          endTime: "2026-01-01T00:25:00.000Z",
+          playerXuidToGametag,
+          rawMatch: matchB,
+        },
+      ],
+    };
+
+    const analytics: MatchAnalytics = {
+      requestedModules: ["killMatrix"],
+      killMatrix: {
+        "3333333333:1111111111": { count: 2, headshotKills: 0, perfects: 0, weapons: [] },
+        "1111111111:3333333333": { count: 1, headshotKills: 0, perfects: 0, weapons: [] },
+      },
+      metadata: {
+        pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 1 },
+        perfectCounts: { total: 0, byXuid: {} },
+      },
+    };
+
+    const store = new DiscordSeriesStatsStore();
+    store.update({
+      analyticsByMatchId: new Map([
+        ["match-a", analytics],
+        ["match-b", analytics],
+      ]),
+      analyticsStatus: ComponentLoaderStatus.LOADED,
+    });
+
+    const presenter = new DiscordSeriesStatsPresenter(
+      renderData,
+      new StatsController(),
+      store,
+      aFakeMatchAnalyticsServiceWith(),
+    );
+
+    const vm = presenter.present(store.getSnapshot());
+
+    // Team 0 (1111111111) should appear before team 1 (3333333333).
+    // Without the games-suffix fix, 1111111111 is dropped from orderedPlayers
+    // because its series name is "1111111111 (1/2 games)".
+    const killerOrder = vm.seriesStats?.killMatrixPivotData.tableRows.map((r) => r.killerGamertag) ?? [];
+    expect(killerOrder).toEqual(["1111111111", "3333333333"]);
+  });
+});

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { HaloInfiniteClient } from "halo-infinite-api";
 import type { Mocked } from "vitest";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import {
   aFakeIndividualTrackerViewServiceWith,
@@ -312,8 +313,8 @@ describe("IndividualTrackerViewerPresenter", () => {
         ],
       });
 
-      const analytics = {
-        requestedModules: ["killMatrix"] as const,
+      const analytics: MatchAnalytics = {
+        requestedModules: ["killMatrix"],
         killMatrix: {
           "3333333333:1111111111": { count: 2, headshotKills: 0, perfects: 0, weapons: [] },
           "1111111111:3333333333": { count: 1, headshotKills: 0, perfects: 0, weapons: [] },

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-presenter.test.ts
@@ -12,7 +12,7 @@ import type { FakeIndividualTrackerViewService } from "../../../../services/indi
 import { aFakeHaloClientWith } from "../../../../services/fakes/halo-client.fake";
 import { aFakeMatchAnalyticsServiceWith } from "../../../../services/stats/fakes/match-analytics.fake";
 import type { MatchAnalyticsService } from "../../../../services/stats/match-analytics-types";
-import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
+import { aFakeCoreStatsWith, aFakeMatchStatsWith, aFakePlayerWith } from "../../../../controllers/stats/fakes/data";
 import { IndividualTrackerViewerPresenter } from "../viewer-presenter";
 import { IndividualTrackerViewerStore } from "../viewer-store";
 
@@ -246,6 +246,103 @@ describe("IndividualTrackerViewerPresenter", () => {
       expect(setMatchStatsErrorSpy).not.toHaveBeenCalled();
       expect(store.getSnapshot().selectedMatchId).toBeNull();
       expect(store.getSnapshot().matchStatsState).toBeNull();
+    });
+
+    it("orders kill matrix rows by team/rank from match stats, not by API Players array order", async () => {
+      // Players are scrambled: team 1 appears first in the API array
+      const scrambledStats = aFakeMatchStatsWith({
+        MatchId: "m-ordering",
+        Players: [
+          aFakePlayerWith({
+            PlayerId: "xuid(3333333333)",
+            LastTeamId: 1,
+            Rank: 1,
+            PlayerTeamStats: [
+              {
+                TeamId: 1,
+                Stats: {
+                  CoreStats: aFakeCoreStatsWith({ Kills: 25, Deaths: 10, Assists: 15, PersonalScore: 4000 }),
+                  PvpStats: { Kills: 25, Deaths: 10, Assists: 15, KDA: 4 },
+                },
+              },
+            ],
+          }),
+          aFakePlayerWith({
+            PlayerId: "xuid(4444444444)",
+            LastTeamId: 1,
+            Rank: 2,
+            PlayerTeamStats: [
+              {
+                TeamId: 1,
+                Stats: {
+                  CoreStats: aFakeCoreStatsWith({ Kills: 20, Deaths: 11, Assists: 12, PersonalScore: 3200 }),
+                  PvpStats: { Kills: 20, Deaths: 11, Assists: 12, KDA: 2.91 },
+                },
+              },
+            ],
+          }),
+          aFakePlayerWith({
+            PlayerId: "xuid(1111111111)",
+            LastTeamId: 0,
+            Rank: 3,
+            PlayerTeamStats: [
+              {
+                TeamId: 0,
+                Stats: {
+                  CoreStats: aFakeCoreStatsWith({ Kills: 10, Deaths: 15, Assists: 5, PersonalScore: 1500 }),
+                  PvpStats: { Kills: 10, Deaths: 15, Assists: 5, KDA: 1 },
+                },
+              },
+            ],
+          }),
+          aFakePlayerWith({
+            PlayerId: "xuid(2222222222)",
+            LastTeamId: 0,
+            Rank: 4,
+            PlayerTeamStats: [
+              {
+                TeamId: 0,
+                Stats: {
+                  CoreStats: aFakeCoreStatsWith({ Kills: 8, Deaths: 12, Assists: 3, PersonalScore: 1200 }),
+                  PvpStats: { Kills: 8, Deaths: 12, Assists: 3, KDA: 0.92 },
+                },
+              },
+            ],
+          }),
+        ],
+      });
+
+      const analytics = {
+        requestedModules: ["killMatrix"] as const,
+        killMatrix: {
+          "3333333333:1111111111": { count: 2, headshotKills: 0, perfects: 0, weapons: [] },
+          "1111111111:3333333333": { count: 1, headshotKills: 0, perfects: 0, weapons: [] },
+        },
+        metadata: {
+          pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 1 },
+          perfectCounts: { total: 0, byXuid: {} },
+        },
+      };
+
+      const service = aFakeIndividualTrackerViewServiceWith();
+      const { haloClient, store, presenter } = aHarness(service, aFakeMatchAnalyticsServiceWith({ analytics }));
+      haloClient.getMatchStats.mockResolvedValue(scrambledStats);
+
+      presenter.selectMatch("m-ordering");
+
+      await vi.waitFor(() => {
+        expect(store.getSnapshot().matchStatsState?.status).toBe("loaded");
+      });
+
+      const panelState = IndividualTrackerViewerPresenter.present(store.getSnapshot()).matchStatsPanelState;
+      if (panelState?.status !== "loaded") {
+        throw new Error("Expected loaded panel state");
+      }
+
+      // Teams array is [team0, team1]; within each team players sort by rank ascending.
+      // Team 0 player 1111111111 (rank 3) should appear before team 1 player 3333333333 (rank 1).
+      const killerOrder = panelState.killMatrixPivotData.tableRows.map((row) => row.killerGamertag);
+      expect(killerOrder).toEqual(["1111111111", "3333333333"]);
     });
 
     it("sets matchStatsState to error when getMatchStats rejects", async () => {

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -72,10 +72,11 @@ export class IndividualTrackerViewerPresenter {
       const killMatrixRows = analytics != null ? controller.getKillMatrix() : null;
       const players = controller.getPlayers();
       const playersByGamertag = new Map(players.map((p) => [p.gamertag, p]));
-      const orderedPlayers = controller
-        .getMatchStats()
+      const matchStats = controller.getMatchStats();
+      const resolvedPlayers = matchStats
         .flatMap((teamData) => teamData.players.map((p) => playersByGamertag.get(p.name)))
         .filter((p): p is KillMatrixPlayer => p != null);
+      const orderedPlayers = resolvedPlayers.length === players.length ? resolvedPlayers : players;
       return {
         status: "loaded",
         matchId: stats.MatchId,
@@ -83,7 +84,7 @@ export class IndividualTrackerViewerPresenter {
         duration: stats.MatchInfo.Duration,
         startTime: stats.MatchInfo.StartTime,
         endTime: stats.MatchInfo.EndTime,
-        data: controller.getMatchStats(),
+        data: matchStats,
         killMatrixPivotData:
           killMatrixRows != null
             ? KillMatrixFormatter.pivot(killMatrixRows, orderedPlayers)

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -9,7 +9,7 @@ import type {
 } from "../../../services/individual-tracker/view-types";
 import { StatsController } from "../../../controllers/stats/stats-controller";
 import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
-import { EMPTY_KILL_MATRIX_PIVOT_DATA } from "../../../controllers/stats/kill-matrix/types";
+import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPlayer } from "../../../controllers/stats/kill-matrix/types";
 import { buildViewerRenderModel } from "./viewer-render-model";
 import type { IndividualTrackerViewerSnapshot, IndividualTrackerViewerStore, MatchStatsState } from "./viewer-store";
 import type { IndividualTrackerViewerViewModel, MatchStatsPanelState } from "./types";
@@ -70,7 +70,12 @@ export class IndividualTrackerViewerPresenter {
         controller.loadAnalytics(analytics, playerMap);
       }
       const killMatrixRows = analytics != null ? controller.getKillMatrix() : null;
-      const orderedPlayers = controller.getPlayers();
+      const players = controller.getPlayers();
+      const playersByGamertag = new Map(players.map((p) => [p.gamertag, p]));
+      const orderedPlayers = controller
+        .getMatchStats()
+        .flatMap((teamData) => teamData.players.map((p) => playersByGamertag.get(p.name)))
+        .filter((p): p is KillMatrixPlayer => p != null);
       return {
         status: "loaded",
         matchId: stats.MatchId,


### PR DESCRIPTION
## Summary

- `viewer-presenter.ts` and `discord-series-stats-presenter.ts` were passing `controller.getPlayers()` directly as `orderedPlayers` for the kill matrix pivot. `getPlayers()` returns players in `match.Players` API order, which can differ from the team/rank order shown in the player stats table.
- Fixed by deriving `orderedPlayers` from `controller.getMatchStats()` (sorted by team then rank), then looking up XUIDs via a `playersByGamertag` map from `getPlayers()`.
- Added a test in `viewer-presenter.test.ts` that scrambles the `Players` array (team 1 first) and asserts the kill matrix rows are ordered by team/rank, not API order.

## Test plan

- [ ] Run `npm test` — all tests pass
- [ ] View the individual match stats page on a match where the player order in the API differs from score order — kill matrix rows should now align with the player stats table ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)