### PR TITLE
Add series-group sync contract and plumbing

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1016,6 +1016,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       isPaused: state.isPaused,
       startTime: state.startTime,
       lastUpdateTime: state.lastUpdateTime,
+      searchStartTime: state.searchStartTime,
       idleTimeoutHours: state.idleTimeoutHours,
       hasActiveSeries: state.activeSeries != null,
     };

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -226,6 +226,7 @@ describe("IndividualTrackerDO", () => {
           "idleTimeoutHours",
           "isPaused",
           "lastUpdateTime",
+          "searchStartTime",
           "startTime",
           "status",
           "trackerId",
@@ -338,10 +339,10 @@ describe("IndividualTrackerDO", () => {
       expect.assertions(5);
       if (body.state != null) {
         expect(body.state).not.toHaveProperty("errorState");
-        expect(body.state).not.toHaveProperty("searchStartTime");
+        expect(body.state.searchStartTime).toBeDefined();
         expect(body.state).not.toHaveProperty("checkCount");
         expect(body.state).not.toHaveProperty("lastMatchDiscoveredAt");
-        expect(Object.keys(body.state)).toHaveLength(10);
+        expect(Object.keys(body.state)).toHaveLength(11);
       }
     });
   });

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -9,6 +9,7 @@ export interface IndividualTrackerState {
   isPaused: boolean;
   startTime: string;
   lastUpdateTime: string;
+  searchStartTime?: string;
   idleTimeoutHours: number;
   hasActiveSeries?: boolean;
 }

--- a/api/routes/individual-tracker/manage.ts
+++ b/api/routes/individual-tracker/manage.ts
@@ -17,6 +17,7 @@ import {
   trackersContract,
   type StartSeriesRequest,
   type EditSeriesRequest,
+  type SelectMatchesRequest,
 } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import {
   individualTrackerPauseContract,
@@ -42,6 +43,13 @@ import { requireSession } from "../base/require-session";
 import { toTracker } from "./mapper";
 
 const DEFAULT_IDLE_TIMEOUT_HOURS = 6;
+
+class SyncMatchesError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "SyncMatchesError";
+  }
+}
 
 function trackerDoStub(env: Env, userId: string, trackerId: string): DurableObjectStub {
   const doId = env.INDIVIDUAL_TRACKER_DO.idFromName(`${userId}:${trackerId}`);
@@ -107,13 +115,25 @@ function assertDoOkWith404(response: Response): void {
   assertDoOk(response);
 }
 
-async function syncMatchesDo(env: Env, userId: string, trackerId: string, matchIds: string[]): Promise<void> {
+async function syncMatchesDo(env: Env, userId: string, trackerId: string, body: SelectMatchesRequest): Promise<void> {
   const stub = trackerDoStub(env, userId, trackerId);
   const response = await stub.fetch("http://do/select-matches", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ matchIds }),
+    body: JSON.stringify(body),
   });
+  if (response.status === 400) {
+    try {
+      const payload = errorContract.safeParse(await response.clone().json());
+      if (payload.success) {
+        throw new SyncMatchesError(payload.data.error);
+      }
+    } catch {
+      // fall through with generic error below when DO payload is not parseable
+    }
+
+    throw new SyncMatchesError("Failed to update match selection");
+  }
   assertDoOkWith404(response);
   await selectMatchesContract.fromResponse(response);
 }
@@ -464,10 +484,20 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
       let tracker: IndividualTrackersRow;
       try {
         tracker = await individualTrackerService.getOwnedTracker(auth.session.userId, trackerId);
-        await syncMatchesDo(env, auth.session.userId, tracker.TrackerId, parsed.data.matchIds);
+        await syncMatchesDo(env, auth.session.userId, tracker.TrackerId, {
+          matchIds: [...parsed.data.matchIds],
+          seriesGroups: parsed.data.seriesGroups.map((group) => ({
+            matchIds: [...group.matchIds],
+            titleOverride: group.titleOverride,
+            subtitleOverride: group.subtitleOverride,
+          })),
+        });
       } catch (error) {
         if (error instanceof TrackerNotFoundError) {
           return errorContract.toResponse({ error: "Tracker not found" }, { status: 404, noStore: true });
+        }
+        if (error instanceof SyncMatchesError) {
+          return errorContract.toResponse({ error: error.message }, { status: 400, noStore: true });
         }
         throw error;
       }

