### PR TITLE
feat(kill-matrix): replace shimmer grid with SortableTable skeleton

### DIFF
--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
@@ -35,28 +35,6 @@
   text-align: right;
 }
 
-.shimmerContainer {
-  display: grid;
-  gap: var(--space-1);
-  grid-template-columns: auto repeat(var(--shimmer-cols, 8), minmax(3rem, 1fr));
-  overflow-x: auto;
-  padding: var(--space-4) 0;
-}
-
-.shimmerHeaderCell {
-  color: var(--halo-gray);
-  font-size: var(--text-sm);
-  font-weight: 600;
-  padding: var(--space-1) var(--space-2);
-}
-
-.shimmerLabelCell {
-  align-items: center;
-  display: flex;
-  font-size: var(--text-sm);
-  padding: var(--space-1) var(--space-2);
-}
-
 .shimmerCell {
   animation: shimmer 1.5s ease-in-out infinite;
   background: linear-gradient(90deg, var(--halo-bg-card) 25%, var(--halo-teal-darker) 50%, var(--halo-bg-card) 75%);

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -52,6 +52,22 @@ export function KillMatrixTable({
   const teamColorOf = (teamId: number | null): string =>
     (teamId != null ? teamColors?.[teamId]?.hex : undefined) ?? "transparent";
 
+  const renderPlayerHeader = (gamertag: string, teamId: number | null): React.ReactNode => (
+    <span className={styles.playerHeader}>
+      {teamId != null && <TeamIcon teamId={teamId} size="x-small" />}
+      {gamertag}
+    </span>
+  );
+
+  const rowTeamStyle = (teamId: number | null): React.CSSProperties =>
+    ({ "--row-team-color": teamColorOf(teamId) }) as React.CSSProperties;
+
+  const colTeamStyle = (teamId: number | null): React.CSSProperties =>
+    ({ "--col-team-color": teamColorOf(teamId) }) as React.CSSProperties;
+
+  const cellTeamStyle = (rowTeamId: number | null, colTeamId: number | null): React.CSSProperties =>
+    ({ "--row-team-color": teamColorOf(rowTeamId), "--col-team-color": teamColorOf(colTeamId) }) as React.CSSProperties;
+
   const columns = React.useMemo<SortableTableColumn<KillMatrixPivotRow>[]>(() => {
     if (effectiveStatus !== ComponentLoaderStatus.LOADED) {
       return [];
@@ -61,48 +77,31 @@ export function KillMatrixTable({
       {
         id: "killer",
         header: activeKillerAxisLabel,
-        accessorFn: (row): string => row.killerGamertag,
+        accessorFn: (row: KillMatrixPivotRow): string => row.killerGamertag,
         sortingFn: "alphanumeric",
         cellClassName: classNames(tableStyles.labelCell, styles.killerCell),
         cellStyle:
           teamColors != null
-            ? (row): React.CSSProperties =>
-                ({ "--row-team-color": teamColorOf(row.killerTeamId) }) as React.CSSProperties
+            ? (row: KillMatrixPivotRow): React.CSSProperties => rowTeamStyle(row.killerTeamId)
             : undefined,
-        cell: (_value, row): React.ReactNode => {
-          const { killerTeamId } = row;
-          return (
-            <span className={styles.playerHeader}>
-              {killerTeamId != null && <TeamIcon teamId={killerTeamId} size="x-small" />}
-              {row.killerGamertag}
-            </span>
-          );
-        },
+        cell: (_value: unknown, row: KillMatrixPivotRow): React.ReactNode =>
+          renderPlayerHeader(row.killerGamertag, row.killerTeamId),
       },
     ];
 
     for (const { gamertag, teamId } of activePivotData.columnHeaders) {
-      const colColor = teamColorOf(teamId);
+      const colTeamId: number | null = teamId;
       cols.push({
         id: gamertag,
-        header: (
-          <span className={styles.playerHeader}>
-            {teamId != null && <TeamIcon teamId={teamId} size="x-small" />}
-            {gamertag}
-          </span>
-        ),
+        header: renderPlayerHeader(gamertag, colTeamId),
         headerClassName: styles.colHeader,
-        headerStyle: teamColors != null ? ({ "--col-team-color": colColor } as React.CSSProperties) : undefined,
+        headerStyle: teamColors != null ? colTeamStyle(colTeamId) : undefined,
         accessorFn: (row: KillMatrixPivotRow): number => row.kills.get(gamertag) ?? 0,
         sortingFn: "basic",
         cellClassName: styles.killCell,
         cellStyle:
           teamColors != null
-            ? (row): React.CSSProperties =>
-                ({
-                  "--row-team-color": teamColorOf(row.killerTeamId),
-                  "--col-team-color": colColor,
-                }) as React.CSSProperties
+            ? (row: KillMatrixPivotRow): React.CSSProperties => cellTeamStyle(row.killerTeamId, colTeamId)
             : undefined,
       });
     }
@@ -122,46 +121,29 @@ export function KillMatrixTable({
         cellClassName: classNames(tableStyles.labelCell, styles.killerCell),
         cellStyle:
           teamColors != null
-            ? (row): React.CSSProperties =>
-                ({
-                  "--row-team-color": teamColorOf(playerHeaders?.[row.index]?.teamId ?? null),
-                }) as React.CSSProperties
+            ? (row): React.CSSProperties => rowTeamStyle(playerHeaders?.[row.index]?.teamId ?? null)
             : undefined,
         cell: (_value, row): React.ReactNode => {
-          const rowHeader = playerHeaders?.[row.index];
-          return (
-            <span className={styles.playerHeader}>
-              {rowHeader?.teamId != null && <TeamIcon teamId={rowHeader.teamId} size="x-small" />}
-              {rowHeader?.gamertag ?? ""}
-            </span>
-          );
+          const ph = playerHeaders?.[row.index];
+          return renderPlayerHeader(ph?.gamertag ?? "", ph?.teamId ?? null);
         },
       },
     ];
 
     for (let i = 0; i < playerCount; i++) {
       const header = playerHeaders?.[i];
-      const colColor = teamColorOf(header?.teamId ?? null);
+      const colTeamId = header?.teamId ?? null;
       cols.push({
         id: `victim-${i.toString()}`,
-        header: (
-          <span className={styles.playerHeader}>
-            {header?.teamId != null && <TeamIcon teamId={header.teamId} size="x-small" />}
-            {header?.gamertag ?? ""}
-          </span>
-        ),
+        header: renderPlayerHeader(header?.gamertag ?? "", colTeamId),
         headerClassName: styles.colHeader,
-        headerStyle: teamColors != null ? ({ "--col-team-color": colColor } as React.CSSProperties) : undefined,
+        headerStyle: teamColors != null ? colTeamStyle(colTeamId) : undefined,
         accessorFn: (): number => 0,
         enableSorting: false,
         cellClassName: styles.killCell,
         cellStyle:
           teamColors != null
-            ? (row): React.CSSProperties =>
-                ({
-                  "--row-team-color": teamColorOf(playerHeaders?.[row.index]?.teamId ?? null),
-                  "--col-team-color": colColor,
-                }) as React.CSSProperties
+            ? (row): React.CSSProperties => cellTeamStyle(playerHeaders?.[row.index]?.teamId ?? null, colTeamId)
             : undefined,
         cell: (): React.ReactNode => <div className={styles.shimmerCell} />,
       });

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -150,7 +150,7 @@ export function KillMatrixTable({
     }
 
     return cols;
-  }, [killerAxisLabel, playerHeaders, playerCount, teamColors]);
+  }, [killerAxisLabel, playerHeaders, teamColors]);
 
   const shimmerRows = React.useMemo(() => Array.from({ length: playerCount }, (_, i) => ({ index: i })), [playerCount]);
 

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -115,7 +115,7 @@ export function KillMatrixTable({
     const cols: SortableTableColumn<{ index: number }>[] = [
       {
         id: "killer",
-        header: killerAxisLabel,
+        header: activeKillerAxisLabel,
         accessorFn: (row): number => row.index,
         enableSorting: false,
         cellClassName: classNames(tableStyles.labelCell, styles.killerCell),
@@ -150,13 +150,18 @@ export function KillMatrixTable({
     }
 
     return cols;
-  }, [killerAxisLabel, playerHeaders, teamColors]);
+  }, [activeKillerAxisLabel, playerHeaders, teamColors]);
 
   const shimmerRows = React.useMemo(() => Array.from({ length: playerCount }, (_, i) => ({ index: i })), [playerCount]);
 
   const shimmer = (
     <div role="region" aria-busy="true" aria-label={ariaLabel}>
-      <SortableTable data={shimmerRows} columns={shimmerColumns} getRowKey={(row): string => row.index.toString()} />
+      <SortableTable
+        data={shimmerRows}
+        columns={shimmerColumns}
+        getRowKey={(row): string => row.index.toString()}
+        ariaLabel={ariaLabel}
+      />
     </div>
   );
 

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -10,6 +10,11 @@ import type { TeamColor } from "../../team-colors/team-colors";
 import type { KillMatrixPivotData, KillMatrixPivotRow } from "../../../controllers/stats/kill-matrix/types";
 import styles from "./kill-matrix-table.module.css";
 
+interface PlayerHeader {
+  readonly gamertag: string;
+  readonly teamId: number | null;
+}
+
 interface KillMatrixTableProps {
   readonly pivotData: KillMatrixPivotData;
   readonly ariaLabel: string;
@@ -18,7 +23,7 @@ interface KillMatrixTableProps {
   readonly status?: ComponentLoaderStatus;
   readonly killerAxisLabel?: string;
   readonly victimAxisLabel?: string;
-  readonly playerGamertags?: readonly string[];
+  readonly playerHeaders?: readonly PlayerHeader[];
   readonly transposedPivotData?: KillMatrixPivotData;
   readonly teamColors?: readonly TeamColor[];
 }
@@ -31,7 +36,7 @@ export function KillMatrixTable({
   status,
   killerAxisLabel = "Killer",
   victimAxisLabel = "Deaths",
-  playerGamertags,
+  playerHeaders,
   transposedPivotData,
   teamColors,
 }: KillMatrixTableProps): React.ReactElement {
@@ -44,13 +49,13 @@ export function KillMatrixTable({
   const activeKillerAxisLabel = isTransposedActive ? "Victim" : killerAxisLabel;
   const activeVictimAxisLabel = isTransposedActive ? "Kills" : victimAxisLabel;
 
+  const teamColorOf = (teamId: number | null): string =>
+    (teamId != null ? teamColors?.[teamId]?.hex : undefined) ?? "transparent";
+
   const columns = React.useMemo<SortableTableColumn<KillMatrixPivotRow>[]>(() => {
     if (effectiveStatus !== ComponentLoaderStatus.LOADED) {
       return [];
     }
-
-    const teamColorOf = (teamId: number | null): string =>
-      (teamId != null ? teamColors?.[teamId]?.hex : undefined) ?? "transparent";
 
     const cols: SortableTableColumn<KillMatrixPivotRow>[] = [
       {
@@ -105,30 +110,71 @@ export function KillMatrixTable({
     return cols;
   }, [effectiveStatus, activeKillerAxisLabel, activePivotData.columnHeaders, teamColors]);
 
-  const playerCount = playerGamertags !== undefined && playerGamertags.length > 0 ? playerGamertags.length : 8;
+  const playerCount = playerHeaders !== undefined && playerHeaders.length > 0 ? playerHeaders.length : 8;
+
+  const shimmerColumns = React.useMemo<SortableTableColumn<{ index: number }>[]>(() => {
+    const cols: SortableTableColumn<{ index: number }>[] = [
+      {
+        id: "killer",
+        header: killerAxisLabel,
+        accessorFn: (row): number => row.index,
+        enableSorting: false,
+        cellClassName: classNames(tableStyles.labelCell, styles.killerCell),
+        cellStyle:
+          teamColors != null
+            ? (row): React.CSSProperties =>
+                ({
+                  "--row-team-color": teamColorOf(playerHeaders?.[row.index]?.teamId ?? null),
+                }) as React.CSSProperties
+            : undefined,
+        cell: (_value, row): React.ReactNode => {
+          const rowHeader = playerHeaders?.[row.index];
+          return (
+            <span className={styles.playerHeader}>
+              {rowHeader?.teamId != null && <TeamIcon teamId={rowHeader.teamId} size="x-small" />}
+              {rowHeader?.gamertag ?? ""}
+            </span>
+          );
+        },
+      },
+    ];
+
+    for (let i = 0; i < playerCount; i++) {
+      const header = playerHeaders?.[i];
+      const colColor = teamColorOf(header?.teamId ?? null);
+      cols.push({
+        id: `victim-${i.toString()}`,
+        header: (
+          <span className={styles.playerHeader}>
+            {header?.teamId != null && <TeamIcon teamId={header.teamId} size="x-small" />}
+            {header?.gamertag ?? ""}
+          </span>
+        ),
+        headerClassName: styles.colHeader,
+        headerStyle: teamColors != null ? ({ "--col-team-color": colColor } as React.CSSProperties) : undefined,
+        accessorFn: (): number => 0,
+        enableSorting: false,
+        cellClassName: styles.killCell,
+        cellStyle:
+          teamColors != null
+            ? (row): React.CSSProperties =>
+                ({
+                  "--row-team-color": teamColorOf(playerHeaders?.[row.index]?.teamId ?? null),
+                  "--col-team-color": colColor,
+                }) as React.CSSProperties
+            : undefined,
+        cell: (): React.ReactNode => <div className={styles.shimmerCell} />,
+      });
+    }
+
+    return cols;
+  }, [killerAxisLabel, playerHeaders, playerCount, teamColors]);
+
+  const shimmerRows = React.useMemo(() => Array.from({ length: playerCount }, (_, i) => ({ index: i })), [playerCount]);
 
   const shimmer = (
-    <div
-      role="region"
-      className={styles.shimmerContainer}
-      style={{ "--shimmer-cols": playerCount } as React.CSSProperties}
-      aria-busy="true"
-      aria-label={ariaLabel}
-    >
-      <div className={styles.shimmerHeaderCell}>{killerAxisLabel}</div>
-      {Array.from({ length: playerCount }, (_, i) => (
-        <div key={i} className={styles.shimmerHeaderCell}>
-          {playerGamertags?.[i]}
-        </div>
-      ))}
-      {Array.from({ length: playerCount }, (_, row) => (
-        <React.Fragment key={row}>
-          <div className={styles.shimmerLabelCell}>{playerGamertags?.[row]}</div>
-          {Array.from({ length: playerCount }, (_col, col) => (
-            <div key={col} className={styles.shimmerCell} />
-          ))}
-        </React.Fragment>
-      ))}
+    <div role="region" aria-busy="true" aria-label={ariaLabel}>
+      <SortableTable data={shimmerRows} columns={shimmerColumns} getRowKey={(row): string => row.index.toString()} />
     </div>
   );
 

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -69,38 +69,42 @@ describe("KillMatrixTable", () => {
     expect(screen.queryByText("No kill matrix data.")).not.toBeInTheDocument();
   });
 
-  it("shows NxN shimmer grid using default 8 players when playerGamertags is an empty array", () => {
+  it("shows NxN shimmer table using default 8 players when playerHeaders is an empty array", () => {
     render(
       <KillMatrixTable
         pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
         ariaLabel="Kill matrix"
         emptyMessage="No kill matrix data."
         status={ComponentLoaderStatus.LOADING}
-        playerGamertags={[]}
+        playerHeaders={[]}
       />,
     );
 
     const shimmer = screen.getByRole("region", { name: "Kill matrix" });
     expect(shimmer).toHaveAttribute("aria-busy", "true");
     // (N+1)^2 cells: 1 killer header + N victim headers + N rows × (1 label + N cells)
-    expect(shimmer.children).toHaveLength(81);
+    expect(shimmer.querySelectorAll("th, td")).toHaveLength(81);
   });
 
-  it("shows NxN shimmer grid using playerGamertags when provided", () => {
+  it("shows NxN shimmer table using playerHeaders when provided", () => {
     render(
       <KillMatrixTable
         pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
         ariaLabel="Kill matrix"
         emptyMessage="No kill matrix data."
         status={ComponentLoaderStatus.LOADING}
-        playerGamertags={["Alpha", "Bravo", "Charlie"]}
+        playerHeaders={[
+          { gamertag: "Alpha", teamId: null },
+          { gamertag: "Bravo", teamId: null },
+          { gamertag: "Charlie", teamId: null },
+        ]}
       />,
     );
 
     const shimmer = screen.getByRole("region", { name: "Kill matrix" });
     expect(shimmer).toHaveAttribute("aria-busy", "true");
     // 3 players: (3+1)^2 = 16 cells; each name appears in header row + row label
-    expect(shimmer.children).toHaveLength(16);
+    expect(shimmer.querySelectorAll("th, td")).toHaveLength(16);
     expect(screen.getAllByText("Alpha")).toHaveLength(2);
     expect(screen.getAllByText("Bravo")).toHaveLength(2);
     expect(screen.getAllByText("Charlie")).toHaveLength(2);

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -176,7 +176,10 @@ export function MatchStats({
     ];
   }, [data]);
 
-  const playerGamertags = React.useMemo(() => data.flatMap((d) => d.players).map((p) => p.name), [data]);
+  const playerHeaders = React.useMemo(
+    () => data.flatMap((d) => d.players.map((p) => ({ gamertag: p.name, teamId: d.teamId }))),
+    [data],
+  );
 
   // Flatten player data for table
   const playerData = React.useMemo(
@@ -280,7 +283,7 @@ export function MatchStats({
                 emptyMessage="Kill matrix data is not available for this match yet."
                 errorMessage="Failed to load kill matrix data for this match."
                 status={killMatrixStatus}
-                playerGamertags={playerGamertags}
+                playerHeaders={playerHeaders}
                 teamColors={teamColors}
               />
             ),

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -167,7 +167,10 @@ export function SeriesStats({
     ];
   }, [playerData, hasPlayerStats]);
 
-  const playerGamertags = React.useMemo(() => playerData.flatMap((d) => d.players).map((p) => p.name), [playerData]);
+  const playerHeaders = React.useMemo(
+    () => playerData.flatMap((d) => d.players.map((p) => ({ gamertag: p.name, teamId: d.teamId }))),
+    [playerData],
+  );
 
   // Flatten player data for table
   const flattenedPlayerData = React.useMemo<MatchStatsRow[]>(
@@ -271,7 +274,7 @@ export function SeriesStats({
                   emptyMessage="Kill matrix data is not available for this series yet."
                   errorMessage="Failed to load kill matrix data for this series."
                   status={killMatrixStatus}
-                  playerGamertags={playerGamertags}
+                  playerHeaders={playerHeaders}
                   teamColors={teamColors}
                 />
               ),


### PR DESCRIPTION
## Summary

- The loading shimmer was a custom CSS grid (`display: grid` with `--shimmer-cols`), which didn't structurally match the real table — headers had no team icons, and the layout didn't align with the loaded state.
- Replaced with an actual `SortableTable<{ index: number }>` skeleton: each column uses the correct `<th>`/`<td>` markup; kill cells render an animated shimmer pill; killer and victim header cells show team icons when `playerHeaders` includes `teamId`.
- Renamed `playerGamertags: string[]` → `playerHeaders: { gamertag: string; teamId: number | null }[]` so callers pass team IDs alongside gamertags; `match-stats.tsx` and `series-stats.tsx` updated accordingly.
- Removed unused CSS classes (`shimmerContainer`, `shimmerHeaderCell`, `shimmerLabelCell`).

## Test plan

- [ ] Run `npm test` — all tests pass
- [ ] Open the discord series stats page or individual match stats while analytics are loading — shimmer should look like the actual table with team icons visible in the header row and first column

🤖 Generated with [Claude Code](https://claude.com/claude-code)