### PR TITLE
DO atomic sync semantics with series-group overrides

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -743,7 +743,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       }
     }
 
+    const hasHydration = needsHydration.length > 0;
     const unchanged =
+      !hasHydration &&
       incoming.join(",") === trackerState.selectedMatchIds.join(",") &&
       body.seriesGroups.length === 0 &&
       (trackerState.seriesGroupOverrides?.length ?? 0) === 0;

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -735,7 +735,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           return true;
         }
         return (
-          existingGroup.matchIds.join(",") !== group.matchIds.join(",") ||
+          buildSeriesGroupKey(existingGroup.matchIds) !== buildSeriesGroupKey(group.matchIds) ||
           existingGroup.titleOverride !== group.titleOverride ||
           existingGroup.subtitleOverride !== group.subtitleOverride
         );

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/cloudflare";
 import { addMilliseconds, compareAsc, differenceInHours } from "date-fns";
 import { type MatchStats, MatchType, type PlaylistCsrContainer, RequestError } from "halo-infinite-api";
+import { errorContract } from "@guilty-spark/shared/contracts/error";
 import { trackerViewMessageContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import {
   editSeriesContract,
@@ -730,9 +731,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     if (needsHydration.length > 0) {
       const hydrationResult = await this.hydrateMatchSummaries(trackerState, needsHydration);
       if (!hydrationResult.success) {
-        return new Response(
-          JSON.stringify({ error: `Failed to hydrate matches: ${hydrationResult.failingIds.join(", ")}` }),
-          { status: 400, headers: { "Content-Type": "application/json" } },
+        return errorContract.toResponse(
+          { error: `Failed to hydrate matches: ${hydrationResult.failingIds.join(", ")}` },
+          { status: 400, noStore: true },
         );
       }
       for (const [matchId, summary] of hydrationResult.summaries) {
@@ -1156,6 +1157,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       ...(state.activeSeries != null ? [state.activeSeries] : []),
       ...(state.completedSeries ?? []),
     ];
+    const seriesGroupOverridesByKey = new Map<string, IndividualTrackerSeriesGroupOverride>();
+    for (const override of state.seriesGroupOverrides ?? []) {
+      seriesGroupOverridesByKey.set(buildSeriesGroupKey(override.matchIds), override);
+    }
 
     const series = groupings.map((matchIds): IndividualTrackerSeriesGroup => {
       const groupSummaries = matchIds
@@ -1185,9 +1190,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
       const matchIdSet = new Set(matchIds);
       const seriesContext = allSeriesContexts.find((ctx) => ctx.matchIds.some((id) => matchIdSet.has(id)));
-      const seriesGroupOverride = (state.seriesGroupOverrides ?? []).find((ov) =>
-        ov.matchIds.some((id) => matchIdSet.has(id)),
-      );
+      const seriesGroupOverride = seriesGroupOverridesByKey.get(buildSeriesGroupKey(matchIds));
 
       const title = seriesContext?.title ?? seriesGroupOverride?.titleOverride ?? defaultTitle;
       const subtitle = seriesContext?.subtitle ?? seriesGroupOverride?.subtitleOverride ?? defaultSubtitle;

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -724,6 +724,22 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
     const body = parsed.data;
     const incoming = [...new Set(body.matchIds)].sort();
+    const selectionChanged = incoming.join(",") !== trackerState.selectedMatchIds.join(",");
+
+    const existingSeriesGroupOverrides = trackerState.seriesGroupOverrides ?? [];
+    const seriesGroupsChanged =
+      existingSeriesGroupOverrides.length !== body.seriesGroups.length ||
+      body.seriesGroups.some((group, index) => {
+        const existingGroup = existingSeriesGroupOverrides[index];
+        if (existingGroup == null) {
+          return true;
+        }
+        return (
+          existingGroup.matchIds.join(",") !== group.matchIds.join(",") ||
+          existingGroup.titleOverride !== group.titleOverride ||
+          existingGroup.subtitleOverride !== group.subtitleOverride
+        );
+      });
 
     const knownSummaries = new Map(Object.entries(trackerState.discoveredMatches));
     const needsHydration = incoming.filter((id) => !knownSummaries.has(id));
@@ -765,11 +781,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
 
     const hasHydration = needsHydration.length > 0;
-    const unchanged =
-      !hasHydration &&
-      incoming.join(",") === trackerState.selectedMatchIds.join(",") &&
-      body.seriesGroups.length === 0 &&
-      (trackerState.seriesGroupOverrides?.length ?? 0) === 0;
+    const unchanged = !hasHydration && !selectionChanged && !seriesGroupsChanged;
 
     if (unchanged) {
       return selectMatchesContract.toResponse({ success: true });
@@ -784,19 +796,19 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       }),
     );
 
-    if (trackerState.activeSeries != null) {
+    if (selectionChanged && trackerState.activeSeries != null) {
       const syncedMatchIdSet = new Set(incoming);
       trackerState.activeSeries.matchIds = trackerState.activeSeries.matchIds.filter((id) => syncedMatchIdSet.has(id));
     }
 
-    if (!trackerState.isPaused) {
+    if (selectionChanged && !trackerState.isPaused) {
       delete trackerState.accumulatedPlayerTotals;
       trackerState.accumulatedMatchIds = [];
     }
 
     await this.setState(trackerState);
     this.broadcastViewState(trackerState);
-    if (!trackerState.isPaused) {
+    if (selectionChanged && !trackerState.isPaused) {
       await this.state.storage.setAlarm(Date.now());
     }
 
@@ -908,6 +920,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       }
 
       if (mapNameResult.status === "rejected") {
+        if (this.isAuthError(mapNameResult.reason)) {
+          this.clearUserHaloService();
+          throw mapNameResult.reason;
+        }
         this.logService.warn(
           mapNameResult.reason,
           new Map([

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -809,7 +809,11 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           continue;
         }
         const playerEntry = matchStats.Players.find((p) => getPlayerXuid(p) === trackerState.xuid);
-        const outcome = getMatchOutcomeLabel(playerEntry?.Outcome ?? null);
+        if (playerEntry == null) {
+          failingIds.push(matchId);
+          continue;
+        }
+        const outcome = getMatchOutcomeLabel(playerEntry.Outcome);
         const mapName = await this.resolveMapName(
           matchStats.MatchInfo.MapVariant.AssetId,
           matchStats.MatchInfo.MapVariant.VersionId,

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -743,9 +743,24 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         }
       }
       trackerState.matchIds.sort((left, right) => {
-        const leftSummary = Preconditions.checkExists(trackerState.discoveredMatches[left]);
-        const rightSummary = Preconditions.checkExists(trackerState.discoveredMatches[right]);
-        return compareAsc(new Date(leftSummary.startTime), new Date(rightSummary.startTime));
+        const leftSummary = trackerState.discoveredMatches[left];
+        const rightSummary = trackerState.discoveredMatches[right];
+
+        // Both have summaries - compare by start time
+        if (leftSummary != null && rightSummary != null) {
+          return compareAsc(new Date(leftSummary.startTime), new Date(rightSummary.startTime));
+        }
+
+        // Missing summaries go to the end
+        if (leftSummary == null) {
+          return 1;
+        }
+        if (rightSummary == null) {
+          return -1;
+        }
+
+        // Fallback to string comparison (should not reach here)
+        return left.localeCompare(right);
       });
     }
 
@@ -804,41 +819,57 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     { success: true; summaries: Map<string, IndividualTrackerMatchSummary> } | { success: false; failingIds: string[] }
   > {
     await this.getUserHaloService(trackerState.userId);
-    const failingIds: string[] = [];
-    const summaries = new Map<string, IndividualTrackerMatchSummary>();
 
-    for (const matchId of matchIds) {
+    let matchStatsArray: (MatchStats | null)[];
+
+    try {
+      // Batch fetch all match details at once
+      matchStatsArray = await this.haloService.getMatchDetails(matchIds);
+    } catch (error) {
+      if (this.isAuthError(error)) {
+        this.clearUserHaloService();
+        throw error;
+      }
+      // If batch fetch fails entirely, treat all IDs as failing
+      this.logService.warn(
+        error,
+        new Map([
+          ["context", "IndividualTracker: batch getMatchDetails failed"],
+          ["matchCount", matchIds.length.toString()],
+        ]),
+      );
+      return { success: false, failingIds: matchIds };
+    }
+
+    const failingIds: string[] = [];
+    const validatedMatches: {
+      matchId: string;
+      matchStats: MatchStats;
+      playerEntry: MatchStats["Players"][0];
+    }[] = [];
+
+    // First pass: validate matches
+    for (let i = 0; i < matchIds.length; i++) {
+      const matchId = matchIds[i];
+      if (matchId == null) {
+        continue;
+      }
+
+      const matchStats = matchStatsArray[i];
+
       try {
-        const [matchStats] = await this.haloService.getMatchDetails([matchId]);
         if (matchStats == null) {
           failingIds.push(matchId);
           continue;
         }
+
         const playerEntry = matchStats.Players.find((p) => getPlayerXuid(p) === trackerState.xuid);
         if (playerEntry == null) {
           failingIds.push(matchId);
           continue;
         }
-        const outcome = getMatchOutcomeLabel(playerEntry.Outcome);
-        const mapName = await this.resolveMapName(
-          matchStats.MatchInfo.MapVariant.AssetId,
-          matchStats.MatchInfo.MapVariant.VersionId,
-        );
-        summaries.set(matchId, {
-          matchId,
-          startTime: matchStats.MatchInfo.StartTime,
-          endTime: matchStats.MatchInfo.EndTime,
-          mapAssetId: matchStats.MatchInfo.MapVariant.AssetId,
-          mapVersionId: matchStats.MatchInfo.MapVariant.VersionId,
-          mapName,
-          modeAssetId: matchStats.MatchInfo.UgcGameVariant.AssetId,
-          gameVariantCategory: matchStats.MatchInfo.GameVariantCategory,
-          outcome,
-          score: buildMatchScore(matchStats),
-          isMatchmaking: matchStats.MatchInfo.Playlist != null,
-          teamRosterSignature: buildTeamRosterSignature(matchStats),
-          teamOutcomes: matchStats.Teams.map((team) => team.Outcome),
-        });
+
+        validatedMatches.push({ matchId, matchStats, playerEntry });
       } catch (error) {
         if (this.isAuthError(error)) {
           this.clearUserHaloService();
@@ -847,12 +878,65 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         this.logService.warn(
           error,
           new Map([
-            ["context", "IndividualTracker: hydrateMatchSummaries failed"],
+            ["context", "IndividualTracker: hydrateMatchSummaries validation failed"],
             ["matchId", matchId],
           ]),
         );
         failingIds.push(matchId);
       }
+    }
+
+    // Resolve all map names in parallel for validated matches
+    const mapNamePromises = validatedMatches.map(async (m) =>
+      this.resolveMapName(m.matchStats.MatchInfo.MapVariant.AssetId, m.matchStats.MatchInfo.MapVariant.VersionId),
+    );
+    const mapNameResults = await Promise.allSettled(mapNamePromises);
+
+    // Build final summaries
+    const summaries = new Map<string, IndividualTrackerMatchSummary>();
+
+    for (let i = 0; i < validatedMatches.length; i++) {
+      const validated = validatedMatches[i];
+      if (validated == null) {
+        continue;
+      }
+
+      const { matchId, matchStats, playerEntry } = validated;
+      const mapNameResult = mapNameResults[i];
+      if (mapNameResult == null) {
+        continue;
+      }
+
+      if (mapNameResult.status === "rejected") {
+        this.logService.warn(
+          mapNameResult.reason,
+          new Map([
+            ["context", "IndividualTracker: map name resolution failed"],
+            ["matchId", matchId],
+          ]),
+        );
+        failingIds.push(matchId);
+        continue;
+      }
+
+      const outcome = getMatchOutcomeLabel(playerEntry.Outcome);
+      const mapName = mapNameResult.value;
+
+      summaries.set(matchId, {
+        matchId,
+        startTime: matchStats.MatchInfo.StartTime,
+        endTime: matchStats.MatchInfo.EndTime,
+        mapAssetId: matchStats.MatchInfo.MapVariant.AssetId,
+        mapVersionId: matchStats.MatchInfo.MapVariant.VersionId,
+        mapName,
+        modeAssetId: matchStats.MatchInfo.UgcGameVariant.AssetId,
+        gameVariantCategory: matchStats.MatchInfo.GameVariantCategory,
+        outcome,
+        score: buildMatchScore(matchStats),
+        isMatchmaking: matchStats.MatchInfo.Playlist != null,
+        teamRosterSignature: buildTeamRosterSignature(matchStats),
+        teamOutcomes: matchStats.Teams.map((team) => team.Outcome),
+      });
     }
 
     if (failingIds.length > 0) {

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1005,9 +1005,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
   private buildSeriesGroupComparisonKey(group: IndividualTrackerSeriesGroupOverride): string {
     // Build a deterministic key from the group's content (excluding order)
+    // Use JSON.stringify to preserve distinction between null and "" (contract allows empty strings)
     const matchIdKey = buildSeriesGroupKey(group.matchIds);
-    const titleKey = group.titleOverride ?? "";
-    const subtitleKey = group.subtitleOverride ?? "";
+    const titleKey = JSON.stringify(group.titleOverride);
+    const subtitleKey = JSON.stringify(group.subtitleOverride);
     return `${matchIdKey}:${titleKey}:${subtitleKey}`;
   }
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -34,6 +34,7 @@ import {
   buildTeamRosterSignature,
   getMatchOutcomeLabel,
 } from "@guilty-spark/shared/halo/match-enrichment";
+import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
 import { computeSeriesTeamWins } from "@guilty-spark/shared/halo/series-score";
 import {
   buildSeriesGroupKey,
@@ -56,6 +57,7 @@ import type {
   IndividualTrackerInternalState,
   IndividualTrackerMatchSummary,
   IndividualTrackerSeriesGroup,
+  IndividualTrackerSeriesGroupOverride,
   IndividualTrackerViewState,
   ActiveSeries,
   SeriesTeam,
@@ -720,15 +722,50 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return parsed.response;
     }
     const body = parsed.data;
-    const known = new Set(trackerState.matchIds);
-    const incoming = body.matchIds.filter((id) => known.has(id)).sort();
-    const unchanged = incoming.join(",") === trackerState.selectedMatchIds.join(",");
+    const incoming = [...new Set(body.matchIds)].sort();
+
+    const knownSummaries = new Map(Object.entries(trackerState.discoveredMatches));
+    const needsHydration = incoming.filter((id) => !knownSummaries.has(id));
+
+    if (needsHydration.length > 0) {
+      const hydrationResult = await this.hydrateMatchSummaries(trackerState, needsHydration);
+      if (!hydrationResult.success) {
+        return new Response(
+          JSON.stringify({ error: `Failed to hydrate matches: ${hydrationResult.failingIds.join(", ")}` }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      for (const [matchId, summary] of hydrationResult.summaries) {
+        trackerState.discoveredMatches[matchId] = summary;
+        if (!trackerState.matchIds.includes(matchId)) {
+          trackerState.matchIds.push(matchId);
+        }
+      }
+    }
+
+    const unchanged =
+      incoming.join(",") === trackerState.selectedMatchIds.join(",") &&
+      body.seriesGroups.length === 0 &&
+      (trackerState.seriesGroupOverrides?.length ?? 0) === 0;
 
     if (unchanged) {
       return selectMatchesContract.toResponse({ success: true });
     }
 
     trackerState.selectedMatchIds = incoming;
+    trackerState.seriesGroupOverrides = body.seriesGroups.map(
+      (group): IndividualTrackerSeriesGroupOverride => ({
+        matchIds: [...group.matchIds],
+        titleOverride: group.titleOverride,
+        subtitleOverride: group.subtitleOverride,
+      }),
+    );
+
+    if (trackerState.activeSeries != null) {
+      const syncedMatchIdSet = new Set(incoming);
+      trackerState.activeSeries.matchIds = trackerState.activeSeries.matchIds.filter((id) => syncedMatchIdSet.has(id));
+    }
+
     if (!trackerState.isPaused) {
       delete trackerState.accumulatedPlayerTotals;
       trackerState.accumulatedMatchIds = [];
@@ -745,10 +782,72 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       new Map<string, JsonAny>([
         ["trackerId", trackerState.trackerId],
         ["selectedCount", incoming.length],
+        ["seriesGroupCount", trackerState.seriesGroupOverrides.length],
       ]),
     );
 
     return selectMatchesContract.toResponse({ success: true });
+  }
+
+  private async hydrateMatchSummaries(
+    trackerState: IndividualTrackerInternalState,
+    matchIds: string[],
+  ): Promise<
+    { success: true; summaries: Map<string, IndividualTrackerMatchSummary> } | { success: false; failingIds: string[] }
+  > {
+    await this.getUserHaloService(trackerState.userId);
+    const failingIds: string[] = [];
+    const summaries = new Map<string, IndividualTrackerMatchSummary>();
+
+    for (const matchId of matchIds) {
+      try {
+        const [matchStats] = await this.haloService.getMatchDetails([matchId]);
+        if (matchStats == null) {
+          failingIds.push(matchId);
+          continue;
+        }
+        const playerEntry = matchStats.Players.find((p) => getPlayerXuid(p) === trackerState.xuid);
+        const outcome = getMatchOutcomeLabel(playerEntry?.Outcome ?? null);
+        const mapName = await this.resolveMapName(
+          matchStats.MatchInfo.MapVariant.AssetId,
+          matchStats.MatchInfo.MapVariant.VersionId,
+        );
+        summaries.set(matchId, {
+          matchId,
+          startTime: matchStats.MatchInfo.StartTime,
+          endTime: matchStats.MatchInfo.EndTime,
+          mapAssetId: matchStats.MatchInfo.MapVariant.AssetId,
+          mapVersionId: matchStats.MatchInfo.MapVariant.VersionId,
+          mapName,
+          modeAssetId: matchStats.MatchInfo.UgcGameVariant.AssetId,
+          gameVariantCategory: matchStats.MatchInfo.GameVariantCategory,
+          outcome,
+          score: buildMatchScore(matchStats),
+          isMatchmaking: matchStats.MatchInfo.Playlist != null,
+          teamRosterSignature: buildTeamRosterSignature(matchStats),
+          teamOutcomes: matchStats.Teams.map((team) => team.Outcome),
+        });
+      } catch (error) {
+        if (this.isAuthError(error)) {
+          this.clearUserHaloService();
+          throw error;
+        }
+        this.logService.warn(
+          error,
+          new Map([
+            ["context", "IndividualTracker: hydrateMatchSummaries failed"],
+            ["matchId", matchId],
+          ]),
+        );
+        failingIds.push(matchId);
+      }
+    }
+
+    if (failingIds.length > 0) {
+      return { success: false, failingIds };
+    }
+
+    return { success: true, summaries };
   }
 
   private async handleStartSeries(request: Request): Promise<Response> {
@@ -1080,9 +1179,12 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
       const matchIdSet = new Set(matchIds);
       const seriesContext = allSeriesContexts.find((ctx) => ctx.matchIds.some((id) => matchIdSet.has(id)));
+      const seriesGroupOverride = (state.seriesGroupOverrides ?? []).find((ov) =>
+        ov.matchIds.some((id) => matchIdSet.has(id)),
+      );
 
-      const title = seriesContext?.title ?? defaultTitle;
-      const subtitle = seriesContext?.subtitle ?? defaultSubtitle;
+      const title = seriesContext?.title ?? seriesGroupOverride?.titleOverride ?? defaultTitle;
+      const subtitle = seriesContext?.subtitle ?? seriesGroupOverride?.subtitleOverride ?? defaultSubtitle;
       const guildIconUrl = seriesContext?.guildIconUrl ?? null;
       const teams = seriesContext?.teams;
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -723,14 +723,12 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return parsed.response;
     }
     const body = parsed.data;
+
     const incoming = [...new Set(body.matchIds)].sort();
     const selectionChanged = incoming.join(",") !== trackerState.selectedMatchIds.join(",");
+    const seriesGroupsChanged = this.detectSeriesGroupChanges(trackerState, body.seriesGroups);
 
-    const existingSeriesGroupOverrides = trackerState.seriesGroupOverrides ?? [];
-    const seriesGroupsChanged =
-      existingSeriesGroupOverrides.length !== body.seriesGroups.length ||
-      !this.seriesGroupsAreEquivalent(existingSeriesGroupOverrides, body.seriesGroups);
-
+    // Hydrate any unknown matches
     const knownSummaries = new Map(Object.entries(trackerState.discoveredMatches));
     const needsHydration = incoming.filter((id) => !knownSummaries.has(id));
 
@@ -742,34 +740,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           { status: 400, noStore: true },
         );
       }
-      for (const [matchId, summary] of hydrationResult.summaries) {
-        trackerState.discoveredMatches[matchId] = summary;
-        if (!trackerState.matchIds.includes(matchId)) {
-          trackerState.matchIds.push(matchId);
-        }
-      }
-      trackerState.matchIds.sort((left, right) => {
-        const leftSummary = trackerState.discoveredMatches[left];
-        const rightSummary = trackerState.discoveredMatches[right];
-
-        // Both have summaries - compare by start time
-        if (leftSummary != null && rightSummary != null) {
-          return compareAsc(new Date(leftSummary.startTime), new Date(rightSummary.startTime));
-        }
-
-        // Missing summaries go to the end
-        if (leftSummary == null) {
-          return 1;
-        }
-        if (rightSummary == null) {
-          return -1;
-        }
-
-        // Fallback to string comparison (should not reach here)
-        return left.localeCompare(right);
-      });
+      this.mergeHydratedMatches(trackerState, hydrationResult.summaries);
     }
 
+    // Determine if state needs to be updated
     const hasHydration = needsHydration.length > 0;
     const unchanged = !hasHydration && !selectionChanged && !seriesGroupsChanged;
 
@@ -777,25 +751,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return selectMatchesContract.toResponse({ success: true });
     }
 
-    trackerState.selectedMatchIds = incoming;
-    trackerState.seriesGroupOverrides = body.seriesGroups.map(
-      (group): IndividualTrackerSeriesGroupOverride => ({
-        matchIds: [...group.matchIds],
-        titleOverride: group.titleOverride,
-        subtitleOverride: group.subtitleOverride,
-      }),
-    );
+    // Apply changes to state
+    this.applySelectMatchesChanges(trackerState, incoming, body.seriesGroups, selectionChanged);
 
-    if (selectionChanged && trackerState.activeSeries != null) {
-      const syncedMatchIdSet = new Set(incoming);
-      trackerState.activeSeries.matchIds = trackerState.activeSeries.matchIds.filter((id) => syncedMatchIdSet.has(id));
-    }
-
-    if (selectionChanged && !trackerState.isPaused) {
-      delete trackerState.accumulatedPlayerTotals;
-      trackerState.accumulatedMatchIds = [];
-    }
-
+    // Persist and broadcast
     await this.setState(trackerState);
     this.broadcastViewState(trackerState);
     if (selectionChanged && !trackerState.isPaused) {
@@ -807,11 +766,76 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       new Map<string, JsonAny>([
         ["trackerId", trackerState.trackerId],
         ["selectedCount", incoming.length],
-        ["seriesGroupCount", trackerState.seriesGroupOverrides.length],
+        ["seriesGroupCount", body.seriesGroups.length],
       ]),
     );
 
     return selectMatchesContract.toResponse({ success: true });
+  }
+
+  private detectSeriesGroupChanges(
+    trackerState: IndividualTrackerInternalState,
+    incomingSeriesGroups: IndividualTrackerSeriesGroupOverride[],
+  ): boolean {
+    const existingSeriesGroupOverrides = trackerState.seriesGroupOverrides ?? [];
+    return (
+      existingSeriesGroupOverrides.length !== incomingSeriesGroups.length ||
+      !this.seriesGroupsAreEquivalent(existingSeriesGroupOverrides, incomingSeriesGroups)
+    );
+  }
+
+  private mergeHydratedMatches(
+    trackerState: IndividualTrackerInternalState,
+    hydratedSummaries: Map<string, IndividualTrackerMatchSummary>,
+  ): void {
+    for (const [matchId, summary] of hydratedSummaries) {
+      trackerState.discoveredMatches[matchId] = summary;
+      if (!trackerState.matchIds.includes(matchId)) {
+        trackerState.matchIds.push(matchId);
+      }
+    }
+
+    trackerState.matchIds.sort((left, right) => {
+      const leftSummary = trackerState.discoveredMatches[left];
+      const rightSummary = trackerState.discoveredMatches[right];
+
+      if (leftSummary != null && rightSummary != null) {
+        return compareAsc(new Date(leftSummary.startTime), new Date(rightSummary.startTime));
+      }
+
+      if (leftSummary == null) {
+        return 1;
+      }
+      if (rightSummary == null) {
+        return -1;
+      }
+
+      return left.localeCompare(right);
+    });
+  }
+
+  private applySelectMatchesChanges(
+    trackerState: IndividualTrackerInternalState,
+    incomingMatchIds: string[],
+    incomingSeriesGroups: IndividualTrackerSeriesGroupOverride[],
+    selectionChanged: boolean,
+  ): void {
+    trackerState.selectedMatchIds = incomingMatchIds;
+    trackerState.seriesGroupOverrides = incomingSeriesGroups.map((group) => ({
+      matchIds: [...group.matchIds],
+      titleOverride: group.titleOverride,
+      subtitleOverride: group.subtitleOverride,
+    }));
+
+    if (selectionChanged && trackerState.activeSeries != null) {
+      const syncedMatchIdSet = new Set(incomingMatchIds);
+      trackerState.activeSeries.matchIds = trackerState.activeSeries.matchIds.filter((id) => syncedMatchIdSet.has(id));
+    }
+
+    if (selectionChanged && !trackerState.isPaused) {
+      delete trackerState.accumulatedPlayerTotals;
+      trackerState.accumulatedMatchIds = [];
+    }
   }
 
   private async hydrateMatchSummaries(
@@ -822,7 +846,22 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   > {
     await this.getUserHaloService(trackerState.userId);
 
-    // Fetch each match individually to track per-match failures
+    const matchStatsById = await this.fetchMatchDetailsForIds(matchIds);
+    const validation = this.validateAndCollectMatches(
+      trackerState,
+      matchIds,
+      matchStatsById.failingIds,
+      matchStatsById.summaries,
+    );
+    const mapNameResults = await this.resolveMapNamesForMatches(validation.validatedMatches);
+    const result = this.buildMatchSummaries(validation.validatedMatches, validation.failingIds, mapNameResults);
+
+    return result;
+  }
+
+  private async fetchMatchDetailsForIds(
+    matchIds: string[],
+  ): Promise<{ summaries: Map<string, MatchStats>; failingIds: string[] }> {
     const matchPromises = matchIds.map(async (matchId) =>
       this.haloService.getMatchDetails([matchId]).then((results) => {
         if (results.length === 0) {
@@ -834,8 +873,8 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     const matchResults = await Promise.allSettled(matchPromises);
 
-    const matchStatsById = new Map<string, MatchStats>();
-    const initialFailingIds: string[] = [];
+    const summaries = new Map<string, MatchStats>();
+    const failingIds: string[] = [];
 
     for (let i = 0; i < matchResults.length; i++) {
       const matchId = matchIds[i];
@@ -860,16 +899,32 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
             ["matchId", matchId],
           ]),
         );
-        initialFailingIds.push(matchId);
+        failingIds.push(matchId);
         continue;
       }
 
       const matchStats = result.value;
       if (matchStats != null) {
-        matchStatsById.set(matchId, matchStats);
+        summaries.set(matchId, matchStats);
       }
     }
 
+    return { summaries, failingIds };
+  }
+
+  private validateAndCollectMatches(
+    trackerState: IndividualTrackerInternalState,
+    matchIds: string[],
+    initialFailingIds: string[],
+    matchStatsById: Map<string, MatchStats>,
+  ): {
+    validatedMatches: {
+      matchId: string;
+      matchStats: MatchStats;
+      playerEntry: MatchStats["Players"][0];
+    }[];
+    failingIds: string[];
+  } {
     const failingIds: string[] = [...initialFailingIds];
     const validatedMatches: {
       matchId: string;
@@ -877,7 +932,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       playerEntry: MatchStats["Players"][0];
     }[] = [];
 
-    // First pass: validate matches that were successfully fetched
     for (const matchId of matchIds) {
       if (initialFailingIds.includes(matchId)) {
         continue;
@@ -913,14 +967,35 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       }
     }
 
-    // Resolve all map names in parallel for validated matches
+    return { validatedMatches, failingIds };
+  }
+
+  private async resolveMapNamesForMatches(
+    validatedMatches: {
+      matchId: string;
+      matchStats: MatchStats;
+      playerEntry: MatchStats["Players"][0];
+    }[],
+  ): Promise<PromiseSettledResult<string>[]> {
     const mapNamePromises = validatedMatches.map(async (m) =>
       this.resolveMapName(m.matchStats.MatchInfo.MapVariant.AssetId, m.matchStats.MatchInfo.MapVariant.VersionId),
     );
-    const mapNameResults = await Promise.allSettled(mapNamePromises);
+    return Promise.allSettled(mapNamePromises);
+  }
 
-    // Build final summaries
+  private buildMatchSummaries(
+    validatedMatches: {
+      matchId: string;
+      matchStats: MatchStats;
+      playerEntry: MatchStats["Players"][0];
+    }[],
+    initialFailingIds: string[],
+    mapNameResults: PromiseSettledResult<string>[],
+  ):
+    | { success: true; summaries: Map<string, IndividualTrackerMatchSummary> }
+    | { success: false; failingIds: string[] } {
     const summaries = new Map<string, IndividualTrackerMatchSummary>();
+    const failingIds: string[] = [...initialFailingIds];
 
     for (let i = 0; i < validatedMatches.length; i++) {
       const validated = validatedMatches[i];
@@ -985,11 +1060,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return false;
     }
 
-    // Create normalized key representations for each group
     const existingKeys = new Set(existing.map((group) => this.buildSeriesGroupComparisonKey(group)));
     const incomingKeys = new Set(incoming.map((group) => this.buildSeriesGroupComparisonKey(group)));
 
-    // Check if the sets are the same size and contain the same keys
     if (existingKeys.size !== incomingKeys.size) {
       return false;
     }
@@ -1004,8 +1077,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   }
 
   private buildSeriesGroupComparisonKey(group: IndividualTrackerSeriesGroupOverride): string {
-    // Build a deterministic key from the group's content (excluding order)
-    // Use JSON.stringify to preserve distinction between null and "" (contract allows empty strings)
     const matchIdKey = buildSeriesGroupKey(group.matchIds);
     const titleKey = JSON.stringify(group.titleOverride);
     const subtitleKey = JSON.stringify(group.subtitleOverride);

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -729,17 +729,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     const existingSeriesGroupOverrides = trackerState.seriesGroupOverrides ?? [];
     const seriesGroupsChanged =
       existingSeriesGroupOverrides.length !== body.seriesGroups.length ||
-      body.seriesGroups.some((group, index) => {
-        const existingGroup = existingSeriesGroupOverrides[index];
-        if (existingGroup == null) {
-          return true;
-        }
-        return (
-          buildSeriesGroupKey(existingGroup.matchIds) !== buildSeriesGroupKey(group.matchIds) ||
-          existingGroup.titleOverride !== group.titleOverride ||
-          existingGroup.subtitleOverride !== group.subtitleOverride
-        );
-      });
+      !this.seriesGroupsAreEquivalent(existingSeriesGroupOverrides, body.seriesGroups);
 
     const knownSummaries = new Map(Object.entries(trackerState.discoveredMatches));
     const needsHydration = incoming.filter((id) => !knownSummaries.has(id));
@@ -985,6 +975,40 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
 
     return { success: true, summaries };
+  }
+
+  private seriesGroupsAreEquivalent(
+    existing: IndividualTrackerSeriesGroupOverride[],
+    incoming: IndividualTrackerSeriesGroupOverride[],
+  ): boolean {
+    if (existing.length !== incoming.length) {
+      return false;
+    }
+
+    // Create normalized key representations for each group
+    const existingKeys = new Set(existing.map((group) => this.buildSeriesGroupComparisonKey(group)));
+    const incomingKeys = new Set(incoming.map((group) => this.buildSeriesGroupComparisonKey(group)));
+
+    // Check if the sets are the same size and contain the same keys
+    if (existingKeys.size !== incomingKeys.size) {
+      return false;
+    }
+
+    for (const key of existingKeys) {
+      if (!incomingKeys.has(key)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private buildSeriesGroupComparisonKey(group: IndividualTrackerSeriesGroupOverride): string {
+    // Build a deterministic key from the group's content (excluding order)
+    const matchIdKey = buildSeriesGroupKey(group.matchIds);
+    const titleKey = group.titleOverride ?? "";
+    const subtitleKey = group.subtitleOverride ?? "";
+    return `${matchIdKey}:${titleKey}:${subtitleKey}`;
   }
 
   private async handleStartSeries(request: Request): Promise<Response> {

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -820,7 +820,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   > {
     await this.getUserHaloService(trackerState.userId);
 
-    let matchStatsArray: (MatchStats | null)[];
+    let matchStatsArray: MatchStats[];
 
     try {
       // Batch fetch all match details at once
@@ -841,6 +841,11 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return { success: false, failingIds: matchIds };
     }
 
+    const matchStatsById = new Map<string, MatchStats>();
+    for (const matchStats of matchStatsArray) {
+      matchStatsById.set(matchStats.MatchId, matchStats);
+    }
+
     const failingIds: string[] = [];
     const validatedMatches: {
       matchId: string;
@@ -849,13 +854,8 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }[] = [];
 
     // First pass: validate matches
-    for (let i = 0; i < matchIds.length; i++) {
-      const matchId = matchIds[i];
-      if (matchId == null) {
-        continue;
-      }
-
-      const matchStats = matchStatsArray[i];
+    for (const matchId of matchIds) {
+      const matchStats = matchStatsById.get(matchId);
 
       try {
         if (matchStats == null) {

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -832,41 +832,66 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   > {
     await this.getUserHaloService(trackerState.userId);
 
-    let matchStatsArray: MatchStats[];
+    // Fetch each match individually to track per-match failures
+    const matchPromises = matchIds.map(async (matchId) =>
+      this.haloService.getMatchDetails([matchId]).then((results) => {
+        if (results.length === 0) {
+          throw new Error(`No match details returned for ${matchId}`);
+        }
+        return results[0];
+      }),
+    );
 
-    try {
-      // Batch fetch all match details at once
-      matchStatsArray = await this.haloService.getMatchDetails(matchIds);
-    } catch (error) {
-      if (this.isAuthError(error)) {
-        this.clearUserHaloService();
-        throw error;
-      }
-      // If batch fetch fails entirely, treat all IDs as failing
-      this.logService.warn(
-        error,
-        new Map([
-          ["context", "IndividualTracker: batch getMatchDetails failed"],
-          ["matchCount", matchIds.length.toString()],
-        ]),
-      );
-      return { success: false, failingIds: matchIds };
-    }
+    const matchResults = await Promise.allSettled(matchPromises);
 
     const matchStatsById = new Map<string, MatchStats>();
-    for (const matchStats of matchStatsArray) {
-      matchStatsById.set(matchStats.MatchId, matchStats);
+    const initialFailingIds: string[] = [];
+
+    for (let i = 0; i < matchResults.length; i++) {
+      const matchId = matchIds[i];
+      if (matchId == null) {
+        continue;
+      }
+
+      const result = matchResults[i];
+      if (result == null) {
+        continue;
+      }
+
+      if (result.status === "rejected") {
+        if (this.isAuthError(result.reason)) {
+          this.clearUserHaloService();
+          throw result.reason;
+        }
+        this.logService.warn(
+          result.reason,
+          new Map([
+            ["context", "IndividualTracker: getMatchDetails failed for ID"],
+            ["matchId", matchId],
+          ]),
+        );
+        initialFailingIds.push(matchId);
+        continue;
+      }
+
+      const matchStats = result.value;
+      if (matchStats != null) {
+        matchStatsById.set(matchId, matchStats);
+      }
     }
 
-    const failingIds: string[] = [];
+    const failingIds: string[] = [...initialFailingIds];
     const validatedMatches: {
       matchId: string;
       matchStats: MatchStats;
       playerEntry: MatchStats["Players"][0];
     }[] = [];
 
-    // First pass: validate matches
+    // First pass: validate matches that were successfully fetched
     for (const matchId of matchIds) {
+      if (initialFailingIds.includes(matchId)) {
+        continue;
+      }
       const matchStats = matchStatsById.get(matchId);
 
       try {

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -742,6 +742,11 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           trackerState.matchIds.push(matchId);
         }
       }
+      trackerState.matchIds.sort((left, right) => {
+        const leftSummary = Preconditions.checkExists(trackerState.discoveredMatches[left]);
+        const rightSummary = Preconditions.checkExists(trackerState.discoveredMatches[right]);
+        return compareAsc(new Date(leftSummary.startTime), new Date(rightSummary.startTime));
+      });
     }
 
     const hasHydration = needsHydration.length > 0;

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -763,6 +763,34 @@ describe("IndividualTrackerDO", () => {
       expect(storagePutSpy).not.toHaveBeenCalled();
     });
 
+    it("returns 500 and does not persist when map-name hydration hits an auth error", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: [],
+          discoveredMatches: {},
+        }),
+      );
+      ownerClient.getMatchStats.mockResolvedValueOnce(
+        aFakeMatchStatsWith({
+          MatchId: "m1",
+          Players: [
+            aFakePlayerWith({
+              PlayerId: "fake-xuid",
+              Outcome: 2,
+            }),
+          ],
+        }),
+      );
+      ownerClient.getSpecificAssetVersion.mockRejectedValue(
+        new RequestError(new URL("https://halo"), new Response(null, { status: 401 })),
+      );
+
+      const response = await individualTrackerDO.fetch(selectRequest(["m1"]));
+
+      expect(response.status).toBe(500);
+      expect(storagePutSpy).not.toHaveBeenCalled();
+    });
+
     it("persists seriesGroupOverrides from the request body", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
@@ -916,6 +944,58 @@ describe("IndividualTrackerDO", () => {
       await individualTrackerDO.fetch(selectRequest(["m1"]));
 
       expect(storageSetAlarmSpy).toHaveBeenCalledWith(Date.now());
+    });
+
+    it("persists seriesGroupOverrides without clearing totals when selection is unchanged", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2"],
+          selectedMatchIds: ["m1", "m2"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m2" }),
+          },
+          accumulatedMatchIds: ["m1"],
+          accumulatedPlayerTotals: {
+            kills: 5,
+            deaths: 2,
+            assists: 1,
+            headshotKills: 1,
+            shotsFired: 50,
+            shotsHit: 25,
+            damageDealt: 2000,
+            damageTaken: 1000,
+            totalLifeSeconds: 60,
+            totalSpawns: 2,
+            totalLifeSpawns: 2,
+          },
+        }),
+      );
+
+      await individualTrackerDO.fetch(
+        selectRequest(
+          ["m1", "m2"],
+          [{ matchIds: ["m1", "m2"], titleOverride: "Series Title", subtitleOverride: null }],
+        ),
+      );
+
+      expect(storagePutSpy).toHaveBeenCalledWith(
+        "individualTrackerState",
+        expect.objectContaining({
+          selectedMatchIds: ["m1", "m2"],
+          seriesGroupOverrides: [
+            expect.objectContaining({
+              matchIds: ["m1", "m2"],
+              titleOverride: "Series Title",
+              subtitleOverride: null,
+            }),
+          ],
+          accumulatedMatchIds: ["m1"],
+        }),
+      );
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted).toHaveProperty("accumulatedPlayerTotals");
+      expect(storageSetAlarmSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -666,43 +666,63 @@ describe("IndividualTrackerDO", () => {
     it("hydrates and includes unknown match IDs via the Halo API", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
-          matchIds: ["m2"],
-          discoveredMatches: {
-            m2: aFakeIndividualTrackerMatchSummaryWith({
-              matchId: "m2",
-              startTime: "2024-11-26T12:00:00.000Z",
-            }),
-          },
+          matchIds: [],
+          discoveredMatches: {},
         }),
       );
-      ownerClient.getMatchStats.mockResolvedValueOnce(
-        aFakeMatchStatsWith({
-          MatchId: "m1",
-          MatchInfo: {
-            ...aFakeMatchStatsWith().MatchInfo,
-            StartTime: "2024-11-26T11:00:00.000Z",
-          },
-          Players: [
-            aFakePlayerWith({
-              PlayerId: "fake-xuid",
-              Outcome: 2,
+      ownerClient.getMatchStats.mockImplementation(async (matchId: string) => {
+        if (matchId === "z-match") {
+          return Promise.resolve(
+            aFakeMatchStatsWith({
+              MatchId: "z-match",
+              MatchInfo: {
+                ...aFakeMatchStatsWith().MatchInfo,
+                StartTime: "2024-11-26T10:00:00.000Z",
+              },
+              Players: [
+                aFakePlayerWith({
+                  PlayerId: "fake-xuid",
+                  Outcome: 2,
+                }),
+              ],
             }),
-          ],
-        }),
-      );
+          );
+        }
 
-      const response = await individualTrackerDO.fetch(selectRequest(["m1", "m2"]));
+        if (matchId === "a-match") {
+          return Promise.resolve(
+            aFakeMatchStatsWith({
+              MatchId: "a-match",
+              MatchInfo: {
+                ...aFakeMatchStatsWith().MatchInfo,
+                StartTime: "2024-11-26T12:00:00.000Z",
+              },
+              Players: [
+                aFakePlayerWith({
+                  PlayerId: "fake-xuid",
+                  Outcome: 2,
+                }),
+              ],
+            }),
+          );
+        }
+
+        return Promise.reject(new Error(`Unexpected match ID: ${matchId}`));
+      });
+
+      const response = await individualTrackerDO.fetch(selectRequest(["z-match", "a-match"]));
 
       expect(response.status).toBe(200);
       expect(storagePutSpy).toHaveBeenCalledWith(
         "individualTrackerState",
         expect.objectContaining({
-          selectedMatchIds: ["m1", "m2"],
-          matchIds: ["m1", "m2"],
+          selectedMatchIds: ["a-match", "z-match"],
+          matchIds: ["z-match", "a-match"],
         }),
       );
       const persisted = lastPersistedState(storagePutSpy);
-      expect(persisted.discoveredMatches["m1"]).toBeDefined();
+      expect(persisted.discoveredMatches["z-match"]?.startTime).toBe("2024-11-26T10:00:00.000Z");
+      expect(persisted.discoveredMatches["a-match"]?.startTime).toBe("2024-11-26T12:00:00.000Z");
     });
 
     it("returns 400 and does not persist when hydration fails for an ID", async () => {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -666,14 +666,22 @@ describe("IndividualTrackerDO", () => {
     it("hydrates and includes unknown match IDs via the Halo API", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
-          matchIds: ["m1"],
+          matchIds: ["m2"],
           discoveredMatches: {
-            m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m2",
+              startTime: "2024-11-26T12:00:00.000Z",
+            }),
           },
         }),
       );
       ownerClient.getMatchStats.mockResolvedValueOnce(
         aFakeMatchStatsWith({
+          MatchId: "m1",
+          MatchInfo: {
+            ...aFakeMatchStatsWith().MatchInfo,
+            StartTime: "2024-11-26T11:00:00.000Z",
+          },
           Players: [
             aFakePlayerWith({
               PlayerId: "fake-xuid",
@@ -683,18 +691,18 @@ describe("IndividualTrackerDO", () => {
         }),
       );
 
-      const response = await individualTrackerDO.fetch(selectRequest(["m1", "unknown-id"]));
+      const response = await individualTrackerDO.fetch(selectRequest(["m1", "m2"]));
 
       expect(response.status).toBe(200);
       expect(storagePutSpy).toHaveBeenCalledWith(
         "individualTrackerState",
         expect.objectContaining({
-          selectedMatchIds: ["m1", "unknown-id"],
-          matchIds: expect.arrayContaining(["m1", "unknown-id"]) as string[],
+          selectedMatchIds: ["m1", "m2"],
+          matchIds: ["m1", "m2"],
         }),
       );
       const persisted = lastPersistedState(storagePutSpy);
-      expect(persisted.discoveredMatches["unknown-id"]).toBeDefined();
+      expect(persisted.discoveredMatches["m1"]).toBeDefined();
     });
 
     it("returns 400 and does not persist when hydration fails for an ID", async () => {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1155,7 +1155,7 @@ describe("IndividualTrackerDO", () => {
       expect(storagePutSpy).toHaveBeenCalled();
       // Verify the state was updated with the new override
       const [, updatedState] = storagePutSpy.mock.calls[0] ?? [];
-      expect((updatedState)?.seriesGroupOverrides?.[0]?.titleOverride).toBe("");
+      expect(updatedState?.seriesGroupOverrides?.[0]?.titleOverride).toBe("");
       expect(response.status).toBe(200);
     });
 
@@ -1196,7 +1196,7 @@ describe("IndividualTrackerDO", () => {
       expect(storagePutSpy).toHaveBeenCalled();
       // Verify the state was updated with the new override
       const [, updatedState] = storagePutSpy.mock.calls[0] ?? [];
-      expect((updatedState)?.seriesGroupOverrides?.[0]?.subtitleOverride).toBe("");
+      expect(updatedState?.seriesGroupOverrides?.[0]?.subtitleOverride).toBe("");
       expect(response.status).toBe(200);
     });
   });

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1070,6 +1070,53 @@ describe("IndividualTrackerDO", () => {
       expect(storagePutSpy).not.toHaveBeenCalled();
       expect(storageSetAlarmSpy).not.toHaveBeenCalled();
     });
+
+    it("treats seriesGroupOverrides in different group order as unchanged", async () => {
+      storagePutSpy.mockClear();
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2", "m3", "m4"],
+          selectedMatchIds: ["m1", "m2", "m3", "m4"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m2" }),
+            m3: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m3" }),
+            m4: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m4" }),
+          },
+          seriesGroupOverrides: [
+            { matchIds: ["m1", "m2"], titleOverride: "Group A", subtitleOverride: null },
+            { matchIds: ["m3", "m4"], titleOverride: "Group B", subtitleOverride: null },
+          ],
+          accumulatedMatchIds: ["m1"],
+          accumulatedPlayerTotals: {
+            kills: 5,
+            deaths: 2,
+            assists: 1,
+            headshotKills: 1,
+            shotsFired: 50,
+            shotsHit: 25,
+            damageDealt: 2000,
+            damageTaken: 1000,
+            totalLifeSeconds: 60,
+            totalSpawns: 2,
+            totalLifeSpawns: 2,
+          },
+        }),
+      );
+
+      await individualTrackerDO.fetch(
+        selectRequest(
+          ["m1", "m2", "m3", "m4"],
+          [
+            { matchIds: ["m3", "m4"], titleOverride: "Group B", subtitleOverride: null },
+            { matchIds: ["m1", "m2"], titleOverride: "Group A", subtitleOverride: null },
+          ],
+        ),
+      );
+
+      expect(storagePutSpy).not.toHaveBeenCalled();
+      expect(storageSetAlarmSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("toViewState() selection filtering", () => {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2,7 +2,12 @@ import { describe, beforeEach, it, expect, vi, afterEach } from "vitest";
 import type { MockInstance } from "vitest";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { trackerViewMessageContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
-import { aFakeCoreStatsWith, aFakeMatchStatsWith, aFakeTeamWith } from "@guilty-spark/shared/halo/fakes/data";
+import {
+  aFakeCoreStatsWith,
+  aFakeMatchStatsWith,
+  aFakePlayerWith,
+  aFakeTeamWith,
+} from "@guilty-spark/shared/halo/fakes/data";
 import {
   AssetKind,
   type HaloInfiniteClient,
@@ -667,6 +672,16 @@ describe("IndividualTrackerDO", () => {
           },
         }),
       );
+      ownerClient.getMatchStats.mockResolvedValueOnce(
+        aFakeMatchStatsWith({
+          Players: [
+            aFakePlayerWith({
+              PlayerId: "fake-xuid",
+              Outcome: 2,
+            }),
+          ],
+        }),
+      );
 
       const response = await individualTrackerDO.fetch(selectRequest(["m1", "unknown-id"]));
 
@@ -696,6 +711,27 @@ describe("IndividualTrackerDO", () => {
       expect(response.status).toBe(400);
       const body: { error: string } = await response.json();
       expect(body.error).toContain("bad-id");
+      expect(storagePutSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 and does not persist when hydration cannot find the tracked player", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1"],
+          discoveredMatches: { m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }) },
+        }),
+      );
+      ownerClient.getMatchStats.mockResolvedValueOnce(
+        aFakeMatchStatsWith({
+          Players: [],
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(selectRequest(["m1", "orphaned-match"]));
+
+      expect(response.status).toBe(400);
+      const body: { error: string } = await response.json();
+      expect(body.error).toContain("orphaned-match");
       expect(storagePutSpy).not.toHaveBeenCalled();
     });
 

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1117,6 +1117,88 @@ describe("IndividualTrackerDO", () => {
       expect(storagePutSpy).not.toHaveBeenCalled();
       expect(storageSetAlarmSpy).not.toHaveBeenCalled();
     });
+
+    it("treats null and empty string titleOverride as distinct changes", async () => {
+      storagePutSpy.mockClear();
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2"],
+          selectedMatchIds: ["m1", "m2"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m2" }),
+          },
+          seriesGroupOverrides: [{ matchIds: ["m1", "m2"], titleOverride: null, subtitleOverride: null }],
+          accumulatedMatchIds: ["m1"],
+          accumulatedPlayerTotals: {
+            kills: 5,
+            deaths: 2,
+            assists: 1,
+            headshotKills: 1,
+            shotsFired: 50,
+            shotsHit: 25,
+            damageDealt: 2000,
+            damageTaken: 1000,
+            totalLifeSeconds: 60,
+            totalSpawns: 2,
+            totalLifeSpawns: 2,
+          },
+        }),
+      );
+
+      // Request same matchIds but with empty string override instead of null
+      const response = await individualTrackerDO.fetch(
+        selectRequest(["m1", "m2"], [{ matchIds: ["m1", "m2"], titleOverride: "", subtitleOverride: null }]),
+      );
+
+      // Should detect the change and persist it
+      expect(storagePutSpy).toHaveBeenCalled();
+      // Verify the state was updated with the new override
+      const [, updatedState] = storagePutSpy.mock.calls[0] ?? [];
+      expect((updatedState)?.seriesGroupOverrides?.[0]?.titleOverride).toBe("");
+      expect(response.status).toBe(200);
+    });
+
+    it("treats null and empty string subtitleOverride as distinct changes", async () => {
+      storagePutSpy.mockClear();
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2"],
+          selectedMatchIds: ["m1", "m2"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m2" }),
+          },
+          seriesGroupOverrides: [{ matchIds: ["m1", "m2"], titleOverride: "Title", subtitleOverride: null }],
+          accumulatedMatchIds: ["m1"],
+          accumulatedPlayerTotals: {
+            kills: 5,
+            deaths: 2,
+            assists: 1,
+            headshotKills: 1,
+            shotsFired: 50,
+            shotsHit: 25,
+            damageDealt: 2000,
+            damageTaken: 1000,
+            totalLifeSeconds: 60,
+            totalSpawns: 2,
+            totalLifeSpawns: 2,
+          },
+        }),
+      );
+
+      // Request same group but with empty string subtitle override instead of null
+      const response = await individualTrackerDO.fetch(
+        selectRequest(["m1", "m2"], [{ matchIds: ["m1", "m2"], titleOverride: "Title", subtitleOverride: "" }]),
+      );
+
+      // Should detect the change and persist it
+      expect(storagePutSpy).toHaveBeenCalled();
+      // Verify the state was updated with the new override
+      const [, updatedState] = storagePutSpy.mock.calls[0] ?? [];
+      expect((updatedState)?.seriesGroupOverrides?.[0]?.subtitleOverride).toBe("");
+      expect(response.status).toBe(200);
+    });
   });
 
   describe("toViewState() selection filtering", () => {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -791,6 +791,34 @@ describe("IndividualTrackerDO", () => {
       expect(storagePutSpy).not.toHaveBeenCalled();
     });
 
+    it("reports only failing IDs when batch hydration has partial failures", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: [],
+          discoveredMatches: {},
+        }),
+      );
+      ownerClient.getMatchStats.mockRejectedValueOnce(new Error("Not found")).mockResolvedValueOnce(
+        aFakeMatchStatsWith({
+          MatchId: "m1",
+          Players: [
+            aFakePlayerWith({
+              PlayerId: "fake-xuid",
+              Outcome: 2,
+            }),
+          ],
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(selectRequest(["bad-id", "m1"]));
+
+      expect(response.status).toBe(400);
+      const body: { error: string } = await response.json();
+      expect(body.error).toContain("bad-id");
+      expect(body.error).not.toContain("m1");
+      expect(storagePutSpy).not.toHaveBeenCalled();
+    });
+
     it("persists seriesGroupOverrides from the request body", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -600,11 +600,11 @@ describe("IndividualTrackerDO", () => {
   });
 
   describe("handleSelectMatches()", () => {
-    const selectRequest = (matchIds: string[]): Request =>
+    const selectRequest = (matchIds: string[], seriesGroups: unknown[] = []): Request =>
       new Request("http://do/select-matches", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ matchIds }),
+        body: JSON.stringify({ matchIds, seriesGroups }),
       });
 
     it("returns 404 when no state exists", async () => {
@@ -616,7 +616,15 @@ describe("IndividualTrackerDO", () => {
     });
 
     it("sets selectedMatchIds from the request body and returns success", async () => {
-      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ matchIds: ["match-1", "match-2"] }));
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["match-1", "match-2"],
+          discoveredMatches: {
+            "match-1": aFakeIndividualTrackerMatchSummaryWith({ matchId: "match-1" }),
+            "match-2": aFakeIndividualTrackerMatchSummaryWith({ matchId: "match-2" }),
+          },
+        }),
+      );
 
       const response = await individualTrackerDO.fetch(selectRequest(["match-2"]));
 
@@ -631,7 +639,15 @@ describe("IndividualTrackerDO", () => {
 
     it("replaces an existing selectedMatchIds with the new list", async () => {
       storageGetSpy.mockResolvedValue(
-        aFakeIndividualTrackerInternalStateWith({ matchIds: ["m1", "m2", "m3"], selectedMatchIds: ["m1", "m2"] }),
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2", "m3"],
+          selectedMatchIds: ["m1", "m2"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m2" }),
+            m3: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m3" }),
+          },
+        }),
       );
 
       await individualTrackerDO.fetch(selectRequest(["m2", "m3"]));
@@ -642,14 +658,144 @@ describe("IndividualTrackerDO", () => {
       );
     });
 
-    it("filters out matchIds that are not in the known matchIds list", async () => {
-      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ matchIds: ["m1", "m2"] }));
+    it("hydrates and includes unknown match IDs via the Halo API", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }),
+          },
+        }),
+      );
 
-      await individualTrackerDO.fetch(selectRequest(["m1", "unknown-id"]));
+      const response = await individualTrackerDO.fetch(selectRequest(["m1", "unknown-id"]));
+
+      expect(response.status).toBe(200);
+      expect(storagePutSpy).toHaveBeenCalledWith(
+        "individualTrackerState",
+        expect.objectContaining({
+          selectedMatchIds: ["m1", "unknown-id"],
+          matchIds: expect.arrayContaining(["m1", "unknown-id"]) as string[],
+        }),
+      );
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.discoveredMatches["unknown-id"]).toBeDefined();
+    });
+
+    it("returns 400 and does not persist when hydration fails for an ID", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1"],
+          discoveredMatches: { m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }) },
+        }),
+      );
+      ownerClient.getMatchStats.mockRejectedValueOnce(new Error("Match not found"));
+
+      const response = await individualTrackerDO.fetch(selectRequest(["m1", "bad-id"]));
+
+      expect(response.status).toBe(400);
+      const body: { error: string } = await response.json();
+      expect(body.error).toContain("bad-id");
+      expect(storagePutSpy).not.toHaveBeenCalled();
+    });
+
+    it("persists seriesGroupOverrides from the request body", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2", "m3", "m4"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m2" }),
+            m3: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m3" }),
+            m4: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m4" }),
+          },
+        }),
+      );
+
+      await individualTrackerDO.fetch(
+        selectRequest(
+          ["m1", "m2", "m3", "m4"],
+          [
+            { matchIds: ["m1", "m2"], titleOverride: "Custom Title", subtitleOverride: "Custom Sub" },
+            { matchIds: ["m3", "m4"], titleOverride: null, subtitleOverride: null },
+          ],
+        ),
+      );
 
       expect(storagePutSpy).toHaveBeenCalledWith(
         "individualTrackerState",
-        expect.objectContaining({ selectedMatchIds: ["m1"] }),
+        expect.objectContaining({
+          seriesGroupOverrides: [
+            { matchIds: ["m1", "m2"], titleOverride: "Custom Title", subtitleOverride: "Custom Sub" },
+            { matchIds: ["m3", "m4"], titleOverride: null, subtitleOverride: null },
+          ],
+        }),
+      );
+    });
+
+    it("reconciles activeSeries matchIds by intersection with synced matchIds", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2", "m3"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m2" }),
+            m3: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m3" }),
+          },
+          activeSeries: {
+            title: "Series Title",
+            subtitle: "Series Sub",
+            guildIconUrl: null,
+            teams: [],
+            matchIds: ["m1", "m2", "m3"],
+            startedAt: new Date().toISOString(),
+            isActive: true,
+          },
+        }),
+      );
+
+      await individualTrackerDO.fetch(selectRequest(["m1", "m2"]));
+
+      expect(storagePutSpy).toHaveBeenCalledWith(
+        "individualTrackerState",
+        expect.objectContaining({
+          activeSeries: expect.objectContaining({ matchIds: ["m1", "m2"] }) as ActiveSeries,
+        }),
+      );
+    });
+
+    it("does not mutate activeSeries title or subtitle during sync", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m2" }),
+          },
+          activeSeries: {
+            title: "Kept Title",
+            subtitle: "Kept Sub",
+            guildIconUrl: null,
+            teams: [],
+            matchIds: ["m1", "m2"],
+            startedAt: new Date().toISOString(),
+            isActive: true,
+          },
+        }),
+      );
+
+      await individualTrackerDO.fetch(
+        selectRequest(
+          ["m1", "m2"],
+          [{ matchIds: ["m1", "m2"], titleOverride: "Override Title", subtitleOverride: null }],
+        ),
+      );
+
+      expect(storagePutSpy).toHaveBeenCalledWith(
+        "individualTrackerState",
+        expect.objectContaining({
+          activeSeries: expect.objectContaining({ title: "Kept Title", subtitle: "Kept Sub" }) as ActiveSeries,
+        }),
       );
     });
 
