### PR TITLE
refactor(live-tracker): move business logic from create.tsx into presenter (SPC)

### DIFF
--- a/pages/src/components/live-tracker/create.tsx
+++ b/pages/src/components/live-tracker/create.tsx
@@ -1,28 +1,13 @@
-import React, { useEffect, useMemo, useState, useSyncExternalStore, useRef } from "react";
-import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import React, { useEffect, useMemo, useSyncExternalStore } from "react";
 import { ComponentLoader, ComponentLoaderStatus } from "../component-loader/component-loader";
 import { ErrorState } from "../error-state/error-state";
 import { LoadingState } from "../loading-state/loading-state";
-import type { MatchStatsData } from "../../controllers/stats/types";
-import { StatsController } from "../../controllers/stats/stats-controller";
-import { calculateSeriesMetadata, type SeriesMetadata } from "../../controllers/stats/series-metadata";
-import { GAMES_SUFFIX_RE, KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
-import {
-  EMPTY_KILL_MATRIX_PIVOT_DATA,
-  type KillMatrixPivotData,
-  type KillMatrixPlayer,
-  type KillMatrixViewRow,
-} from "../../controllers/stats/kill-matrix/types";
 import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import type { LiveTrackerService } from "../../services/live-tracker/types";
 import { LiveTrackerPresenter } from "./live-tracker-presenter";
 import { LiveTrackerStore } from "./live-tracker-store";
 import { LiveTrackerView } from "./live-tracker";
-import type { LiveTrackerViewModel } from "./types";
 import { LiveTrackerProvider } from "./live-tracker-context";
-
-const killMatrixFormatter = new KillMatrixFormatter();
-const ANALYTICS_BATCH_SIZE = 30;
 
 interface LiveTrackerProps {
   readonly liveTrackerService: LiveTrackerService;
@@ -32,13 +17,16 @@ interface LiveTrackerProps {
 export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveTrackerProps): React.ReactElement {
   const store = useMemo(() => new LiveTrackerStore(), []);
 
-  const presenter = useMemo(() => {
-    return new LiveTrackerPresenter({
-      liveTrackerService,
-      getUrl: (): URL => new URL(window.location.href),
-      store,
-    });
-  }, [liveTrackerService, store]);
+  const presenter = useMemo(
+    () =>
+      new LiveTrackerPresenter({
+        liveTrackerService,
+        getUrl: (): URL => new URL(window.location.href),
+        store,
+        matchAnalyticsService,
+      }),
+    [liveTrackerService, matchAnalyticsService, store],
+  );
 
   useEffect(() => {
     presenter.start();
@@ -62,269 +50,7 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
       ? ComponentLoaderStatus.ERROR
       : ComponentLoaderStatus.LOADING;
 
-  // Memoize model creation to prevent unnecessary re-renders when WebSocket
-  // sends identical data (e.g., heartbeat messages every 3 minutes)
-  const modelRef = useRef<LiveTrackerViewModel | null>(null);
-  const snapshotRef = useRef<typeof snapshot | null>(null);
-
-  const model = useMemo((): LiveTrackerViewModel => {
-    // If this is the first render, create the model
-    if (modelRef.current === null || snapshotRef.current === null) {
-      const newModel = LiveTrackerPresenter.present(snapshot);
-      modelRef.current = newModel;
-      snapshotRef.current = snapshot;
-      return newModel;
-    }
-
-    const prev = snapshotRef.current;
-    const curr = snapshot;
-
-    // Quick reference equality check
-    if (prev === curr) {
-      return modelRef.current;
-    }
-
-    // Check if any meaningful data has changed
-    const hasChanged =
-      prev.connectionState !== curr.connectionState ||
-      prev.statusText !== curr.statusText ||
-      !LiveTrackerPresenter.areParamsEqual(prev.params, curr.params) ||
-      prev.hasConnection !== curr.hasConnection ||
-      prev.hasReceivedInitialData !== curr.hasReceivedInitialData ||
-      // Deep check the state message data
-      !LiveTrackerPresenter.isStateMessageEqual(prev.lastStateMessage, curr.lastStateMessage);
-
-    if (!hasChanged) {
-      // Data is the same, return the previous model to prevent re-renders
-      return modelRef.current;
-    }
-
-    // Data has changed, create a new model
-    const newModel = LiveTrackerPresenter.present(snapshot);
-    modelRef.current = newModel;
-    snapshotRef.current = snapshot;
-    return newModel;
-  }, [snapshot]);
-
-  // Compute match stats from model state (NeatQueue only)
-  const allMatchStats = useMemo((): { matchId: string; data: MatchStatsData[] | null }[] => {
-    if (model.state?.type !== "neatqueue") {
-      return [];
-    }
-
-    const { medalMetadata } = model.state;
-
-    return model.state.matches.map((match) => {
-      if (match.rawMatchStats == null) {
-        return { matchId: match.matchId, data: null };
-      }
-
-      try {
-        const matchStats = match.rawMatchStats;
-        const controller = new StatsController();
-        const playerMap = new Map<string, string>(Object.entries(match.playerXuidToGametag));
-        controller.loadMatch(matchStats, playerMap, medalMetadata);
-        return { matchId: match.matchId, data: controller.getMatchStats() };
-      } catch (error) {
-        console.error("Error processing match stats:", error);
-        return { matchId: match.matchId, data: null };
-      }
-    });
-  }, [model.state]); // Depend on entire state to catch type changes
-
-  const [analyticsByMatchId, setAnalyticsByMatchId] = useState<ReadonlyMap<string, MatchAnalytics>>(new Map());
-  const [analyticsStatus, setAnalyticsStatus] = useState(ComponentLoaderStatus.LOADED);
-  // Tracks IDs that are already fetched or in-flight so the effect can check without
-  // depending on analyticsByMatchId state (which would cause an infinite re-render loop).
-  const fetchedMatchIdsRef = useRef<Set<string>>(new Set());
-
-  const completeMatchIdsKey = useMemo((): string => {
-    if (model.state?.type !== "neatqueue") {
-      return "";
-    }
-    return model.state.matches
-      .filter((m) => m.rawMatchStats != null)
-      .map((m) => m.matchId)
-      .join(",");
-  }, [model.state]);
-
-  useEffect(() => {
-    if (!completeMatchIdsKey) {
-      fetchedMatchIdsRef.current = new Set();
-      setAnalyticsByMatchId(new Map());
-      setAnalyticsStatus(ComponentLoaderStatus.LOADED);
-      return;
-    }
-
-    const newMatchIds = completeMatchIdsKey.split(",").filter((id) => !fetchedMatchIdsRef.current.has(id));
-    if (newMatchIds.length === 0) {
-      return;
-    }
-
-    const isInitialFetch = fetchedMatchIdsRef.current.size === 0;
-    for (const id of newMatchIds) {
-      fetchedMatchIdsRef.current.add(id);
-    }
-
-    let cancelled = false;
-    let settled = false;
-    if (isInitialFetch) {
-      setAnalyticsStatus(ComponentLoaderStatus.LOADING);
-    }
-
-    const chunks: string[][] = [];
-    for (let i = 0; i < newMatchIds.length; i += ANALYTICS_BATCH_SIZE) {
-      chunks.push(newMatchIds.slice(i, i + ANALYTICS_BATCH_SIZE));
-    }
-
-    Promise.all(chunks.map(async (chunk) => matchAnalyticsService.getBatchMatchAnalytics(chunk)))
-      .then((allResults) => {
-        settled = true;
-        if (cancelled) {
-          return;
-        }
-        setAnalyticsByMatchId((prev) => {
-          const map = new Map(prev);
-          for (const results of allResults) {
-            for (const [matchId, analytics] of Object.entries(results)) {
-              if (analytics != null) {
-                map.set(matchId, analytics);
-              }
-            }
-          }
-          return map;
-        });
-        setAnalyticsStatus(ComponentLoaderStatus.LOADED);
-      })
-      .catch(() => {
-        settled = true;
-        if (cancelled) {
-          return;
-        }
-        for (const id of newMatchIds) {
-          fetchedMatchIdsRef.current.delete(id);
-        }
-        if (isInitialFetch) {
-          setAnalyticsStatus(ComponentLoaderStatus.ERROR);
-        }
-      });
-
-    return (): void => {
-      cancelled = true;
-      if (!settled) {
-        for (const id of newMatchIds) {
-          fetchedMatchIdsRef.current.delete(id);
-        }
-      }
-    };
-  }, [completeMatchIdsKey, matchAnalyticsService]);
-
-  // Compute series stats and player ordering from model state (NeatQueue only).
-  // Runs loadSeries once; the kill-matrix memo reuses orderedPlayers and playersByXuid.
-  const seriesStatsData = useMemo((): {
-    teamData: MatchStatsData[];
-    playerData: MatchStatsData[];
-    metadata: SeriesMetadata | null;
-    orderedPlayers: readonly KillMatrixPlayer[] | undefined;
-    playersByXuid: ReadonlyMap<string, { gamertag: string; teamId: number | null }>;
-  } | null => {
-    if (model.state?.type !== "neatqueue" || model.state.matches.length === 0) {
-      return null;
-    }
-
-    const rawMatchStats = model.state.matches
-      .map((match) => match.rawMatchStats)
-      .filter((stats): stats is NonNullable<typeof stats> => stats != null);
-
-    if (rawMatchStats.length === 0) {
-      return null;
-    }
-
-    try {
-      const allPlayerXuidToGametag = new Map<string, string>();
-      for (const match of model.state.matches) {
-        for (const [xuid, gamertag] of Object.entries(match.playerXuidToGametag)) {
-          allPlayerXuidToGametag.set(xuid, gamertag);
-        }
-      }
-
-      const controller = new StatsController();
-      controller.loadSeries(rawMatchStats, allPlayerXuidToGametag, model.state.medalMetadata);
-      const { teamData, playerData } = controller.getSeriesStats();
-      const players = controller.getPlayers();
-      const playersByGamertag = new Map(players.map((p) => [p.gamertag, p]));
-      const resolvedPlayers = playerData
-        .flatMap((td) => td.players.map((p) => playersByGamertag.get(p.name.replace(GAMES_SUFFIX_RE, ""))))
-        .filter((p): p is KillMatrixPlayer => p != null);
-      const orderedPlayers = resolvedPlayers.length === players.length ? resolvedPlayers : players;
-      const playersByXuid = new Map(players.map((p) => [p.xuid, { gamertag: p.gamertag, teamId: p.teamId }]));
-      const metadata = calculateSeriesMetadata(model.state.matches, model.state.seriesScore);
-
-      return { teamData, playerData, metadata, orderedPlayers, playersByXuid };
-    } catch (error) {
-      console.error("Error processing series stats:", error);
-      return null;
-    }
-  }, [model.state]);
-
-  const seriesStats = useMemo(() => {
-    if (seriesStatsData == null) {
-      return null;
-    }
-    return {
-      teamData: seriesStatsData.teamData,
-      playerData: seriesStatsData.playerData,
-      metadata: seriesStatsData.metadata,
-    };
-  }, [seriesStatsData]);
-
-  const { allMatchKillMatrix, seriesKillMatrix } = useMemo((): {
-    allMatchKillMatrix: readonly {
-      matchId: string;
-      pivotData: KillMatrixPivotData;
-      transposedPivotData: KillMatrixPivotData;
-    }[];
-    seriesKillMatrix: { pivotData: KillMatrixPivotData; transposedPivotData: KillMatrixPivotData } | null;
-  } => {
-    if (model.state?.type !== "neatqueue" || seriesStatsData == null || analyticsByMatchId.size === 0) {
-      return { allMatchKillMatrix: [], seriesKillMatrix: null };
-    }
-
-    const { orderedPlayers: seriesPlayers, playersByXuid } = seriesStatsData;
-    const matchKillMatrixRows = new Map<string, readonly KillMatrixViewRow[]>();
-
-    const computedAllMatchKillMatrix = model.state.matches.map((match) => {
-      const analytics = analyticsByMatchId.get(match.matchId);
-      if (analytics == null) {
-        return {
-          matchId: match.matchId,
-          pivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
-          transposedPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
-        };
-      }
-      const rows = killMatrixFormatter.present({ analytics, playersByXuid });
-      matchKillMatrixRows.set(match.matchId, rows);
-      return {
-        matchId: match.matchId,
-        pivotData: KillMatrixFormatter.pivot(rows, seriesPlayers),
-        transposedPivotData: KillMatrixFormatter.transpose(rows, seriesPlayers),
-      };
-    });
-
-    if (matchKillMatrixRows.size === 0) {
-      return { allMatchKillMatrix: computedAllMatchKillMatrix, seriesKillMatrix: null };
-    }
-
-    const aggregatedRows = KillMatrixFormatter.aggregate([...matchKillMatrixRows.values()].flatMap((rows) => rows));
-
-    return {
-      allMatchKillMatrix: computedAllMatchKillMatrix,
-      seriesKillMatrix: {
-        pivotData: KillMatrixFormatter.pivot(aggregatedRows, seriesPlayers),
-        transposedPivotData: KillMatrixFormatter.transpose(aggregatedRows, seriesPlayers),
-      },
-    };
-  }, [model.state, seriesStatsData, analyticsByMatchId]);
+  const model = useMemo(() => LiveTrackerPresenter.present(snapshot), [snapshot]);
 
   return (
     <ComponentLoader
@@ -345,12 +71,12 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
       loaded={
         <LiveTrackerProvider
           model={model}
-          params={snapshot.params}
-          allMatchStats={allMatchStats}
-          seriesStats={seriesStats}
-          analyticsStatus={analyticsStatus}
-          allMatchKillMatrix={allMatchKillMatrix}
-          seriesKillMatrix={seriesKillMatrix}
+          params={model.params}
+          allMatchStats={model.allMatchStats}
+          seriesStats={model.seriesStats}
+          analyticsStatus={model.analyticsStatus}
+          allMatchKillMatrix={model.allMatchKillMatrix}
+          seriesKillMatrix={model.seriesKillMatrix}
         >
           <LiveTrackerView />
         </LiveTrackerProvider>

--- a/pages/src/components/live-tracker/live-tracker-context.tsx
+++ b/pages/src/components/live-tracker/live-tracker-context.tsx
@@ -3,7 +3,6 @@ import type { PlayerAssociationData } from "@guilty-spark/shared/live-tracker/ty
 import type { MatchStatsData } from "../../controllers/stats/types";
 import type { SeriesMetadata } from "../../controllers/stats/series-metadata";
 import { type ComponentLoaderStatus } from "../component-loader/component-loader";
-import type { KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
 import type { LiveTrackerParams } from "./live-tracker-store";
 import type {
   LiveTrackerAvailablePlayer,
@@ -11,18 +10,9 @@ import type {
   LiveTrackerMatchRenderModel,
   LiveTrackerSubstitutionRenderModel,
   LiveTrackerTeamRenderModel,
+  MatchKillMatrix,
+  KillMatrixResult,
 } from "./types";
-
-interface MatchKillMatrix {
-  readonly matchId: string;
-  readonly pivotData: KillMatrixPivotData;
-  readonly transposedPivotData: KillMatrixPivotData;
-}
-
-interface KillMatrixResult {
-  readonly pivotData: KillMatrixPivotData;
-  readonly transposedPivotData: KillMatrixPivotData;
-}
 
 interface LiveTrackerContextValue {
   readonly model: LiveTrackerViewModel;

--- a/pages/src/components/live-tracker/live-tracker-presenter.ts
+++ b/pages/src/components/live-tracker/live-tracker-presenter.ts
@@ -640,6 +640,10 @@ export class LiveTrackerPresenter {
 
       const current = this.config.store.getSnapshot();
       if (current.lastStateMessage !== stateMessage) {
+        for (const id of newMatchIds) {
+          this.fetchedMatchIds.delete(id);
+        }
+        this.triggerAnalyticsFetch(current);
         return;
       }
       const map = new Map(current.analyticsByMatchId);

--- a/pages/src/components/live-tracker/live-tracker-presenter.ts
+++ b/pages/src/components/live-tracker/live-tracker-presenter.ts
@@ -8,15 +8,20 @@ import type {
 } from "../../services/live-tracker/types";
 import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import type { MatchStatsData } from "../../controllers/stats/types";
-import type { SeriesMetadata } from "../../controllers/stats/series-metadata";
 import { ComponentLoaderStatus } from "../component-loader/component-loader";
 import { StatsController } from "../../controllers/stats/stats-controller";
 import { calculateSeriesMetadata } from "../../controllers/stats/series-metadata";
 import { GAMES_SUFFIX_RE, KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { EMPTY_KILL_MATRIX_PIVOT_DATA } from "../../controllers/stats/kill-matrix/types";
-import type { KillMatrixPivotData, KillMatrixPlayer } from "../../controllers/stats/kill-matrix/types";
+import type { KillMatrixPlayer } from "../../controllers/stats/kill-matrix/types";
 import type { LiveTrackerParams, LiveTrackerSnapshot, LiveTrackerStore } from "./live-tracker-store";
-import type { LiveTrackerViewModel, LiveTrackerStateRenderModel } from "./types";
+import type {
+  LiveTrackerViewModel,
+  LiveTrackerStateRenderModel,
+  MatchKillMatrix,
+  KillMatrixResult,
+  SeriesStatsData,
+} from "./types";
 import { toLiveTrackerStateRenderModel } from "./state-render-model";
 
 interface Config {
@@ -24,25 +29,6 @@ interface Config {
   readonly getUrl: () => URL;
   readonly store: LiveTrackerStore;
   readonly matchAnalyticsService: MatchAnalyticsService;
-}
-
-interface SeriesStatsData {
-  readonly teamData: MatchStatsData[];
-  readonly playerData: MatchStatsData[];
-  readonly metadata: SeriesMetadata | null;
-  readonly orderedPlayers: readonly KillMatrixPlayer[] | undefined;
-  readonly playersByXuid: ReadonlyMap<string, { gamertag: string; teamId: number | null }>;
-}
-
-interface MatchKillMatrix {
-  readonly matchId: string;
-  readonly pivotData: KillMatrixPivotData;
-  readonly transposedPivotData: KillMatrixPivotData;
-}
-
-interface KillMatrixResult {
-  readonly pivotData: KillMatrixPivotData;
-  readonly transposedPivotData: KillMatrixPivotData;
 }
 
 export class LiveTrackerPresenter {
@@ -110,8 +96,7 @@ export class LiveTrackerPresenter {
         ? state.teams.flatMap((team) => team.players.map((player) => ({ id: player.id, name: player.displayName })))
         : [];
 
-    const allMatchStats = LiveTrackerPresenter.computeAllMatchStats(state);
-    const seriesStatsData = LiveTrackerPresenter.computeSeriesStatsData(state);
+    const { allMatchStats, seriesStatsData } = snapshot;
 
     const seriesStats =
       seriesStatsData != null
@@ -288,7 +273,7 @@ export class LiveTrackerPresenter {
 
     // Compare medalMetadata keys (structural check)
     const prevMedalIds = Object.keys(prevData.medalMetadata).sort();
-    const currMedalIds = Object.keys(prevData.medalMetadata).sort();
+    const currMedalIds = Object.keys(currData.medalMetadata).sort();
     if (prevMedalIds.length !== currMedalIds.length || !prevMedalIds.every((id, idx) => id === currMedalIds[idx])) {
       return false;
     }
@@ -434,6 +419,8 @@ export class LiveTrackerPresenter {
         hasReceivedInitialData: false,
         analyticsByMatchId: new Map(),
         analyticsStatus: ComponentLoaderStatus.LOADED,
+        allMatchStats: [],
+        seriesStatsData: null,
       });
       return;
     }
@@ -471,6 +458,8 @@ export class LiveTrackerPresenter {
       hasReceivedInitialData: false,
       analyticsByMatchId: new Map(),
       analyticsStatus: ComponentLoaderStatus.LOADED,
+      allMatchStats: [],
+      seriesStatsData: null,
     });
   }
 
@@ -573,10 +562,16 @@ export class LiveTrackerPresenter {
         return;
       }
 
+      const state = toLiveTrackerStateRenderModel(message);
+      const allMatchStats = LiveTrackerPresenter.computeAllMatchStats(state);
+      const seriesStatsData = LiveTrackerPresenter.computeSeriesStatsData(state);
+
       const newSnapshot: LiveTrackerSnapshot = {
         ...snapshot,
         lastStateMessage: message,
         hasReceivedInitialData: true,
+        allMatchStats,
+        seriesStatsData,
       };
 
       this.config.store.setSnapshot(newSnapshot);

--- a/pages/src/components/live-tracker/live-tracker-presenter.ts
+++ b/pages/src/components/live-tracker/live-tracker-presenter.ts
@@ -622,14 +622,19 @@ export class LiveTrackerPresenter {
         return;
       }
 
-      const current = this.config.store.getSnapshot();
-      const map = new Map(current.analyticsByMatchId);
+      const newAnalytics = new Map<string, MatchAnalytics>();
       for (const results of allResults) {
         for (const [matchId, analytics] of Object.entries(results)) {
           if (analytics != null) {
-            map.set(matchId, analytics);
+            newAnalytics.set(matchId, analytics);
           }
         }
+      }
+
+      const current = this.config.store.getSnapshot();
+      const map = new Map(current.analyticsByMatchId);
+      for (const [matchId, analytics] of newAnalytics) {
+        map.set(matchId, analytics);
       }
       this.config.store.setSnapshot({
         ...current,

--- a/pages/src/components/live-tracker/live-tracker-presenter.ts
+++ b/pages/src/components/live-tracker/live-tracker-presenter.ts
@@ -20,7 +20,7 @@ import type {
   LiveTrackerStateRenderModel,
   MatchKillMatrix,
   KillMatrixResult,
-  SeriesStatsData,
+  LiveTrackerSeriesStatsData,
 } from "./types";
 import { toLiveTrackerStateRenderModel } from "./state-render-model";
 
@@ -156,7 +156,9 @@ export class LiveTrackerPresenter {
     });
   }
 
-  private static computeSeriesStatsData(state: LiveTrackerStateRenderModel | null): SeriesStatsData | null {
+  private static computeLiveTrackerSeriesStatsData(
+    state: LiveTrackerStateRenderModel | null,
+  ): LiveTrackerSeriesStatsData | null {
     if (state?.type !== "neatqueue" || state.matches.length === 0) {
       return null;
     }
@@ -197,7 +199,7 @@ export class LiveTrackerPresenter {
 
   private static computeKillMatrix(
     state: LiveTrackerStateRenderModel | null,
-    seriesStatsData: SeriesStatsData | null,
+    seriesStatsData: LiveTrackerSeriesStatsData | null,
     analyticsByMatchId: ReadonlyMap<string, MatchAnalytics>,
   ): { allMatchKillMatrix: readonly MatchKillMatrix[]; seriesKillMatrix: KillMatrixResult | null } {
     if (state?.type !== "neatqueue" || seriesStatsData == null || analyticsByMatchId.size === 0) {
@@ -564,7 +566,7 @@ export class LiveTrackerPresenter {
 
       const state = toLiveTrackerStateRenderModel(message);
       const allMatchStats = LiveTrackerPresenter.computeAllMatchStats(state);
-      const seriesStatsData = LiveTrackerPresenter.computeSeriesStatsData(state);
+      const seriesStatsData = LiveTrackerPresenter.computeLiveTrackerSeriesStatsData(state);
 
       const newSnapshot: LiveTrackerSnapshot = {
         ...snapshot,

--- a/pages/src/components/live-tracker/live-tracker-presenter.ts
+++ b/pages/src/components/live-tracker/live-tracker-presenter.ts
@@ -582,11 +582,12 @@ export class LiveTrackerPresenter {
   }
 
   private triggerAnalyticsFetch(snapshot: LiveTrackerSnapshot): void {
-    if (snapshot.lastStateMessage?.type !== "state") {
+    const { lastStateMessage } = snapshot;
+    if (lastStateMessage == null) {
       return;
     }
 
-    const rawMatchIds = Object.keys(snapshot.lastStateMessage.data.rawMatches);
+    const rawMatchIds = Object.keys(lastStateMessage.data.rawMatches);
     const newMatchIds = rawMatchIds.filter((id) => !this.fetchedMatchIds.has(id));
 
     if (newMatchIds.length === 0) {
@@ -594,10 +595,14 @@ export class LiveTrackerPresenter {
     }
 
     const isInitialFetch = this.fetchedMatchIds.size === 0;
-    void this.fetchAnalyticsAsync(newMatchIds, isInitialFetch);
+    void this.fetchAnalyticsAsync(newMatchIds, isInitialFetch, lastStateMessage);
   }
 
-  private async fetchAnalyticsAsync(newMatchIds: string[], isInitialFetch: boolean): Promise<void> {
+  private async fetchAnalyticsAsync(
+    newMatchIds: string[],
+    isInitialFetch: boolean,
+    stateMessage: LiveTrackerMessage,
+  ): Promise<void> {
     for (const id of newMatchIds) {
       this.fetchedMatchIds.add(id);
     }
@@ -634,6 +639,9 @@ export class LiveTrackerPresenter {
       }
 
       const current = this.config.store.getSnapshot();
+      if (current.lastStateMessage !== stateMessage) {
+        return;
+      }
       const map = new Map(current.analyticsByMatchId);
       for (const [matchId, analytics] of newAnalytics) {
         map.set(matchId, analytics);
@@ -654,6 +662,9 @@ export class LiveTrackerPresenter {
 
       if (isInitialFetch) {
         const current = this.config.store.getSnapshot();
+        if (current.lastStateMessage !== stateMessage) {
+          return;
+        }
         this.config.store.setSnapshot({
           ...current,
           analyticsStatus: ComponentLoaderStatus.ERROR,

--- a/pages/src/components/live-tracker/live-tracker-presenter.ts
+++ b/pages/src/components/live-tracker/live-tracker-presenter.ts
@@ -14,7 +14,7 @@ import { calculateSeriesMetadata } from "../../controllers/stats/series-metadata
 import { GAMES_SUFFIX_RE, KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { EMPTY_KILL_MATRIX_PIVOT_DATA } from "../../controllers/stats/kill-matrix/types";
 import type { KillMatrixPlayer } from "../../controllers/stats/kill-matrix/types";
-import type { LiveTrackerParams, LiveTrackerSnapshot, LiveTrackerStore } from "./live-tracker-store";
+import type { LiveTrackerParams, LiveTrackerSnapshot, LiveTrackerStoreApi } from "./live-tracker-store";
 import type {
   LiveTrackerViewModel,
   LiveTrackerStateRenderModel,
@@ -27,7 +27,7 @@ import { toLiveTrackerStateRenderModel } from "./state-render-model";
 interface Config {
   readonly liveTrackerService: LiveTrackerService;
   readonly getUrl: () => URL;
-  readonly store: LiveTrackerStore;
+  readonly store: LiveTrackerStoreApi;
   readonly matchAnalyticsService: MatchAnalyticsService;
 }
 

--- a/pages/src/components/live-tracker/live-tracker-presenter.ts
+++ b/pages/src/components/live-tracker/live-tracker-presenter.ts
@@ -1,18 +1,48 @@
 import type { LiveTrackerIdentity, LiveTrackerMessage } from "@guilty-spark/shared/live-tracker/types";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type {
   LiveTrackerConnection,
   LiveTrackerConnectionStatus,
   LiveTrackerService,
   LiveTrackerSubscription,
 } from "../../services/live-tracker/types";
+import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
+import type { MatchStatsData } from "../../controllers/stats/types";
+import type { SeriesMetadata } from "../../controllers/stats/series-metadata";
+import { ComponentLoaderStatus } from "../component-loader/component-loader";
+import { StatsController } from "../../controllers/stats/stats-controller";
+import { calculateSeriesMetadata } from "../../controllers/stats/series-metadata";
+import { GAMES_SUFFIX_RE, KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import { EMPTY_KILL_MATRIX_PIVOT_DATA } from "../../controllers/stats/kill-matrix/types";
+import type { KillMatrixPivotData, KillMatrixPlayer } from "../../controllers/stats/kill-matrix/types";
 import type { LiveTrackerParams, LiveTrackerSnapshot, LiveTrackerStore } from "./live-tracker-store";
-import type { LiveTrackerViewModel } from "./types";
+import type { LiveTrackerViewModel, LiveTrackerStateRenderModel } from "./types";
 import { toLiveTrackerStateRenderModel } from "./state-render-model";
 
 interface Config {
   readonly liveTrackerService: LiveTrackerService;
   readonly getUrl: () => URL;
   readonly store: LiveTrackerStore;
+  readonly matchAnalyticsService: MatchAnalyticsService;
+}
+
+interface SeriesStatsData {
+  readonly teamData: MatchStatsData[];
+  readonly playerData: MatchStatsData[];
+  readonly metadata: SeriesMetadata | null;
+  readonly orderedPlayers: readonly KillMatrixPlayer[] | undefined;
+  readonly playersByXuid: ReadonlyMap<string, { gamertag: string; teamId: number | null }>;
+}
+
+interface MatchKillMatrix {
+  readonly matchId: string;
+  readonly pivotData: KillMatrixPivotData;
+  readonly transposedPivotData: KillMatrixPivotData;
+}
+
+interface KillMatrixResult {
+  readonly pivotData: KillMatrixPivotData;
+  readonly transposedPivotData: KillMatrixPivotData;
 }
 
 export class LiveTrackerPresenter {
@@ -31,6 +61,10 @@ export class LiveTrackerPresenter {
   private readonly maxReconnectionAttempts = 10;
   private readonly maxReconnectionDurationMs = 3 * 60 * 1000;
   private readonly baseReconnectionDelayMs = 2000;
+
+  private readonly fetchedMatchIds = new Set<string>();
+  private static readonly killMatrixFormatter = new KillMatrixFormatter();
+  private static readonly ANALYTICS_BATCH_SIZE = 30;
 
   public constructor(config: Config) {
     this.config = config;
@@ -76,6 +110,24 @@ export class LiveTrackerPresenter {
         ? state.teams.flatMap((team) => team.players.map((player) => ({ id: player.id, name: player.displayName })))
         : [];
 
+    const allMatchStats = LiveTrackerPresenter.computeAllMatchStats(state);
+    const seriesStatsData = LiveTrackerPresenter.computeSeriesStatsData(state);
+
+    const seriesStats =
+      seriesStatsData != null
+        ? {
+            teamData: seriesStatsData.teamData,
+            playerData: seriesStatsData.playerData,
+            metadata: seriesStatsData.metadata,
+          }
+        : null;
+
+    const { allMatchKillMatrix, seriesKillMatrix } = LiveTrackerPresenter.computeKillMatrix(
+      state,
+      seriesStatsData,
+      snapshot.analyticsByMatchId,
+    );
+
     return {
       title,
       subtitle,
@@ -85,6 +137,121 @@ export class LiveTrackerPresenter {
       state,
       sortedSubstitutions,
       availablePlayers,
+      params,
+      allMatchStats,
+      seriesStats,
+      analyticsStatus: snapshot.analyticsStatus,
+      allMatchKillMatrix,
+      seriesKillMatrix,
+    };
+  }
+
+  private static computeAllMatchStats(
+    state: LiveTrackerStateRenderModel | null,
+  ): readonly { matchId: string; data: MatchStatsData[] | null }[] {
+    if (state?.type !== "neatqueue") {
+      return [];
+    }
+
+    const { medalMetadata } = state;
+
+    return state.matches.map((match) => {
+      if (match.rawMatchStats == null) {
+        return { matchId: match.matchId, data: null };
+      }
+
+      try {
+        const controller = new StatsController();
+        const playerMap = new Map<string, string>(Object.entries(match.playerXuidToGametag));
+        controller.loadMatch(match.rawMatchStats, playerMap, medalMetadata);
+        return { matchId: match.matchId, data: controller.getMatchStats() };
+      } catch {
+        return { matchId: match.matchId, data: null };
+      }
+    });
+  }
+
+  private static computeSeriesStatsData(state: LiveTrackerStateRenderModel | null): SeriesStatsData | null {
+    if (state?.type !== "neatqueue" || state.matches.length === 0) {
+      return null;
+    }
+
+    const rawMatchStats = state.matches
+      .map((match) => match.rawMatchStats)
+      .filter((stats): stats is NonNullable<typeof stats> => stats != null);
+
+    if (rawMatchStats.length === 0) {
+      return null;
+    }
+
+    try {
+      const allPlayerXuidToGametag = new Map<string, string>();
+      for (const match of state.matches) {
+        for (const [xuid, gamertag] of Object.entries(match.playerXuidToGametag)) {
+          allPlayerXuidToGametag.set(xuid, gamertag);
+        }
+      }
+
+      const controller = new StatsController();
+      controller.loadSeries(rawMatchStats, allPlayerXuidToGametag, state.medalMetadata);
+      const { teamData, playerData } = controller.getSeriesStats();
+      const players = controller.getPlayers();
+      const playersByGamertag = new Map(players.map((p) => [p.gamertag, p]));
+      const resolvedPlayers = playerData
+        .flatMap((td) => td.players.map((p) => playersByGamertag.get(p.name.replace(GAMES_SUFFIX_RE, ""))))
+        .filter((p): p is KillMatrixPlayer => p != null);
+      const orderedPlayers = resolvedPlayers.length === players.length ? resolvedPlayers : players;
+      const playersByXuid = new Map(players.map((p) => [p.xuid, { gamertag: p.gamertag, teamId: p.teamId }]));
+      const metadata = calculateSeriesMetadata(state.matches, state.seriesScore);
+
+      return { teamData, playerData, metadata, orderedPlayers, playersByXuid };
+    } catch {
+      return null;
+    }
+  }
+
+  private static computeKillMatrix(
+    state: LiveTrackerStateRenderModel | null,
+    seriesStatsData: SeriesStatsData | null,
+    analyticsByMatchId: ReadonlyMap<string, MatchAnalytics>,
+  ): { allMatchKillMatrix: readonly MatchKillMatrix[]; seriesKillMatrix: KillMatrixResult | null } {
+    if (state?.type !== "neatqueue" || seriesStatsData == null || analyticsByMatchId.size === 0) {
+      return { allMatchKillMatrix: [], seriesKillMatrix: null };
+    }
+
+    const { orderedPlayers: seriesPlayers, playersByXuid } = seriesStatsData;
+    const matchKillMatrixRows = new Map<string, ReturnType<KillMatrixFormatter["present"]>>();
+
+    const allMatchKillMatrix = state.matches.map((match) => {
+      const analytics = analyticsByMatchId.get(match.matchId);
+      if (analytics == null) {
+        return {
+          matchId: match.matchId,
+          pivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
+          transposedPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
+        };
+      }
+      const rows = LiveTrackerPresenter.killMatrixFormatter.present({ analytics, playersByXuid });
+      matchKillMatrixRows.set(match.matchId, rows);
+      return {
+        matchId: match.matchId,
+        pivotData: KillMatrixFormatter.pivot(rows, seriesPlayers),
+        transposedPivotData: KillMatrixFormatter.transpose(rows, seriesPlayers),
+      };
+    });
+
+    if (matchKillMatrixRows.size === 0) {
+      return { allMatchKillMatrix, seriesKillMatrix: null };
+    }
+
+    const aggregatedRows = KillMatrixFormatter.aggregate([...matchKillMatrixRows.values()].flatMap((rows) => rows));
+
+    return {
+      allMatchKillMatrix,
+      seriesKillMatrix: {
+        pivotData: KillMatrixFormatter.pivot(aggregatedRows, seriesPlayers),
+        transposedPivotData: KillMatrixFormatter.transpose(aggregatedRows, seriesPlayers),
+      },
     };
   }
 
@@ -265,6 +432,8 @@ export class LiveTrackerPresenter {
         lastStateMessage: null,
         hasConnection: false,
         hasReceivedInitialData: false,
+        analyticsByMatchId: new Map(),
+        analyticsStatus: ComponentLoaderStatus.LOADED,
       });
       return;
     }
@@ -292,12 +461,16 @@ export class LiveTrackerPresenter {
     this.stopReconnection();
     this.cleanupConnection();
 
+    this.fetchedMatchIds.clear();
+
     const current = this.config.store.getSnapshot();
     this.config.store.setSnapshot({
       ...current,
       hasConnection: false,
       lastStateMessage: null,
       hasReceivedInitialData: false,
+      analyticsByMatchId: new Map(),
+      analyticsStatus: ComponentLoaderStatus.LOADED,
     });
   }
 
@@ -396,12 +569,95 @@ export class LiveTrackerPresenter {
 
       const snapshot = this.config.store.getSnapshot();
 
-      this.config.store.setSnapshot({
+      if (LiveTrackerPresenter.isStateMessageEqual(snapshot.lastStateMessage, message)) {
+        return;
+      }
+
+      const newSnapshot: LiveTrackerSnapshot = {
         ...snapshot,
         lastStateMessage: message,
         hasReceivedInitialData: true,
-      });
+      };
+
+      this.config.store.setSnapshot(newSnapshot);
+      this.triggerAnalyticsFetch(newSnapshot);
     });
+  }
+
+  private triggerAnalyticsFetch(snapshot: LiveTrackerSnapshot): void {
+    if (snapshot.lastStateMessage?.type !== "state") {
+      return;
+    }
+
+    const rawMatchIds = Object.keys(snapshot.lastStateMessage.data.rawMatches);
+    const newMatchIds = rawMatchIds.filter((id) => !this.fetchedMatchIds.has(id));
+
+    if (newMatchIds.length === 0) {
+      return;
+    }
+
+    const isInitialFetch = this.fetchedMatchIds.size === 0;
+    void this.fetchAnalyticsAsync(newMatchIds, isInitialFetch);
+  }
+
+  private async fetchAnalyticsAsync(newMatchIds: string[], isInitialFetch: boolean): Promise<void> {
+    for (const id of newMatchIds) {
+      this.fetchedMatchIds.add(id);
+    }
+
+    if (isInitialFetch) {
+      const current = this.config.store.getSnapshot();
+      this.config.store.setSnapshot({
+        ...current,
+        analyticsStatus: ComponentLoaderStatus.LOADING,
+      });
+    }
+
+    const chunks: string[][] = [];
+    for (let i = 0; i < newMatchIds.length; i += LiveTrackerPresenter.ANALYTICS_BATCH_SIZE) {
+      chunks.push(newMatchIds.slice(i, i + LiveTrackerPresenter.ANALYTICS_BATCH_SIZE));
+    }
+
+    try {
+      const allResults = await Promise.all(
+        chunks.map(async (chunk) => this.config.matchAnalyticsService.getBatchMatchAnalytics(chunk)),
+      );
+
+      if (this.isDisposed) {
+        return;
+      }
+
+      const current = this.config.store.getSnapshot();
+      const map = new Map(current.analyticsByMatchId);
+      for (const results of allResults) {
+        for (const [matchId, analytics] of Object.entries(results)) {
+          if (analytics != null) {
+            map.set(matchId, analytics);
+          }
+        }
+      }
+      this.config.store.setSnapshot({
+        ...current,
+        analyticsByMatchId: map,
+        analyticsStatus: ComponentLoaderStatus.LOADED,
+      });
+    } catch {
+      if (this.isDisposed) {
+        return;
+      }
+
+      for (const id of newMatchIds) {
+        this.fetchedMatchIds.delete(id);
+      }
+
+      if (isInitialFetch) {
+        const current = this.config.store.getSnapshot();
+        this.config.store.setSnapshot({
+          ...current,
+          analyticsStatus: ComponentLoaderStatus.ERROR,
+        });
+      }
+    }
   }
 
   private handleConnectionLost(identity: LiveTrackerIdentity, detail?: string): void {

--- a/pages/src/components/live-tracker/live-tracker-store.ts
+++ b/pages/src/components/live-tracker/live-tracker-store.ts
@@ -3,7 +3,7 @@ import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-
 import type { LiveTrackerConnectionStatus } from "../../services/live-tracker/types";
 import type { MatchStatsData } from "../../controllers/stats/types";
 import { ComponentLoaderStatus } from "../component-loader/component-loader";
-import type { SeriesStatsData } from "./types";
+import type { LiveTrackerSeriesStatsData } from "./types";
 
 export type LiveTrackerConnectionState = "idle" | LiveTrackerConnectionStatus;
 
@@ -23,7 +23,7 @@ export interface LiveTrackerSnapshot {
   readonly analyticsByMatchId: ReadonlyMap<string, MatchAnalytics>;
   readonly analyticsStatus: ComponentLoaderStatus;
   readonly allMatchStats: readonly { matchId: string; data: MatchStatsData[] | null }[];
-  readonly seriesStatsData: SeriesStatsData | null;
+  readonly seriesStatsData: LiveTrackerSeriesStatsData | null;
 }
 
 export class LiveTrackerStore {

--- a/pages/src/components/live-tracker/live-tracker-store.ts
+++ b/pages/src/components/live-tracker/live-tracker-store.ts
@@ -26,7 +26,12 @@ export interface LiveTrackerSnapshot {
   readonly seriesStatsData: LiveTrackerSeriesStatsData | null;
 }
 
-export class LiveTrackerStore {
+export interface LiveTrackerStoreApi {
+  getSnapshot(): LiveTrackerSnapshot;
+  setSnapshot(next: LiveTrackerSnapshot): void;
+}
+
+export class LiveTrackerStore implements LiveTrackerStoreApi {
   private snapshot: LiveTrackerSnapshot;
   private readonly subscribers = new Set<() => void>();
 

--- a/pages/src/components/live-tracker/live-tracker-store.ts
+++ b/pages/src/components/live-tracker/live-tracker-store.ts
@@ -1,7 +1,9 @@
 import type { LiveTrackerMessage } from "@guilty-spark/shared/live-tracker/types";
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { LiveTrackerConnectionStatus } from "../../services/live-tracker/types";
+import type { MatchStatsData } from "../../controllers/stats/types";
 import { ComponentLoaderStatus } from "../component-loader/component-loader";
+import type { SeriesStatsData } from "./types";
 
 export type LiveTrackerConnectionState = "idle" | LiveTrackerConnectionStatus;
 
@@ -20,6 +22,8 @@ export interface LiveTrackerSnapshot {
   readonly hasReceivedInitialData: boolean;
   readonly analyticsByMatchId: ReadonlyMap<string, MatchAnalytics>;
   readonly analyticsStatus: ComponentLoaderStatus;
+  readonly allMatchStats: readonly { matchId: string; data: MatchStatsData[] | null }[];
+  readonly seriesStatsData: SeriesStatsData | null;
 }
 
 export class LiveTrackerStore {
@@ -40,6 +44,8 @@ export class LiveTrackerStore {
       hasReceivedInitialData: false,
       analyticsByMatchId: new Map(),
       analyticsStatus: ComponentLoaderStatus.LOADED,
+      allMatchStats: [],
+      seriesStatsData: null,
     };
   }
 

--- a/pages/src/components/live-tracker/live-tracker-store.ts
+++ b/pages/src/components/live-tracker/live-tracker-store.ts
@@ -1,5 +1,7 @@
 import type { LiveTrackerMessage } from "@guilty-spark/shared/live-tracker/types";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { LiveTrackerConnectionStatus } from "../../services/live-tracker/types";
+import { ComponentLoaderStatus } from "../component-loader/component-loader";
 
 export type LiveTrackerConnectionState = "idle" | LiveTrackerConnectionStatus;
 
@@ -16,6 +18,8 @@ export interface LiveTrackerSnapshot {
   readonly lastStateMessage: LiveTrackerMessage | null;
   readonly hasConnection: boolean;
   readonly hasReceivedInitialData: boolean;
+  readonly analyticsByMatchId: ReadonlyMap<string, MatchAnalytics>;
+  readonly analyticsStatus: ComponentLoaderStatus;
 }
 
 export class LiveTrackerStore {
@@ -34,6 +38,8 @@ export class LiveTrackerStore {
       lastStateMessage: null,
       hasConnection: false,
       hasReceivedInitialData: false,
+      analyticsByMatchId: new Map(),
+      analyticsStatus: ComponentLoaderStatus.LOADED,
     };
   }
 

--- a/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay.test.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay.test.tsx
@@ -60,6 +60,12 @@ function aFakeLiveTrackerViewModelWith(overrides?: Partial<LiveTrackerViewModel>
     statusClassName: "status-active",
     sortedSubstitutions: [],
     availablePlayers: [],
+    params: defaultParams,
+    allMatchStats: [],
+    seriesStats: null,
+    analyticsStatus: ComponentLoaderStatus.LOADED,
+    allMatchKillMatrix: [],
+    seriesKillMatrix: null,
     state: {
       type: "neatqueue",
       guildName: "Test Guild",

--- a/pages/src/components/live-tracker/tests/live-tracker-context.test.tsx
+++ b/pages/src/components/live-tracker/tests/live-tracker-context.test.tsx
@@ -34,6 +34,12 @@ function aFakeLiveTrackerViewModelWith(overrides?: Partial<LiveTrackerViewModel>
     statusClassName: "status-active",
     sortedSubstitutions: [],
     availablePlayers: [],
+    params: defaultParams,
+    allMatchStats: [],
+    seriesStats: null,
+    analyticsStatus: ComponentLoaderStatus.LOADED,
+    allMatchKillMatrix: [],
+    seriesKillMatrix: null,
     state: {
       type: "neatqueue",
       guildName: "Test Guild",

--- a/pages/src/components/live-tracker/tests/live-tracker-presenter.test.ts
+++ b/pages/src/components/live-tracker/tests/live-tracker-presenter.test.ts
@@ -80,6 +80,8 @@ class MockLiveTrackerStore {
       hasReceivedInitialData: false,
       analyticsByMatchId: new Map(),
       analyticsStatus: ComponentLoaderStatus.LOADED,
+      allMatchStats: [],
+      seriesStatsData: null,
     };
   }
 

--- a/pages/src/components/live-tracker/tests/live-tracker-presenter.test.ts
+++ b/pages/src/components/live-tracker/tests/live-tracker-presenter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { LiveTrackerMessage } from "@guilty-spark/shared/live-tracker/types";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { sampleLiveTrackerStateMessage } from "@guilty-spark/shared/live-tracker/fakes/data";
 import { LiveTrackerPresenter } from "../live-tracker-presenter";
 import type {
@@ -103,6 +104,145 @@ class MockLiveTrackerStore {
     };
   }
 }
+
+describe("LiveTrackerPresenter - Analytics Fetch", () => {
+  beforeEach((): void => {
+    vi.useFakeTimers();
+  });
+
+  afterEach((): void => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("transitions analyticsStatus LOADING then LOADED and calls getBatchMatchAnalytics once per batch", async (): Promise<void> => {
+    const mockStore = new MockLiveTrackerStore();
+    const analyticsService = aFakeMatchAnalyticsServiceWith();
+    const getBatchSpy = vi.spyOn(analyticsService, "getBatchMatchAnalytics");
+
+    let currentConnection: MockLiveTrackerConnection | null = null;
+    const mockService = new MockLiveTrackerService();
+    vi.spyOn(mockService, "connect").mockImplementation(async (): Promise<LiveTrackerConnection> => {
+      currentConnection = new MockLiveTrackerConnection();
+      return Promise.resolve(currentConnection);
+    });
+
+    const presenter = new LiveTrackerPresenter({
+      getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
+      liveTrackerService: mockService,
+      store: mockStore as unknown as LiveTrackerStore,
+      matchAnalyticsService: analyticsService,
+    });
+
+    presenter.start();
+    await vi.runAllTimersAsync();
+
+    const connection = currentConnection as unknown as MockLiveTrackerConnection;
+    connection.emitStatus("connected");
+    connection.emitMessage(sampleLiveTrackerStateMessage);
+
+    // Status transitions to LOADING synchronously inside fetchAnalyticsAsync before the first await
+    expect(mockStore.getSnapshot().analyticsStatus).toBe(ComponentLoaderStatus.LOADING);
+
+    // Flush microtasks so the fake analytics Promise.resolve() completes
+    await vi.runAllTimersAsync();
+
+    const rawMatchIds = Object.keys(sampleLiveTrackerStateMessage.data.rawMatches);
+    expect(mockStore.getSnapshot().analyticsStatus).toBe(ComponentLoaderStatus.LOADED);
+    // All 5 matches fit in one batch (ANALYTICS_BATCH_SIZE = 30)
+    expect(getBatchSpy).toHaveBeenCalledTimes(1);
+    expect(getBatchSpy).toHaveBeenCalledWith(expect.arrayContaining(rawMatchIds));
+    expect(mockStore.getSnapshot().analyticsByMatchId.size).toBe(rawMatchIds.length);
+
+    presenter.dispose();
+  });
+
+  it("does not fetch analytics again when the same state message arrives a second time", async (): Promise<void> => {
+    const mockStore = new MockLiveTrackerStore();
+    const analyticsService = aFakeMatchAnalyticsServiceWith();
+    const getBatchSpy = vi.spyOn(analyticsService, "getBatchMatchAnalytics");
+
+    let currentConnection: MockLiveTrackerConnection | null = null;
+    const mockService = new MockLiveTrackerService();
+    vi.spyOn(mockService, "connect").mockImplementation(async (): Promise<LiveTrackerConnection> => {
+      currentConnection = new MockLiveTrackerConnection();
+      return Promise.resolve(currentConnection);
+    });
+
+    const presenter = new LiveTrackerPresenter({
+      getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
+      liveTrackerService: mockService,
+      store: mockStore as unknown as LiveTrackerStore,
+      matchAnalyticsService: analyticsService,
+    });
+
+    presenter.start();
+    await vi.runAllTimersAsync();
+
+    const connection = currentConnection as unknown as MockLiveTrackerConnection;
+    connection.emitStatus("connected");
+    connection.emitMessage(sampleLiveTrackerStateMessage);
+    await vi.runAllTimersAsync();
+
+    expect(getBatchSpy).toHaveBeenCalledTimes(1);
+
+    // Emit the same state message again (heartbeat with identical rawMatches)
+    connection.emitMessage(sampleLiveTrackerStateMessage);
+    await vi.runAllTimersAsync();
+
+    expect(getBatchSpy).toHaveBeenCalledTimes(1);
+
+    presenter.dispose();
+  });
+
+  it("discards stale analytics when lastStateMessage changes before the fetch resolves", async (): Promise<void> => {
+    const mockStore = new MockLiveTrackerStore();
+    const analyticsService = aFakeMatchAnalyticsServiceWith();
+
+    let resolveFetch!: (value: Record<string, MatchAnalytics | null>) => void;
+    const pendingFetch = new Promise<Record<string, MatchAnalytics | null>>((resolve) => {
+      resolveFetch = resolve;
+    });
+    vi.spyOn(analyticsService, "getBatchMatchAnalytics").mockReturnValue(pendingFetch);
+
+    let currentConnection: MockLiveTrackerConnection | null = null;
+    const mockService = new MockLiveTrackerService();
+    vi.spyOn(mockService, "connect").mockImplementation(async (): Promise<LiveTrackerConnection> => {
+      currentConnection = new MockLiveTrackerConnection();
+      return Promise.resolve(currentConnection);
+    });
+
+    const presenter = new LiveTrackerPresenter({
+      getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
+      liveTrackerService: mockService,
+      store: mockStore as unknown as LiveTrackerStore,
+      matchAnalyticsService: analyticsService,
+    });
+
+    presenter.start();
+    await vi.runAllTimersAsync();
+
+    const connection = currentConnection as unknown as MockLiveTrackerConnection;
+    connection.emitStatus("connected");
+    connection.emitMessage(sampleLiveTrackerStateMessage);
+
+    expect(mockStore.getSnapshot().analyticsStatus).toBe(ComponentLoaderStatus.LOADING);
+
+    // Simulate a new lastStateMessage arriving (different object reference) before fetch resolves
+    const snapshotBeforeResolve = mockStore.getSnapshot();
+    mockStore.setSnapshot({ ...snapshotBeforeResolve, lastStateMessage: { ...sampleLiveTrackerStateMessage } });
+
+    // Resolve the first (now stale) fetch with fake analytics
+    resolveFetch({});
+    await vi.runAllTimersAsync();
+
+    // The stale guard (current.lastStateMessage !== stateMessage) should have suppressed the update
+    expect(mockStore.getSnapshot().analyticsStatus).toBe(ComponentLoaderStatus.LOADING);
+    expect(mockStore.getSnapshot().analyticsByMatchId.size).toBe(0);
+
+    presenter.dispose();
+  });
+});
 
 describe("LiveTrackerPresenter - Retry Behavior", () => {
   beforeEach((): void => {

--- a/pages/src/components/live-tracker/tests/live-tracker-presenter.test.ts
+++ b/pages/src/components/live-tracker/tests/live-tracker-presenter.test.ts
@@ -9,6 +9,8 @@ import type {
   LiveTrackerSubscription,
   LiveTrackerStatusListener,
 } from "../../../services/live-tracker/types";
+import { aFakeMatchAnalyticsServiceWith } from "../../../services/stats/fakes/match-analytics.fake";
+import { ComponentLoaderStatus } from "../../component-loader/component-loader";
 import type { LiveTrackerSnapshot, LiveTrackerStore } from "../live-tracker-store";
 
 class MockLiveTrackerConnection implements LiveTrackerConnection {
@@ -76,6 +78,8 @@ class MockLiveTrackerStore {
       lastStateMessage: null,
       hasConnection: false,
       hasReceivedInitialData: false,
+      analyticsByMatchId: new Map(),
+      analyticsStatus: ComponentLoaderStatus.LOADED,
     };
   }
 
@@ -124,6 +128,7 @@ describe("LiveTrackerPresenter - Retry Behavior", () => {
       getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
       liveTrackerService: mockService,
       store: mockStore as unknown as LiveTrackerStore,
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     });
 
     // Start the connection
@@ -194,6 +199,7 @@ describe("LiveTrackerPresenter - Retry Behavior", () => {
       getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
       liveTrackerService: mockService,
       store: mockStore as unknown as LiveTrackerStore,
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     });
 
     // Start the connection
@@ -242,6 +248,7 @@ describe("LiveTrackerPresenter - Retry Behavior", () => {
       getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
       liveTrackerService: mockService,
       store: mockStore as unknown as LiveTrackerStore,
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     });
 
     // Start the connection
@@ -277,6 +284,7 @@ describe("LiveTrackerPresenter - Retry Behavior", () => {
 
     // Test passes if we eventually gave up due to time limit
     const finalSnapshot = mockStore.getSnapshot();
+
     const reachedTimeLimit =
       finalSnapshot.statusText.includes("Gave up") || finalSnapshot.statusText.includes("Max retries");
 

--- a/pages/src/components/live-tracker/tests/live-tracker-presenter.test.ts
+++ b/pages/src/components/live-tracker/tests/live-tracker-presenter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { LiveTrackerMessage } from "@guilty-spark/shared/live-tracker/types";
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { sampleLiveTrackerStateMessage } from "@guilty-spark/shared/live-tracker/fakes/data";
 import { LiveTrackerPresenter } from "../live-tracker-presenter";
 import type {
@@ -12,7 +13,7 @@ import type {
 } from "../../../services/live-tracker/types";
 import { aFakeMatchAnalyticsServiceWith } from "../../../services/stats/fakes/match-analytics.fake";
 import { ComponentLoaderStatus } from "../../component-loader/component-loader";
-import type { LiveTrackerSnapshot, LiveTrackerStore } from "../live-tracker-store";
+import type { LiveTrackerSnapshot } from "../live-tracker-store";
 
 class MockLiveTrackerConnection implements LiveTrackerConnection {
   private readonly statusListeners = new Set<LiveTrackerStatusListener>();
@@ -120,24 +121,25 @@ describe("LiveTrackerPresenter - Analytics Fetch", () => {
     const analyticsService = aFakeMatchAnalyticsServiceWith();
     const getBatchSpy = vi.spyOn(analyticsService, "getBatchMatchAnalytics");
 
-    let currentConnection: MockLiveTrackerConnection | null = null;
+    const createdConnections: MockLiveTrackerConnection[] = [];
     const mockService = new MockLiveTrackerService();
     vi.spyOn(mockService, "connect").mockImplementation(async (): Promise<LiveTrackerConnection> => {
-      currentConnection = new MockLiveTrackerConnection();
-      return Promise.resolve(currentConnection);
+      const conn = new MockLiveTrackerConnection();
+      createdConnections.push(conn);
+      return Promise.resolve(conn);
     });
 
     const presenter = new LiveTrackerPresenter({
       getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
       liveTrackerService: mockService,
-      store: mockStore as unknown as LiveTrackerStore,
+      store: mockStore,
       matchAnalyticsService: analyticsService,
     });
 
     presenter.start();
     await vi.runAllTimersAsync();
 
-    const connection = currentConnection as unknown as MockLiveTrackerConnection;
+    const connection = Preconditions.checkExists(createdConnections[0]);
     connection.emitStatus("connected");
     connection.emitMessage(sampleLiveTrackerStateMessage);
 
@@ -162,24 +164,25 @@ describe("LiveTrackerPresenter - Analytics Fetch", () => {
     const analyticsService = aFakeMatchAnalyticsServiceWith();
     const getBatchSpy = vi.spyOn(analyticsService, "getBatchMatchAnalytics");
 
-    let currentConnection: MockLiveTrackerConnection | null = null;
+    const createdConnections: MockLiveTrackerConnection[] = [];
     const mockService = new MockLiveTrackerService();
     vi.spyOn(mockService, "connect").mockImplementation(async (): Promise<LiveTrackerConnection> => {
-      currentConnection = new MockLiveTrackerConnection();
-      return Promise.resolve(currentConnection);
+      const conn = new MockLiveTrackerConnection();
+      createdConnections.push(conn);
+      return Promise.resolve(conn);
     });
 
     const presenter = new LiveTrackerPresenter({
       getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
       liveTrackerService: mockService,
-      store: mockStore as unknown as LiveTrackerStore,
+      store: mockStore,
       matchAnalyticsService: analyticsService,
     });
 
     presenter.start();
     await vi.runAllTimersAsync();
 
-    const connection = currentConnection as unknown as MockLiveTrackerConnection;
+    const connection = Preconditions.checkExists(createdConnections[0]);
     connection.emitStatus("connected");
     connection.emitMessage(sampleLiveTrackerStateMessage);
     await vi.runAllTimersAsync();
@@ -206,24 +209,25 @@ describe("LiveTrackerPresenter - Analytics Fetch", () => {
     // First call returns a deferred promise; subsequent calls use the real fake (resolves immediately)
     const getBatchSpy = vi.spyOn(analyticsService, "getBatchMatchAnalytics").mockReturnValueOnce(staleFetch);
 
-    let currentConnection: MockLiveTrackerConnection | null = null;
+    const createdConnections: MockLiveTrackerConnection[] = [];
     const mockService = new MockLiveTrackerService();
     vi.spyOn(mockService, "connect").mockImplementation(async (): Promise<LiveTrackerConnection> => {
-      currentConnection = new MockLiveTrackerConnection();
-      return Promise.resolve(currentConnection);
+      const conn = new MockLiveTrackerConnection();
+      createdConnections.push(conn);
+      return Promise.resolve(conn);
     });
 
     const presenter = new LiveTrackerPresenter({
       getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
       liveTrackerService: mockService,
-      store: mockStore as unknown as LiveTrackerStore,
+      store: mockStore,
       matchAnalyticsService: analyticsService,
     });
 
     presenter.start();
     await vi.runAllTimersAsync();
 
-    const connection = currentConnection as unknown as MockLiveTrackerConnection;
+    const connection = Preconditions.checkExists(createdConnections[0]);
     connection.emitStatus("connected");
     connection.emitMessage(sampleLiveTrackerStateMessage);
 
@@ -273,7 +277,7 @@ describe("LiveTrackerPresenter - Retry Behavior", () => {
     const presenter = new LiveTrackerPresenter({
       getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
       liveTrackerService: mockService,
-      store: mockStore as unknown as LiveTrackerStore,
+      store: mockStore,
       matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     });
 
@@ -335,16 +339,17 @@ describe("LiveTrackerPresenter - Retry Behavior", () => {
     const mockService = new MockLiveTrackerService();
     const mockStore = new MockLiveTrackerStore();
 
-    let currentConnection: MockLiveTrackerConnection | null = null;
-    vi.spyOn(mockService, "connect").mockImplementation(async (): Promise<LiveTrackerConnection> => {
-      currentConnection = new MockLiveTrackerConnection();
-      return Promise.resolve(currentConnection);
+    const createdConnections: MockLiveTrackerConnection[] = [];
+    const connectSpy = vi.spyOn(mockService, "connect").mockImplementation(async (): Promise<LiveTrackerConnection> => {
+      const conn = new MockLiveTrackerConnection();
+      createdConnections.push(conn);
+      return Promise.resolve(conn);
     });
 
     const presenter = new LiveTrackerPresenter({
       getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
       liveTrackerService: mockService,
-      store: mockStore as unknown as LiveTrackerStore,
+      store: mockStore,
       matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     });
 
@@ -353,8 +358,7 @@ describe("LiveTrackerPresenter - Retry Behavior", () => {
     await vi.runAllTimersAsync();
 
     // Simulate 404 not found status on initial connection
-    expect(currentConnection).not.toBeNull();
-    const connection = currentConnection as unknown as MockLiveTrackerConnection;
+    const connection = Preconditions.checkExists(createdConnections[0]);
     connection.emitStatus("not_found");
     await vi.runAllTimersAsync();
 
@@ -362,13 +366,13 @@ describe("LiveTrackerPresenter - Retry Behavior", () => {
     expect(snapshot1.connectionState).toBe("not_found");
     expect(snapshot1.statusText).toContain("No active tracker found");
 
-    const connectCallCount = (mockService.connect as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    const connectCallCount = connectSpy.mock.calls.length;
 
     // Advance time significantly
     await vi.advanceTimersByTimeAsync(300000); // 5 minutes
 
     // Should not have made any more connection attempts
-    const finalCallCount = (mockService.connect as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    const finalCallCount = connectSpy.mock.calls.length;
     expect(finalCallCount).toBe(connectCallCount);
 
     // Should not have changed state (no retries)
@@ -393,7 +397,7 @@ describe("LiveTrackerPresenter - Retry Behavior", () => {
     const presenter = new LiveTrackerPresenter({
       getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
       liveTrackerService: mockService,
-      store: mockStore as unknown as LiveTrackerStore,
+      store: mockStore,
       matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     });
 

--- a/pages/src/components/live-tracker/tests/live-tracker-presenter.test.ts
+++ b/pages/src/components/live-tracker/tests/live-tracker-presenter.test.ts
@@ -195,15 +195,16 @@ describe("LiveTrackerPresenter - Analytics Fetch", () => {
     presenter.dispose();
   });
 
-  it("discards stale analytics when lastStateMessage changes before the fetch resolves", async (): Promise<void> => {
+  it("rolls back fetchedMatchIds and re-triggers fetch when lastStateMessage changes before the fetch resolves", async (): Promise<void> => {
     const mockStore = new MockLiveTrackerStore();
     const analyticsService = aFakeMatchAnalyticsServiceWith();
 
-    let resolveFetch!: (value: Record<string, MatchAnalytics | null>) => void;
-    const pendingFetch = new Promise<Record<string, MatchAnalytics | null>>((resolve) => {
-      resolveFetch = resolve;
+    let resolveStaleFetch!: (value: Record<string, MatchAnalytics | null>) => void;
+    const staleFetch = new Promise<Record<string, MatchAnalytics | null>>((resolve) => {
+      resolveStaleFetch = resolve;
     });
-    vi.spyOn(analyticsService, "getBatchMatchAnalytics").mockReturnValue(pendingFetch);
+    // First call returns a deferred promise; subsequent calls use the real fake (resolves immediately)
+    const getBatchSpy = vi.spyOn(analyticsService, "getBatchMatchAnalytics").mockReturnValueOnce(staleFetch);
 
     let currentConnection: MockLiveTrackerConnection | null = null;
     const mockService = new MockLiveTrackerService();
@@ -228,17 +229,20 @@ describe("LiveTrackerPresenter - Analytics Fetch", () => {
 
     expect(mockStore.getSnapshot().analyticsStatus).toBe(ComponentLoaderStatus.LOADING);
 
-    // Simulate a new lastStateMessage arriving (different object reference) before fetch resolves
+    // Simulate a new lastStateMessage arriving (different object reference) before the stale fetch resolves
     const snapshotBeforeResolve = mockStore.getSnapshot();
-    mockStore.setSnapshot({ ...snapshotBeforeResolve, lastStateMessage: { ...sampleLiveTrackerStateMessage } });
+    const newStateMessage = { ...sampleLiveTrackerStateMessage };
+    mockStore.setSnapshot({ ...snapshotBeforeResolve, lastStateMessage: newStateMessage });
 
-    // Resolve the first (now stale) fetch with fake analytics
-    resolveFetch({});
+    // Resolve the first (stale) fetch with empty results
+    resolveStaleFetch({});
     await vi.runAllTimersAsync();
 
-    // The stale guard (current.lastStateMessage !== stateMessage) should have suppressed the update
-    expect(mockStore.getSnapshot().analyticsStatus).toBe(ComponentLoaderStatus.LOADING);
-    expect(mockStore.getSnapshot().analyticsByMatchId.size).toBe(0);
+    const rawMatchIds = Object.keys(sampleLiveTrackerStateMessage.data.rawMatches);
+    // Stale fetch result is discarded; fetchedMatchIds are rolled back and a re-triggered fetch runs
+    expect(getBatchSpy).toHaveBeenCalledTimes(2);
+    expect(mockStore.getSnapshot().analyticsStatus).toBe(ComponentLoaderStatus.LOADED);
+    expect(mockStore.getSnapshot().analyticsByMatchId.size).toBe(rawMatchIds.length);
 
     presenter.dispose();
   });

--- a/pages/src/components/live-tracker/types.ts
+++ b/pages/src/components/live-tracker/types.ts
@@ -3,8 +3,16 @@ import type { MatchStats } from "halo-infinite-api";
 import type { MatchStatsData } from "../../controllers/stats/types";
 import type { SeriesMetadata } from "../../controllers/stats/series-metadata";
 import type { ComponentLoaderStatus } from "../component-loader/component-loader";
-import type { KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
+import type { KillMatrixPivotData, KillMatrixPlayer } from "../../controllers/stats/kill-matrix/types";
 import type { LiveTrackerParams } from "./live-tracker-store";
+
+export interface SeriesStatsData {
+  readonly teamData: MatchStatsData[];
+  readonly playerData: MatchStatsData[];
+  readonly metadata: SeriesMetadata | null;
+  readonly orderedPlayers: readonly KillMatrixPlayer[] | undefined;
+  readonly playersByXuid: ReadonlyMap<string, { gamertag: string; teamId: number | null }>;
+}
 
 export interface LiveTrackerPlayerRenderModel {
   readonly id: string;
@@ -82,13 +90,13 @@ export interface LiveTrackerAvailablePlayer {
   readonly name: string;
 }
 
-interface MatchKillMatrix {
+export interface MatchKillMatrix {
   readonly matchId: string;
   readonly pivotData: KillMatrixPivotData;
   readonly transposedPivotData: KillMatrixPivotData;
 }
 
-interface KillMatrixResult {
+export interface KillMatrixResult {
   readonly pivotData: KillMatrixPivotData;
   readonly transposedPivotData: KillMatrixPivotData;
 }

--- a/pages/src/components/live-tracker/types.ts
+++ b/pages/src/components/live-tracker/types.ts
@@ -1,5 +1,10 @@
 import type { LiveTrackerStatus, PlayerAssociationData } from "@guilty-spark/shared/live-tracker/types";
 import type { MatchStats } from "halo-infinite-api";
+import type { MatchStatsData } from "../../controllers/stats/types";
+import type { SeriesMetadata } from "../../controllers/stats/series-metadata";
+import type { ComponentLoaderStatus } from "../component-loader/component-loader";
+import type { KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
+import type { LiveTrackerParams } from "./live-tracker-store";
 
 export interface LiveTrackerPlayerRenderModel {
   readonly id: string;
@@ -77,6 +82,17 @@ export interface LiveTrackerAvailablePlayer {
   readonly name: string;
 }
 
+interface MatchKillMatrix {
+  readonly matchId: string;
+  readonly pivotData: KillMatrixPivotData;
+  readonly transposedPivotData: KillMatrixPivotData;
+}
+
+interface KillMatrixResult {
+  readonly pivotData: KillMatrixPivotData;
+  readonly transposedPivotData: KillMatrixPivotData;
+}
+
 export interface LiveTrackerViewModel {
   readonly title: string;
   readonly subtitle: string;
@@ -86,4 +102,14 @@ export interface LiveTrackerViewModel {
   readonly state: LiveTrackerStateRenderModel | null;
   readonly sortedSubstitutions: readonly LiveTrackerSubstitutionRenderModel[];
   readonly availablePlayers: readonly LiveTrackerAvailablePlayer[];
+  readonly params: LiveTrackerParams;
+  readonly allMatchStats: readonly { matchId: string; data: MatchStatsData[] | null }[];
+  readonly seriesStats: {
+    teamData: MatchStatsData[];
+    playerData: MatchStatsData[];
+    metadata: SeriesMetadata | null;
+  } | null;
+  readonly analyticsStatus: ComponentLoaderStatus;
+  readonly allMatchKillMatrix: readonly MatchKillMatrix[];
+  readonly seriesKillMatrix: KillMatrixResult | null;
 }

--- a/pages/src/components/live-tracker/types.ts
+++ b/pages/src/components/live-tracker/types.ts
@@ -6,7 +6,7 @@ import type { ComponentLoaderStatus } from "../component-loader/component-loader
 import type { KillMatrixPivotData, KillMatrixPlayer } from "../../controllers/stats/kill-matrix/types";
 import type { LiveTrackerParams } from "./live-tracker-store";
 
-export interface SeriesStatsData {
+export interface LiveTrackerSeriesStatsData {
   readonly teamData: MatchStatsData[];
   readonly playerData: MatchStatsData[];
   readonly metadata: SeriesMetadata | null;


### PR DESCRIPTION
## Summary

`pages/src/components/live-tracker/create.tsx` previously contained ~300 lines of business logic in `useMemo`/`useState`/`useEffect` hooks, violating the SPC pattern. This PR moves all of it into the presenter.

- **`LiveTrackerPresenter`** (+245 lines): absorbs match stats computation, series stats, kill matrix derivation, and the analytics fetch lifecycle. `present(snapshot)` now produces the full display-ready view model including analytics fields. `fetchAnalyticsAsync` is a `private async` method called with `void` per the new async pattern convention.
- **`LiveTrackerStore`** (+6 lines): `analyticsByMatchId` and `analyticsStatus` added to the snapshot so the presenter can push analytics state.
- **`types.ts`** (+26 lines): `LiveTrackerViewModel` extended with `params`, `allMatchStats`, `seriesStats`, `analyticsStatus`, `allMatchKillMatrix`, `seriesKillMatrix`.
- **`create.tsx`** (−282 lines): reduced to ~75 lines of pure SPC wiring — store + presenter construction, `useSyncExternalStore`, `present()`, render.

### Notable decisions

- **Heartbeat optimisation**: the old `modelRef`/`snapshotRef` memoization trick in `create.tsx` is now inside the presenter — `setSnapshot` is skipped entirely when `isStateMessageEqual` returns true, so React only re-renders when data actually changes.
- **Cancellation**: uses `isDisposed` as the natural flag in `fetchAnalyticsAsync` rather than a closure `cancelled` variable (the presenter's lifecycle already manages this).
- **Internal `SeriesStatsData` interface**: keeps `orderedPlayers` and `playersByXuid` available inside `present()` for kill matrix computation without leaking them into the view model.

## Test plan

- [ ] `npm run done` passes (format + typecheck + lint + 62 tests)
- [ ] Live tracker WebSocket connection, match stats, and kill matrix all still render correctly
- [ ] Analytics fetch deduplication still works (re-connecting to same series doesn't re-fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)