### PR TITLE
feat(live-tracker): wire batch analytics and kill matrix into live tracker

### DIFF
--- a/pages/src/apps/live-tracker/create.tsx
+++ b/pages/src/apps/live-tracker/create.tsx
@@ -82,7 +82,10 @@ export function LiveTrackerApp({ apiHost }: LiveTrackerAppProps): ReactElement {
       error={<ErrorState />}
       loaded={
         services ? (
-          <LiveTracker liveTrackerService={services.liveTrackerService} />
+          <LiveTracker
+            liveTrackerService={services.liveTrackerService}
+            matchAnalyticsService={services.matchAnalyticsService}
+          />
         ) : (
           <ErrorState message="Services failed to load" />
         )

--- a/pages/src/apps/live-tracker/services.ts
+++ b/pages/src/apps/live-tracker/services.ts
@@ -1,22 +1,27 @@
+import { installMatchAnalyticsService } from "../../services/stats/install";
+import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import { RealLiveTrackerService } from "../../services/live-tracker/live-tracker";
 import type { LiveTrackerService } from "../../services/live-tracker/types";
 import { getMode } from "../../services/mode";
 
 export interface Services {
   readonly liveTrackerService: LiveTrackerService;
+  readonly matchAnalyticsService: MatchAnalyticsService;
 }
 
 export async function installServices(apiHost: string): Promise<Services> {
   const mode = getMode();
+  const matchAnalyticsService = await installMatchAnalyticsService(apiHost);
 
   if (mode === "FAKE") {
     return import("../../services/fakes/install.fake").then(async ({ installFakeServices }) => {
       const { liveTrackerService } = await installFakeServices();
-      return { liveTrackerService };
+      return { liveTrackerService, matchAnalyticsService };
     });
   }
 
   return {
     liveTrackerService: new RealLiveTrackerService({ apiHost }),
+    matchAnalyticsService,
   };
 }

--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -4,7 +4,7 @@ import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { MatchStatsData } from "../../controllers/stats/types";
 import { StatsController } from "../../controllers/stats/stats-controller";
-import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import { GAMES_SUFFIX_RE, KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import {
   EMPTY_KILL_MATRIX_PIVOT_DATA,
   type KillMatrixPlayer,
@@ -164,7 +164,6 @@ export class DiscordSeriesStatsPresenter {
         seriesData = this.controller.getSeriesStats();
         const players = this.controller.getPlayers();
         const playersByGamertag = new Map(players.map((p) => [p.gamertag, p]));
-        const GAMES_SUFFIX_RE = /\s+\(\d+\/\d+ games\)$/;
         const resolvedPlayers = seriesData.playerData
           .flatMap((teamData) =>
             teamData.players.map((p) => playersByGamertag.get(p.name.replace(GAMES_SUFFIX_RE, ""))),

--- a/pages/src/components/live-tracker/create.tsx
+++ b/pages/src/components/live-tracker/create.tsx
@@ -132,7 +132,10 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
   }, [model.state]); // Depend on entire state to catch type changes
 
   const [analyticsByMatchId, setAnalyticsByMatchId] = useState<ReadonlyMap<string, MatchAnalytics>>(new Map());
-  const [analyticsStatus, setAnalyticsStatus] = useState(ComponentLoaderStatus.LOADING);
+  const [analyticsStatus, setAnalyticsStatus] = useState(ComponentLoaderStatus.LOADED);
+  // Tracks IDs that are already fetched or in-flight so the effect can check without
+  // depending on analyticsByMatchId state (which would cause an infinite re-render loop).
+  const fetchedMatchIdsRef = useRef<Set<string>>(new Set());
 
   const completeMatchIdsKey = useMemo((): string => {
     if (model.state?.type !== "neatqueue") {return "";}
@@ -144,37 +147,114 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
 
   useEffect(() => {
     if (!completeMatchIdsKey) {
+      fetchedMatchIdsRef.current = new Set();
       setAnalyticsByMatchId(new Map());
       setAnalyticsStatus(ComponentLoaderStatus.LOADED);
       return;
     }
 
+    const newMatchIds = completeMatchIdsKey.split(",").filter((id) => !fetchedMatchIdsRef.current.has(id));
+    if (newMatchIds.length === 0) {return;}
+
+    const isInitialFetch = fetchedMatchIdsRef.current.size === 0;
+    for (const id of newMatchIds) {
+      fetchedMatchIdsRef.current.add(id);
+    }
+
     let cancelled = false;
-    setAnalyticsStatus(ComponentLoaderStatus.LOADING);
-    const matchIds = completeMatchIdsKey.split(",");
+    if (isInitialFetch) {
+      setAnalyticsStatus(ComponentLoaderStatus.LOADING);
+    }
 
     matchAnalyticsService
-      .getBatchMatchAnalytics(matchIds)
+      .getBatchMatchAnalytics(newMatchIds)
       .then((results) => {
         if (cancelled) {return;}
-        const map = new Map<string, MatchAnalytics>();
-        for (const [matchId, analytics] of Object.entries(results)) {
-          if (analytics != null) {
-            map.set(matchId, analytics);
+        setAnalyticsByMatchId((prev) => {
+          const map = new Map(prev);
+          for (const [matchId, analytics] of Object.entries(results)) {
+            if (analytics != null) {
+              map.set(matchId, analytics);
+            }
           }
-        }
-        setAnalyticsByMatchId(map);
+          return map;
+        });
         setAnalyticsStatus(ComponentLoaderStatus.LOADED);
       })
       .catch(() => {
         if (cancelled) {return;}
+        for (const id of newMatchIds) {
+          fetchedMatchIdsRef.current.delete(id);
+        }
         setAnalyticsStatus(ComponentLoaderStatus.ERROR);
       });
 
     return (): void => {
       cancelled = true;
+      for (const id of newMatchIds) {
+        fetchedMatchIdsRef.current.delete(id);
+      }
     };
   }, [completeMatchIdsKey, matchAnalyticsService]);
+
+  // Compute series stats and player ordering from model state (NeatQueue only).
+  // Runs loadSeries once; the kill-matrix memo reuses orderedPlayers and playersByXuid.
+  const seriesStatsData = useMemo((): {
+    teamData: MatchStatsData[];
+    playerData: MatchStatsData[];
+    metadata: SeriesMetadata | null;
+    orderedPlayers: readonly KillMatrixPlayer[] | undefined;
+    playersByXuid: ReadonlyMap<string, { gamertag: string; teamId: number | null }>;
+  } | null => {
+    if (model.state?.type !== "neatqueue" || model.state.matches.length === 0) {
+      return null;
+    }
+
+    const rawMatchStats = model.state.matches
+      .map((match) => match.rawMatchStats)
+      .filter((stats): stats is NonNullable<typeof stats> => stats != null);
+
+    if (rawMatchStats.length === 0) {
+      return null;
+    }
+
+    try {
+      const allPlayerXuidToGametag = new Map<string, string>();
+      for (const match of model.state.matches) {
+        for (const [xuid, gamertag] of Object.entries(match.playerXuidToGametag)) {
+          allPlayerXuidToGametag.set(xuid, gamertag);
+        }
+      }
+
+      const controller = new StatsController();
+      controller.loadSeries(rawMatchStats, allPlayerXuidToGametag, model.state.medalMetadata);
+      const { teamData, playerData } = controller.getSeriesStats();
+      const players = controller.getPlayers();
+      const playersByGamertag = new Map(players.map((p) => [p.gamertag, p]));
+      const resolvedPlayers = playerData
+        .flatMap((td) => td.players.map((p) => playersByGamertag.get(p.name.replace(GAMES_SUFFIX_RE, ""))))
+        .filter((p): p is KillMatrixPlayer => p != null);
+      const orderedPlayers = resolvedPlayers.length === players.length ? resolvedPlayers : players;
+      const playersByXuid = new Map(players.map((p) => [p.xuid, { gamertag: p.gamertag, teamId: p.teamId }]));
+      const metadata = calculateSeriesMetadata(model.state.matches, model.state.seriesScore);
+
+      return { teamData, playerData, metadata, orderedPlayers, playersByXuid };
+    } catch (error) {
+      console.error("Error processing series stats:", error);
+      return null;
+    }
+  }, [model.state]);
+
+  const seriesStats = useMemo(() => {
+    if (seriesStatsData == null) {
+      return null;
+    }
+    return {
+      teamData: seriesStatsData.teamData,
+      playerData: seriesStatsData.playerData,
+      metadata: seriesStatsData.metadata,
+    };
+  }, [seriesStatsData]);
 
   const { allMatchKillMatrix, seriesKillMatrix } = useMemo((): {
     allMatchKillMatrix: readonly {
@@ -184,47 +264,14 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
     }[];
     seriesKillMatrix: { pivotData: KillMatrixPivotData; transposedPivotData: KillMatrixPivotData } | null;
   } => {
-    if (model.state?.type !== "neatqueue" || analyticsByMatchId.size === 0) {
+    if (model.state?.type !== "neatqueue" || seriesStatsData == null || analyticsByMatchId.size === 0) {
       return { allMatchKillMatrix: [], seriesKillMatrix: null };
     }
 
-    const { medalMetadata } = model.state;
+    const { orderedPlayers: seriesPlayers, playersByXuid } = seriesStatsData;
     const formatter = new KillMatrixFormatter();
-
-    const allPlayerXuidToGametag = new Map<string, string>();
-    for (const match of model.state.matches) {
-      for (const [xuid, gamertag] of Object.entries(match.playerXuidToGametag)) {
-        allPlayerXuidToGametag.set(xuid, gamertag);
-      }
-    }
-
-    let seriesPlayers: readonly KillMatrixPlayer[] | undefined;
-    let playersByXuid: ReadonlyMap<string, { gamertag: string; teamId: number | null }> = new Map();
-
-    const rawMatchStats = model.state.matches
-      .map((m) => m.rawMatchStats)
-      .filter((s): s is NonNullable<typeof s> => s != null);
-
-    if (rawMatchStats.length > 0) {
-      try {
-        const seriesController = new StatsController();
-        seriesController.loadSeries(rawMatchStats, allPlayerXuidToGametag, medalMetadata);
-        const players = seriesController.getPlayers();
-        const playersByGamertag = new Map(players.map((p) => [p.gamertag, p]));
-        const seriesData = seriesController.getSeriesStats();
-        const resolvedPlayers = seriesData.playerData
-          .flatMap((teamData) =>
-            teamData.players.map((p) => playersByGamertag.get(p.name.replace(GAMES_SUFFIX_RE, ""))),
-          )
-          .filter((p): p is KillMatrixPlayer => p != null);
-        seriesPlayers = resolvedPlayers.length === players.length ? resolvedPlayers : players;
-        playersByXuid = new Map(players.map((p) => [p.xuid, { gamertag: p.gamertag, teamId: p.teamId }]));
-      } catch (error) {
-        console.error("Error building kill matrix player data:", error);
-      }
-    }
-
     const matchKillMatrixRows = new Map<string, readonly KillMatrixViewRow[]>();
+
     const computedAllMatchKillMatrix = model.state.matches.map((match) => {
       const analytics = analyticsByMatchId.get(match.matchId);
       if (analytics == null) {
@@ -256,45 +303,7 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
         transposedPivotData: KillMatrixFormatter.transpose(aggregatedRows, seriesPlayers),
       },
     };
-  }, [model.state, analyticsByMatchId]);
-
-  // Compute series stats from model state (NeatQueue only)
-  const seriesStats = useMemo((): {
-    teamData: MatchStatsData[];
-    playerData: MatchStatsData[];
-    metadata: SeriesMetadata | null;
-  } | null => {
-    if (model.state?.type !== "neatqueue" || model.state.matches.length === 0) {
-      return null;
-    }
-
-    const rawMatchStats = model.state.matches
-      .map((match) => match.rawMatchStats)
-      .filter((stats): stats is NonNullable<typeof stats> => stats != null);
-
-    if (rawMatchStats.length === 0) {
-      return null;
-    }
-
-    try {
-      const allPlayerXuidToGametag = new Map<string, string>();
-      for (const match of model.state.matches) {
-        for (const [xuid, gamertag] of Object.entries(match.playerXuidToGametag)) {
-          allPlayerXuidToGametag.set(xuid, gamertag);
-        }
-      }
-
-      const controller = new StatsController();
-      controller.loadSeries(rawMatchStats, allPlayerXuidToGametag, model.state.medalMetadata);
-      const { teamData, playerData } = controller.getSeriesStats();
-      const metadata = calculateSeriesMetadata(model.state.matches, model.state.seriesScore);
-
-      return { teamData, playerData, metadata };
-    } catch (error) {
-      console.error("Error processing series stats:", error);
-      return null;
-    }
-  }, [model.state]); // Depend on entire state to catch type changes
+  }, [model.state, seriesStatsData, analyticsByMatchId]);
 
   return (
     <ComponentLoader

--- a/pages/src/components/live-tracker/create.tsx
+++ b/pages/src/components/live-tracker/create.tsx
@@ -22,6 +22,7 @@ import type { LiveTrackerViewModel } from "./types";
 import { LiveTrackerProvider } from "./live-tracker-context";
 
 const killMatrixFormatter = new KillMatrixFormatter();
+const ANALYTICS_BATCH_SIZE = 30;
 
 interface LiveTrackerProps {
   readonly liveTrackerService: LiveTrackerService;
@@ -171,18 +172,24 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
       setAnalyticsStatus(ComponentLoaderStatus.LOADING);
     }
 
-    matchAnalyticsService
-      .getBatchMatchAnalytics(newMatchIds)
-      .then((results) => {
+    const chunks: string[][] = [];
+    for (let i = 0; i < newMatchIds.length; i += ANALYTICS_BATCH_SIZE) {
+      chunks.push(newMatchIds.slice(i, i + ANALYTICS_BATCH_SIZE));
+    }
+
+    Promise.all(chunks.map(async (chunk) => matchAnalyticsService.getBatchMatchAnalytics(chunk)))
+      .then((allResults) => {
         settled = true;
         if (cancelled) {
           return;
         }
         setAnalyticsByMatchId((prev) => {
           const map = new Map(prev);
-          for (const [matchId, analytics] of Object.entries(results)) {
-            if (analytics != null) {
-              map.set(matchId, analytics);
+          for (const results of allResults) {
+            for (const [matchId, analytics] of Object.entries(results)) {
+              if (analytics != null) {
+                map.set(matchId, analytics);
+              }
             }
           }
           return map;

--- a/pages/src/components/live-tracker/create.tsx
+++ b/pages/src/components/live-tracker/create.tsx
@@ -1,10 +1,19 @@
-import React, { useEffect, useMemo, useSyncExternalStore, useRef } from "react";
+import React, { useEffect, useMemo, useState, useSyncExternalStore, useRef } from "react";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { ComponentLoader, ComponentLoaderStatus } from "../component-loader/component-loader";
 import { ErrorState } from "../error-state/error-state";
 import { LoadingState } from "../loading-state/loading-state";
 import type { MatchStatsData } from "../../controllers/stats/types";
 import { StatsController } from "../../controllers/stats/stats-controller";
 import { calculateSeriesMetadata, type SeriesMetadata } from "../../controllers/stats/series-metadata";
+import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import {
+  EMPTY_KILL_MATRIX_PIVOT_DATA,
+  type KillMatrixPivotData,
+  type KillMatrixPlayer,
+  type KillMatrixViewRow,
+} from "../../controllers/stats/kill-matrix/types";
+import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import type { LiveTrackerService } from "../../services/live-tracker/types";
 import { LiveTrackerPresenter } from "./live-tracker-presenter";
 import { LiveTrackerStore } from "./live-tracker-store";
@@ -12,11 +21,14 @@ import { LiveTrackerView } from "./live-tracker";
 import type { LiveTrackerViewModel } from "./types";
 import { LiveTrackerProvider } from "./live-tracker-context";
 
+const GAMES_SUFFIX_RE = /\s+\(\d+\/\d+ games\)$/;
+
 interface LiveTrackerProps {
   readonly liveTrackerService: LiveTrackerService;
+  readonly matchAnalyticsService: MatchAnalyticsService;
 }
 
-export function LiveTracker({ liveTrackerService }: LiveTrackerProps): React.ReactElement {
+export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveTrackerProps): React.ReactElement {
   const store = useMemo(() => new LiveTrackerStore(), []);
 
   const presenter = useMemo(() => {
@@ -119,6 +131,133 @@ export function LiveTracker({ liveTrackerService }: LiveTrackerProps): React.Rea
     });
   }, [model.state]); // Depend on entire state to catch type changes
 
+  const [analyticsByMatchId, setAnalyticsByMatchId] = useState<ReadonlyMap<string, MatchAnalytics>>(new Map());
+  const [analyticsStatus, setAnalyticsStatus] = useState(ComponentLoaderStatus.LOADING);
+
+  const completeMatchIdsKey = useMemo((): string => {
+    if (model.state?.type !== "neatqueue") {return "";}
+    return model.state.matches
+      .filter((m) => m.rawMatchStats != null)
+      .map((m) => m.matchId)
+      .join(",");
+  }, [model.state]);
+
+  useEffect(() => {
+    if (!completeMatchIdsKey) {
+      setAnalyticsByMatchId(new Map());
+      setAnalyticsStatus(ComponentLoaderStatus.LOADED);
+      return;
+    }
+
+    let cancelled = false;
+    setAnalyticsStatus(ComponentLoaderStatus.LOADING);
+    const matchIds = completeMatchIdsKey.split(",");
+
+    matchAnalyticsService
+      .getBatchMatchAnalytics(matchIds)
+      .then((results) => {
+        if (cancelled) {return;}
+        const map = new Map<string, MatchAnalytics>();
+        for (const [matchId, analytics] of Object.entries(results)) {
+          if (analytics != null) {
+            map.set(matchId, analytics);
+          }
+        }
+        setAnalyticsByMatchId(map);
+        setAnalyticsStatus(ComponentLoaderStatus.LOADED);
+      })
+      .catch(() => {
+        if (cancelled) {return;}
+        setAnalyticsStatus(ComponentLoaderStatus.ERROR);
+      });
+
+    return (): void => {
+      cancelled = true;
+    };
+  }, [completeMatchIdsKey, matchAnalyticsService]);
+
+  const { allMatchKillMatrix, seriesKillMatrix } = useMemo((): {
+    allMatchKillMatrix: readonly {
+      matchId: string;
+      pivotData: KillMatrixPivotData;
+      transposedPivotData: KillMatrixPivotData;
+    }[];
+    seriesKillMatrix: { pivotData: KillMatrixPivotData; transposedPivotData: KillMatrixPivotData } | null;
+  } => {
+    if (model.state?.type !== "neatqueue" || analyticsByMatchId.size === 0) {
+      return { allMatchKillMatrix: [], seriesKillMatrix: null };
+    }
+
+    const { medalMetadata } = model.state;
+    const formatter = new KillMatrixFormatter();
+
+    const allPlayerXuidToGametag = new Map<string, string>();
+    for (const match of model.state.matches) {
+      for (const [xuid, gamertag] of Object.entries(match.playerXuidToGametag)) {
+        allPlayerXuidToGametag.set(xuid, gamertag);
+      }
+    }
+
+    let seriesPlayers: readonly KillMatrixPlayer[] | undefined;
+    let playersByXuid: ReadonlyMap<string, { gamertag: string; teamId: number | null }> = new Map();
+
+    const rawMatchStats = model.state.matches
+      .map((m) => m.rawMatchStats)
+      .filter((s): s is NonNullable<typeof s> => s != null);
+
+    if (rawMatchStats.length > 0) {
+      try {
+        const seriesController = new StatsController();
+        seriesController.loadSeries(rawMatchStats, allPlayerXuidToGametag, medalMetadata);
+        const players = seriesController.getPlayers();
+        const playersByGamertag = new Map(players.map((p) => [p.gamertag, p]));
+        const seriesData = seriesController.getSeriesStats();
+        const resolvedPlayers = seriesData.playerData
+          .flatMap((teamData) =>
+            teamData.players.map((p) => playersByGamertag.get(p.name.replace(GAMES_SUFFIX_RE, ""))),
+          )
+          .filter((p): p is KillMatrixPlayer => p != null);
+        seriesPlayers = resolvedPlayers.length === players.length ? resolvedPlayers : players;
+        playersByXuid = new Map(players.map((p) => [p.xuid, { gamertag: p.gamertag, teamId: p.teamId }]));
+      } catch (error) {
+        console.error("Error building kill matrix player data:", error);
+      }
+    }
+
+    const matchKillMatrixRows = new Map<string, readonly KillMatrixViewRow[]>();
+    const computedAllMatchKillMatrix = model.state.matches.map((match) => {
+      const analytics = analyticsByMatchId.get(match.matchId);
+      if (analytics == null) {
+        return {
+          matchId: match.matchId,
+          pivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
+          transposedPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
+        };
+      }
+      const rows = formatter.present({ analytics, playersByXuid });
+      matchKillMatrixRows.set(match.matchId, rows);
+      return {
+        matchId: match.matchId,
+        pivotData: KillMatrixFormatter.pivot(rows, seriesPlayers),
+        transposedPivotData: KillMatrixFormatter.transpose(rows, seriesPlayers),
+      };
+    });
+
+    if (matchKillMatrixRows.size === 0) {
+      return { allMatchKillMatrix: computedAllMatchKillMatrix, seriesKillMatrix: null };
+    }
+
+    const aggregatedRows = KillMatrixFormatter.aggregate([...matchKillMatrixRows.values()].flatMap((rows) => rows));
+
+    return {
+      allMatchKillMatrix: computedAllMatchKillMatrix,
+      seriesKillMatrix: {
+        pivotData: KillMatrixFormatter.pivot(aggregatedRows, seriesPlayers),
+        transposedPivotData: KillMatrixFormatter.transpose(aggregatedRows, seriesPlayers),
+      },
+    };
+  }, [model.state, analyticsByMatchId]);
+
   // Compute series stats from model state (NeatQueue only)
   const seriesStats = useMemo((): {
     teamData: MatchStatsData[];
@@ -179,6 +318,9 @@ export function LiveTracker({ liveTrackerService }: LiveTrackerProps): React.Rea
           params={snapshot.params}
           allMatchStats={allMatchStats}
           seriesStats={seriesStats}
+          analyticsStatus={analyticsStatus}
+          allMatchKillMatrix={allMatchKillMatrix}
+          seriesKillMatrix={seriesKillMatrix}
         >
           <LiveTrackerView />
         </LiveTrackerProvider>

--- a/pages/src/components/live-tracker/create.tsx
+++ b/pages/src/components/live-tracker/create.tsx
@@ -21,6 +21,8 @@ import { LiveTrackerView } from "./live-tracker";
 import type { LiveTrackerViewModel } from "./types";
 import { LiveTrackerProvider } from "./live-tracker-context";
 
+const killMatrixFormatter = new KillMatrixFormatter();
+
 interface LiveTrackerProps {
   readonly liveTrackerService: LiveTrackerService;
   readonly matchAnalyticsService: MatchAnalyticsService;
@@ -173,7 +175,9 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
       .getBatchMatchAnalytics(newMatchIds)
       .then((results) => {
         settled = true;
-        if (cancelled) {return;}
+        if (cancelled) {
+          return;
+        }
         setAnalyticsByMatchId((prev) => {
           const map = new Map(prev);
           for (const [matchId, analytics] of Object.entries(results)) {
@@ -187,7 +191,9 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
       })
       .catch(() => {
         settled = true;
-        if (cancelled) {return;}
+        if (cancelled) {
+          return;
+        }
         for (const id of newMatchIds) {
           fetchedMatchIdsRef.current.delete(id);
         }
@@ -276,7 +282,6 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
     }
 
     const { orderedPlayers: seriesPlayers, playersByXuid } = seriesStatsData;
-    const formatter = new KillMatrixFormatter();
     const matchKillMatrixRows = new Map<string, readonly KillMatrixViewRow[]>();
 
     const computedAllMatchKillMatrix = model.state.matches.map((match) => {
@@ -288,7 +293,7 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
           transposedPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
         };
       }
-      const rows = formatter.present({ analytics, playersByXuid });
+      const rows = killMatrixFormatter.present({ analytics, playersByXuid });
       matchKillMatrixRows.set(match.matchId, rows);
       return {
         matchId: match.matchId,

--- a/pages/src/components/live-tracker/create.tsx
+++ b/pages/src/components/live-tracker/create.tsx
@@ -204,7 +204,9 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
         for (const id of newMatchIds) {
           fetchedMatchIdsRef.current.delete(id);
         }
-        setAnalyticsStatus(ComponentLoaderStatus.ERROR);
+        if (isInitialFetch) {
+          setAnalyticsStatus(ComponentLoaderStatus.ERROR);
+        }
       });
 
     return (): void => {

--- a/pages/src/components/live-tracker/create.tsx
+++ b/pages/src/components/live-tracker/create.tsx
@@ -6,7 +6,7 @@ import { LoadingState } from "../loading-state/loading-state";
 import type { MatchStatsData } from "../../controllers/stats/types";
 import { StatsController } from "../../controllers/stats/stats-controller";
 import { calculateSeriesMetadata, type SeriesMetadata } from "../../controllers/stats/series-metadata";
-import { KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import { GAMES_SUFFIX_RE, KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import {
   EMPTY_KILL_MATRIX_PIVOT_DATA,
   type KillMatrixPivotData,
@@ -20,8 +20,6 @@ import { LiveTrackerStore } from "./live-tracker-store";
 import { LiveTrackerView } from "./live-tracker";
 import type { LiveTrackerViewModel } from "./types";
 import { LiveTrackerProvider } from "./live-tracker-context";
-
-const GAMES_SUFFIX_RE = /\s+\(\d+\/\d+ games\)$/;
 
 interface LiveTrackerProps {
   readonly liveTrackerService: LiveTrackerService;
@@ -138,7 +136,9 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
   const fetchedMatchIdsRef = useRef<Set<string>>(new Set());
 
   const completeMatchIdsKey = useMemo((): string => {
-    if (model.state?.type !== "neatqueue") {return "";}
+    if (model.state?.type !== "neatqueue") {
+      return "";
+    }
     return model.state.matches
       .filter((m) => m.rawMatchStats != null)
       .map((m) => m.matchId)
@@ -154,7 +154,9 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
     }
 
     const newMatchIds = completeMatchIdsKey.split(",").filter((id) => !fetchedMatchIdsRef.current.has(id));
-    if (newMatchIds.length === 0) {return;}
+    if (newMatchIds.length === 0) {
+      return;
+    }
 
     const isInitialFetch = fetchedMatchIdsRef.current.size === 0;
     for (const id of newMatchIds) {
@@ -162,6 +164,7 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
     }
 
     let cancelled = false;
+    let settled = false;
     if (isInitialFetch) {
       setAnalyticsStatus(ComponentLoaderStatus.LOADING);
     }
@@ -169,6 +172,7 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
     matchAnalyticsService
       .getBatchMatchAnalytics(newMatchIds)
       .then((results) => {
+        settled = true;
         if (cancelled) {return;}
         setAnalyticsByMatchId((prev) => {
           const map = new Map(prev);
@@ -182,6 +186,7 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
         setAnalyticsStatus(ComponentLoaderStatus.LOADED);
       })
       .catch(() => {
+        settled = true;
         if (cancelled) {return;}
         for (const id of newMatchIds) {
           fetchedMatchIdsRef.current.delete(id);
@@ -191,8 +196,10 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
 
     return (): void => {
       cancelled = true;
-      for (const id of newMatchIds) {
-        fetchedMatchIdsRef.current.delete(id);
+      if (!settled) {
+        for (const id of newMatchIds) {
+          fetchedMatchIdsRef.current.delete(id);
+        }
       }
     };
   }, [completeMatchIdsKey, matchAnalyticsService]);

--- a/pages/src/components/live-tracker/live-tracker-context.tsx
+++ b/pages/src/components/live-tracker/live-tracker-context.tsx
@@ -40,7 +40,7 @@ interface LiveTrackerContextValue {
 
 const LiveTrackerContext = createContext<LiveTrackerContextValue | null>(null);
 
-interface LiveTrackerProviderProps {
+export interface LiveTrackerProviderProps {
   readonly model: LiveTrackerViewModel;
   readonly params: LiveTrackerParams;
   readonly allMatchStats: readonly { matchId: string; data: MatchStatsData[] | null }[];

--- a/pages/src/components/live-tracker/live-tracker-context.tsx
+++ b/pages/src/components/live-tracker/live-tracker-context.tsx
@@ -2,6 +2,8 @@ import React, { createContext, useContext, useMemo } from "react";
 import type { PlayerAssociationData } from "@guilty-spark/shared/live-tracker/types";
 import type { MatchStatsData } from "../../controllers/stats/types";
 import type { SeriesMetadata } from "../../controllers/stats/series-metadata";
+import { type ComponentLoaderStatus } from "../component-loader/component-loader";
+import type { KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
 import type { LiveTrackerParams } from "./live-tracker-store";
 import type {
   LiveTrackerAvailablePlayer,
@@ -10,6 +12,17 @@ import type {
   LiveTrackerSubstitutionRenderModel,
   LiveTrackerTeamRenderModel,
 } from "./types";
+
+interface MatchKillMatrix {
+  readonly matchId: string;
+  readonly pivotData: KillMatrixPivotData;
+  readonly transposedPivotData: KillMatrixPivotData;
+}
+
+interface KillMatrixResult {
+  readonly pivotData: KillMatrixPivotData;
+  readonly transposedPivotData: KillMatrixPivotData;
+}
 
 interface LiveTrackerContextValue {
   readonly model: LiveTrackerViewModel;
@@ -20,6 +33,9 @@ interface LiveTrackerContextValue {
     playerData: MatchStatsData[];
     metadata: SeriesMetadata | null;
   } | null;
+  readonly analyticsStatus: ComponentLoaderStatus;
+  readonly allMatchKillMatrix: readonly MatchKillMatrix[];
+  readonly seriesKillMatrix: KillMatrixResult | null;
 }
 
 const LiveTrackerContext = createContext<LiveTrackerContextValue | null>(null);
@@ -33,6 +49,9 @@ interface LiveTrackerProviderProps {
     playerData: MatchStatsData[];
     metadata: SeriesMetadata | null;
   } | null;
+  readonly analyticsStatus: ComponentLoaderStatus;
+  readonly allMatchKillMatrix: readonly MatchKillMatrix[];
+  readonly seriesKillMatrix: KillMatrixResult | null;
   readonly children: React.ReactNode;
 }
 
@@ -41,6 +60,9 @@ export function LiveTrackerProvider({
   params,
   allMatchStats,
   seriesStats,
+  analyticsStatus,
+  allMatchKillMatrix,
+  seriesKillMatrix,
   children,
 }: LiveTrackerProviderProps): React.ReactElement {
   // Memoize context value to prevent unnecessary re-renders
@@ -50,8 +72,11 @@ export function LiveTrackerProvider({
       params,
       allMatchStats,
       seriesStats,
+      analyticsStatus,
+      allMatchKillMatrix,
+      seriesKillMatrix,
     }),
-    [model, params, allMatchStats, seriesStats],
+    [model, params, allMatchStats, seriesStats, analyticsStatus, allMatchKillMatrix, seriesKillMatrix],
   );
 
   return <LiveTrackerContext.Provider value={value}>{children}</LiveTrackerContext.Provider>;
@@ -227,4 +252,28 @@ export function useTrackerIdentity(): { guildId: string; queueNumber: number } |
 export function useTrackerParams(): LiveTrackerParams {
   const { params } = useLiveTrackerContext();
   return params;
+}
+
+/**
+ * Select analytics loading status
+ */
+export function useAnalyticsStatus(): ComponentLoaderStatus {
+  const { analyticsStatus } = useLiveTrackerContext();
+  return analyticsStatus;
+}
+
+/**
+ * Select kill matrix data for all matches
+ */
+export function useAllMatchKillMatrix(): readonly MatchKillMatrix[] {
+  const { allMatchKillMatrix } = useLiveTrackerContext();
+  return allMatchKillMatrix;
+}
+
+/**
+ * Select series-level kill matrix data
+ */
+export function useSeriesKillMatrix(): KillMatrixResult | null {
+  const { seriesKillMatrix } = useLiveTrackerContext();
+  return seriesKillMatrix;
 }

--- a/pages/src/components/live-tracker/live-tracker.tsx
+++ b/pages/src/components/live-tracker/live-tracker.tsx
@@ -22,6 +22,9 @@ import {
   useHasMatches,
   useSubstitutions,
   useAvailablePlayers,
+  useAllMatchKillMatrix,
+  useSeriesKillMatrix,
+  useAnalyticsStatus,
 } from "./live-tracker-context";
 import type { LiveTrackerStateRenderModel } from "./types";
 import styles from "./live-tracker.module.css";
@@ -53,6 +56,9 @@ export function LiveTrackerView(): React.ReactElement {
 
   const sortedSubstitutionsList = useSubstitutions();
   const availablePlayers = useAvailablePlayers();
+  const allMatchKillMatrix = useAllMatchKillMatrix();
+  const seriesKillMatrix = useSeriesKillMatrix();
+  const analyticsStatus = useAnalyticsStatus();
 
   const { settings, setSettings } = useStreamerSettings();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -369,6 +375,9 @@ export function LiveTrackerView(): React.ReactElement {
                   title="Series Totals"
                   metadata={seriesStats.metadata}
                   teamColors={teamColorsArray}
+                  killMatrixPivotData={seriesKillMatrix?.pivotData}
+                  transposedKillMatrixPivotData={seriesKillMatrix?.transposedPivotData}
+                  killMatrixStatus={analyticsStatus}
                 />
               </Container>
             )}
@@ -406,6 +415,8 @@ export function LiveTrackerView(): React.ReactElement {
                     // Add match
                     const matchStats = allMatchStats.find((stats) => stats.matchId === match.matchId);
 
+                    const matchKillMatrix = allMatchKillMatrix.find((km) => km.matchId === match.matchId);
+
                     elements.push(
                       matchStats?.data ? (
                         <Container
@@ -429,6 +440,9 @@ export function LiveTrackerView(): React.ReactElement {
                             startTime={match.startTime}
                             endTime={match.endTime}
                             teamColors={teamColorsArray}
+                            killMatrixPivotData={matchKillMatrix?.pivotData}
+                            transposedKillMatrixPivotData={matchKillMatrix?.transposedPivotData}
+                            killMatrixStatus={analyticsStatus}
                           />
                         </Container>
                       ) : (

--- a/pages/src/components/live-tracker/streamer-overlay/stats-panel.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/stats-panel.tsx
@@ -1,12 +1,19 @@
 import React, { memo } from "react";
 import type { PlayerAssociationData } from "@guilty-spark/shared/live-tracker/types";
+import type { ComponentLoaderStatus } from "../../component-loader/component-loader";
 import type { TeamColor } from "../../team-colors/team-colors";
 import { MatchStats as MatchStatsView } from "../../stats/match-stats";
 import { SeriesStats } from "../../stats/series-stats";
 import type { MatchStatsData } from "../../../controllers/stats/types";
 import type { SeriesMetadata } from "../../../controllers/stats/series-metadata";
+import type { KillMatrixPivotData } from "../../../controllers/stats/kill-matrix/types";
 import { PlayerPreSeriesInfo } from "../../player-pre-series-info/player-pre-series-info";
 import type { LiveTrackerMatchRenderModel, LiveTrackerTeamRenderModel } from "../types";
+
+interface KillMatrixData {
+  readonly pivotData: KillMatrixPivotData;
+  readonly transposedPivotData: KillMatrixPivotData;
+}
 
 interface StatsPanelContentProps {
   readonly selectedTab: number;
@@ -22,6 +29,9 @@ interface StatsPanelContentProps {
   readonly selectedMatch: LiveTrackerMatchRenderModel | null;
   readonly teamColors: TeamColor[];
   readonly gameModeIconUrl: (gameMode: string, gameVariantCategory?: number) => string;
+  readonly matchKillMatrix: KillMatrixData | null;
+  readonly seriesKillMatrix: KillMatrixData | null;
+  readonly analyticsStatus: ComponentLoaderStatus;
 }
 
 function StatsPanelContentComponent({
@@ -34,6 +44,9 @@ function StatsPanelContentComponent({
   selectedMatch,
   teamColors,
   gameModeIconUrl,
+  matchKillMatrix,
+  seriesKillMatrix,
+  analyticsStatus,
 }: StatsPanelContentProps): React.ReactElement | null {
   if (selectedTab === -1 && matchesLength === 0 && playersAssociationData != null) {
     return (
@@ -49,6 +62,9 @@ function StatsPanelContentComponent({
         title="Series Totals"
         metadata={seriesStats.metadata}
         teamColors={teamColors}
+        killMatrixPivotData={seriesKillMatrix?.pivotData}
+        transposedKillMatrixPivotData={seriesKillMatrix?.transposedPivotData}
+        killMatrixStatus={analyticsStatus}
       />
     );
   }
@@ -71,6 +87,9 @@ function StatsPanelContentComponent({
         startTime={selectedMatch.startTime}
         endTime={selectedMatch.endTime}
         teamColors={teamColors}
+        killMatrixPivotData={matchKillMatrix?.pivotData}
+        transposedKillMatrixPivotData={matchKillMatrix?.transposedPivotData}
+        killMatrixStatus={analyticsStatus}
       />
     );
   }

--- a/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
@@ -9,7 +9,15 @@ import { RankIcon } from "../../icons/rank-icon";
 import discordLogo from "../../../assets/discord-logo.png";
 import xboxLogo from "../../../assets/xbox-logo.png";
 import { ALL_SLAYER_STATS, type AllStreamerSettings } from "../settings/types";
-import { useTrackerState, useAllMatchStats, useSeriesStats, useTrackerInfo } from "../live-tracker-context";
+import {
+  useTrackerState,
+  useAllMatchStats,
+  useSeriesStats,
+  useTrackerInfo,
+  useAllMatchKillMatrix,
+  useSeriesKillMatrix,
+  useAnalyticsStatus,
+} from "../live-tracker-context";
 import type { LiveTrackerNeatQueueStateRenderModel } from "../types";
 import { TopSection } from "../../streamer-overlay/top-section";
 import { TeamDetailsContent } from "../../streamer-overlay/team-details-content";
@@ -64,6 +72,9 @@ function NeatQueueStreamerOverlay({
 }: NeatQueueStreamerOverlayProps): React.ReactElement {
   const allMatchStats = useAllMatchStats();
   const seriesStats = useSeriesStats();
+  const allMatchKillMatrix = useAllMatchKillMatrix();
+  const seriesKillMatrix = useSeriesKillMatrix();
+  const analyticsStatus = useAnalyticsStatus();
   const trackerInfo = useTrackerInfo();
 
   const title =
@@ -358,6 +369,7 @@ function NeatQueueStreamerOverlay({
     (tabIndex: number): React.ReactElement | null => {
       const selectedMatchStats = tabIndex >= 0 ? (allMatchStats[tabIndex]?.data ?? null) : null;
       const selectedMatch = tabIndex >= 0 ? (neatQueueState.matches[tabIndex] ?? null) : null;
+      const matchKillMatrix = tabIndex >= 0 ? (allMatchKillMatrix[tabIndex] ?? null) : null;
       return (
         <StatsPanelContent
           selectedTab={tabIndex}
@@ -369,10 +381,22 @@ function NeatQueueStreamerOverlay({
           selectedMatch={selectedMatch}
           teamColors={teamColors}
           gameModeIconUrl={gameModeIconUrl}
+          matchKillMatrix={matchKillMatrix}
+          seriesKillMatrix={seriesKillMatrix}
+          analyticsStatus={analyticsStatus}
         />
       );
     },
-    [allMatchStats, gameModeIconUrl, neatQueueState, seriesStats, teamColors],
+    [
+      allMatchStats,
+      allMatchKillMatrix,
+      analyticsStatus,
+      gameModeIconUrl,
+      neatQueueState,
+      seriesKillMatrix,
+      seriesStats,
+      teamColors,
+    ],
   );
 
   const renderPlayerNameContent = useCallback(

--- a/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay.test.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from "@testing-library/react";
 import type { TeamColor } from "../../../team-colors/team-colors";
 import type { StreamerOverlayProps } from "../streamer-overlay";
 import { LiveTrackerProvider } from "../../live-tracker-context";
+import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import type { LiveTrackerViewModel } from "../../types";
 import { DEFAULT_ALL_SETTINGS } from "../../settings/types";
 
@@ -106,7 +107,15 @@ describe("StreamerOverlay", () => {
     const model = aFakeLiveTrackerViewModelWith({ state: null });
 
     render(
-      <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+      <LiveTrackerProvider
+        params={defaultParams}
+        model={model}
+        allMatchStats={[]}
+        seriesStats={null}
+        analyticsStatus={ComponentLoaderStatus.LOADED}
+        allMatchKillMatrix={[]}
+        seriesKillMatrix={null}
+      >
         <StreamerOverlay {...defaultProps} />
       </LiveTrackerProvider>,
     );
@@ -118,7 +127,15 @@ describe("StreamerOverlay", () => {
     const model = aFakeLiveTrackerViewModelWith();
 
     render(
-      <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+      <LiveTrackerProvider
+        params={defaultParams}
+        model={model}
+        allMatchStats={[]}
+        seriesStats={null}
+        analyticsStatus={ComponentLoaderStatus.LOADED}
+        allMatchKillMatrix={[]}
+        seriesKillMatrix={null}
+      >
         <StreamerOverlay {...defaultProps} />
       </LiveTrackerProvider>,
     );
@@ -185,7 +202,15 @@ describe("StreamerOverlay", () => {
     ];
 
     render(
-      <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={allMatchStats} seriesStats={null}>
+      <LiveTrackerProvider
+        params={defaultParams}
+        model={model}
+        allMatchStats={allMatchStats}
+        seriesStats={null}
+        analyticsStatus={ComponentLoaderStatus.LOADED}
+        allMatchKillMatrix={[]}
+        seriesKillMatrix={null}
+      >
         <StreamerOverlay {...defaultProps} />
       </LiveTrackerProvider>,
     );
@@ -233,7 +258,15 @@ describe("StreamerOverlay", () => {
     const allMatchStats = [{ matchId: "match1", data: null }];
 
     render(
-      <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={allMatchStats} seriesStats={null}>
+      <LiveTrackerProvider
+        params={defaultParams}
+        model={model}
+        allMatchStats={allMatchStats}
+        seriesStats={null}
+        analyticsStatus={ComponentLoaderStatus.LOADED}
+        allMatchKillMatrix={[]}
+        seriesKillMatrix={null}
+      >
         <StreamerOverlay {...defaultProps} />
       </LiveTrackerProvider>,
     );

--- a/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay.test.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type { TeamColor } from "../../../team-colors/team-colors";
 import type { StreamerOverlayProps } from "../streamer-overlay";
-import { LiveTrackerProvider } from "../../live-tracker-context";
+import { LiveTrackerProvider, type LiveTrackerProviderProps } from "../../live-tracker-context";
 import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import type { LiveTrackerViewModel } from "../../types";
 import { DEFAULT_ALL_SETTINGS } from "../../settings/types";
@@ -88,6 +88,16 @@ function aFakeLiveTrackerViewModelWith(overrides?: Partial<LiveTrackerViewModel>
   };
 }
 
+const defaultProviderProps: Omit<LiveTrackerProviderProps, "children"> = {
+  params: defaultParams,
+  model: aFakeLiveTrackerViewModelWith(),
+  allMatchStats: [] as { matchId: string; data: never[] }[],
+  seriesStats: null,
+  analyticsStatus: ComponentLoaderStatus.LOADED,
+  allMatchKillMatrix: [],
+  seriesKillMatrix: null,
+};
+
 describe("StreamerOverlay", () => {
   const teamColors: TeamColor[] = [
     { id: "eagle", name: "Eagle", hex: "#0066CC" },
@@ -107,15 +117,7 @@ describe("StreamerOverlay", () => {
     const model = aFakeLiveTrackerViewModelWith({ state: null });
 
     render(
-      <LiveTrackerProvider
-        params={defaultParams}
-        model={model}
-        allMatchStats={[]}
-        seriesStats={null}
-        analyticsStatus={ComponentLoaderStatus.LOADED}
-        allMatchKillMatrix={[]}
-        seriesKillMatrix={null}
-      >
+      <LiveTrackerProvider {...defaultProviderProps} model={model}>
         <StreamerOverlay {...defaultProps} />
       </LiveTrackerProvider>,
     );
@@ -124,18 +126,8 @@ describe("StreamerOverlay", () => {
   });
 
   it("renders streamer overlay with settings UI", () => {
-    const model = aFakeLiveTrackerViewModelWith();
-
     render(
-      <LiveTrackerProvider
-        params={defaultParams}
-        model={model}
-        allMatchStats={[]}
-        seriesStats={null}
-        analyticsStatus={ComponentLoaderStatus.LOADED}
-        allMatchKillMatrix={[]}
-        seriesKillMatrix={null}
-      >
+      <LiveTrackerProvider {...defaultProviderProps}>
         <StreamerOverlay {...defaultProps} />
       </LiveTrackerProvider>,
     );
@@ -202,15 +194,7 @@ describe("StreamerOverlay", () => {
     ];
 
     render(
-      <LiveTrackerProvider
-        params={defaultParams}
-        model={model}
-        allMatchStats={allMatchStats}
-        seriesStats={null}
-        analyticsStatus={ComponentLoaderStatus.LOADED}
-        allMatchKillMatrix={[]}
-        seriesKillMatrix={null}
-      >
+      <LiveTrackerProvider {...defaultProviderProps} model={model} allMatchStats={allMatchStats}>
         <StreamerOverlay {...defaultProps} />
       </LiveTrackerProvider>,
     );
@@ -258,15 +242,7 @@ describe("StreamerOverlay", () => {
     const allMatchStats = [{ matchId: "match1", data: null }];
 
     render(
-      <LiveTrackerProvider
-        params={defaultParams}
-        model={model}
-        allMatchStats={allMatchStats}
-        seriesStats={null}
-        analyticsStatus={ComponentLoaderStatus.LOADED}
-        allMatchKillMatrix={[]}
-        seriesKillMatrix={null}
-      >
+      <LiveTrackerProvider {...defaultProviderProps} model={model} allMatchStats={allMatchStats}>
         <StreamerOverlay {...defaultProps} />
       </LiveTrackerProvider>,
     );

--- a/pages/src/components/live-tracker/tests/live-tracker-context.test.tsx
+++ b/pages/src/components/live-tracker/tests/live-tracker-context.test.tsx
@@ -20,6 +20,7 @@ import {
   useMatchCount,
   useHasMatches,
   useTrackerIdentity,
+  type LiveTrackerProviderProps,
 } from "../live-tracker-context";
 
 const defaultParams = { type: "team" as const, server: "test-server", queue: "5" };
@@ -77,7 +78,7 @@ function aFakeLiveTrackerViewModelWith(overrides?: Partial<LiveTrackerViewModel>
   };
 }
 
-const defaultProviderProps = {
+const defaultProviderProps: Omit<LiveTrackerProviderProps, "children"> = {
   params: defaultParams,
   model: aFakeLiveTrackerViewModelWith(),
   allMatchStats: [] as { matchId: string; data: never[] }[],
@@ -85,7 +86,7 @@ const defaultProviderProps = {
   analyticsStatus: ComponentLoaderStatus.LOADED,
   allMatchKillMatrix: [],
   seriesKillMatrix: null,
-} as const;
+};
 
 describe("LiveTrackerContext", () => {
   it("throws error when hooks used outside provider", () => {

--- a/pages/src/components/live-tracker/tests/live-tracker-context.test.tsx
+++ b/pages/src/components/live-tracker/tests/live-tracker-context.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { renderHook } from "@testing-library/react";
 import type { PlayerAssociationData } from "@guilty-spark/shared/live-tracker/types";
 import type { LiveTrackerViewModel } from "../types";
+import { ComponentLoaderStatus } from "../../component-loader/component-loader";
 import {
   LiveTrackerProvider,
   useTrackerInfo,
@@ -89,7 +90,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerInfo(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -107,7 +116,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerState(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -126,7 +143,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerTeams(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -141,7 +166,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerTeams(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -155,7 +188,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerMatches(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -170,7 +211,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerMatches(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -209,7 +258,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerPlayersData(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -223,7 +280,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useSeriesScore(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -237,7 +302,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useSeriesScore(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -256,7 +329,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useAllMatchStats(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={allMatchStats} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={allMatchStats}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -277,7 +358,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useSeriesStats(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={seriesStats}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={seriesStats}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -291,7 +380,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useMatchByIndex(0), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -305,7 +402,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useMatchByIndex(5), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -319,7 +424,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useMatchByIndex(-1), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -344,7 +457,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useSubstitutions(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -359,7 +480,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useMatchCount(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -373,7 +502,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useMatchCount(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -387,7 +524,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useHasMatches(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -401,7 +546,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useHasMatches(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -425,7 +578,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useHasMatches(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -439,7 +600,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerIdentity(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),
@@ -454,7 +623,15 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerIdentity(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider params={defaultParams} model={model} allMatchStats={[]} seriesStats={null}>
+        <LiveTrackerProvider
+          params={defaultParams}
+          model={model}
+          allMatchStats={[]}
+          seriesStats={null}
+          analyticsStatus={ComponentLoaderStatus.LOADED}
+          allMatchKillMatrix={[]}
+          seriesKillMatrix={null}
+        >
           {children}
         </LiveTrackerProvider>
       ),

--- a/pages/src/components/live-tracker/tests/live-tracker-context.test.tsx
+++ b/pages/src/components/live-tracker/tests/live-tracker-context.test.tsx
@@ -22,7 +22,6 @@ import {
   useTrackerIdentity,
 } from "../live-tracker-context";
 
-// Default params for test cases
 const defaultParams = { type: "team" as const, server: "test-server", queue: "5" };
 
 function aFakeLiveTrackerViewModelWith(overrides?: Partial<LiveTrackerViewModel>): LiveTrackerViewModel {
@@ -78,6 +77,16 @@ function aFakeLiveTrackerViewModelWith(overrides?: Partial<LiveTrackerViewModel>
   };
 }
 
+const defaultProviderProps = {
+  params: defaultParams,
+  model: aFakeLiveTrackerViewModelWith(),
+  allMatchStats: [] as { matchId: string; data: never[] }[],
+  seriesStats: null,
+  analyticsStatus: ComponentLoaderStatus.LOADED,
+  allMatchKillMatrix: [],
+  seriesKillMatrix: null,
+} as const;
+
 describe("LiveTrackerContext", () => {
   it("throws error when hooks used outside provider", () => {
     expect(() => {
@@ -86,21 +95,9 @@ describe("LiveTrackerContext", () => {
   });
 
   it("provides tracker info to hooks", () => {
-    const model = aFakeLiveTrackerViewModelWith();
-
     const { result } = renderHook(() => useTrackerInfo(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -112,21 +109,9 @@ describe("LiveTrackerContext", () => {
   });
 
   it("provides tracker state to hooks", () => {
-    const model = aFakeLiveTrackerViewModelWith();
-
     const { result } = renderHook(() => useTrackerState(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -139,21 +124,9 @@ describe("LiveTrackerContext", () => {
   });
 
   it("provides teams to hooks", () => {
-    const model = aFakeLiveTrackerViewModelWith();
-
     const { result } = renderHook(() => useTrackerTeams(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -166,17 +139,7 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerTeams(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -184,21 +147,9 @@ describe("LiveTrackerContext", () => {
   });
 
   it("provides matches to hooks", () => {
-    const model = aFakeLiveTrackerViewModelWith();
-
     const { result } = renderHook(() => useTrackerMatches(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -211,17 +162,7 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerMatches(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -258,17 +199,7 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerPlayersData(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -276,21 +207,9 @@ describe("LiveTrackerContext", () => {
   });
 
   it("provides series score to hooks", () => {
-    const model = aFakeLiveTrackerViewModelWith();
-
     const { result } = renderHook(() => useSeriesScore(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -302,17 +221,7 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useSeriesScore(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -325,21 +234,9 @@ describe("LiveTrackerContext", () => {
       { matchId: "match2", data: [] },
     ];
 
-    const model = aFakeLiveTrackerViewModelWith();
-
     const { result } = renderHook(() => useAllMatchStats(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={allMatchStats}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} allMatchStats={allMatchStats}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -354,21 +251,9 @@ describe("LiveTrackerContext", () => {
       metadata: null,
     };
 
-    const model = aFakeLiveTrackerViewModelWith();
-
     const { result } = renderHook(() => useSeriesStats(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={seriesStats}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} seriesStats={seriesStats}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -376,21 +261,9 @@ describe("LiveTrackerContext", () => {
   });
 
   it("provides match by index to hooks", () => {
-    const model = aFakeLiveTrackerViewModelWith();
-
     const { result } = renderHook(() => useMatchByIndex(0), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -398,21 +271,9 @@ describe("LiveTrackerContext", () => {
   });
 
   it("returns null for invalid match index", () => {
-    const model = aFakeLiveTrackerViewModelWith();
-
     const { result } = renderHook(() => useMatchByIndex(5), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -420,21 +281,9 @@ describe("LiveTrackerContext", () => {
   });
 
   it("returns null for negative match index", () => {
-    const model = aFakeLiveTrackerViewModelWith();
-
     const { result } = renderHook(() => useMatchByIndex(-1), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -457,17 +306,7 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useSubstitutions(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -476,21 +315,9 @@ describe("LiveTrackerContext", () => {
   });
 
   it("provides match count to hooks", () => {
-    const model = aFakeLiveTrackerViewModelWith();
-
     const { result } = renderHook(() => useMatchCount(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -502,17 +329,7 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useMatchCount(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -520,21 +337,9 @@ describe("LiveTrackerContext", () => {
   });
 
   it("provides has matches flag to hooks", () => {
-    const model = aFakeLiveTrackerViewModelWith();
-
     const { result } = renderHook(() => useHasMatches(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -546,17 +351,7 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useHasMatches(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -578,17 +373,7 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useHasMatches(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -596,21 +381,9 @@ describe("LiveTrackerContext", () => {
   });
 
   it("provides tracker identity to hooks", () => {
-    const model = aFakeLiveTrackerViewModelWith();
-
     const { result } = renderHook(() => useTrackerIdentity(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
       ),
     });
 
@@ -623,17 +396,7 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerIdentity(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider
-          params={defaultParams}
-          model={model}
-          allMatchStats={[]}
-          seriesStats={null}
-          analyticsStatus={ComponentLoaderStatus.LOADED}
-          allMatchKillMatrix={[]}
-          seriesKillMatrix={null}
-        >
-          {children}
-        </LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
       ),
     });
 

--- a/pages/src/components/live-tracker/tests/live-tracker-context.test.tsx
+++ b/pages/src/components/live-tracker/tests/live-tracker-context.test.tsx
@@ -96,9 +96,7 @@ describe("LiveTrackerContext", () => {
 
   it("provides tracker info to hooks", () => {
     const { result } = renderHook(() => useTrackerInfo(), {
-      wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
-      ),
+      wrapper: ({ children }) => <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>,
     });
 
     expect(result.current.title).toBe("Test Guild");
@@ -110,9 +108,7 @@ describe("LiveTrackerContext", () => {
 
   it("provides tracker state to hooks", () => {
     const { result } = renderHook(() => useTrackerState(), {
-      wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
-      ),
+      wrapper: ({ children }) => <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>,
     });
 
     expect.assertions(3);
@@ -125,9 +121,7 @@ describe("LiveTrackerContext", () => {
 
   it("provides teams to hooks", () => {
     const { result } = renderHook(() => useTrackerTeams(), {
-      wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
-      ),
+      wrapper: ({ children }) => <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>,
     });
 
     expect(result.current?.length).toBe(1);
@@ -139,7 +133,9 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerTeams(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>
+          {children}
+        </LiveTrackerProvider>
       ),
     });
 
@@ -148,9 +144,7 @@ describe("LiveTrackerContext", () => {
 
   it("provides matches to hooks", () => {
     const { result } = renderHook(() => useTrackerMatches(), {
-      wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
-      ),
+      wrapper: ({ children }) => <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>,
     });
 
     expect(result.current?.length).toBe(1);
@@ -162,7 +156,9 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerMatches(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>
+          {children}
+        </LiveTrackerProvider>
       ),
     });
 
@@ -199,7 +195,9 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerPlayersData(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>
+          {children}
+        </LiveTrackerProvider>
       ),
     });
 
@@ -208,9 +206,7 @@ describe("LiveTrackerContext", () => {
 
   it("provides series score to hooks", () => {
     const { result } = renderHook(() => useSeriesScore(), {
-      wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
-      ),
+      wrapper: ({ children }) => <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>,
     });
 
     expect(result.current).toBe("1:0");
@@ -221,7 +217,9 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useSeriesScore(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>
+          {children}
+        </LiveTrackerProvider>
       ),
     });
 
@@ -236,7 +234,9 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useAllMatchStats(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps} allMatchStats={allMatchStats}>{children}</LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} allMatchStats={allMatchStats}>
+          {children}
+        </LiveTrackerProvider>
       ),
     });
 
@@ -253,7 +253,9 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useSeriesStats(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps} seriesStats={seriesStats}>{children}</LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} seriesStats={seriesStats}>
+          {children}
+        </LiveTrackerProvider>
       ),
     });
 
@@ -262,9 +264,7 @@ describe("LiveTrackerContext", () => {
 
   it("provides match by index to hooks", () => {
     const { result } = renderHook(() => useMatchByIndex(0), {
-      wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
-      ),
+      wrapper: ({ children }) => <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>,
     });
 
     expect(result.current?.matchId).toBe("match1");
@@ -272,9 +272,7 @@ describe("LiveTrackerContext", () => {
 
   it("returns null for invalid match index", () => {
     const { result } = renderHook(() => useMatchByIndex(5), {
-      wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
-      ),
+      wrapper: ({ children }) => <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>,
     });
 
     expect(result.current).toBeNull();
@@ -282,9 +280,7 @@ describe("LiveTrackerContext", () => {
 
   it("returns null for negative match index", () => {
     const { result } = renderHook(() => useMatchByIndex(-1), {
-      wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
-      ),
+      wrapper: ({ children }) => <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>,
     });
 
     expect(result.current).toBeNull();
@@ -306,7 +302,9 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useSubstitutions(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>
+          {children}
+        </LiveTrackerProvider>
       ),
     });
 
@@ -316,9 +314,7 @@ describe("LiveTrackerContext", () => {
 
   it("provides match count to hooks", () => {
     const { result } = renderHook(() => useMatchCount(), {
-      wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
-      ),
+      wrapper: ({ children }) => <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>,
     });
 
     expect(result.current).toBe(1);
@@ -329,7 +325,9 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useMatchCount(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>
+          {children}
+        </LiveTrackerProvider>
       ),
     });
 
@@ -338,9 +336,7 @@ describe("LiveTrackerContext", () => {
 
   it("provides has matches flag to hooks", () => {
     const { result } = renderHook(() => useHasMatches(), {
-      wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
-      ),
+      wrapper: ({ children }) => <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>,
     });
 
     expect(result.current).toBe(true);
@@ -351,7 +347,9 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useHasMatches(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>
+          {children}
+        </LiveTrackerProvider>
       ),
     });
 
@@ -373,7 +371,9 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useHasMatches(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>
+          {children}
+        </LiveTrackerProvider>
       ),
     });
 
@@ -382,9 +382,7 @@ describe("LiveTrackerContext", () => {
 
   it("provides tracker identity to hooks", () => {
     const { result } = renderHook(() => useTrackerIdentity(), {
-      wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>
-      ),
+      wrapper: ({ children }) => <LiveTrackerProvider {...defaultProviderProps}>{children}</LiveTrackerProvider>,
     });
 
     expect(result.current?.guildId).toBe("Test Guild");
@@ -396,7 +394,9 @@ describe("LiveTrackerContext", () => {
 
     const { result } = renderHook(() => useTrackerIdentity(), {
       wrapper: ({ children }) => (
-        <LiveTrackerProvider {...defaultProviderProps} model={model}>{children}</LiveTrackerProvider>
+        <LiveTrackerProvider {...defaultProviderProps} model={model}>
+          {children}
+        </LiveTrackerProvider>
       ),
     });
 

--- a/pages/src/components/live-tracker/tests/live-tracker.test.tsx
+++ b/pages/src/components/live-tracker/tests/live-tracker.test.tsx
@@ -11,6 +11,7 @@ import type {
 } from "../../../services/live-tracker/types";
 import { aFakeLiveTrackerScenarioWith } from "../../../services/live-tracker/fakes/scenario";
 import { aFakeLiveTrackerServiceWith } from "../../../services/live-tracker/fakes/live-tracker.fake";
+import { aFakeMatchAnalyticsServiceWith } from "../../../services/stats/fakes/match-analytics.fake";
 import { LiveTracker } from "../create";
 
 function isSteppableLiveTrackerConnection(
@@ -83,7 +84,9 @@ describe("LiveTracker", () => {
       return Promise.resolve(connection);
     });
 
-    render(<LiveTracker liveTrackerService={liveTrackerService} />);
+    render(
+      <LiveTracker liveTrackerService={liveTrackerService} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Connecting...")).toBeInTheDocument();
@@ -123,7 +126,9 @@ describe("LiveTracker", () => {
     const liveTrackerService = aFakeLiveTrackerServiceWith();
     vi.spyOn(liveTrackerService, "connect").mockResolvedValue(notFoundConnection);
 
-    render(<LiveTracker liveTrackerService={liveTrackerService} />);
+    render(
+      <LiveTracker liveTrackerService={liveTrackerService} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Connection Failed")).toBeInTheDocument();

--- a/pages/src/components/live-tracker/tests/live-tracker.test.tsx
+++ b/pages/src/components/live-tracker/tests/live-tracker.test.tsx
@@ -3,7 +3,11 @@ import "@testing-library/jest-dom/vitest";
 import { describe, expect, it, vi, afterEach } from "vitest";
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
 
-import type { LiveTrackerMessage, LiveTrackerStateMessage } from "@guilty-spark/shared/live-tracker/types";
+import type {
+  LiveTrackerMatchSummary,
+  LiveTrackerMessage,
+  LiveTrackerStateMessage,
+} from "@guilty-spark/shared/live-tracker/types";
 import type {
   LiveTrackerConnection,
   LiveTrackerStatusListener,
@@ -18,6 +22,72 @@ function isSteppableLiveTrackerConnection(
   connection: LiveTrackerConnection,
 ): connection is SteppableLiveTrackerConnection {
   return "step" in connection && typeof connection.step === "function";
+}
+
+function aMatchSummary(matchId: string): LiveTrackerMatchSummary {
+  return {
+    matchId,
+    gameTypeAndMap: "Slayer: Aquarius",
+    gameType: "Slayer",
+    gameMap: "Aquarius",
+    gameMapThumbnailUrl: "data:,",
+    duration: "10m 0s",
+    gameScore: "50:49",
+    gameSubScore: null,
+    startTime: "2024-12-31T23:50:00.000Z",
+    endTime: "2025-01-01T00:00:00.000Z",
+    playerXuidToGametag: {},
+  };
+}
+
+function aStateMessage(matchIds: readonly string[], rawMatchIds: readonly string[] = []): LiveTrackerStateMessage {
+  return {
+    type: "state",
+    timestamp: "2025-01-01T00:00:00.000Z",
+    data: {
+      type: "neatqueue",
+      guildId: "1",
+      guildIcon: null,
+      guildName: "Guild 1",
+      channelId: "2",
+      queueNumber: 3,
+      status: "active",
+      lastUpdateTime: "2025-01-01T00:00:00.000Z",
+      players: [],
+      teams: [],
+      substitutions: [],
+      matchSummaries: matchIds.map(aMatchSummary),
+      rawMatches: Object.fromEntries(
+        rawMatchIds.map((id) => [id, { MatchId: id, Teams: [], Players: [], MatchInfo: {} }]),
+      ),
+      seriesScore: "0:0",
+      medalMetadata: {},
+      playersAssociationData: {},
+    },
+  };
+}
+
+async function renderLiveTrackerWith(
+  stateMessage: LiveTrackerStateMessage,
+  analyticsService = aFakeMatchAnalyticsServiceWith(),
+): Promise<SteppableLiveTrackerConnection> {
+  window.history.pushState({}, "", "/tracker?server=1&queue=3");
+
+  const scenario = aFakeLiveTrackerScenarioWith({
+    intervalMs: 10,
+    frames: [stateMessage] satisfies readonly LiveTrackerMessage[],
+  });
+  const liveTrackerService = aFakeLiveTrackerServiceWith({ scenario, mode: "manual" });
+  const connection = await liveTrackerService.connect({ type: "team" as const, guildId: "1", queueNumber: "3" });
+  vi.spyOn(liveTrackerService, "connect").mockResolvedValue(connection);
+
+  render(<LiveTracker liveTrackerService={liveTrackerService} matchAnalyticsService={analyticsService} />);
+  await waitFor(() => expect(screen.getByText("Connecting...")).toBeInTheDocument());
+
+  if (!isSteppableLiveTrackerConnection(connection)) {
+    throw new Error("Expected steppable fake connection in manual mode");
+  }
+  return connection;
 }
 
 describe("LiveTracker", () => {
@@ -107,6 +177,65 @@ describe("LiveTracker", () => {
     });
 
     expect(screen.getByText("Matches")).toBeInTheDocument();
+  });
+
+  describe("analytics effect", () => {
+    it("calls getBatchMatchAnalytics for match IDs that have rawMatchStats", async () => {
+      const analyticsService = aFakeMatchAnalyticsServiceWith();
+      const spy = vi.spyOn(analyticsService, "getBatchMatchAnalytics");
+
+      const connection = await renderLiveTrackerWith(aStateMessage(["m1"], ["m1"]), analyticsService);
+      connection.step();
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(["m1"]);
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call getBatchMatchAnalytics when no matches have rawMatchStats", async () => {
+      const analyticsService = aFakeMatchAnalyticsServiceWith();
+      const spy = vi.spyOn(analyticsService, "getBatchMatchAnalytics");
+
+      const connection = await renderLiveTrackerWith(aStateMessage(["m1"], []), analyticsService);
+      connection.step();
+
+      await waitFor(() => expect(screen.getByText(/Series overview/i)).toBeInTheDocument());
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("chunks analytics requests at 30 match IDs per batch", async () => {
+      const matchIds = Array.from({ length: 31 }, (_, i) => `m${(i + 1).toString()}`);
+      const analyticsService = aFakeMatchAnalyticsServiceWith();
+      const spy = vi.spyOn(analyticsService, "getBatchMatchAnalytics");
+
+      const connection = await renderLiveTrackerWith(aStateMessage(matchIds, matchIds), analyticsService);
+      connection.step();
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledTimes(2);
+      });
+      expect(spy.mock.calls[0]?.[0]).toHaveLength(30);
+      expect(spy.mock.calls[1]?.[0]).toHaveLength(1);
+    });
+
+    it("does not re-fetch analytics for match IDs already fetched", async () => {
+      const analyticsService = aFakeMatchAnalyticsServiceWith();
+      const spy = vi.spyOn(analyticsService, "getBatchMatchAnalytics");
+
+      const connection = await renderLiveTrackerWith(aStateMessage(["m1"], ["m1"]), analyticsService);
+      connection.step();
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+      connection.step();
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/Series overview/i).length).toBeGreaterThan(0);
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("shows an error state when the tracker is not found", async () => {

--- a/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
+++ b/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
@@ -1,5 +1,7 @@
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+
+export const GAMES_SUFFIX_RE = /\s+\(\d+\/\d+ games\)$/;
 import type {
   KillMatrixClassification,
   KillMatrixColumnHeader,

--- a/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
+++ b/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
@@ -1,7 +1,5 @@
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
-
-export const GAMES_SUFFIX_RE = /\s+\(\d+\/\d+ games\)$/;
 import type {
   KillMatrixClassification,
   KillMatrixColumnHeader,
@@ -9,6 +7,8 @@ import type {
   KillMatrixPlayer,
   KillMatrixViewRow,
 } from "./types";
+
+export const GAMES_SUFFIX_RE = /\s+\(\d+\/\d+ games\)$/;
 
 interface KillMatrixFormatterPlayerLookup {
   readonly gamertag: string;


### PR DESCRIPTION
## Summary
- Adds `matchAnalyticsService` to `LiveTracker` and wires it through the live tracker stack so the Kill Matrix tab appears in both series-level and per-match views
- Implements an incremental analytics fetch with a ref-based approach to avoid infinite re-render loops and prevent duplicate fetches while a request is in-flight (two-flag `cancelled`/`settled` pattern)
- Extracts shared `GAMES_SUFFIX_RE` regex to `kill-matrix-formatter.ts`; hoists `KillMatrixFormatter` to a module-level singleton in `create.tsx`

## Test plan
- [ ] All existing live-tracker tests pass
- [ ] Start a live tracker with an active NeatQueue series and verify the Kill Matrix tab appears for each match and for series totals
- [ ] Verify no loading flash on the Kill Matrix tab when analytics load incrementally (new match completes while viewing)
- [ ] Verify FAKE mode still works (kill matrix shows empty state gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)