@@ -658,6 +804,10 @@ describe("IndividualTrackerDO", () => {
         aFakeIndividualTrackerInternalStateWith({
           matchIds: ["m1", "m2"],
           selectedMatchIds: ["m1"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m2" }),
+          },
           accumulatedMatchIds: ["m1"],
           accumulatedPlayerTotals: {
             kills: 5,
@@ -689,7 +839,15 @@ describe("IndividualTrackerDO", () => {
     });
 
     it("schedules an immediate alarm after selection changes", async () => {
-      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ matchIds: ["m1", "m2"] }));
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m2" }),
+          },
+        }),
+      );
 
       await individualTrackerDO.fetch(selectRequest(["m1"]));
 
@@ -759,6 +917,75 @@ describe("IndividualTrackerDO", () => {
 
       expect(body.state?.matches).toHaveLength(1);
       expect(body.state?.matches[0]?.matchId).toBe("m2");
+    });
+
+    it("applies seriesGroupOverride title and subtitle to series when no active/completed series context", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2"],
+          selectedMatchIds: ["m1", "m2"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m1",
+              teamRosterSignature: "0:1|1:2",
+              teamOutcomes: [2, 3],
+            }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m2",
+              teamRosterSignature: "0:1|1:2",
+              teamOutcomes: [2, 3],
+            }),
+          },
+          seriesGroupOverrides: [
+            { matchIds: ["m1", "m2"], titleOverride: "Custom Series", subtitleOverride: "Custom Sub" },
+          ],
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect(body.state?.series[0]?.title).toBe("Custom Series");
+      expect(body.state?.series[0]?.subtitle).toBe("Custom Sub");
+    });
+
+    it("active series title takes precedence over seriesGroupOverride title", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2"],
+          selectedMatchIds: ["m1", "m2"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m1",
+              teamRosterSignature: "0:1|1:2",
+              teamOutcomes: [2, 3],
+            }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m2",
+              teamRosterSignature: "0:1|1:2",
+              teamOutcomes: [2, 3],
+            }),
+          },
+          activeSeries: {
+            title: "Active Series Title",
+            subtitle: "Active Sub",
+            guildIconUrl: null,
+            teams: [],
+            matchIds: ["m1", "m2"],
+            startedAt: new Date().toISOString(),
+            isActive: true,
+          },
+          seriesGroupOverrides: [
+            { matchIds: ["m1", "m2"], titleOverride: "Override Title", subtitleOverride: "Override Sub" },
+          ],
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect(body.state?.series[0]?.title).toBe("Active Series Title");
+      expect(body.state?.series[0]?.subtitle).toBe("Active Sub");
     });
   });
 

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -997,6 +997,51 @@ describe("IndividualTrackerDO", () => {
       expect(persisted).toHaveProperty("accumulatedPlayerTotals");
       expect(storageSetAlarmSpy).not.toHaveBeenCalled();
     });