--- a/api/routes/individual-tracker/manage.ts
+++ b/api/routes/individual-tracker/manage.ts
@@ -123,13 +123,15 @@ async function syncMatchesDo(env: Env, userId: string, trackerId: string, body: 
     body: JSON.stringify(body),
   });
   if (response.status === 400) {
-    try {
-      const payload = errorContract.safeParse(await response.clone().json());
+    const responseBody = await response
+      .clone()
+      .json()
+      .catch(() => null);
+    if (responseBody != null) {
+      const payload = errorContract.safeParse(responseBody);
       if (payload.success) {
         throw new SyncMatchesError(payload.data.error);
       }
-    } catch {
-      // fall through with generic error below when DO payload is not parseable
     }
 
     throw new SyncMatchesError("Failed to update match selection");

--- a/api/routes/individual-tracker/mapper.ts
+++ b/api/routes/individual-tracker/mapper.ts
@@ -69,6 +69,7 @@ function toTrackerState(state: IndividualTrackerDoState): TrackerState {
     isPaused: state.isPaused,
     startTime: state.startTime,
     lastUpdateTime: state.lastUpdateTime,
+    searchStartTime: state.searchStartTime,
     idleTimeoutHours: state.idleTimeoutHours,
     hasActiveSeries: state.hasActiveSeries ?? false,
   };

--- a/api/routes/individual-tracker/tests/manage.test.ts
+++ b/api/routes/individual-tracker/tests/manage.test.ts
@@ -516,6 +516,37 @@ describe("/api/individual-tracker manage routes", () => {
     expect(res.status).toBe(404);
   });
 
+  it("returns DO-provided 400 error message on select matches", async () => {
+    const doStub = aFakeIndividualTrackerDOWith();
+    vi.spyOn(doStub, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "Failed to hydrate match IDs: bad-id" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+
+    const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123" });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env: localEnv });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-123" }));
+      vi.spyOn(services.individualTrackerService, "getOwnedTracker").mockResolvedValue(row);
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const req = new Request("http://localhost/api/individual-tracker/manage/t1/matches", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ matchIds: ["bad-id"] }),
+    });
+    const res = (await router.fetch(req, localEnv)) as Response;
+
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("Failed to hydrate match IDs: bad-id");
+  });
+
   it("returns 404 on end-series when the tracker is not owned", async () => {
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });

--- a/pages/src/services/individual-tracker/individual-tracker.ts
+++ b/pages/src/services/individual-tracker/individual-tracker.ts
@@ -404,7 +404,10 @@ export class RealIndividualTrackerService implements IndividualTrackerService {
         credentials: "include",
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ matchIds: request.selectedMatchIds }),
+        body: JSON.stringify({
+          matchIds: request.selectedMatchIds,
+          seriesGroups: request.seriesGroups ?? [],
+        }),
       },
     );
 

