### PR TITLE
fix(individual-tracker): auto-add all matches >= 2min to selectedMatchIds

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -318,11 +318,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       await this.enrichScore(summary);
       trackerState.discoveredMatches[matchId] = summary;
       trackerState.matchIds.push(matchId);
-      if (trackerState.selectedMatchIds.length > 0) {
-        const durationSeconds = getDurationInSeconds(match.MatchInfo.Duration);
-        if (durationSeconds >= 120) {
-          trackerState.selectedMatchIds = [...trackerState.selectedMatchIds, matchId].sort();
-        }
+      const durationSeconds = getDurationInSeconds(match.MatchInfo.Duration);
+      if (durationSeconds >= 120) {
+        trackerState.selectedMatchIds = [...trackerState.selectedMatchIds, matchId].sort();
       }
       newlyDiscovered.add(matchId);
       discoveredNewMatch = true;

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -826,7 +826,7 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.discoveredMatches).not.toHaveProperty("match-too-old");
     });
 
-    it("auto-appends a new match to selectedMatchIds when selectedMatchIds is set and duration >= 120s", async () => {
+    it("auto-appends a new match to selectedMatchIds when duration >= 120s", async () => {
       ownerClient.getPlayerMatches.mockResolvedValue([
         aFakePlayerMatch("match-new", "2024-11-26T11:30:00.000Z", 2, "PT5M"),
       ]);
@@ -870,7 +870,7 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.selectedMatchIds).toEqual(["match-existing"]);
     });
 
-    it("does not auto-append to selectedMatchIds when it is empty", async () => {
+    it("auto-appends to selectedMatchIds even when it starts empty", async () => {
       ownerClient.getPlayerMatches.mockResolvedValue([aFakePlayerMatch("match-new", "2024-11-26T11:30:00.000Z")]);
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
@@ -885,7 +885,7 @@ describe("IndividualTrackerDO", () => {
       await individualTrackerDO.alarm();
 
       const persisted = lastPersistedState(storagePutSpy);
-      expect(persisted.selectedMatchIds).toEqual([]);
+      expect(persisted.selectedMatchIds).toEqual(["match-new"]);
     });
 
     it("stores outcome, score, and the resolved map name for a newly discovered match", async () => {
@@ -966,8 +966,12 @@ describe("IndividualTrackerDO", () => {
       const state = aFakeIndividualTrackerInternalStateWith({
         startTime: now.toISOString(),
         searchStartTime: "2024-11-26T11:00:00.000Z",
-        matchIds: [],
-        discoveredMatches: {},
+        matchIds: ["match-new"],
+        selectedMatchIds: ["match-new"],
+        accumulatedMatchIds: ["match-new"],
+        discoveredMatches: {
+          "match-new": aFakeIndividualTrackerMatchSummaryWith({ matchId: "match-new", score: "", teamOutcomes: [] }),
+        },
       });
       storageGetSpy.mockResolvedValue(state);
 
@@ -976,7 +980,7 @@ describe("IndividualTrackerDO", () => {
 
       expect(state.discoveredMatches["match-new"]?.score).toBe("");
       expect(state.discoveredMatches["match-new"]?.teamOutcomes).toEqual([]);
-      expect(ownerClient.getMatchStats).toHaveBeenCalledTimes(1);
+      expect(ownerClient.getMatchStats).not.toHaveBeenCalled();
     });
 
     it("retries map-name resolution on a later poll when it initially fails", async () => {


### PR DESCRIPTION
## Summary

- Removes the `if (trackerState.selectedMatchIds.length > 0)` guard that was preventing new matches from auto-populating `selectedMatchIds` on fresh trackers
- The game-selection dialog is a revision mechanism (not an approval gate) — all newly discovered matches ≥ 2 minutes should always auto-add to `selectedMatchIds`, regardless of whether the list starts empty
- Users can also now add matches from before the tracker's search start time via the dialog

## Test plan

- [ ] Updated test "does not re-fetch stats every poll for an enriched match whose stats have no teams" — pre-populates state with match already discovered and accumulated so it correctly isolates the no-re-enrichment behaviour
- [ ] Updated test description "auto-appends to selectedMatchIds even when it starts empty" with the new expectation that empty-list trackers do populate
- [ ] All 110 tests pass (`npm run done` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)