+
+    it("treats seriesGroupOverrides with different matchId orderings as unchanged", async () => {
+      storagePutSpy.mockClear();
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2"],
+          selectedMatchIds: ["m1", "m2"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m1" }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({ matchId: "m2" }),
+          },
+          seriesGroupOverrides: [
+            {
+              matchIds: ["m1", "m2"],
+              titleOverride: "Series Title",
+              subtitleOverride: null,
+            },
+          ],
+          accumulatedMatchIds: ["m1"],
+          accumulatedPlayerTotals: {
+            kills: 5,
+            deaths: 2,
+            assists: 1,
+            headshotKills: 1,
+            shotsFired: 50,
+            shotsHit: 25,
+            damageDealt: 2000,
+            damageTaken: 1000,
+            totalLifeSeconds: 60,
+            totalSpawns: 2,
+            totalLifeSpawns: 2,
+          },
+        }),
+      );
+
+      await individualTrackerDO.fetch(
+        selectRequest(
+          ["m1", "m2"],
+          [{ matchIds: ["m2", "m1"], titleOverride: "Series Title", subtitleOverride: null }],
+        ),
+      );
+
+      expect(storagePutSpy).not.toHaveBeenCalled();
+      expect(storageSetAlarmSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("toViewState() selection filtering", () => {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -973,7 +973,7 @@ describe("IndividualTrackerDO", () => {
             }),
           },
           seriesGroupOverrides: [
-            { matchIds: ["m1", "m2"], titleOverride: "Custom Series", subtitleOverride: "Custom Sub" },
+            { matchIds: ["m2", "m1"], titleOverride: "Custom Series", subtitleOverride: "Custom Sub" },
           ],
         }),
       );