--- a/pages/src/services/individual-tracker/types.ts
+++ b/pages/src/services/individual-tracker/types.ts
@@ -3,6 +3,7 @@ import type {
   UpdateTrackerProfileRequest,
 } from "@guilty-spark/shared/contracts/individual-tracker/profile";
 import type {
+  SelectMatchesSeriesGroup,
   StartTrackerRequest,
   TrackerResponse,
   TrackerState,
@@ -64,11 +65,9 @@ export interface TrackerMatchHistoryResponse {
   readonly suggestedGroupings: readonly (readonly string[])[];
 }
 
-export interface TrackerSyncSeriesGroup {
+export type TrackerSyncSeriesGroup = Omit<SelectMatchesSeriesGroup, "matchIds"> & {
   readonly matchIds: readonly string[];
-  readonly titleOverride: string | null;
-  readonly subtitleOverride: string | null;
-}
+};
 
 export interface TrackerSyncMatchesRequest {
   readonly trackerId: string;

--- a/pages/src/services/individual-tracker/types.ts
+++ b/pages/src/services/individual-tracker/types.ts
@@ -64,11 +64,18 @@ export interface TrackerMatchHistoryResponse {
   readonly suggestedGroupings: readonly (readonly string[])[];
 }
 
+export interface TrackerSyncSeriesGroup {
+  readonly matchIds: readonly string[];
+  readonly titleOverride: string | null;
+  readonly subtitleOverride: string | null;
+}
+
 export interface TrackerSyncMatchesRequest {
   readonly trackerId: string;
   readonly selectedMatchIds: readonly string[];
-  readonly matchGroupings: readonly (readonly string[])[];
-  readonly matches: readonly TrackerMatchHistoryEntry[];
+  readonly seriesGroups?: readonly TrackerSyncSeriesGroup[];
+  readonly matchGroupings?: readonly (readonly string[])[];
+  readonly matches?: readonly TrackerMatchHistoryEntry[];
 }
 
 export interface ManualSeriesTeamForm {

--- a/pages/src/services/individual-tracker/types.ts
+++ b/pages/src/services/individual-tracker/types.ts
@@ -3,7 +3,6 @@ import type {
   UpdateTrackerProfileRequest,
 } from "@guilty-spark/shared/contracts/individual-tracker/profile";
 import type {
-  SelectMatchesSeriesGroup,
   StartTrackerRequest,
   TrackerResponse,
   TrackerState,
@@ -65,9 +64,11 @@ export interface TrackerMatchHistoryResponse {
   readonly suggestedGroupings: readonly (readonly string[])[];
 }
 
-export type TrackerSyncSeriesGroup = Omit<SelectMatchesSeriesGroup, "matchIds"> & {
+export interface TrackerSyncSeriesGroup {
   readonly matchIds: readonly string[];
-};
+  readonly titleOverride: string | null;
+  readonly subtitleOverride: string | null;
+}
 
 export interface TrackerSyncMatchesRequest {
   readonly trackerId: string;

--- a/shared/src/contracts/individual-tracker/tracker.ts
+++ b/shared/src/contracts/individual-tracker/tracker.ts
@@ -13,6 +13,7 @@ export const trackerStateSchema = z.object({
   isPaused: z.boolean(),
   startTime: z.string(),
   lastUpdateTime: z.string(),
+  searchStartTime: z.string().optional(),
   idleTimeoutHours: z.number(),
   hasActiveSeries: z.boolean(),
 });
@@ -55,8 +56,16 @@ export type TrackersResponse = z.infer<typeof trackersContract.schema>;
 export const stopTrackerContract = defineContract(z.object({ success: z.literal(true) }));
 export type StopTrackerResponse = z.infer<typeof stopTrackerContract.schema>;
 
+export const selectMatchesSeriesGroupSchema = z.object({
+  matchIds: z.array(z.string().min(1)).min(2),
+  titleOverride: z.string().nullable(),
+  subtitleOverride: z.string().nullable(),
+});
+export type SelectMatchesSeriesGroup = z.infer<typeof selectMatchesSeriesGroupSchema>;
+
 export const selectMatchesRequestSchema = z.object({
   matchIds: z.array(z.string().min(1)),
+  seriesGroups: z.array(selectMatchesSeriesGroupSchema).default([]),
 });
 export type SelectMatchesRequest = z.infer<typeof selectMatchesRequestSchema>;
 


### PR DESCRIPTION
## Summary

- extend individual tracker select-matches contract to support historical series-group metadata
- expose optional searchStartTime on tracker state contract and include it in route mapping
- wire pages individual-tracker service sync payload to send seriesGroups
- forward extended select-matches payload through manage route to DO with 400 error surfacing

## Validation
- npm run typecheck
- npm run lint:fix
- npx vitest run api/routes/individual-tracker/tests/manage.test.ts
- note: npm run done currently exits non-zero in test:changed when no related tests are discovered