### PR TITLE
debug(individual-tracker): add poll filter diagnostics

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -280,12 +280,16 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     let discoveredNewMatch = false;
     let viewChanged = false;
     const newlyDiscovered = new Set<string>();
+    let skippedAlreadyKnown = 0;
+    let skippedBeforeStart = 0;
     for (const match of matches) {
       const matchId = match.MatchId;
       if (trackerState.matchIds.includes(matchId)) {
+        skippedAlreadyKnown++;
         continue;
       }
       if (new Date(match.MatchInfo.StartTime) < searchStart) {
+        skippedBeforeStart++;
         continue;
       }
 
@@ -330,6 +334,20 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         ]),
       );
     }
+
+    this.logService.info(
+      "IndividualTracker: poll filter summary",
+      new Map<string, JsonAny>([
+        ["trackerId", trackerState.trackerId],
+        ["searchStartTime", trackerState.searchStartTime],
+        ["totalFetched", matches.length],
+        ["skippedAlreadyKnown", skippedAlreadyKnown],
+        ["skippedBeforeStart", skippedBeforeStart],
+        ["newlyDiscovered", newlyDiscovered.size],
+        ["oldestMatchStartTime", matches.at(-1)?.MatchInfo.StartTime ?? "none"],
+        ["newestMatchStartTime", matches.at(0)?.MatchInfo.StartTime ?? "none"],
+      ]),
+    );
 
     if (trackerState.activeSeries != null && newlyDiscovered.size > 0) {
       const existingSeriesMatchIds = new Set(trackerState.activeSeries.matchIds);


### PR DESCRIPTION
## Summary

- Adds a `poll filter summary` log after the match-filtering loop in `IndividualTrackerDO.poll()`
- Tracks how many matches are dropped by each of the two filter conditions: already-known (`matchIds.includes`) vs before the search cutoff (`StartTime < searchStartTime`)
- Logs `searchStartTime`, `totalFetched`, `skippedAlreadyKnown`, `skippedBeforeStart`, `newlyDiscovered`, and the newest/oldest match start times in the fetched window

## Why

The individual tracker is successfully retrieving matches from the Halo API but not adding any to the tracker. The existing logs confirm the API call succeeds but the "added new match to tracker" log never fires. This diagnostic log will reveal in observability exactly which filter condition is responsible and whether the fetched match window overlaps with `searchStartTime` at all.

## Test plan

- [ ] Deploy and play a match while the tracker is running
- [ ] Check observability for `poll filter summary` — `newestMatchStartTime` should be after `searchStartTime` if a new match was played; if `skippedBeforeStart == totalFetched` and `newestMatchStartTime < searchStartTime`, the cutoff is wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)