@@ -983,6 +983,46 @@ describe("IndividualTrackerDO", () => {
 
       expect(body.state?.series[0]?.title).toBe("Custom Series");
       expect(body.state?.series[0]?.subtitle).toBe("Custom Sub");
+    });
+
+    it("does not apply a seriesGroupOverride to a non-matching group with overlapping matchIds", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2", "m3", "m4"],
+          selectedMatchIds: ["m1", "m2", "m3", "m4"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m1",
+              teamRosterSignature: "0:1|1:2",
+              teamOutcomes: [2, 3],
+            }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m2",
+              teamRosterSignature: "0:1|1:2",
+              teamOutcomes: [2, 3],
+            }),
+            m3: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m3",
+              teamRosterSignature: "0:1|1:2",
+              teamOutcomes: [2, 3],
+            }),
+            m4: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m4",
+              teamRosterSignature: "0:1|1:2",
+              teamOutcomes: [2, 3],
+            }),
+          },
+          seriesGroupOverrides: [
+            { matchIds: ["m1", "m2", "m3"], titleOverride: "Overlapping Override", subtitleOverride: "Bad Match" },
+          ],
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect(body.state?.series.map((series) => series.title)).not.toContain("Overlapping Override");
+      expect(body.state?.series.map((series) => series.subtitle)).not.toContain("Bad Match");
     });
 
     it("active series title takes precedence over seriesGroupOverride title", async () => {

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -106,6 +106,7 @@ export interface IndividualTrackerInternalState extends IndividualTrackerState {
   accumulatedMatchIds?: string[];
   activeSeries?: ActiveSeries;
   completedSeries?: ActiveSeries[];
+  seriesGroupOverrides?: IndividualTrackerSeriesGroupOverride[];
   errorState: {
     consecutiveErrors: number;
     backoffMinutes: number;
@@ -134,6 +135,12 @@ export interface IndividualTrackerEditSeriesRequest {
 
 export interface IndividualTrackerStartSeriesResponse {
   success: true;
+}
+
+export interface IndividualTrackerSeriesGroupOverride {
+  matchIds: string[];
+  titleOverride: string | null;
+  subtitleOverride: string | null;
 }
 
 export interface IndividualTrackerSelectMatchesRequest {

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -145,6 +145,7 @@ export interface IndividualTrackerSeriesGroupOverride {
 
 export interface IndividualTrackerSelectMatchesRequest {
   matchIds: string[];
+  seriesGroups?: IndividualTrackerSeriesGroupOverride[];
 }
 
 export interface IndividualTrackerSelectMatchesResponse {


### PR DESCRIPTION
## Summary

Second increment of the game-sync + DO consistency plan.

### Changes
- **New type** `IndividualTrackerSeriesGroupOverride` and `seriesGroupOverrides` field on `IndividualTrackerInternalState`
- **Atomic sync**: `handleSelectMatches` now hydrates unknown match IDs via the Halo API before persisting. If any ID fails to resolve, the entire sync is rejected with a 400 and the failing IDs are included in the error message.
- **Series-group overrides**: `seriesGroups` from the sync request body are persisted as `seriesGroupOverrides` and applied as title/subtitle in `toViewState` composition. Active/completed series context takes precedence.
- **Active-series reconciliation**: during sync, `activeSeries.matchIds` is pruned to the intersection with the synced `matchIds`. Title, subtitle, teams are not mutated.
- Updated and expanded `handleSelectMatches` tests; added `toViewState` series-group override tests.

### Plan reference
Delivery step 2: DO sync semantics (atomic full-sync replacement + series-group override persistence + active-series reconciliation).