### PR TITLE
refactor(async): extract fire-and-forget chains to async methods with void

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,10 +158,10 @@ public loadMatches(): void {
 private async loadMatchesAsync(): Promise<void> {
   try {
     const result = await this.config.service.fetchSomething();
-    if (this.isDisposed) return;
+    if (this.isDisposed) { return; }
     this.config.store.batchUpdate({ data: result });
   } catch (err: unknown) {
-    if (this.isDisposed) return;
+    if (this.isDisposed) { return; }
     this.config.store.batchUpdate({ error: "Failed" });
   }
 }
@@ -176,10 +176,14 @@ useEffect(() => {
   async function fetchDirectory(): Promise<void> {
     try {
       const dir = await service.getDirectory(gamertag);
-      if (isCancelled) return;
+      if (isCancelled) {
+        return;
+      }
       setDirectory(dir);
     } catch {
-      if (isCancelled) return;
+      if (isCancelled) {
+        return;
+      }
       setError(true);
     }
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,58 @@ switch (item.type) {
 
 **Functions**: Functions to be single single responsibility, when needing to do multiple things, break it down into individual functions that are called / chained.
 
+## Async Patterns
+
+**Fire-and-forget calls**: always extract to a named async function — never chain `.then().catch()` for side-effectful work. Call with `void` to communicate intent.
+
+**Presenters** — extract to a `private async` method named `<publicMethod>Async`:
+
+```typescript
+public loadMatches(): void {
+  void this.loadMatchesAsync();
+}
+
+private async loadMatchesAsync(): Promise<void> {
+  try {
+    const result = await this.config.service.fetchSomething();
+    if (this.isDisposed) return;
+    this.config.store.batchUpdate({ data: result });
+  } catch (err: unknown) {
+    if (this.isDisposed) return;
+    this.config.store.batchUpdate({ error: "Failed" });
+  }
+}
+```
+
+**Hooks/effects** — extract to a named inner async function:
+
+```typescript
+useEffect(() => {
+  let isCancelled = false;
+
+  async function fetchDirectory(): Promise<void> {
+    try {
+      const dir = await service.getDirectory(gamertag);
+      if (isCancelled) return;
+      setDirectory(dir);
+    } catch {
+      if (isCancelled) return;
+      setError(true);
+    }
+  }
+
+  void fetchDirectory();
+
+  return (): void => {
+    isCancelled = true;
+  };
+}, [deps]);
+```
+
+**`void` usage**: marks intentional fire-and-forget calls — not a linter silencer for unintentional floating promises. The `@typescript-eslint/no-floating-promises` rule is enabled.
+
+**Exception**: transformation chains that return a value (e.g. passed to `Promise.all`) are fine as-is.
+
 ## CSS / Styling
 
 CSS Modules only — all styling via `.module.css`. Use `classnames` package for conditional classes; never template-literal class strings. Pass dynamic values via CSS variables in the `style` prop: `style={{ "--accent": color }}` (only acceptable `style` usage).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -70,6 +70,7 @@ export default defineConfig(
       "@typescript-eslint/promise-function-async": "error",
       "@typescript-eslint/strict-boolean-expressions": "error",
       "@typescript-eslint/switch-exhaustiveness-check": "error",
+      "@typescript-eslint/no-floating-promises": "error",
       "import/order": "error",
       curly: ["error", "all"],
       "default-case": "error",

--- a/pages/src/apps/discord-series-stats/create.tsx
+++ b/pages/src/apps/discord-series-stats/create.tsx
@@ -98,22 +98,25 @@ export function DiscordSeriesStatsApp({ apiHost, guildId, queueNumber }: Discord
     setServices(null);
     setLoadingServices(ComponentLoaderStatus.PENDING);
 
-    installServices(apiHost)
-      .then((installedServices) => {
+    async function loadServices(): Promise<void> {
+      try {
+        const installedServices = await installServices(apiHost);
         if (isCancelled) {
           return;
         }
 
         setServices(installedServices);
         setLoadingServices(ComponentLoaderStatus.LOADED);
-      })
-      .catch(() => {
+      } catch {
         if (isCancelled) {
           return;
         }
 
         setLoadingServices(ComponentLoaderStatus.ERROR);
-      });
+      }
+    }
+
+    void loadServices();
 
     return (): void => {
       isCancelled = true;

--- a/pages/src/apps/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/apps/discord-series-stats/discord-series-stats-presenter.ts
@@ -37,22 +37,22 @@ export class DiscordSeriesStatsPresenter {
     const activeRequest = this.requestNumber;
 
     this.store.setLoading();
+    void this.startAsync(activeRequest);
+  }
 
-    this.fetchStats()
-      .then((response) => {
-        if (this.isDisposed || activeRequest !== this.requestNumber) {
-          return;
-        }
-
-        this.store.setLoaded(response);
-      })
-      .catch(() => {
-        if (this.isDisposed || activeRequest !== this.requestNumber) {
-          return;
-        }
-
-        this.store.setError("Failed to load stats");
-      });
+  private async startAsync(activeRequest: number): Promise<void> {
+    try {
+      const response = await this.fetchStats();
+      if (this.isDisposed || activeRequest !== this.requestNumber) {
+        return;
+      }
+      this.store.setLoaded(response);
+    } catch {
+      if (this.isDisposed || activeRequest !== this.requestNumber) {
+        return;
+      }
+      this.store.setError("Failed to load stats");
+    }
   }
 
   dispose(): void {

--- a/pages/src/apps/follow-live/create.tsx
+++ b/pages/src/apps/follow-live/create.tsx
@@ -27,20 +27,23 @@ export function FollowLiveApp({ apiHost, gamertag, variant = "viewer" }: FollowL
     setServices(null);
     setState(ComponentLoaderStatus.PENDING);
 
-    installServices(apiHost)
-      .then((installedServices) => {
+    async function loadServices(): Promise<void> {
+      try {
+        const installedServices = await installServices(apiHost);
         if (isCancelled) {
           return;
         }
         setServices(installedServices);
         setState(ComponentLoaderStatus.LOADED);
-      })
-      .catch(() => {
+      } catch {
         if (isCancelled) {
           return;
         }
         setState(ComponentLoaderStatus.ERROR);
-      });
+      }
+    }
+
+    void loadServices();
 
     return (): void => {
       isCancelled = true;

--- a/pages/src/apps/individual-tracker-manager/create.tsx
+++ b/pages/src/apps/individual-tracker-manager/create.tsx
@@ -21,20 +21,23 @@ export function IndividualTrackerManagerApp({ apiHost }: IndividualTrackerManage
     setServices(null);
     setState(ComponentLoaderStatus.PENDING);
 
-    installServices(apiHost)
-      .then((installedServices) => {
+    async function loadServices(): Promise<void> {
+      try {
+        const installedServices = await installServices(apiHost);
         if (isCancelled) {
           return;
         }
         setServices(installedServices);
         setState(ComponentLoaderStatus.LOADED);
-      })
-      .catch(() => {
+      } catch {
         if (isCancelled) {
           return;
         }
         setState(ComponentLoaderStatus.ERROR);
-      });
+      }
+    }
+
+    void loadServices();
 
     return (): void => {
       isCancelled = true;

--- a/pages/src/apps/individual-tracker-overlay/create.tsx
+++ b/pages/src/apps/individual-tracker-overlay/create.tsx
@@ -26,20 +26,23 @@ export function IndividualTrackerOverlayApp({ apiHost, trackerId }: IndividualTr
     setServices(null);
     setState(ComponentLoaderStatus.PENDING);
 
-    installServices(apiHost)
-      .then((installedServices) => {
+    async function loadServices(): Promise<void> {
+      try {
+        const installedServices = await installServices(apiHost);
         if (isCancelled) {
           return;
         }
         setServices(installedServices);
         setState(ComponentLoaderStatus.LOADED);
-      })
-      .catch(() => {
+      } catch {
         if (isCancelled) {
           return;
         }
         setState(ComponentLoaderStatus.ERROR);
-      });
+      }
+    }
+
+    void loadServices();
 
     return (): void => {
       isCancelled = true;

--- a/pages/src/apps/individual-tracker-viewer/create.tsx
+++ b/pages/src/apps/individual-tracker-viewer/create.tsx
@@ -32,8 +32,9 @@ export function IndividualTrackerViewerApp({ apiHost, trackerId }: IndividualTra
     setServices(null);
     setState(ComponentLoaderStatus.PENDING);
 
-    installServices(apiHost)
-      .then(async (installedServices) => {
+    async function loadServices(): Promise<void> {
+      try {
+        const installedServices = await installServices(apiHost);
         const session = await installedServices.authService.getSession();
         if (isCancelled) {
           return;
@@ -46,13 +47,15 @@ export function IndividualTrackerViewerApp({ apiHost, trackerId }: IndividualTra
 
         setServices(installedServices);
         setState(ComponentLoaderStatus.LOADED);
-      })
-      .catch(() => {
+      } catch {
         if (isCancelled) {
           return;
         }
         setState(ComponentLoaderStatus.ERROR);
-      });
+      }
+    }
+
+    void loadServices();
 
     return (): void => {
       isCancelled = true;

--- a/pages/src/apps/live-tracker/create.tsx
+++ b/pages/src/apps/live-tracker/create.tsx
@@ -50,21 +50,24 @@ export function LiveTrackerApp({ apiHost }: LiveTrackerAppProps): ReactElement {
     setServices(null);
     setLoadingServices(ComponentLoaderStatus.PENDING);
 
-    installServices(apiHost)
-      .then((installedServices) => {
+    async function loadServices(): Promise<void> {
+      try {
+        const installedServices = await installServices(apiHost);
         if (isCancelled) {
           return;
         }
 
         setServices(installedServices);
         setLoadingServices(ComponentLoaderStatus.LOADED);
-      })
-      .catch(() => {
+      } catch {
         if (isCancelled) {
           return;
         }
         setLoadingServices(ComponentLoaderStatus.ERROR);
-      });
+      }
+    }
+
+    void loadServices();
 
     return (): void => {
       isCancelled = true;

--- a/pages/src/apps/login/create.tsx
+++ b/pages/src/apps/login/create.tsx
@@ -21,22 +21,25 @@ export function LoginApp({ apiHost }: LoginAppProps): ReactElement {
     setAuthService(null);
     setLoadingServices(ComponentLoaderStatus.PENDING);
 
-    installServices(apiHost)
-      .then((installedServices) => {
+    async function loadServices(): Promise<void> {
+      try {
+        const installedServices = await installServices(apiHost);
         if (isCancelled) {
           return;
         }
 
         setAuthService(installedServices.authService);
         setLoadingServices(ComponentLoaderStatus.LOADED);
-      })
-      .catch(() => {
+      } catch {
         if (isCancelled) {
           return;
         }
 
         setLoadingServices(ComponentLoaderStatus.ERROR);
-      });
+      }
+    }
+
+    void loadServices();
 
     return (): void => {
       isCancelled = true;

--- a/pages/src/components/follow/use-follow-live-directory.ts
+++ b/pages/src/components/follow/use-follow-live-directory.ts
@@ -57,9 +57,9 @@ export function useFollowLiveDirectory({
 
     const connection = followLiveService.connectDirectory(gamertag);
 
-    followLiveService
-      .getDirectory(gamertag)
-      .then((dir) => {
+    async function fetchDirectory(): Promise<void> {
+      try {
+        const dir = await followLiveService.getDirectory(gamertag);
         if (isCancelled) {
           return;
         }
@@ -69,14 +69,16 @@ export function useFollowLiveDirectory({
         setSelectedTrackerId(liveId);
         setDirectoryStatus("connected");
         initialLoadDoneRef.current = true;
-      })
-      .catch(() => {
+      } catch {
         if (isCancelled) {
           return;
         }
         setDirectoryStatus("error");
         initialLoadDoneRef.current = true;
-      });
+      }
+    }
+
+    void fetchDirectory();
 
     const dirSubscription = connection.subscribe((updatedDirectory) => {
       if (isCancelled || !initialLoadDoneRef.current) {

--- a/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-connections/streamer-connections-presenter.ts
@@ -199,23 +199,25 @@ export class StreamerConnectionsPresenter {
     const generation = ++this.saveGeneration;
     const settings = snapshotToSettings(this.config.store.getSnapshot());
     this.config.store.setSaving();
-    this.config.settingsService
-      .updateSettings(settings)
-      .then((saved) => {
-        if (this.isDisposed || generation !== this.saveGeneration || this.debounceTimer !== null) {
-          return;
-        }
-        const snapshot = this.config.store.getSnapshot();
-        const parsed = settingsToSnapshot(saved, snapshot);
-        applyParsedSettingsToStore(this.config.store, parsed, snapshot.gamertag);
-        this.config.store.setSaved();
-      })
-      .catch((err: unknown) => {
-        if (this.isDisposed || generation !== this.saveGeneration || this.debounceTimer !== null) {
-          return;
-        }
-        const message = err instanceof Error ? err.message : "Failed to save settings";
-        this.config.store.setSaveError(message);
-      });
+    void this.saveAsync(generation, settings);
+  }
+
+  private async saveAsync(generation: number, settings: StreamerViewSettings): Promise<void> {
+    try {
+      const saved = await this.config.settingsService.updateSettings(settings);
+      if (this.isDisposed || generation !== this.saveGeneration || this.debounceTimer !== null) {
+        return;
+      }
+      const snapshot = this.config.store.getSnapshot();
+      const parsed = settingsToSnapshot(saved, snapshot);
+      applyParsedSettingsToStore(this.config.store, parsed, snapshot.gamertag);
+      this.config.store.setSaved();
+    } catch (err: unknown) {
+      if (this.isDisposed || generation !== this.saveGeneration || this.debounceTimer !== null) {
+        return;
+      }
+      const message = err instanceof Error ? err.message : "Failed to save settings";
+      this.config.store.setSaveError(message);
+    }
   }
 }

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
@@ -3,7 +3,7 @@ import type { IndividualTrackerSeriesGroup } from "../series-group-metadata";
 import { alignSeriesGroupsToGroupings } from "../series-group-metadata";
 import { applyAddToAdjacentGroup, applyBreakFromGroup } from "../grouping-utils";
 import { shouldHideShortDurationMatch } from "../match-duration-filter";
-import type { GameSelectionDialogStore } from "./game-selection-dialog-store";
+import type { GameSelectionDialogSnapshot, GameSelectionDialogStore } from "./game-selection-dialog-store";
 
 interface Config {
   readonly store: GameSelectionDialogStore;
@@ -33,7 +33,7 @@ export class GameSelectionDialogPresenter {
       return;
     }
 
-    const { store, service, xuid, initialSelectedMatchIds, initialGroupings, initialSeriesGroups } = this.config;
+    const { store, initialSelectedMatchIds, initialGroupings, initialSeriesGroups } = this.config;
 
     store.batchUpdate({
       matches: null,
@@ -46,29 +46,32 @@ export class GameSelectionDialogPresenter {
       errorMessage: null,
     });
 
-    service
-      .getMatchHistory(xuid, 0, 25)
-      .then((response) => {
-        if (this.isDisposed) {
-          return;
-        }
-        const snapshot = store.getSnapshot();
-        const groupings = snapshot.groupings.length > 0 ? snapshot.groupings : [...response.suggestedGroupings];
-        store.batchUpdate({
-          matches: response.matches,
-          groupings,
-          seriesGroups: alignSeriesGroupsToGroupings(groupings, Array.from(snapshot.seriesGroups)),
-          hasMore: response.matches.length >= 25,
-        });
-      })
-      .catch((err: unknown) => {
-        if (this.isDisposed) {
-          return;
-        }
-        store.batchUpdate({
-          errorMessage: err instanceof Error ? err.message : "Failed to load matches.",
-        });
+    void this.loadMatchesAsync();
+  }
+
+  private async loadMatchesAsync(): Promise<void> {
+    const { store, service, xuid } = this.config;
+    try {
+      const response = await service.getMatchHistory(xuid, 0, 25);
+      if (this.isDisposed) {
+        return;
+      }
+      const snapshot = store.getSnapshot();
+      const groupings = snapshot.groupings.length > 0 ? snapshot.groupings : [...response.suggestedGroupings];
+      store.batchUpdate({
+        matches: response.matches,
+        groupings,
+        seriesGroups: alignSeriesGroupsToGroupings(groupings, Array.from(snapshot.seriesGroups)),
+        hasMore: response.matches.length >= 25,
       });
+    } catch (err: unknown) {
+      if (this.isDisposed) {
+        return;
+      }
+      store.batchUpdate({
+        errorMessage: err instanceof Error ? err.message : "Failed to load matches.",
+      });
+    }
   }
 
   public loadMore(): void {
@@ -76,31 +79,31 @@ export class GameSelectionDialogPresenter {
       return;
     }
 
-    const { store, service, xuid } = this.config;
-    const snapshot = store.getSnapshot();
+    const snapshot = this.config.store.getSnapshot();
 
     if (snapshot.matches == null) {
       return;
     }
 
-    const start = snapshot.matches.length;
+    void this.loadMoreAsync(snapshot.matches.length);
+  }
 
-    service
-      .getMatchHistory(xuid, start, 25)
-      .then((response) => {
-        if (this.isDisposed) {
-          return;
-        }
-        const current = store.getSnapshot();
-        const allMatches = current.matches != null ? [...current.matches, ...response.matches] : response.matches;
-        store.batchUpdate({
-          matches: allMatches,
-          hasMore: response.matches.length >= 25,
-        });
-      })
-      .catch(() => {
-        /* keep existing data visible */
+  private async loadMoreAsync(start: number): Promise<void> {
+    const { store, service, xuid } = this.config;
+    try {
+      const response = await service.getMatchHistory(xuid, start, 25);
+      if (this.isDisposed) {
+        return;
+      }
+      const current = store.getSnapshot();
+      const allMatches = current.matches != null ? [...current.matches, ...response.matches] : response.matches;
+      store.batchUpdate({
+        matches: allMatches,
+        hasMore: response.matches.length >= 25,
       });
+    } catch {
+      /* keep existing data visible */
+    }
   }
 
   public toggleMatch(matchId: string): void {
@@ -176,37 +179,38 @@ export class GameSelectionDialogPresenter {
       return;
     }
 
-    const { store, service, trackerId, onSynced } = this.config;
-    const snapshot = store.getSnapshot();
+    const snapshot = this.config.store.getSnapshot();
 
     if (snapshot.isSyncing) {
       return;
     }
 
-    store.batchUpdate({ isSyncing: true, errorMessage: null });
+    this.config.store.batchUpdate({ isSyncing: true, errorMessage: null });
+    void this.syncAndCloseAsync(snapshot);
+  }
 
-    service
-      .syncMatchesToTracker({
+  private async syncAndCloseAsync(snapshot: GameSelectionDialogSnapshot): Promise<void> {
+    const { store, service, trackerId, onSynced } = this.config;
+    try {
+      await service.syncMatchesToTracker({
         trackerId,
         selectedMatchIds: Array.from(snapshot.selectedMatchIds),
         matchGroupings: snapshot.groupings,
         matches: snapshot.matches ?? [],
-      })
-      .then(() => {
-        if (this.isDisposed) {
-          return;
-        }
-        onSynced();
-      })
-      .catch((err: unknown) => {
-        if (this.isDisposed) {
-          return;
-        }
-        store.batchUpdate({
-          isSyncing: false,
-          errorMessage: err instanceof Error ? err.message : "Failed to sync game selection.",
-        });
       });
+      if (this.isDisposed) {
+        return;
+      }
+      onSynced();
+    } catch (err: unknown) {
+      if (this.isDisposed) {
+        return;
+      }
+      store.batchUpdate({
+        isSyncing: false,
+        errorMessage: err instanceof Error ? err.message : "Failed to sync game selection.",
+      });
+    }
   }
 
   public static present(snapshot: ReturnType<GameSelectionDialogStore["getSnapshot"]>): {


### PR DESCRIPTION
## Summary

- Enables `@typescript-eslint/no-floating-promises` ESLint rule
- Extracts all `.then().catch()` fire-and-forget chains to named async helpers, called with explicit `void`
- Updates `AGENTS.md` with an **Async Patterns** section codifying this convention

### Pattern applied

**Presenters** → private `async methodNameAsync()` called with `void this.methodNameAsync()`:
- `game-selection-dialog-presenter.ts` — `loadMatchesAsync`, `loadMoreAsync`, `syncAndCloseAsync`
- `streamer-connections-presenter.ts` — `saveAsync`
- `discord-series-stats-presenter.ts` — `startAsync`

**Hooks/effects** → named inner `async function` called with `void`:
- `use-follow-live-directory.ts` — `fetchDirectory`
- 7 app `create.tsx` files (`follow-live`, `individual-tracker-viewer`, `individual-tracker-overlay`, `live-tracker`, `individual-tracker-manager`, `discord-series-stats`, `login`) — `loadServices` (service initialisation pattern)

### Not touched
- `viewer-presenter.ts` — transformation chain assigned to `analyticsPromise`, passed to `Promise.all` — intentionally left as-is
- `pages/src/components/live-tracker/create.tsx` — the component-level file is pending a follow-up SPC architectural refactor (distinct from `pages/src/apps/live-tracker/create.tsx` which was updated above)

## Test plan

- [ ] `npm run done` passes (format + typecheck + lint + tests)
- [ ] All presenters still function correctly (same observable behaviour)
- [ ] `no-floating-promises` rule fires on any new unhandled promise added in future PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)