### PR TITLE
improve individual tracker session authentication performance

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -82,6 +82,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   private readonly logService: LogService;
   private readonly webSocketAdapter: WebSocketHibernationAdapter;
   private userHaloService: HaloService | null = null;
+  private userHaloServiceUserId: string | null = null;
   private topBarStatsCacheKey: string | undefined;
   private cachedTopBarStats: readonly TopBarStatItem[] | undefined;
   private cachedResolvedRosterCount: number | undefined;
@@ -273,7 +274,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         ]),
       );
       if (this.isAuthError(error)) {
-        this.userHaloService = null;
+        this.clearUserHaloService();
       }
       throw error;
     }
@@ -419,7 +420,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       matchStats = Preconditions.checkExists((await this.haloService.getMatchDetails([summary.matchId]))[0]);
     } catch (error) {
       if (this.isAuthError(error)) {
-        this.userHaloService = null;
+        this.clearUserHaloService();
         throw error;
       }
       this.logService.warn(
@@ -462,7 +463,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         matchStats = Preconditions.checkExists((await this.haloService.getMatchDetails([matchId]))[0]);
       } catch (error) {
         if (this.isAuthError(error)) {
-          this.userHaloService = null;
+          this.clearUserHaloService();
           throw error;
         }
         this.logService.warn(
@@ -485,7 +486,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return await this.haloService.getMapName(assetId, versionId);
     } catch (error) {
       if (this.isAuthError(error)) {
-        this.userHaloService = null;
+        this.clearUserHaloService();
         throw error;
       }
       this.logService.warn(
@@ -528,7 +529,16 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
 
     this.userHaloService = this.services.haloService.withUserClient(client);
+    this.userHaloServiceUserId = userId;
     return this.userHaloService;
+  }
+
+  private clearUserHaloService(): void {
+    if (this.userHaloServiceUserId != null) {
+      this.services.userTokenProvider.clearCachedClient(this.userHaloServiceUserId);
+    }
+    this.userHaloService = null;
+    this.userHaloServiceUserId = null;
   }
 
   private get haloService(): HaloService {
@@ -541,7 +551,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return result.get(xuid) ?? null;
     } catch (err: unknown) {
       if (this.isAuthError(err)) {
-        this.userHaloService = null;
+        this.clearUserHaloService();
       }
       this.logService.warn(
         err,
@@ -559,7 +569,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return await this.haloService.getPlayerEsra(xuid);
     } catch (err: unknown) {
       if (this.isAuthError(err)) {
-        this.userHaloService = null;
+        this.clearUserHaloService();
       }
       this.logService.warn(
         err,

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -107,6 +107,7 @@ describe("IndividualTrackerDO", () => {
   let storageDeleteAlarmSpy: MockInstance<typeof mockStorage.deleteAlarm>;
   let ownerClient: MockProxy<HaloInfiniteClient>;
   let getClientForUser: MockInstance<UserTokenProvider["getClientForUser"]>;
+  let clearCachedClient: MockInstance<UserTokenProvider["clearCachedClient"]>;
   let userTokenProvider: UserTokenProvider;
 
   beforeEach(() => {
@@ -121,7 +122,8 @@ describe("IndividualTrackerDO", () => {
     ownerClient.getPlayerMatches.mockResolvedValue([]);
     ownerClient.getMatchStats.mockResolvedValue(aFakeWinMatchStats());
     getClientForUser = vi.fn<UserTokenProvider["getClientForUser"]>().mockResolvedValue(ownerClient);
-    userTokenProvider = { getClientForUser } as unknown as UserTokenProvider;
+    clearCachedClient = vi.fn<UserTokenProvider["clearCachedClient"]>();
+    userTokenProvider = { getClientForUser, clearCachedClient } as unknown as UserTokenProvider;
 
     services = installFakeServicesWith({ userTokenProvider });
     env = aFakeEnvWith();
@@ -1041,6 +1043,7 @@ describe("IndividualTrackerDO", () => {
       await individualTrackerDO.alarm();
 
       expect(getClientForUser).toHaveBeenCalledTimes(2);
+      expect(clearCachedClient).toHaveBeenCalled();
     });
 
     it("does not treat a non-401 RequestError as an auth error", async () => {
@@ -1085,6 +1088,7 @@ describe("IndividualTrackerDO", () => {
 
       await individualTrackerDO.alarm();
       expect(getClientForUser).toHaveBeenCalledTimes(2);
+      expect(clearCachedClient).toHaveBeenCalled();
     });
 
     it("sets lastMatchDiscoveredAt and resets errorState when new matches are found", async () => {

--- a/api/routes/halo-proxy/halo-proxy.ts
+++ b/api/routes/halo-proxy/halo-proxy.ts
@@ -40,7 +40,7 @@ async function resolveOwnerClient(request: Request, services: Services): Promise
 async function resolveHaloProxyClient(request: Request, services: Services): Promise<ResolveHaloProxyClientResult> {
   const sessionWithMetadata = await services.authService.validateSessionWithAuthMetadata(request);
   if (sessionWithMetadata !== null) {
-    const {session} = sessionWithMetadata;
+    const { session } = sessionWithMetadata;
     const cachedXstsToken = await services.authService.getCachedHaloXstsTokenForAuthMetadata(
       sessionWithMetadata.authMetadata,
     );

--- a/api/routes/halo-proxy/halo-proxy.ts
+++ b/api/routes/halo-proxy/halo-proxy.ts
@@ -38,10 +38,12 @@ async function resolveOwnerClient(request: Request, services: Services): Promise
 }
 
 async function resolveHaloProxyClient(request: Request, services: Services): Promise<ResolveHaloProxyClientResult> {
-  const session = await services.authService.validateSession(request);
-
-  if (session !== null) {
-    const cachedXstsToken = await services.authService.getCachedHaloXstsTokenForSession(session.sessionId);
+  const sessionWithMetadata = await services.authService.validateSessionWithAuthMetadata(request);
+  if (sessionWithMetadata !== null) {
+    const {session} = sessionWithMetadata;
+    const cachedXstsToken = await services.authService.getCachedHaloXstsTokenForAuthMetadata(
+      sessionWithMetadata.authMetadata,
+    );
     if (cachedXstsToken != null) {
       const client = new HaloInfiniteClient(new StaticXstsTicketTokenSpartanTokenProvider(cachedXstsToken.XSTSToken));
       return { ok: true, resolved: { client } };
@@ -69,7 +71,11 @@ async function resolveHaloProxyClient(request: Request, services: Services): Pro
     }
 
     const xstsTokenInfo = await services.xboxService.exchangeMicrosoftAccessTokenForXstsToken(microsoftAccessToken);
-    await services.authService.cacheHaloXstsTokenForSession(session.sessionId, xstsTokenInfo);
+    await services.authService.cacheHaloXstsTokenForSessionAuthMetadata(
+      session.sessionId,
+      sessionWithMetadata.authMetadata,
+      xstsTokenInfo,
+    );
     const client = new HaloInfiniteClient(new StaticXstsTicketTokenSpartanTokenProvider(xstsTokenInfo.XSTSToken));
     return { ok: true, resolved: { client } };
   }

--- a/api/routes/halo-proxy/halo-proxy.ts
+++ b/api/routes/halo-proxy/halo-proxy.ts
@@ -41,6 +41,12 @@ async function resolveHaloProxyClient(request: Request, services: Services): Pro
   const session = await services.authService.validateSession(request);
 
   if (session !== null) {
+    const cachedXstsToken = await services.authService.getCachedHaloXstsTokenForSession(session.sessionId);
+    if (cachedXstsToken != null) {
+      const client = new HaloInfiniteClient(new StaticXstsTicketTokenSpartanTokenProvider(cachedXstsToken.XSTSToken));
+      return { ok: true, resolved: { client } };
+    }
+
     let microsoftAccessToken = session.accessToken;
 
     if (session.isExpired) {
@@ -63,6 +69,7 @@ async function resolveHaloProxyClient(request: Request, services: Services): Pro
     }
 
     const xstsTokenInfo = await services.xboxService.exchangeMicrosoftAccessTokenForXstsToken(microsoftAccessToken);
+    await services.authService.cacheHaloXstsTokenForSession(session.sessionId, xstsTokenInfo);
     const client = new HaloInfiniteClient(new StaticXstsTicketTokenSpartanTokenProvider(xstsTokenInfo.XSTSToken));
     return { ok: true, resolved: { client } };
   }

--- a/api/routes/halo-proxy/tests/halo-proxy.test.ts
+++ b/api/routes/halo-proxy/tests/halo-proxy.test.ts
@@ -87,7 +87,7 @@ describe("/proxy/halo-infinite/:operation route", () => {
     const sessionClient = aFakeHaloInfiniteClient();
     const sessionGetUserSpy = vi.spyOn(sessionClient, "getUser");
     let exchangeSpy!: MockInstance<XboxService["exchangeMicrosoftAccessTokenForXstsToken"]>;
-    let cacheHaloXstsTokenSpy!: MockInstance<AuthService["cacheHaloXstsTokenForSession"]>;
+    let cacheHaloXstsTokenSpy!: MockInstance<AuthService["cacheHaloXstsTokenForSessionAuthMetadata"]>;
     vi.mocked(StaticXstsTicketTokenSpartanTokenProvider).mockClear();
     vi.mocked(HaloInfiniteClient).mockClear();
     vi.mocked(HaloInfiniteClient).mockImplementation(function () {
@@ -96,16 +96,21 @@ describe("/proxy/halo-infinite/:operation route", () => {
 
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });
-      vi.spyOn(services.authService, "validateSession").mockResolvedValue({
-        sessionId: "session-123",
-        userId: "user-123",
-        accessToken: "access-token",
-        refreshToken: undefined,
-        expiresAt: Date.now() + 3600000,
-        isExpired: false,
+      vi.spyOn(services.authService, "validateSessionWithAuthMetadata").mockResolvedValue({
+        session: {
+          sessionId: "session-123",
+          userId: "user-123",
+          accessToken: "access-token",
+          refreshToken: undefined,
+          expiresAt: Date.now() + 3600000,
+          isExpired: false,
+        },
+        authMetadata: {},
       });
-      vi.spyOn(services.authService, "getCachedHaloXstsTokenForSession").mockResolvedValue(null);
-      cacheHaloXstsTokenSpy = vi.spyOn(services.authService, "cacheHaloXstsTokenForSession").mockResolvedValue();
+      vi.spyOn(services.authService, "getCachedHaloXstsTokenForAuthMetadata").mockResolvedValue(null);
+      cacheHaloXstsTokenSpy = vi
+        .spyOn(services.authService, "cacheHaloXstsTokenForSessionAuthMetadata")
+        .mockResolvedValue();
       exchangeSpy = vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockResolvedValue({
         XSTSToken: "session-xsts-token",
         userHash: "session-user-hash",
@@ -125,6 +130,7 @@ describe("/proxy/halo-infinite/:operation route", () => {
     expect(exchangeSpy).toHaveBeenCalledWith("access-token");
     expect(cacheHaloXstsTokenSpy).toHaveBeenCalledWith(
       "session-123",
+      expect.any(Object),
       expect.objectContaining({ XSTSToken: "session-xsts-token" }),
     );
     expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).toHaveBeenCalledWith("session-xsts-token");
@@ -135,7 +141,7 @@ describe("/proxy/halo-infinite/:operation route", () => {
     const sessionClient = aFakeHaloInfiniteClient();
     const sessionGetUserSpy = vi.spyOn(sessionClient, "getUser");
     let exchangeSpy!: MockInstance<XboxService["exchangeMicrosoftAccessTokenForXstsToken"]>;
-    let cacheHaloXstsTokenSpy!: MockInstance<AuthService["cacheHaloXstsTokenForSession"]>;
+    let cacheHaloXstsTokenSpy!: MockInstance<AuthService["cacheHaloXstsTokenForSessionAuthMetadata"]>;
 
     vi.mocked(StaticXstsTicketTokenSpartanTokenProvider).mockClear();
     vi.mocked(HaloInfiniteClient).mockClear();
@@ -145,20 +151,25 @@ describe("/proxy/halo-infinite/:operation route", () => {
 
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });
-      vi.spyOn(services.authService, "validateSession").mockResolvedValue({
-        sessionId: "session-123",
-        userId: "user-123",
-        accessToken: "access-token",
-        refreshToken: undefined,
-        expiresAt: Date.now() + 3600000,
-        isExpired: false,
+      vi.spyOn(services.authService, "validateSessionWithAuthMetadata").mockResolvedValue({
+        session: {
+          sessionId: "session-123",
+          userId: "user-123",
+          accessToken: "access-token",
+          refreshToken: undefined,
+          expiresAt: Date.now() + 3600000,
+          isExpired: false,
+        },
+        authMetadata: {},
       });
-      vi.spyOn(services.authService, "getCachedHaloXstsTokenForSession").mockResolvedValue({
+      vi.spyOn(services.authService, "getCachedHaloXstsTokenForAuthMetadata").mockResolvedValue({
         XSTSToken: "cached-session-xsts-token",
         userHash: "cached-user-hash",
         expiresOn: new Date(Date.now() + 3600_000),
       });
-      cacheHaloXstsTokenSpy = vi.spyOn(services.authService, "cacheHaloXstsTokenForSession").mockResolvedValue();
+      cacheHaloXstsTokenSpy = vi
+        .spyOn(services.authService, "cacheHaloXstsTokenForSessionAuthMetadata")
+        .mockResolvedValue();
       exchangeSpy = vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockResolvedValue({
         XSTSToken: "session-xsts-token",
         userHash: "session-user-hash",
@@ -195,15 +206,18 @@ describe("/proxy/halo-infinite/:operation route", () => {
 
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });
-      vi.spyOn(services.authService, "validateSession").mockResolvedValue({
-        sessionId: "session-123",
-        userId: "user-123",
-        accessToken: "expired-access-token",
-        refreshToken: "refresh-token",
-        expiresAt: Date.now() - 1000,
-        isExpired: true,
+      vi.spyOn(services.authService, "validateSessionWithAuthMetadata").mockResolvedValue({
+        session: {
+          sessionId: "session-123",
+          userId: "user-123",
+          accessToken: "expired-access-token",
+          refreshToken: "refresh-token",
+          expiresAt: Date.now() - 1000,
+          isExpired: true,
+        },
+        authMetadata: {},
       });
-      vi.spyOn(services.authService, "getCachedHaloXstsTokenForSession").mockResolvedValue(null);
+      vi.spyOn(services.authService, "getCachedHaloXstsTokenForAuthMetadata").mockResolvedValue(null);
       refreshSessionSpy = vi.spyOn(services.authService, "refreshSession").mockResolvedValue({
         sessionId: "session-123",
         userId: "user-123",
@@ -212,7 +226,7 @@ describe("/proxy/halo-infinite/:operation route", () => {
         expiresAt: Date.now() + 3600_000,
         issuedAt: Date.now(),
       });
-      vi.spyOn(services.authService, "cacheHaloXstsTokenForSession").mockResolvedValue();
+      vi.spyOn(services.authService, "cacheHaloXstsTokenForSessionAuthMetadata").mockResolvedValue();
       exchangeSpy = vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockResolvedValue({
         XSTSToken: "refreshed-session-xsts-token",
         userHash: "session-user-hash",
@@ -239,15 +253,18 @@ describe("/proxy/halo-infinite/:operation route", () => {
     let clearSessionCookieSpy!: MockInstance<AuthService["clearSessionCookie"]>;
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });
-      vi.spyOn(services.authService, "validateSession").mockResolvedValue({
-        sessionId: "session-123",
-        userId: "user-123",
-        accessToken: "expired-access-token",
-        refreshToken: "refresh-token",
-        expiresAt: Date.now() - 1000,
-        isExpired: true,
+      vi.spyOn(services.authService, "validateSessionWithAuthMetadata").mockResolvedValue({
+        session: {
+          sessionId: "session-123",
+          userId: "user-123",
+          accessToken: "expired-access-token",
+          refreshToken: "refresh-token",
+          expiresAt: Date.now() - 1000,
+          isExpired: true,
+        },
+        authMetadata: {},
       });
-      vi.spyOn(services.authService, "getCachedHaloXstsTokenForSession").mockResolvedValue(null);
+      vi.spyOn(services.authService, "getCachedHaloXstsTokenForAuthMetadata").mockResolvedValue(null);
       vi.spyOn(services.authService, "refreshSession").mockRejectedValue(new Error("refresh failed"));
       clearSessionCookieSpy = vi.spyOn(services.authService, "clearSessionCookie");
       return services;
@@ -269,15 +286,18 @@ describe("/proxy/halo-infinite/:operation route", () => {
     let clearSessionCookieSpy!: MockInstance<AuthService["clearSessionCookie"]>;
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });
-      vi.spyOn(services.authService, "validateSession").mockResolvedValue({
-        sessionId: "session-123",
-        userId: "user-123",
-        accessToken: "expired-access-token",
-        refreshToken: "refresh-token",
-        expiresAt: Date.now() - 1000,
-        isExpired: true,
+      vi.spyOn(services.authService, "validateSessionWithAuthMetadata").mockResolvedValue({
+        session: {
+          sessionId: "session-123",
+          userId: "user-123",
+          accessToken: "expired-access-token",
+          refreshToken: "refresh-token",
+          expiresAt: Date.now() - 1000,
+          isExpired: true,
+        },
+        authMetadata: {},
       });
-      vi.spyOn(services.authService, "getCachedHaloXstsTokenForSession").mockResolvedValue(null);
+      vi.spyOn(services.authService, "getCachedHaloXstsTokenForAuthMetadata").mockResolvedValue(null);
       vi.spyOn(services.authService, "refreshSession").mockResolvedValue(null);
       clearSessionCookieSpy = vi.spyOn(services.authService, "clearSessionCookie");
       return services;
@@ -306,14 +326,19 @@ describe("/proxy/halo-infinite/:operation route", () => {
     let findIdentitySpy!: MockInstance<DatabaseService["findActiveXboxIdentityByGamertag"]>;
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });
-      vi.spyOn(services.authService, "validateSession").mockResolvedValue({
-        sessionId: "session-123",
-        userId: "user-123",
-        accessToken: "access-token",
-        refreshToken: undefined,
-        expiresAt: Date.now() + 3600000,
-        isExpired: false,
+      vi.spyOn(services.authService, "validateSessionWithAuthMetadata").mockResolvedValue({
+        session: {
+          sessionId: "session-123",
+          userId: "user-123",
+          accessToken: "access-token",
+          refreshToken: undefined,
+          expiresAt: Date.now() + 3600000,
+          isExpired: false,
+        },
+        authMetadata: {},
       });
+      vi.spyOn(services.authService, "getCachedHaloXstsTokenForAuthMetadata").mockResolvedValue(null);
+      vi.spyOn(services.authService, "cacheHaloXstsTokenForSessionAuthMetadata").mockResolvedValue();
       vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockResolvedValue({
         XSTSToken: "session-xsts-token",
         userHash: "session-user-hash",

--- a/api/routes/halo-proxy/tests/halo-proxy.test.ts
+++ b/api/routes/halo-proxy/tests/halo-proxy.test.ts
@@ -3,10 +3,12 @@ import type { MockInstance } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type * as HaloInfiniteApi from "halo-infinite-api";
 import { HaloInfiniteClient, StaticXstsTicketTokenSpartanTokenProvider } from "halo-infinite-api";
+import * as haloProxyOperations from "@guilty-spark/shared/halo/halo-infinite-proxy-operations";
 import type { TokenInfo } from "../../../services/xbox/types";
 import type { XboxService } from "../../../services/xbox/xbox";
 import type { UserTokenProvider } from "../../../services/halo/user-token-provider";
 import type { DatabaseService } from "../../../services/database/database";
+import type { AuthService } from "../../../services/auth/auth";
 import { createApiRouter } from "../../../base/router";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import { aFakeCacheStorage } from "../../../base/fakes/cache.fake";
@@ -69,10 +71,23 @@ describe("/proxy/halo-infinite/:operation route", () => {
     expect(await res.text()).toBe("Method not allowed");
   });
 
+  it("returns 404 when an allowlisted operation cannot be resolved", async () => {
+    const resolveSpy = vi.spyOn(haloProxyOperations, "resolveHaloProxyOperation").mockReturnValue(null);
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => installFakeServicesWith({ env }));
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(getRequest("http://localhost/proxy/halo-infinite/getUser"), env, ctx)) as Response;
+
+    expect(res.status).toBe(404);
+    expect(await res.text()).toContain("Operation not found: getUser");
+    resolveSpy.mockRestore();
+  });
+
   it("derives the client from a valid session via the session XSTS token", async () => {
     const sessionClient = aFakeHaloInfiniteClient();
     const sessionGetUserSpy = vi.spyOn(sessionClient, "getUser");
     let exchangeSpy!: MockInstance<XboxService["exchangeMicrosoftAccessTokenForXstsToken"]>;
+    let cacheHaloXstsTokenSpy!: MockInstance<AuthService["cacheHaloXstsTokenForSession"]>;
     vi.mocked(StaticXstsTicketTokenSpartanTokenProvider).mockClear();
     vi.mocked(HaloInfiniteClient).mockClear();
     vi.mocked(HaloInfiniteClient).mockImplementation(function () {
@@ -89,6 +104,8 @@ describe("/proxy/halo-infinite/:operation route", () => {
         expiresAt: Date.now() + 3600000,
         isExpired: false,
       });
+      vi.spyOn(services.authService, "getCachedHaloXstsTokenForSession").mockResolvedValue(null);
+      cacheHaloXstsTokenSpy = vi.spyOn(services.authService, "cacheHaloXstsTokenForSession").mockResolvedValue();
       exchangeSpy = vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockResolvedValue({
         XSTSToken: "session-xsts-token",
         userHash: "session-user-hash",
@@ -106,8 +123,176 @@ describe("/proxy/halo-infinite/:operation route", () => {
 
     expect(res.status).toBe(200);
     expect(exchangeSpy).toHaveBeenCalledWith("access-token");
+    expect(cacheHaloXstsTokenSpy).toHaveBeenCalledWith(
+      "session-123",
+      expect.objectContaining({ XSTSToken: "session-xsts-token" }),
+    );
     expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).toHaveBeenCalledWith("session-xsts-token");
     expect(sessionGetUserSpy).toHaveBeenCalledWith("discord_user_01");
+  });
+
+  it("reuses cached session XSTS token and skips token exchange", async () => {
+    const sessionClient = aFakeHaloInfiniteClient();
+    const sessionGetUserSpy = vi.spyOn(sessionClient, "getUser");
+    let exchangeSpy!: MockInstance<XboxService["exchangeMicrosoftAccessTokenForXstsToken"]>;
+    let cacheHaloXstsTokenSpy!: MockInstance<AuthService["cacheHaloXstsTokenForSession"]>;
+
+    vi.mocked(StaticXstsTicketTokenSpartanTokenProvider).mockClear();
+    vi.mocked(HaloInfiniteClient).mockClear();
+    vi.mocked(HaloInfiniteClient).mockImplementation(function () {
+      return sessionClient;
+    });
+
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue({
+        sessionId: "session-123",
+        userId: "user-123",
+        accessToken: "access-token",
+        refreshToken: undefined,
+        expiresAt: Date.now() + 3600000,
+        isExpired: false,
+      });
+      vi.spyOn(services.authService, "getCachedHaloXstsTokenForSession").mockResolvedValue({
+        XSTSToken: "cached-session-xsts-token",
+        userHash: "cached-user-hash",
+        expiresOn: new Date(Date.now() + 3600_000),
+      });
+      cacheHaloXstsTokenSpy = vi.spyOn(services.authService, "cacheHaloXstsTokenForSession").mockResolvedValue();
+      exchangeSpy = vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockResolvedValue({
+        XSTSToken: "session-xsts-token",
+        userHash: "session-user-hash",
+        expiresOn: new Date("2025-01-01T06:00:00.000Z"),
+      } satisfies TokenInfo);
+      return services;
+    });
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22", {
+      method: "GET",
+      headers: { cookie: "auth-session=valid-token" },
+    });
+    const res = (await router.fetch(req, env, ctx)) as Response;
+
+    expect(res.status).toBe(200);
+    expect(exchangeSpy).not.toHaveBeenCalled();
+    expect(cacheHaloXstsTokenSpy).not.toHaveBeenCalled();
+    expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).toHaveBeenCalledWith("cached-session-xsts-token");
+    expect(sessionGetUserSpy).toHaveBeenCalledWith("discord_user_01");
+  });
+
+  it("refreshes an expired session and exchanges token using refreshed access token", async () => {
+    const sessionClient = aFakeHaloInfiniteClient();
+    const sessionGetUserSpy = vi.spyOn(sessionClient, "getUser");
+    let refreshSessionSpy!: MockInstance<AuthService["refreshSession"]>;
+    let exchangeSpy!: MockInstance<XboxService["exchangeMicrosoftAccessTokenForXstsToken"]>;
+
+    vi.mocked(StaticXstsTicketTokenSpartanTokenProvider).mockClear();
+    vi.mocked(HaloInfiniteClient).mockClear();
+    vi.mocked(HaloInfiniteClient).mockImplementation(function () {
+      return sessionClient;
+    });
+
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue({
+        sessionId: "session-123",
+        userId: "user-123",
+        accessToken: "expired-access-token",
+        refreshToken: "refresh-token",
+        expiresAt: Date.now() - 1000,
+        isExpired: true,
+      });
+      vi.spyOn(services.authService, "getCachedHaloXstsTokenForSession").mockResolvedValue(null);
+      refreshSessionSpy = vi.spyOn(services.authService, "refreshSession").mockResolvedValue({
+        sessionId: "session-123",
+        userId: "user-123",
+        accessToken: "refreshed-access-token",
+        refreshToken: "rotated-refresh-token",
+        expiresAt: Date.now() + 3600_000,
+        issuedAt: Date.now(),
+      });
+      vi.spyOn(services.authService, "cacheHaloXstsTokenForSession").mockResolvedValue();
+      exchangeSpy = vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockResolvedValue({
+        XSTSToken: "refreshed-session-xsts-token",
+        userHash: "session-user-hash",
+        expiresOn: new Date("2025-01-01T06:00:00.000Z"),
+      } satisfies TokenInfo);
+      return services;
+    });
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22", {
+      method: "GET",
+      headers: { cookie: "auth-session=valid-token" },
+    });
+    const res = (await router.fetch(req, env, ctx)) as Response;
+
+    expect(res.status).toBe(200);
+    expect(refreshSessionSpy).toHaveBeenCalledOnce();
+    expect(exchangeSpy).toHaveBeenCalledWith("refreshed-access-token");
+    expect(vi.mocked(StaticXstsTicketTokenSpartanTokenProvider)).toHaveBeenCalledWith("refreshed-session-xsts-token");
+    expect(sessionGetUserSpy).toHaveBeenCalledWith("discord_user_01");
+  });
+
+  it("returns 401 and clears cookie when refreshing an expired session throws", async () => {
+    let clearSessionCookieSpy!: MockInstance<AuthService["clearSessionCookie"]>;
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue({
+        sessionId: "session-123",
+        userId: "user-123",
+        accessToken: "expired-access-token",
+        refreshToken: "refresh-token",
+        expiresAt: Date.now() - 1000,
+        isExpired: true,
+      });
+      vi.spyOn(services.authService, "getCachedHaloXstsTokenForSession").mockResolvedValue(null);
+      vi.spyOn(services.authService, "refreshSession").mockRejectedValue(new Error("refresh failed"));
+      clearSessionCookieSpy = vi.spyOn(services.authService, "clearSessionCookie");
+      return services;
+    });
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22", {
+      method: "GET",
+      headers: { cookie: "auth-session=valid-token" },
+    });
+    const res = (await router.fetch(req, env, ctx)) as Response;
+
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("Unauthorized");
+    expect(clearSessionCookieSpy).toHaveBeenCalledOnce();
+  });
+
+  it("returns 401 and clears cookie when refreshing an expired session returns null", async () => {
+    let clearSessionCookieSpy!: MockInstance<AuthService["clearSessionCookie"]>;
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue({
+        sessionId: "session-123",
+        userId: "user-123",
+        accessToken: "expired-access-token",
+        refreshToken: "refresh-token",
+        expiresAt: Date.now() - 1000,
+        isExpired: true,
+      });
+      vi.spyOn(services.authService, "getCachedHaloXstsTokenForSession").mockResolvedValue(null);
+      vi.spyOn(services.authService, "refreshSession").mockResolvedValue(null);
+      clearSessionCookieSpy = vi.spyOn(services.authService, "clearSessionCookie");
+      return services;
+    });
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const req = new Request("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22", {
+      method: "GET",
+      headers: { cookie: "auth-session=valid-token" },
+    });
+    const res = (await router.fetch(req, env, ctx)) as Response;
+
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("Unauthorized");
+    expect(clearSessionCookieSpy).toHaveBeenCalledOnce();
   });
 
   it("prefers the session client and ignores the gamertag when both are present", async () => {
@@ -219,6 +404,37 @@ describe("/proxy/halo-infinite/:operation route", () => {
     expect(res.status).toBe(200);
     expect(botGetUserSpy).toHaveBeenCalledWith("discord_user_01");
     expect(getClientForUserSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the bot client when owner identity lookup throws", async () => {
+    const botClient = aFakeHaloInfiniteClient();
+    const botGetUserSpy = vi.spyOn(botClient, "getUser");
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env, haloInfiniteClient: botClient });
+      vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockRejectedValue(new Error("db down"));
+      return services;
+    });
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const req = getRequest("http://localhost/proxy/halo-infinite/getUser?arg=%22discord_user_01%22&gamertag=OwnerTag");
+    const res = (await router.fetch(req, env, ctx)) as Response;
+
+    expect(res.status).toBe(200);
+    expect(botGetUserSpy).toHaveBeenCalledWith("discord_user_01");
+  });
+
+  it("returns 400 when proxy args cannot be parsed", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => installFakeServicesWith({ env }));
+    haloProxyRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(
+      getRequest("http://localhost/proxy/halo-infinite/getUser?arg=not-json"),
+      env,
+      ctx,
+    )) as Response;
+
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain("Invalid query arguments");
   });
 
   it("serves a second request with a different gamertag from the gamertag-stripped cache entry", async () => {

--- a/api/services/auth/auth.ts
+++ b/api/services/auth/auth.ts
@@ -3,6 +3,7 @@ import { safeRedirectPath } from "@guilty-spark/shared/base/safe-redirect";
 import { z } from "zod";
 import type { DatabaseService } from "../database/database";
 import type { UserSessionsRow } from "../database/types/user_sessions";
+import type { TokenInfo } from "../xbox/types";
 import { MicrosoftAuthService } from "./microsoft-auth";
 import { SessionManager, SESSION_COOKIE_MAX_AGE_SECONDS } from "./session-manager";
 import { TokenEncryptor } from "./token-encryptor";
@@ -29,7 +30,12 @@ const authMetadataSchema = z.object({
   xboxGamertag: z.string().optional().catch(undefined),
   xboxXuid: z.string().optional().catch(undefined),
   xboxProfileCheckedAt: z.number().optional().catch(undefined),
+  haloXstsTokenEncrypted: z.string().optional().catch(undefined),
+  haloXstsUserHash: z.string().optional().catch(undefined),
+  haloXstsExpiresAt: z.number().optional().catch(undefined),
 });
+
+const XSTS_EXPIRY_SKEW_MS = 60_000;
 
 const pkceStatePayloadSchema = z.object({
   codeVerifier: z.string().min(1),
@@ -282,7 +288,28 @@ export class AuthService {
         return null;
       }
 
-      const refreshToken = await this.tokenEncryptor.decrypt(credentials.RefreshToken);
+      const firstTry = await this.refreshMicrosoftAccessTokenWithStoredCredentials(userId, credentials.RefreshToken);
+      if (firstTry != null) {
+        return firstTry;
+      }
+
+      const latestCredentials = await this.databaseService.getUserCredentials(userId);
+      if (latestCredentials == null || latestCredentials.RefreshToken === credentials.RefreshToken) {
+        return null;
+      }
+
+      return await this.refreshMicrosoftAccessTokenWithStoredCredentials(userId, latestCredentials.RefreshToken);
+    } catch {
+      return null;
+    }
+  }
+
+  private async refreshMicrosoftAccessTokenWithStoredCredentials(
+    userId: string,
+    encryptedRefreshToken: string,
+  ): Promise<string | null> {
+    try {
+      const refreshToken = await this.tokenEncryptor.decrypt(encryptedRefreshToken);
       const tokens = await this.microsoftAuth.refreshAccessToken(refreshToken);
 
       if (tokens.refresh_token != null && tokens.refresh_token !== "") {
@@ -297,6 +324,51 @@ export class AuthService {
     } catch {
       return null;
     }
+  }
+
+  public async getCachedHaloXstsTokenForSession(sessionId: string): Promise<TokenInfo | null> {
+    const session = await this.databaseService.getUserSession(sessionId);
+    if (session == null) {
+      return null;
+    }
+
+    const metadata = this.parseAuthMetadata(session.AuthMetadataJson);
+    const encryptedToken = metadata.haloXstsTokenEncrypted;
+    const userHash = metadata.haloXstsUserHash;
+    const expiresAt = metadata.haloXstsExpiresAt;
+
+    if (encryptedToken == null || userHash == null || expiresAt == null) {
+      return null;
+    }
+
+    if (Date.now() >= expiresAt - XSTS_EXPIRY_SKEW_MS) {
+      return null;
+    }
+
+    try {
+      const token = await this.tokenEncryptor.decrypt(encryptedToken);
+      return {
+        XSTSToken: token,
+        userHash,
+        expiresOn: new Date(expiresAt),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  public async cacheHaloXstsTokenForSession(sessionId: string, tokenInfo: TokenInfo): Promise<void> {
+    const session = await this.databaseService.getUserSession(sessionId);
+    if (session == null) {
+      return;
+    }
+
+    const metadata = this.parseAuthMetadata(session.AuthMetadataJson);
+    metadata.haloXstsTokenEncrypted = await this.tokenEncryptor.encrypt(tokenInfo.XSTSToken);
+    metadata.haloXstsUserHash = tokenInfo.userHash;
+    metadata.haloXstsExpiresAt = tokenInfo.expiresOn.getTime();
+
+    await this.databaseService.updateSessionAuthMetadata(sessionId, JSON.stringify(metadata));
   }
 
   /**

--- a/api/services/auth/auth.ts
+++ b/api/services/auth/auth.ts
@@ -15,6 +15,7 @@ import type {
   AuthCallbackResult,
   AuthMetadata,
   XboxSessionProfile,
+  SessionWithAuthMetadata,
 } from "./types";
 
 const sessionCookiePayloadSchema = z.object({
@@ -139,7 +140,9 @@ export class AuthService {
       return;
     }
 
-    const mergedMetadata = this.parseAuthMetadata(existingSession.AuthMetadataJson);
+    const mergedMetadata: Mutable<AuthMetadata> = {
+      ...this.parseAuthMetadata(existingSession.AuthMetadataJson),
+    };
     if (profile.avatarUrl != null) {
       mergedMetadata.avatarUrl = profile.avatarUrl;
     }
@@ -201,6 +204,11 @@ export class AuthService {
    * Validate a session token from a request.
    */
   public async validateSession(request: Request): Promise<AuthSession | null> {
+    const sessionWithMetadata = await this.validateSessionWithAuthMetadata(request);
+    return sessionWithMetadata?.session ?? null;
+  }
+
+  public async validateSessionWithAuthMetadata(request: Request): Promise<SessionWithAuthMetadata | null> {
     const token = this.sessionManager.extractSessionToken(request);
     if (token == null) {
       return null;
@@ -216,7 +224,7 @@ export class AuthService {
       return null;
     }
 
-    return await this.toAuthSession(session);
+    return await this.toAuthSessionWithAuthMetadata(session);
   }
 
   public async invalidateSession(request: Request): Promise<void> {
@@ -334,9 +342,17 @@ export class AuthService {
       }
 
       const metadata = this.parseAuthMetadata(session.AuthMetadataJson);
-      const encryptedToken = metadata.haloXstsTokenEncrypted;
-      const userHash = metadata.haloXstsUserHash;
-      const expiresAt = metadata.haloXstsExpiresAt;
+      return await this.getCachedHaloXstsTokenForAuthMetadata(metadata);
+    } catch {
+      return null;
+    }
+  }
+
+  public async getCachedHaloXstsTokenForAuthMetadata(authMetadata: AuthMetadata): Promise<TokenInfo | null> {
+    try {
+      const encryptedToken = authMetadata.haloXstsTokenEncrypted;
+      const userHash = authMetadata.haloXstsUserHash;
+      const expiresAt = authMetadata.haloXstsExpiresAt;
 
       if (encryptedToken == null || userHash == null || expiresAt == null) {
         return null;
@@ -365,6 +381,21 @@ export class AuthService {
       }
 
       const metadata = this.parseAuthMetadata(session.AuthMetadataJson);
+      await this.cacheHaloXstsTokenForSessionAuthMetadata(sessionId, metadata, tokenInfo);
+    } catch {
+      // Best-effort cache write only; auth flow must continue on storage/encryption failures.
+    }
+  }
+
+  public async cacheHaloXstsTokenForSessionAuthMetadata(
+    sessionId: string,
+    authMetadata: AuthMetadata,
+    tokenInfo: TokenInfo,
+  ): Promise<void> {
+    try {
+      const metadata: Mutable<AuthMetadata> = {
+        ...authMetadata,
+      };
       metadata.haloXstsTokenEncrypted = await this.tokenEncryptor.encrypt(tokenInfo.XSTSToken);
       metadata.haloXstsUserHash = tokenInfo.userHash;
       metadata.haloXstsExpiresAt = tokenInfo.expiresOn.getTime();
@@ -470,16 +501,52 @@ export class AuthService {
     }
   }
 
-  private parseAuthMetadata(authMetadataJson: string): z.infer<typeof authMetadataSchema> {
+  private parseAuthMetadata(authMetadataJson: string): AuthMetadata {
     try {
       const parsed = authMetadataSchema.safeParse(JSON.parse(authMetadataJson));
-      return parsed.success ? parsed.data : {};
+      if (!parsed.success) {
+        return {};
+      }
+
+      const metadata: Mutable<AuthMetadata> = {};
+      if (parsed.data.email != null) {
+        metadata.email = parsed.data.email;
+      }
+      if (parsed.data.name != null) {
+        metadata.name = parsed.data.name;
+      }
+      if (parsed.data.preferredUsername != null) {
+        metadata.preferredUsername = parsed.data.preferredUsername;
+      }
+      if (parsed.data.avatarUrl != null) {
+        metadata.avatarUrl = parsed.data.avatarUrl;
+      }
+      if (parsed.data.xboxGamertag != null) {
+        metadata.xboxGamertag = parsed.data.xboxGamertag;
+      }
+      if (parsed.data.xboxXuid != null) {
+        metadata.xboxXuid = parsed.data.xboxXuid;
+      }
+      if (parsed.data.xboxProfileCheckedAt != null) {
+        metadata.xboxProfileCheckedAt = parsed.data.xboxProfileCheckedAt;
+      }
+      if (parsed.data.haloXstsTokenEncrypted != null) {
+        metadata.haloXstsTokenEncrypted = parsed.data.haloXstsTokenEncrypted;
+      }
+      if (parsed.data.haloXstsUserHash != null) {
+        metadata.haloXstsUserHash = parsed.data.haloXstsUserHash;
+      }
+      if (parsed.data.haloXstsExpiresAt != null) {
+        metadata.haloXstsExpiresAt = parsed.data.haloXstsExpiresAt;
+      }
+
+      return metadata;
     } catch {
       return {};
     }
   }
 
-  private async toAuthSession(session: UserSessionsRow): Promise<AuthSession> {
+  private async toAuthSessionWithAuthMetadata(session: UserSessionsRow): Promise<SessionWithAuthMetadata> {
     const expiresAt = session.ExpiresAt * 1000;
     const isExpired = expiresAt < Date.now();
     const accessToken = await this.tokenEncryptor.decrypt(session.AccessToken);
@@ -507,7 +574,10 @@ export class AuthService {
     if (metadata.xboxProfileCheckedAt != null) {
       authSession.xboxProfileCheckedAt = metadata.xboxProfileCheckedAt;
     }
-    return authSession;
+    return {
+      session: authSession,
+      authMetadata: metadata,
+    };
   }
 
   private async readSessionCookiePayload(token: string): Promise<SessionCookiePayload | null> {

--- a/api/services/auth/auth.ts
+++ b/api/services/auth/auth.ts
@@ -327,25 +327,25 @@ export class AuthService {
   }
 
   public async getCachedHaloXstsTokenForSession(sessionId: string): Promise<TokenInfo | null> {
-    const session = await this.databaseService.getUserSession(sessionId);
-    if (session == null) {
-      return null;
-    }
-
-    const metadata = this.parseAuthMetadata(session.AuthMetadataJson);
-    const encryptedToken = metadata.haloXstsTokenEncrypted;
-    const userHash = metadata.haloXstsUserHash;
-    const expiresAt = metadata.haloXstsExpiresAt;
-
-    if (encryptedToken == null || userHash == null || expiresAt == null) {
-      return null;
-    }
-
-    if (Date.now() >= expiresAt - XSTS_EXPIRY_SKEW_MS) {
-      return null;
-    }
-
     try {
+      const session = await this.databaseService.getUserSession(sessionId);
+      if (session == null) {
+        return null;
+      }
+
+      const metadata = this.parseAuthMetadata(session.AuthMetadataJson);
+      const encryptedToken = metadata.haloXstsTokenEncrypted;
+      const userHash = metadata.haloXstsUserHash;
+      const expiresAt = metadata.haloXstsExpiresAt;
+
+      if (encryptedToken == null || userHash == null || expiresAt == null) {
+        return null;
+      }
+
+      if (Date.now() >= expiresAt - XSTS_EXPIRY_SKEW_MS) {
+        return null;
+      }
+
       const token = await this.tokenEncryptor.decrypt(encryptedToken);
       return {
         XSTSToken: token,
@@ -358,17 +358,21 @@ export class AuthService {
   }
 
   public async cacheHaloXstsTokenForSession(sessionId: string, tokenInfo: TokenInfo): Promise<void> {
-    const session = await this.databaseService.getUserSession(sessionId);
-    if (session == null) {
-      return;
+    try {
+      const session = await this.databaseService.getUserSession(sessionId);
+      if (session == null) {
+        return;
+      }
+
+      const metadata = this.parseAuthMetadata(session.AuthMetadataJson);
+      metadata.haloXstsTokenEncrypted = await this.tokenEncryptor.encrypt(tokenInfo.XSTSToken);
+      metadata.haloXstsUserHash = tokenInfo.userHash;
+      metadata.haloXstsExpiresAt = tokenInfo.expiresOn.getTime();
+
+      await this.databaseService.updateSessionAuthMetadata(sessionId, JSON.stringify(metadata));
+    } catch {
+      // Best-effort cache write only; auth flow must continue on storage/encryption failures.
     }
-
-    const metadata = this.parseAuthMetadata(session.AuthMetadataJson);
-    metadata.haloXstsTokenEncrypted = await this.tokenEncryptor.encrypt(tokenInfo.XSTSToken);
-    metadata.haloXstsUserHash = tokenInfo.userHash;
-    metadata.haloXstsExpiresAt = tokenInfo.expiresOn.getTime();
-
-    await this.databaseService.updateSessionAuthMetadata(sessionId, JSON.stringify(metadata));
   }
 
   /**

--- a/api/services/auth/tests/auth.test.ts
+++ b/api/services/auth/tests/auth.test.ts
@@ -1048,4 +1048,27 @@ describe("AuthService", () => {
 
     expect(updateMetadataSpy).not.toHaveBeenCalled();
   });
+
+  it("returns null for cached Halo XSTS token when reading session fails", async () => {
+    vi.spyOn(databaseService, "getUserSession").mockRejectedValue(new Error("db unavailable"));
+
+    const cached = await service.getCachedHaloXstsTokenForSession("session-123");
+
+    expect(cached).toBeNull();
+  });
+
+  it("does nothing when caching a Halo XSTS token and session storage fails", async () => {
+    vi.spyOn(databaseService, "getUserSession").mockRejectedValue(new Error("db unavailable"));
+    const updateMetadataSpy = vi.spyOn(databaseService, "updateSessionAuthMetadata").mockResolvedValue();
+
+    await expect(
+      service.cacheHaloXstsTokenForSession("session-123", {
+        XSTSToken: "session-xsts-token",
+        userHash: "session-user-hash",
+        expiresOn: new Date(Date.now() + 3_600_000),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(updateMetadataSpy).not.toHaveBeenCalled();
+  });
 });

--- a/api/services/auth/tests/auth.test.ts
+++ b/api/services/auth/tests/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import type { MockInstance } from "vitest";
 import { AuthService } from "../auth";
+import { SessionManager } from "../session-manager";
 import { TokenEncryptor } from "../token-encryptor";
 import { aFakeSessionTokenPayload, aFakePKCEState } from "../fakes/data";
 import type { AuthSession } from "../types";
@@ -10,6 +11,7 @@ import {
   aFakeUserSessionsRow,
 } from "../../database/fakes/database.fake";
 import type { DatabaseService } from "../../database/database";
+import type { TokenInfo } from "../../xbox/types";
 import { aSignedMicrosoftIdTokenWith } from "./id-token-signing";
 
 describe("AuthService", () => {
@@ -54,6 +56,59 @@ describe("AuthService", () => {
     await expect(service.handleCallback(request, "code", "invalid-state")).rejects.toThrow(
       "Invalid or expired state parameter",
     );
+  });
+
+  it("throws when PKCE state is older than 10 minutes", async () => {
+    const signedToken = await aSignedMicrosoftIdTokenWith({
+      clientId: "test-client-id",
+      issuerTemplate: "https://login.microsoftonline.com/{tenantid}/v2.0",
+      tenantId: "test-tenant-id",
+    });
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: "access-token",
+            expires_in: 3600,
+            refresh_token: "refresh-token",
+            id_token: signedToken.token,
+            token_type: "Bearer",
+            scope: "openid email",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(signedToken.openIdConfiguration), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(signedToken.jwkSet), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const { state, codeVerifier } = aFakePKCEState();
+    const response = new Response();
+    await service.setPkceStateCookie(response, {
+      state,
+      codeVerifier,
+      issuedAt: Date.now() - 11 * 60 * 1000,
+      redirectTo: "/individual-tracker",
+    });
+
+    const cookieHeader = response.headers.get("Set-Cookie") ?? "";
+    const pkceCookie = cookieHeader.split(";")[0] ?? "";
+    const request = new Request("http://localhost", {
+      headers: {
+        Cookie: pkceCookie,
+      },
+    });
+
+    await expect(service.handleCallback(request, "code", state)).rejects.toThrow("State parameter expired");
   });
 
   it("creates session token from payload", async () => {
@@ -274,6 +329,72 @@ describe("AuthService", () => {
     expect(session).toBeNull();
   });
 
+  it("returns null when session cookie token signature is invalid", async () => {
+    const request = new Request("http://localhost", {
+      headers: {
+        Cookie: "auth-session=invalid-token",
+      },
+    });
+
+    const session = await service.validateSession(request);
+
+    expect(session).toBeNull();
+  });
+
+  it("returns null when signed session cookie payload is not the expected shape", async () => {
+    const manager = new SessionManager("a".repeat(64));
+    const token = await manager.createSignedToken(JSON.stringify({ foo: "bar" }));
+
+    const request = new Request("http://localhost", {
+      headers: {
+        Cookie: `auth-session=${token}`,
+      },
+    });
+
+    const session = await service.validateSession(request);
+
+    expect(session).toBeNull();
+  });
+
+  it("returns null when signed session cookie payload is not valid JSON", async () => {
+    const manager = new SessionManager("a".repeat(64));
+    const token = await manager.createSignedToken("not-json");
+
+    const request = new Request("http://localhost", {
+      headers: {
+        Cookie: `auth-session=${token}`,
+      },
+    });
+
+    const session = await service.validateSession(request);
+
+    expect(session).toBeNull();
+  });
+
+  it("returns null when the session token is valid but no persisted session row exists", async () => {
+    const payload = aFakeSessionTokenPayload();
+    const token = await service.createSessionToken(payload);
+    vi.spyOn(databaseService, "getUserSession").mockResolvedValue(null);
+
+    const request = new Request("http://localhost", {
+      headers: {
+        Cookie: `auth-session=${token}`,
+      },
+    });
+
+    const session = await service.validateSession(request);
+
+    expect(session).toBeNull();
+  });
+
+  it("does nothing when invalidating a request without a valid session", async () => {
+    const deleteUserSessionSpy = vi.spyOn(databaseService, "deleteUserSession").mockResolvedValue();
+
+    await service.invalidateSession(new Request("http://localhost"));
+
+    expect(deleteUserSessionSpy).not.toHaveBeenCalled();
+  });
+
   it("deletes the persisted session for a valid request", async () => {
     const payload = aFakeSessionTokenPayload();
     const token = await service.createSessionToken(payload);
@@ -364,6 +485,39 @@ describe("AuthService", () => {
     expect(persistedCredentials?.RefreshToken).not.toContain("new-refresh-token");
   });
 
+  it("returns null when refreshSession cannot find the persisted session row", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "new-access-token",
+          expires_in: 3600,
+          refresh_token: "new-refresh-token",
+          token_type: "Bearer",
+          scope: "openid profile",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const session: AuthSession = {
+      sessionId: "missing-session",
+      userId: "user-123",
+      accessToken: "old-access-token",
+      refreshToken: "old-refresh-token",
+      expiresAt: Date.now() - 1000,
+      isExpired: true,
+    };
+
+    vi.spyOn(databaseService, "getUserSession").mockResolvedValue(null);
+
+    const refreshed = await service.refreshSession(session);
+
+    expect(refreshed).toBeNull();
+  });
+
   describe("getMicrosoftAccessTokenForUser()", () => {
     const tokenEncryptionSecret = "b".repeat(64);
 
@@ -412,6 +566,14 @@ describe("AuthService", () => {
       expect(upsertUserCredentialsSpy).not.toHaveBeenCalled();
     });
 
+    it("fails closed when getUserCredentials throws", async () => {
+      vi.spyOn(databaseService, "getUserCredentials").mockRejectedValue(new Error("db unavailable"));
+
+      const result = await service.getMicrosoftAccessTokenForUser("user-123");
+
+      expect(result).toBeNull();
+    });
+
     it("fails closed (returns null) when the refresh request throws", async () => {
       const encryptor = new TokenEncryptor(tokenEncryptionSecret);
       vi.spyOn(databaseService, "getUserCredentials").mockResolvedValue({
@@ -426,6 +588,94 @@ describe("AuthService", () => {
       const result = await service.getMicrosoftAccessTokenForUser("user-123");
 
       expect(result).toBeNull();
+    });
+
+    it("retries once with the latest stored refresh token when credentials rotated concurrently", async () => {
+      const encryptor = new TokenEncryptor(tokenEncryptionSecret);
+      const oldEncryptedRefreshToken = await encryptor.encrypt("old-refresh-token");
+      const newEncryptedRefreshToken = await encryptor.encrypt("new-refresh-token");
+
+      const getUserCredentialsSpy = vi
+        .spyOn(databaseService, "getUserCredentials")
+        .mockResolvedValueOnce({
+          UserId: "user-123",
+          RefreshToken: oldEncryptedRefreshToken,
+          UpdatedAt: Math.floor(Date.now() / 1000),
+        })
+        .mockResolvedValueOnce({
+          UserId: "user-123",
+          RefreshToken: newEncryptedRefreshToken,
+          UpdatedAt: Math.floor(Date.now() / 1000),
+        });
+
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response("invalid_grant", { status: 400, statusText: "Bad Request" }))
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: "recovered-access-token",
+              expires_in: 3600,
+              token_type: "Bearer",
+              scope: "openid profile",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+
+      const result = await service.getMicrosoftAccessTokenForUser("user-123");
+
+      expect(result).toBe("recovered-access-token");
+      expect(getUserCredentialsSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns null when refresh fails and latest credentials row is missing", async () => {
+      const encryptor = new TokenEncryptor(tokenEncryptionSecret);
+      const encryptedRefreshToken = await encryptor.encrypt("stale-refresh-token");
+
+      const getUserCredentialsSpy = vi
+        .spyOn(databaseService, "getUserCredentials")
+        .mockResolvedValueOnce({
+          UserId: "user-123",
+          RefreshToken: encryptedRefreshToken,
+          UpdatedAt: Math.floor(Date.now() / 1000),
+        })
+        .mockResolvedValueOnce(null);
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("invalid_grant", { status: 400, statusText: "Bad Request" }),
+      );
+
+      const result = await service.getMicrosoftAccessTokenForUser("user-123");
+
+      expect(result).toBeNull();
+      expect(getUserCredentialsSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns null when refresh fails and latest credentials have the same token", async () => {
+      const encryptor = new TokenEncryptor(tokenEncryptionSecret);
+      const encryptedRefreshToken = await encryptor.encrypt("same-refresh-token");
+
+      const getUserCredentialsSpy = vi
+        .spyOn(databaseService, "getUserCredentials")
+        .mockResolvedValueOnce({
+          UserId: "user-123",
+          RefreshToken: encryptedRefreshToken,
+          UpdatedAt: Math.floor(Date.now() / 1000),
+        })
+        .mockResolvedValueOnce({
+          UserId: "user-123",
+          RefreshToken: encryptedRefreshToken,
+          UpdatedAt: Math.floor(Date.now() / 1000),
+        });
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("invalid_grant", { status: 400, statusText: "Bad Request" }),
+      );
+
+      const result = await service.getMicrosoftAccessTokenForUser("user-123");
+
+      expect(result).toBeNull();
+      expect(getUserCredentialsSpy).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -456,6 +706,24 @@ describe("AuthService", () => {
       xboxGamertag: "Spartan117",
       xboxXuid: "2533274",
     });
+  });
+
+  it("merges xboxProfileCheckedAt into the persisted session metadata", async () => {
+    vi.spyOn(databaseService, "getUserSession").mockResolvedValue(
+      aFakeUserSessionsRow({
+        SessionId: "session-123",
+        AuthMetadataJson: JSON.stringify({ email: "user@example.com" }),
+      }),
+    );
+    const updateMetadataSpy = vi.spyOn(databaseService, "updateSessionAuthMetadata").mockResolvedValue();
+
+    await service.attachSessionProfile("session-123", {
+      xboxProfileCheckedAt: 123456,
+    });
+
+    const [, authMetadataJson] = updateMetadataSpy.mock.calls[0] ?? [];
+    const metadata = JSON.parse(authMetadataJson ?? "{}") as Record<string, unknown>;
+    expect(metadata["xboxProfileCheckedAt"]).toBe(123456);
   });
 
   it("does nothing when attaching a profile to a missing session", async () => {
@@ -552,5 +820,232 @@ describe("AuthService", () => {
     expect(session?.avatarUrl).toBe("https://example.com/avatar.png");
     expect(session?.xboxGamertag).toBe("Spartan117");
     expect(session?.xboxXuid).toBe("2533274");
+  });
+
+  it("surfaces xboxProfileCheckedAt from session metadata", async () => {
+    const payload = aFakeSessionTokenPayload();
+    const token = await service.createSessionToken(payload);
+    vi.spyOn(databaseService, "getUserSession").mockResolvedValue(
+      aFakeUserSessionsRow({
+        SessionId: payload.sessionId,
+        UserId: payload.userId,
+        AccessToken: payload.accessToken,
+        RefreshToken: payload.refreshToken ?? null,
+        ExpiresAt: Math.floor(payload.expiresAt / 1000),
+        AuthMetadataJson: JSON.stringify({ xboxProfileCheckedAt: 12345 }),
+      }),
+    );
+
+    const request = new Request("http://localhost", {
+      headers: {
+        Cookie: `auth-session=${token}`,
+      },
+    });
+
+    const session = await service.validateSession(request);
+    expect(session?.xboxProfileCheckedAt).toBe(12345);
+  });
+
+  it("tolerates malformed auth metadata JSON during session validation", async () => {
+    const payload = aFakeSessionTokenPayload();
+    const token = await service.createSessionToken(payload);
+    vi.spyOn(databaseService, "getUserSession").mockResolvedValue(
+      aFakeUserSessionsRow({
+        SessionId: payload.sessionId,
+        UserId: payload.userId,
+        AccessToken: payload.accessToken,
+        RefreshToken: payload.refreshToken ?? null,
+        ExpiresAt: Math.floor(payload.expiresAt / 1000),
+        AuthMetadataJson: "{bad-json",
+      }),
+    );
+
+    const request = new Request("http://localhost", {
+      headers: {
+        Cookie: `auth-session=${token}`,
+      },
+    });
+
+    const session = await service.validateSession(request);
+    expect(session).not.toBeNull();
+    expect(session?.avatarUrl).toBeUndefined();
+  });
+
+  it("clears PKCE state cookie", () => {
+    const response = new Response();
+
+    service.clearPkceStateCookie(response);
+
+    const setCookie = response.headers.get("Set-Cookie");
+    expect(setCookie).toContain("auth-pkce-state=");
+    expect(setCookie).toContain("Max-Age=0");
+  });
+
+  it("throws when signed PKCE payload does not match expected object shape", async () => {
+    const manager = new SessionManager("a".repeat(64));
+    const token = await manager.createSignedToken(JSON.stringify({ invalid: true }));
+
+    const request = new Request("http://localhost", {
+      headers: {
+        Cookie: `auth-pkce-state=${token}`,
+      },
+    });
+
+    await expect(service.handleCallback(request, "code", "state")).rejects.toThrow(
+      "Invalid or expired state parameter",
+    );
+  });
+
+  it("throws when PKCE state cookie is missing", async () => {
+    const request = new Request("http://localhost");
+
+    await expect(service.handleCallback(request, "code", "state")).rejects.toThrow(
+      "Invalid or expired state parameter",
+    );
+  });
+
+  it("throws when PKCE state parameter does not match", async () => {
+    const { state, codeVerifier } = aFakePKCEState();
+    const response = new Response();
+    await service.setPkceStateCookie(response, {
+      state,
+      codeVerifier,
+      issuedAt: Date.now(),
+      redirectTo: "/individual-tracker",
+    });
+
+    const cookieHeader = response.headers.get("Set-Cookie") ?? "";
+    const pkceCookie = cookieHeader.split(";")[0] ?? "";
+    const request = new Request("http://localhost", {
+      headers: {
+        Cookie: pkceCookie,
+      },
+    });
+
+    await expect(service.handleCallback(request, "code", "different-state")).rejects.toThrow(
+      "Invalid or expired state parameter",
+    );
+  });
+
+  it("stores a session-scoped Halo XSTS token encrypted in auth metadata", async () => {
+    vi.spyOn(databaseService, "getUserSession").mockResolvedValue(
+      aFakeUserSessionsRow({
+        SessionId: "session-123",
+        AuthMetadataJson: JSON.stringify({ email: "user@example.com" }),
+      }),
+    );
+    const updateMetadataSpy = vi.spyOn(databaseService, "updateSessionAuthMetadata").mockResolvedValue();
+
+    const tokenInfo: TokenInfo = {
+      XSTSToken: "session-xsts-token",
+      userHash: "session-user-hash",
+      expiresOn: new Date(Date.now() + 3600_000),
+    };
+
+    await service.cacheHaloXstsTokenForSession("session-123", tokenInfo);
+
+    expect(updateMetadataSpy).toHaveBeenCalledTimes(1);
+    const [, authMetadataJson] = updateMetadataSpy.mock.calls[0] ?? [];
+    const metadata = JSON.parse(authMetadataJson ?? "{}") as Record<string, unknown>;
+
+    expect(metadata["email"]).toBe("user@example.com");
+    expect(metadata["haloXstsTokenEncrypted"]).toEqual(expect.any(String));
+    expect(String(metadata["haloXstsTokenEncrypted"]).includes("session-xsts-token")).toBe(false);
+    expect(metadata["haloXstsUserHash"]).toBe("session-user-hash");
+    expect(metadata["haloXstsExpiresAt"]).toBe(tokenInfo.expiresOn.getTime());
+  });
+
+  it("returns a cached Halo XSTS token when session metadata contains a valid encrypted token", async () => {
+    const encryptor = new TokenEncryptor("b".repeat(64));
+    const encryptedToken = await encryptor.encrypt("session-xsts-token");
+
+    vi.spyOn(databaseService, "getUserSession").mockResolvedValue(
+      aFakeUserSessionsRow({
+        SessionId: "session-123",
+        AuthMetadataJson: JSON.stringify({
+          haloXstsTokenEncrypted: encryptedToken,
+          haloXstsUserHash: "session-user-hash",
+          haloXstsExpiresAt: Date.now() + 3600_000,
+        }),
+      }),
+    );
+
+    const cached = await service.getCachedHaloXstsTokenForSession("session-123");
+
+    expect(cached).not.toBeNull();
+    expect(cached?.XSTSToken).toBe("session-xsts-token");
+    expect(cached?.userHash).toBe("session-user-hash");
+    expect(cached?.expiresOn).toBeInstanceOf(Date);
+  });
+
+  it("returns null for cached Halo XSTS token when session is missing", async () => {
+    vi.spyOn(databaseService, "getUserSession").mockResolvedValue(null);
+
+    const cached = await service.getCachedHaloXstsTokenForSession("missing-session");
+
+    expect(cached).toBeNull();
+  });
+
+  it("returns null for cached Halo XSTS token when required metadata fields are missing", async () => {
+    vi.spyOn(databaseService, "getUserSession").mockResolvedValue(
+      aFakeUserSessionsRow({
+        SessionId: "session-123",
+        AuthMetadataJson: JSON.stringify({ haloXstsUserHash: "session-user-hash" }),
+      }),
+    );
+
+    const cached = await service.getCachedHaloXstsTokenForSession("session-123");
+
+    expect(cached).toBeNull();
+  });
+
+  it("returns null for cached Halo XSTS token when token is inside expiry skew", async () => {
+    const encryptor = new TokenEncryptor("b".repeat(64));
+    const encryptedToken = await encryptor.encrypt("session-xsts-token");
+
+    vi.spyOn(databaseService, "getUserSession").mockResolvedValue(
+      aFakeUserSessionsRow({
+        SessionId: "session-123",
+        AuthMetadataJson: JSON.stringify({
+          haloXstsTokenEncrypted: encryptedToken,
+          haloXstsUserHash: "session-user-hash",
+          haloXstsExpiresAt: Date.now() + 30_000,
+        }),
+      }),
+    );
+
+    const cached = await service.getCachedHaloXstsTokenForSession("session-123");
+
+    expect(cached).toBeNull();
+  });
+
+  it("returns null for cached Halo XSTS token when encrypted token cannot be decrypted", async () => {
+    vi.spyOn(databaseService, "getUserSession").mockResolvedValue(
+      aFakeUserSessionsRow({
+        SessionId: "session-123",
+        AuthMetadataJson: JSON.stringify({
+          haloXstsTokenEncrypted: "enc-v1.invalid-token",
+          haloXstsUserHash: "session-user-hash",
+          haloXstsExpiresAt: Date.now() + 3_600_000,
+        }),
+      }),
+    );
+
+    const cached = await service.getCachedHaloXstsTokenForSession("session-123");
+
+    expect(cached).toBeNull();
+  });
+
+  it("does nothing when caching a Halo XSTS token for a missing session", async () => {
+    vi.spyOn(databaseService, "getUserSession").mockResolvedValue(null);
+    const updateMetadataSpy = vi.spyOn(databaseService, "updateSessionAuthMetadata").mockResolvedValue();
+
+    await service.cacheHaloXstsTokenForSession("missing-session", {
+      XSTSToken: "session-xsts-token",
+      userHash: "session-user-hash",
+      expiresOn: new Date(Date.now() + 3_600_000),
+    });
+
+    expect(updateMetadataSpy).not.toHaveBeenCalled();
   });
 });

--- a/api/services/auth/types.ts
+++ b/api/services/auth/types.ts
@@ -64,6 +64,14 @@ export interface AuthMetadata {
   readonly xboxGamertag?: string;
   readonly xboxXuid?: string;
   readonly xboxProfileCheckedAt?: number;
+  readonly haloXstsTokenEncrypted?: string;
+  readonly haloXstsUserHash?: string;
+  readonly haloXstsExpiresAt?: number;
+}
+
+export interface SessionWithAuthMetadata {
+  readonly session: AuthSession;
+  readonly authMetadata: AuthMetadata;
 }
 
 export type XboxSessionProfile = Pick<AuthMetadata, "avatarUrl" | "xboxGamertag" | "xboxXuid" | "xboxProfileCheckedAt">;

--- a/api/services/halo/tests/user-token-provider.test.ts
+++ b/api/services/halo/tests/user-token-provider.test.ts
@@ -7,6 +7,23 @@ import { aFakeLogServiceWith } from "../../log/fakes/log.fake";
 import { aFakeXboxServiceWith } from "../../xbox/fakes/xbox.fake";
 import type { TokenInfo } from "../../xbox/types";
 
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolveFn) => {
+    resolve = resolveFn;
+  });
+
+  return {
+    promise,
+    resolve(value: T): void {
+      if (resolve == null) {
+        throw new Error("Expected deferred resolver to exist");
+      }
+      resolve(value);
+    },
+  };
+}
+
 vi.mock("halo-infinite-api", async (importOriginal) => {
   const actual = await importOriginal<typeof HaloInfiniteApi>();
   return {
@@ -17,6 +34,10 @@ vi.mock("halo-infinite-api", async (importOriginal) => {
 });
 
 describe("UserTokenProvider", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.clearAllMocks();
@@ -67,5 +88,98 @@ describe("UserTokenProvider", () => {
 
     expect(client).toBeNull();
     expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses cached client when token has not expired", async () => {
+    const authService = aFakeAuthServiceWith();
+    const xboxService = aFakeXboxServiceWith();
+    vi.spyOn(authService, "getMicrosoftAccessTokenForUser").mockResolvedValue("owner-access-token");
+    const exchangeSpy = vi.spyOn(xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockResolvedValue({
+      XSTSToken: "owner-xsts-token",
+      userHash: "owner-user-hash",
+      expiresOn: new Date("2030-01-01T00:00:00.000Z"),
+    } satisfies TokenInfo);
+
+    const provider = new UserTokenProvider({ authService, xboxService, logService: aFakeLogServiceWith() });
+
+    const firstClient = await provider.getClientForUser("user-123");
+    const secondClient = await provider.getClientForUser("user-123");
+
+    expect(exchangeSpy).toHaveBeenCalledTimes(1);
+    expect(firstClient).toBe(secondClient);
+  });
+
+  it("re-mints client after clearCachedClient is called", async () => {
+    const authService = aFakeAuthServiceWith();
+    const xboxService = aFakeXboxServiceWith();
+    vi.spyOn(authService, "getMicrosoftAccessTokenForUser").mockResolvedValue("owner-access-token");
+    const exchangeSpy = vi.spyOn(xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockResolvedValue({
+      XSTSToken: "owner-xsts-token",
+      userHash: "owner-user-hash",
+      expiresOn: new Date("2030-01-01T00:00:00.000Z"),
+    } satisfies TokenInfo);
+
+    const provider = new UserTokenProvider({ authService, xboxService, logService: aFakeLogServiceWith() });
+
+    await provider.getClientForUser("user-123");
+    provider.clearCachedClient("user-123");
+    await provider.getClientForUser("user-123");
+
+    expect(exchangeSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates concurrent client mint requests for the same user", async () => {
+    const authService = aFakeAuthServiceWith();
+    const xboxService = aFakeXboxServiceWith();
+    vi.spyOn(authService, "getMicrosoftAccessTokenForUser").mockResolvedValue("owner-access-token");
+    const deferred = createDeferred<TokenInfo>();
+    const exchangeSpy = vi
+      .spyOn(xboxService, "exchangeMicrosoftAccessTokenForXstsToken")
+      .mockImplementation(() => deferred.promise);
+
+    const provider = new UserTokenProvider({ authService, xboxService, logService: aFakeLogServiceWith() });
+
+    const firstPromise = provider.getClientForUser("user-123");
+    const secondPromise = provider.getClientForUser("user-123");
+
+    deferred.resolve({
+      XSTSToken: "owner-xsts-token",
+      userHash: "owner-user-hash",
+      expiresOn: new Date("2030-01-01T00:00:00.000Z"),
+    });
+
+    const [firstClient, secondClient] = await Promise.all([firstPromise, secondPromise]);
+
+    expect(exchangeSpy).toHaveBeenCalledTimes(1);
+    expect(firstClient).toBe(secondClient);
+  });
+
+  it("re-mints client when cached token is inside expiry skew", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-20T00:00:00.000Z"));
+
+    const authService = aFakeAuthServiceWith();
+    const xboxService = aFakeXboxServiceWith();
+    vi.spyOn(authService, "getMicrosoftAccessTokenForUser").mockResolvedValue("owner-access-token");
+    const exchangeSpy = vi.spyOn(xboxService, "exchangeMicrosoftAccessTokenForXstsToken");
+    exchangeSpy
+      .mockResolvedValueOnce({
+        XSTSToken: "owner-xsts-token-1",
+        userHash: "owner-user-hash",
+        expiresOn: new Date(Date.now() + 5 * 60_000),
+      } satisfies TokenInfo)
+      .mockResolvedValueOnce({
+        XSTSToken: "owner-xsts-token-2",
+        userHash: "owner-user-hash",
+        expiresOn: new Date(Date.now() + 5 * 60_000),
+      } satisfies TokenInfo);
+
+    const provider = new UserTokenProvider({ authService, xboxService, logService: aFakeLogServiceWith() });
+
+    await provider.getClientForUser("user-123");
+    vi.setSystemTime(new Date(Date.now() + 5 * 60_000 - 30_000));
+    await provider.getClientForUser("user-123");
+
+    expect(exchangeSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/api/services/halo/tests/user-token-provider.test.ts
+++ b/api/services/halo/tests/user-token-provider.test.ts
@@ -135,7 +135,7 @@ describe("UserTokenProvider", () => {
     const deferred = createDeferred<TokenInfo>();
     const exchangeSpy = vi
       .spyOn(xboxService, "exchangeMicrosoftAccessTokenForXstsToken")
-      .mockImplementation(() => deferred.promise);
+      .mockImplementation(async () => deferred.promise);
 
     const provider = new UserTokenProvider({ authService, xboxService, logService: aFakeLogServiceWith() });
 

--- a/api/services/halo/user-token-provider.ts
+++ b/api/services/halo/user-token-provider.ts
@@ -9,10 +9,19 @@ export interface UserTokenProviderOpts {
   logService: LogService;
 }
 
+interface CachedUserClient {
+  readonly client: HaloInfiniteClient;
+  readonly expiresAtMs: number;
+}
+
 export class UserTokenProvider {
+  private static readonly CACHE_EXPIRY_SKEW_MS = 60_000;
+
   private readonly authService: AuthService;
   private readonly xboxService: XboxService;
   private readonly logService: LogService;
+  private readonly cachedClientsByUserId = new Map<string, CachedUserClient>();
+  private readonly inFlightClientByUserId = new Map<string, Promise<HaloInfiniteClient | null>>();
 
   constructor({ authService, xboxService, logService }: UserTokenProviderOpts) {
     this.authService = authService;
@@ -20,7 +29,31 @@ export class UserTokenProvider {
     this.logService = logService;
   }
 
+  public clearCachedClient(userId: string): void {
+    this.cachedClientsByUserId.delete(userId);
+    this.inFlightClientByUserId.delete(userId);
+  }
+
   async getClientForUser(userId: string): Promise<HaloInfiniteClient | null> {
+    const cached = this.cachedClientsByUserId.get(userId);
+    if (cached != null && Date.now() < cached.expiresAtMs - UserTokenProvider.CACHE_EXPIRY_SKEW_MS) {
+      return cached.client;
+    }
+
+    const inFlightClient = this.inFlightClientByUserId.get(userId);
+    if (inFlightClient != null) {
+      return inFlightClient;
+    }
+
+    const mintClientPromise = this.getClientForUserUncached(userId).finally(() => {
+      this.inFlightClientByUserId.delete(userId);
+    });
+    this.inFlightClientByUserId.set(userId, mintClientPromise);
+
+    return mintClientPromise;
+  }
+
+  private async getClientForUserUncached(userId: string): Promise<HaloInfiniteClient | null> {
     try {
       const accessToken = await this.authService.getMicrosoftAccessTokenForUser(userId);
       if (accessToken == null) {
@@ -28,7 +61,12 @@ export class UserTokenProvider {
       }
 
       const xstsTokenInfo = await this.xboxService.exchangeMicrosoftAccessTokenForXstsToken(accessToken);
-      return new HaloInfiniteClient(new StaticXstsTicketTokenSpartanTokenProvider(xstsTokenInfo.XSTSToken));
+      const client = new HaloInfiniteClient(new StaticXstsTicketTokenSpartanTokenProvider(xstsTokenInfo.XSTSToken));
+      this.cachedClientsByUserId.set(userId, {
+        client,
+        expiresAtMs: xstsTokenInfo.expiresOn.getTime(),
+      });
+      return client;
     } catch (error) {
       this.logService.warn(
         "UserTokenProvider: failed to mint Halo client for user",

--- a/api/services/halo/user-token-provider.ts
+++ b/api/services/halo/user-token-provider.ts
@@ -36,8 +36,12 @@ export class UserTokenProvider {
 
   async getClientForUser(userId: string): Promise<HaloInfiniteClient | null> {
     const cached = this.cachedClientsByUserId.get(userId);
-    if (cached != null && Date.now() < cached.expiresAtMs - UserTokenProvider.CACHE_EXPIRY_SKEW_MS) {
-      return cached.client;
+    if (cached != null) {
+      if (Date.now() < cached.expiresAtMs - UserTokenProvider.CACHE_EXPIRY_SKEW_MS) {
+        return cached.client;
+      }
+
+      this.cachedClientsByUserId.delete(userId);
     }
 
     const inFlightClient = this.inFlightClientByUserId.get(userId);

--- a/api/tests/server.test.ts
+++ b/api/tests/server.test.ts
@@ -178,14 +178,19 @@ describe("Server", () => {
 
       const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
         const services = installFakeServicesWith({ env });
-        vi.spyOn(services.authService, "validateSession").mockResolvedValue({
-          sessionId: "session-123",
-          userId: "user-123",
-          accessToken: "access-token",
-          refreshToken: undefined,
-          expiresAt: Date.now() + 3600000,
-          isExpired: false,
+        vi.spyOn(services.authService, "validateSessionWithAuthMetadata").mockResolvedValue({
+          session: {
+            sessionId: "session-123",
+            userId: "user-123",
+            accessToken: "access-token",
+            refreshToken: undefined,
+            expiresAt: Date.now() + 3600000,
+            isExpired: false,
+          },
+          authMetadata: {},
         });
+        vi.spyOn(services.authService, "getCachedHaloXstsTokenForAuthMetadata").mockResolvedValue(null);
+        vi.spyOn(services.authService, "cacheHaloXstsTokenForSessionAuthMetadata").mockResolvedValue();
         exchangeMicrosoftAccessTokenForXstsTokenSpy = vi
           .spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken")
           .mockResolvedValue({
@@ -236,14 +241,19 @@ describe("Server", () => {
 
       const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
         const services = installFakeServicesWith({ env });
-        vi.spyOn(services.authService, "validateSession").mockResolvedValue({
-          sessionId: "session-123",
-          userId: "user-123",
-          accessToken: "expired-access-token",
-          refreshToken: "refresh-token",
-          expiresAt: Date.now() - 1000,
-          isExpired: true,
+        vi.spyOn(services.authService, "validateSessionWithAuthMetadata").mockResolvedValue({
+          session: {
+            sessionId: "session-123",
+            userId: "user-123",
+            accessToken: "expired-access-token",
+            refreshToken: "refresh-token",
+            expiresAt: Date.now() - 1000,
+            isExpired: true,
+          },
+          authMetadata: {},
         });
+        vi.spyOn(services.authService, "getCachedHaloXstsTokenForAuthMetadata").mockResolvedValue(null);
+        vi.spyOn(services.authService, "cacheHaloXstsTokenForSessionAuthMetadata").mockResolvedValue();
         vi.spyOn(services.authService, "refreshSession").mockResolvedValue({
           sessionId: "session-123",
           userId: "user-123",
@@ -282,14 +292,18 @@ describe("Server", () => {
     it("returns 401 and clears the cookie when an expired session cannot be refreshed", async () => {
       const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
         const services = installFakeServicesWith({ env });
-        vi.spyOn(services.authService, "validateSession").mockResolvedValue({
-          sessionId: "session-123",
-          userId: "user-123",
-          accessToken: "expired-access-token",
-          refreshToken: "refresh-token",
-          expiresAt: Date.now() - 1000,
-          isExpired: true,
+        vi.spyOn(services.authService, "validateSessionWithAuthMetadata").mockResolvedValue({
+          session: {
+            sessionId: "session-123",
+            userId: "user-123",
+            accessToken: "expired-access-token",
+            refreshToken: "refresh-token",
+            expiresAt: Date.now() - 1000,
+            isExpired: true,
+          },
+          authMetadata: {},
         });
+        vi.spyOn(services.authService, "getCachedHaloXstsTokenForAuthMetadata").mockResolvedValue(null);
         vi.spyOn(services.authService, "refreshSession").mockResolvedValue(null);
         return services;
       });


### PR DESCRIPTION
## Context

This PR reduces repeated authentication/token-exchange work in the API worker by introducing caching/deduplication for Halo client minting and by caching a session-scoped Halo XSTS token in session metadata so the halo-proxy route can often skip the Xbox exchange call.

## Changes

Add per-user Halo client caching + concurrent mint deduplication in UserTokenProvider, and clear the cache when auth errors occur in the IndividualTracker durable object.
Add session-metadata caching for Halo XSTS tokens in AuthService, and update the halo-proxy route to prefer the cached token when available.
Expand test coverage across auth, halo-proxy, UserTokenProvider, and the IndividualTracker durable object to validate the new caching/refresh behavior.
