### PR TITLE
Game selection preload and grouping fixes

### DIFF
--- a/api/routes/individual-tracker/mapper.ts
+++ b/api/routes/individual-tracker/mapper.ts
@@ -127,7 +127,6 @@ export function toTrackerView(
     lastMatchDiscoveredAt: doState == null ? null : doState.lastMatchDiscoveredAt,
     hasActiveSeries: doState?.hasActiveSeries ?? false,
     hasRecentCompletedSeries: doState?.hasRecentCompletedSeries ?? false,
-    ...(doState?.searchStartTime !== undefined ? { searchStartTime: doState.searchStartTime } : {}),
     ...(doState?.activeSeriesContext !== undefined ? { activeSeriesContext: doState.activeSeriesContext } : {}),
     ...(doState?.topBarStats != null ? { topBarStats: [...doState.topBarStats] } : {}),
   };

--- a/api/routes/individual-tracker/mapper.ts
+++ b/api/routes/individual-tracker/mapper.ts
@@ -127,6 +127,7 @@ export function toTrackerView(
     lastMatchDiscoveredAt: doState == null ? null : doState.lastMatchDiscoveredAt,
     hasActiveSeries: doState?.hasActiveSeries ?? false,
     hasRecentCompletedSeries: doState?.hasRecentCompletedSeries ?? false,
+    ...(doState?.searchStartTime !== undefined ? { searchStartTime: doState.searchStartTime } : {}),
     ...(doState?.activeSeriesContext !== undefined ? { activeSeriesContext: doState.activeSeriesContext } : {}),
     ...(doState?.topBarStats != null ? { topBarStats: [...doState.topBarStats] } : {}),
   };

--- a/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
+++ b/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
@@ -64,7 +64,6 @@ function LiveTrackersSectionInternal({
               initialGroupings={snapshot.gameSelectionDialogState.initialGroupings}
               initialSeriesGroups={snapshot.gameSelectionDialogState.initialSeriesGroups}
               searchStartTime={snapshot.gameSelectionDialogState.searchStartTime}
-              activeSeriesContext={snapshot.gameSelectionDialogState.activeSeriesContext}
               hasActiveSeriesWarning={snapshot.gameSelectionDialogState.hasActiveSeriesWarning}
               onClose={(): void => {
                 controller.closeGameSelectionDialog();

--- a/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
+++ b/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
@@ -65,6 +65,7 @@ function LiveTrackersSectionInternal({
               initialSeriesGroups={snapshot.gameSelectionDialogState.initialSeriesGroups}
               searchStartTime={snapshot.gameSelectionDialogState.searchStartTime}
               activeSeriesContext={snapshot.gameSelectionDialogState.activeSeriesContext}
+              hasActiveSeriesWarning={snapshot.gameSelectionDialogState.hasActiveSeriesWarning}
               onClose={(): void => {
                 controller.closeGameSelectionDialog();
               }}

--- a/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
+++ b/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
@@ -63,6 +63,8 @@ function LiveTrackersSectionInternal({
               initialSelectedMatchIds={snapshot.gameSelectionDialogState.initialSelectedMatchIds}
               initialGroupings={snapshot.gameSelectionDialogState.initialGroupings}
               initialSeriesGroups={snapshot.gameSelectionDialogState.initialSeriesGroups}
+              searchStartTime={snapshot.gameSelectionDialogState.searchStartTime}
+              activeSeriesContext={snapshot.gameSelectionDialogState.activeSeriesContext}
               onClose={(): void => {
                 controller.closeGameSelectionDialog();
               }}

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -651,8 +651,11 @@ export class LiveTrackersPresenter {
       initialGroupings: liveView?.series.map((s) => s.matchIds) ?? [],
       initialSeriesGroups:
         liveView?.series.map((s) => ({ matchIds: s.matchIds, titleOverride: null, subtitleOverride: null })) ?? [],
-      ...(liveView?.searchStartTime !== undefined ? { searchStartTime: liveView.searchStartTime } : {}),
+      ...(liveView?.matches != null && liveView.matches.length > 0
+        ? { searchStartTime: liveView.matches[0]?.startTime }
+        : {}),
       ...(liveView?.activeSeriesContext !== undefined ? { activeSeriesContext: liveView.activeSeriesContext } : {}),
+      hasActiveSeriesWarning: item.hasActiveSeries,
     };
     this.updateSnapshot((s) => ({ ...s, gameSelectionDialogState: dialogState }));
   }

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -651,10 +651,11 @@ export class LiveTrackersPresenter {
       initialGroupings: liveView?.series.map((s) => s.matchIds) ?? [],
       initialSeriesGroups:
         liveView?.series.map((s) => ({ matchIds: s.matchIds, titleOverride: null, subtitleOverride: null })) ?? [],
-      ...(liveView?.matches != null && liveView.matches.length > 0
-        ? { searchStartTime: liveView.matches[0]?.startTime }
-        : {}),
-      ...(liveView?.activeSeriesContext !== undefined ? { activeSeriesContext: liveView.activeSeriesContext } : {}),
+      ...(liveView?.searchStartTime !== undefined
+        ? { searchStartTime: liveView.searchStartTime }
+        : liveView?.matches != null && liveView.matches.length > 0
+          ? { searchStartTime: liveView.matches[0]?.startTime }
+          : {}),
       hasActiveSeriesWarning: item.hasActiveSeries,
     };
     this.updateSnapshot((s) => ({ ...s, gameSelectionDialogState: dialogState }));

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -651,6 +651,8 @@ export class LiveTrackersPresenter {
       initialGroupings: liveView?.series.map((s) => s.matchIds) ?? [],
       initialSeriesGroups:
         liveView?.series.map((s) => ({ matchIds: s.matchIds, titleOverride: null, subtitleOverride: null })) ?? [],
+      ...(liveView?.searchStartTime !== undefined ? { searchStartTime: liveView.searchStartTime } : {}),
+      ...(liveView?.activeSeriesContext !== undefined ? { activeSeriesContext: liveView.activeSeriesContext } : {}),
     };
     this.updateSnapshot((s) => ({ ...s, gameSelectionDialogState: dialogState }));
   }

--- a/pages/src/components/individual-tracker-manager/types.ts
+++ b/pages/src/components/individual-tracker-manager/types.ts
@@ -1,4 +1,3 @@
-import type { TrackerLiveView } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { IndividualTrackerSeriesGroup } from "../individual-tracker/series-group-metadata";
 import type { SeriesInitialData } from "../individual-tracker/manual-series-dialog/manual-series-dialog-store";
 
@@ -10,7 +9,6 @@ export interface GameSelectionDialogState {
   readonly initialGroupings: readonly (readonly string[])[];
   readonly initialSeriesGroups: readonly IndividualTrackerSeriesGroup[];
   readonly searchStartTime?: string;
-  readonly activeSeriesContext?: NonNullable<TrackerLiveView["activeSeriesContext"]>;
   readonly hasActiveSeriesWarning?: boolean;
 }
 

--- a/pages/src/components/individual-tracker-manager/types.ts
+++ b/pages/src/components/individual-tracker-manager/types.ts
@@ -1,3 +1,4 @@
+import type { TrackerLiveView } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { IndividualTrackerSeriesGroup } from "../individual-tracker/series-group-metadata";
 import type { SeriesInitialData } from "../individual-tracker/manual-series-dialog/manual-series-dialog-store";
 
@@ -9,11 +10,7 @@ export interface GameSelectionDialogState {
   readonly initialGroupings: readonly (readonly string[])[];
   readonly initialSeriesGroups: readonly IndividualTrackerSeriesGroup[];
   readonly searchStartTime?: string;
-  readonly activeSeriesContext?: {
-    readonly title: string;
-    readonly subtitle: string | null;
-    readonly teams: readonly unknown[];
-  };
+  readonly activeSeriesContext?: NonNullable<TrackerLiveView["activeSeriesContext"]>;
 }
 
 export interface ManualSeriesDialogState {

--- a/pages/src/components/individual-tracker-manager/types.ts
+++ b/pages/src/components/individual-tracker-manager/types.ts
@@ -8,6 +8,12 @@ export interface GameSelectionDialogState {
   readonly initialSelectedMatchIds: readonly string[];
   readonly initialGroupings: readonly (readonly string[])[];
   readonly initialSeriesGroups: readonly IndividualTrackerSeriesGroup[];
+  readonly searchStartTime?: string;
+  readonly activeSeriesContext?: {
+    readonly title: string;
+    readonly subtitle: string | null;
+    readonly teams: readonly unknown[];
+  };
 }
 
 export interface ManualSeriesDialogState {

--- a/pages/src/components/individual-tracker-manager/types.ts
+++ b/pages/src/components/individual-tracker-manager/types.ts
@@ -11,6 +11,7 @@ export interface GameSelectionDialogState {
   readonly initialSeriesGroups: readonly IndividualTrackerSeriesGroup[];
   readonly searchStartTime?: string;
   readonly activeSeriesContext?: NonNullable<TrackerLiveView["activeSeriesContext"]>;
+  readonly hasActiveSeriesWarning?: boolean;
 }
 
 export interface ManualSeriesDialogState {

--- a/pages/src/components/individual-tracker/game-selection-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/game-selection-dialog/create.tsx
@@ -13,6 +13,12 @@ export interface GameSelectionDialogSectionProps {
   readonly initialSelectedMatchIds: readonly string[];
   readonly initialGroupings: readonly (readonly string[])[];
   readonly initialSeriesGroups: readonly IndividualTrackerSeriesGroup[];
+  readonly searchStartTime?: string;
+  readonly activeSeriesContext?: {
+    readonly title: string;
+    readonly subtitle: string | null;
+    readonly teams: readonly unknown[];
+  };
   readonly onClose: () => void;
   readonly onSynced: () => void;
   readonly individualTrackerService: IndividualTrackerService;
@@ -26,6 +32,8 @@ export function GameSelectionDialogSection({
   initialSelectedMatchIds,
   initialGroupings,
   initialSeriesGroups,
+  searchStartTime,
+  activeSeriesContext,
   onClose,
   onSynced,
   individualTrackerService,
@@ -45,11 +53,23 @@ export function GameSelectionDialogSection({
         initialSelectedMatchIds,
         initialGroupings,
         initialSeriesGroups,
+        searchStartTime,
+        activeSeriesContext,
         onSynced: (): void => {
           onSyncedRef.current();
         },
       }),
-    [store, individualTrackerService, trackerId, xuid, initialSelectedMatchIds, initialGroupings, initialSeriesGroups],
+    [
+      store,
+      individualTrackerService,
+      trackerId,
+      xuid,
+      initialSelectedMatchIds,
+      initialGroupings,
+      initialSeriesGroups,
+      searchStartTime,
+      activeSeriesContext,
+    ],
   );
 
   useEffect(() => {
@@ -89,6 +109,7 @@ export function GameSelectionDialogSection({
       selectedMatchIds={snapshot.selectedMatchIds}
       hasMore={snapshot.hasMore}
       hideShortGames={snapshot.hideShortGames}
+      hasActiveSeriesWarning={snapshot.hasActiveSeriesWarning}
       onClose={onClose}
       onSyncAndClose={handleSyncAndClose}
       onMatchToggle={(matchId): void => {

--- a/pages/src/components/individual-tracker/game-selection-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/game-selection-dialog/create.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
-import type { TrackerLiveView } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
 import type { IndividualTrackerSeriesGroup } from "../series-group-metadata";
 import { GameSelectionDialogPresenter } from "./game-selection-dialog-presenter";
@@ -15,7 +14,6 @@ export interface GameSelectionDialogSectionProps {
   readonly initialGroupings: readonly (readonly string[])[];
   readonly initialSeriesGroups: readonly IndividualTrackerSeriesGroup[];
   readonly searchStartTime?: string;
-  readonly activeSeriesContext?: NonNullable<TrackerLiveView["activeSeriesContext"]>;
   readonly hasActiveSeriesWarning?: boolean;
   readonly onClose: () => void;
   readonly onSynced: () => void;
@@ -31,7 +29,6 @@ export function GameSelectionDialogSection({
   initialGroupings,
   initialSeriesGroups,
   searchStartTime,
-  activeSeriesContext,
   hasActiveSeriesWarning,
   onClose,
   onSynced,
@@ -53,7 +50,6 @@ export function GameSelectionDialogSection({
         initialGroupings,
         initialSeriesGroups,
         searchStartTime,
-        activeSeriesContext,
         hasActiveSeriesWarning,
         onSynced: (): void => {
           onSyncedRef.current();
@@ -68,7 +64,6 @@ export function GameSelectionDialogSection({
       initialGroupings,
       initialSeriesGroups,
       searchStartTime,
-      activeSeriesContext,
       hasActiveSeriesWarning,
     ],
   );

--- a/pages/src/components/individual-tracker/game-selection-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/game-selection-dialog/create.tsx
@@ -16,6 +16,7 @@ export interface GameSelectionDialogSectionProps {
   readonly initialSeriesGroups: readonly IndividualTrackerSeriesGroup[];
   readonly searchStartTime?: string;
   readonly activeSeriesContext?: NonNullable<TrackerLiveView["activeSeriesContext"]>;
+  readonly hasActiveSeriesWarning?: boolean;
   readonly onClose: () => void;
   readonly onSynced: () => void;
   readonly individualTrackerService: IndividualTrackerService;
@@ -31,6 +32,7 @@ export function GameSelectionDialogSection({
   initialSeriesGroups,
   searchStartTime,
   activeSeriesContext,
+  hasActiveSeriesWarning,
   onClose,
   onSynced,
   individualTrackerService,
@@ -52,6 +54,7 @@ export function GameSelectionDialogSection({
         initialSeriesGroups,
         searchStartTime,
         activeSeriesContext,
+        hasActiveSeriesWarning,
         onSynced: (): void => {
           onSyncedRef.current();
         },
@@ -66,6 +69,7 @@ export function GameSelectionDialogSection({
       initialSeriesGroups,
       searchStartTime,
       activeSeriesContext,
+      hasActiveSeriesWarning,
     ],
   );
 

--- a/pages/src/components/individual-tracker/game-selection-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/game-selection-dialog/create.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import type { TrackerLiveView } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
 import type { IndividualTrackerSeriesGroup } from "../series-group-metadata";
 import { GameSelectionDialogPresenter } from "./game-selection-dialog-presenter";
@@ -14,11 +15,7 @@ export interface GameSelectionDialogSectionProps {
   readonly initialGroupings: readonly (readonly string[])[];
   readonly initialSeriesGroups: readonly IndividualTrackerSeriesGroup[];
   readonly searchStartTime?: string;
-  readonly activeSeriesContext?: {
-    readonly title: string;
-    readonly subtitle: string | null;
-    readonly teams: readonly unknown[];
-  };
+  readonly activeSeriesContext?: NonNullable<TrackerLiveView["activeSeriesContext"]>;
   readonly onClose: () => void;
   readonly onSynced: () => void;
   readonly individualTrackerService: IndividualTrackerService;

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
@@ -13,6 +13,12 @@ interface Config {
   readonly initialSelectedMatchIds: readonly string[];
   readonly initialGroupings: readonly (readonly string[])[];
   readonly initialSeriesGroups: readonly IndividualTrackerSeriesGroup[];
+  readonly searchStartTime?: string;
+  readonly activeSeriesContext?: {
+    readonly title: string;
+    readonly subtitle: string | null;
+    readonly teams: readonly unknown[];
+  };
   readonly onSynced: () => void;
 }
 
@@ -43,6 +49,7 @@ export class GameSelectionDialogPresenter {
       hasMore: false,
       hideShortGames: true,
       isSyncing: false,
+      hasActiveSeriesWarning: false,
       errorMessage: null,
     });
 
@@ -50,19 +57,61 @@ export class GameSelectionDialogPresenter {
   }
 
   private async loadMatchesAsync(): Promise<void> {
-    const { store, service, xuid } = this.config;
+    const { store, service, xuid, initialSelectedMatchIds, searchStartTime, activeSeriesContext } = this.config;
     try {
-      const response = await service.getMatchHistory(xuid, 0, 25);
-      if (this.isDisposed) {
-        return;
+      const allLoadedMatches: unknown[] = [];
+      const maxPages = 4;
+      const pageSize = 25;
+      const targetMatchIds = new Set(initialSelectedMatchIds);
+      const searchStartTimeMs = searchStartTime != null ? new Date(searchStartTime).getTime() : 0;
+
+      // Load pages until all initial matches are found, we've covered searchStartTime, or we reach max pages
+      for (let pageIndex = 0; pageIndex < maxPages; pageIndex++) {
+        const offset = pageIndex * pageSize;
+        const response = await service.getMatchHistory(xuid, offset, pageSize);
+
+        if (this.isDisposed) {
+          return;
+        }
+
+        allLoadedMatches.push(...response.matches);
+
+        // Check if all target matches are now loaded
+        const loadedMatchIds = new Set(allLoadedMatches.map((m: unknown) => (m as { matchId: string }).matchId));
+        const allFound = Array.from(targetMatchIds).every((id) => loadedMatchIds.has(id));
+
+        // Check if we've covered the searchStartTime boundary (if provided)
+        const reachedSearchBoundary =
+          searchStartTimeMs === 0 ||
+          response.matches.length === 0 ||
+          response.matches.some(
+            (m: unknown) => new Date((m as { startTime: string }).startTime).getTime() < searchStartTimeMs,
+          );
+
+        // Stop early if all matches found AND we've reached the search boundary, or if we got fewer than pageSize (end of history)
+        if ((allFound && reachedSearchBoundary) || response.matches.length < pageSize) {
+          const snapshot = store.getSnapshot();
+          const groupings = snapshot.groupings.length > 0 ? snapshot.groupings : [...response.suggestedGroupings];
+          store.batchUpdate({
+            matches: allLoadedMatches as never,
+            groupings,
+            seriesGroups: alignSeriesGroupsToGroupings(groupings, Array.from(snapshot.seriesGroups)),
+            hasMore: false,
+            hasActiveSeriesWarning: activeSeriesContext !== undefined,
+          });
+          return;
+        }
       }
+
+      // Reached max pages without finding all (rare edge case, but acceptable per requirements)
       const snapshot = store.getSnapshot();
-      const groupings = snapshot.groupings.length > 0 ? snapshot.groupings : [...response.suggestedGroupings];
+      const groupings = snapshot.groupings.length > 0 ? snapshot.groupings : [];
       store.batchUpdate({
-        matches: response.matches,
+        matches: allLoadedMatches as never,
         groupings,
         seriesGroups: alignSeriesGroupsToGroupings(groupings, Array.from(snapshot.seriesGroups)),
-        hasMore: response.matches.length >= 25,
+        hasMore: true,
+        hasActiveSeriesWarning: activeSeriesContext !== undefined,
       });
     } catch (err: unknown) {
       if (this.isDisposed) {

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
@@ -1,9 +1,11 @@
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
+import { analyzeMatchGroupings } from "@guilty-spark/shared/halo/match-enrichment";
 import type { IndividualTrackerSeriesGroup } from "../series-group-metadata";
 import { alignSeriesGroupsToGroupings } from "../series-group-metadata";
 import { applyAddToAdjacentGroup, applyBreakFromGroup } from "../grouping-utils";
 import { shouldHideShortDurationMatch } from "../match-duration-filter";
 import type { GameSelectionDialogSnapshot, GameSelectionDialogStore } from "./game-selection-dialog-store";
+import type { TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
 
 interface Config {
   readonly store: GameSelectionDialogStore;
@@ -59,7 +61,7 @@ export class GameSelectionDialogPresenter {
   private async loadMatchesAsync(): Promise<void> {
     const { store, service, xuid, initialSelectedMatchIds, searchStartTime, activeSeriesContext } = this.config;
     try {
-      const allLoadedMatches: unknown[] = [];
+      const allLoadedMatches: TrackerMatchHistoryEntry[] = [];
       const maxPages = 4;
       const pageSize = 25;
       const targetMatchIds = new Set(initialSelectedMatchIds);
@@ -77,7 +79,7 @@ export class GameSelectionDialogPresenter {
         allLoadedMatches.push(...response.matches);
 
         // Check if all target matches are now loaded
-        const loadedMatchIds = new Set(allLoadedMatches.map((m: unknown) => (m as { matchId: string }).matchId));
+        const loadedMatchIds = new Set(allLoadedMatches.map((match) => match.matchId));
         const allFound = Array.from(targetMatchIds).every((id) => loadedMatchIds.has(id));
 
         // Check if we've covered the searchStartTime boundary (if provided)
@@ -85,7 +87,7 @@ export class GameSelectionDialogPresenter {
           searchStartTimeMs === 0 ||
           response.matches.length === 0 ||
           response.matches.some(
-            (m: unknown) => new Date((m as { startTime: string }).startTime).getTime() < searchStartTimeMs,
+            (match) => new Date(match.startTime).getTime() < searchStartTimeMs,
           );
 
         // Stop early if all matches found AND we've reached the search boundary, or if we got fewer than pageSize (end of history)
@@ -93,7 +95,7 @@ export class GameSelectionDialogPresenter {
           const snapshot = store.getSnapshot();
           const groupings = snapshot.groupings.length > 0 ? snapshot.groupings : [...response.suggestedGroupings];
           store.batchUpdate({
-            matches: allLoadedMatches as never,
+            matches: allLoadedMatches,
             groupings,
             seriesGroups: alignSeriesGroupsToGroupings(groupings, Array.from(snapshot.seriesGroups)),
             hasMore: response.matches.length >= pageSize,
@@ -107,7 +109,7 @@ export class GameSelectionDialogPresenter {
       const snapshot = store.getSnapshot();
       const groupings = snapshot.groupings.length > 0 ? snapshot.groupings : [];
       store.batchUpdate({
-        matches: allLoadedMatches as never,
+        matches: allLoadedMatches,
         groupings,
         seriesGroups: alignSeriesGroupsToGroupings(groupings, Array.from(snapshot.seriesGroups)),
         hasMore: true,
@@ -146,8 +148,12 @@ export class GameSelectionDialogPresenter {
       }
       const current = store.getSnapshot();
       const allMatches = current.matches != null ? [...current.matches, ...response.matches] : response.matches;
+      const nextGroupings = this.mergeSuggestedGroupings(current.groupings, allMatches, start);
+      const nextSeriesGroups = alignSeriesGroupsToGroupings(nextGroupings, Array.from(current.seriesGroups));
       store.batchUpdate({
         matches: allMatches,
+        groupings: nextGroupings,
+        seriesGroups: nextSeriesGroups,
         hasMore: response.matches.length >= 25,
       });
     } catch {
@@ -283,5 +289,70 @@ export class GameSelectionDialogPresenter {
     const snapshot = this.config.store.getSnapshot();
     const nextSeriesGroups = alignSeriesGroupsToGroupings(nextGroupings, Array.from(snapshot.seriesGroups));
     this.config.store.batchUpdate({ groupings: nextGroupings, seriesGroups: nextSeriesGroups });
+  }
+
+  private mergeSuggestedGroupings(
+    currentGroupings: readonly (readonly string[])[],
+    allMatches: readonly TrackerMatchHistoryEntry[],
+    previousMatchCount: number,
+  ): readonly (readonly string[])[] {
+    const pageSize = 25;
+    const lookbackStart = Math.max(0, previousMatchCount - pageSize);
+    const boundaryMatches = allMatches.slice(lookbackStart);
+    const newMatchIds = new Set(allMatches.slice(previousMatchCount).map((match) => match.matchId));
+    const suggestedGroupings = this.computeSuggestedGroupings(boundaryMatches).filter((group) =>
+      group.some((matchId) => newMatchIds.has(matchId)),
+    );
+    const usedMatchIds = new Set(currentGroupings.flatMap((group) => group));
+    const nextGroupings = currentGroupings.map((group) => [...group]);
+
+    for (const suggestedGroup of suggestedGroupings) {
+      if (suggestedGroup.some((matchId) => usedMatchIds.has(matchId))) {
+        continue;
+      }
+
+      nextGroupings.push([...suggestedGroup]);
+      for (const matchId of suggestedGroup) {
+        usedMatchIds.add(matchId);
+      }
+    }
+
+    return this.sortGroupingsByTimeline(nextGroupings, allMatches);
+  }
+
+  private computeSuggestedGroupings(allMatches: readonly TrackerMatchHistoryEntry[]): readonly (readonly string[])[] {
+    return analyzeMatchGroupings(
+      allMatches.map((match) => ({
+        matchId: match.matchId,
+        isMatchmaking: match.isMatchmaking,
+        teamRosterSignature: this.getTeamRosterSignature(match),
+      })),
+    );
+  }
+
+  private getTeamRosterSignature(match: TrackerMatchHistoryEntry): string | null {
+    if (match.isMatchmaking || match.teams.length === 0) {
+      return null;
+    }
+
+    return match.teams
+      .map((team, index) => `${index.toString()}:${[...team].sort().join(",")}`)
+      .join("|");
+  }
+
+  private sortGroupingsByTimeline(
+    groupings: readonly (readonly string[])[],
+    allMatches: readonly TrackerMatchHistoryEntry[],
+  ): readonly (readonly string[])[] {
+    const matchIndex = new Map<string, number>();
+    for (const [index, match] of allMatches.entries()) {
+      matchIndex.set(match.matchId, index);
+    }
+
+    return [...groupings].sort((leftGroup, rightGroup) => {
+      const leftIndex = Math.min(...leftGroup.map((matchId) => matchIndex.get(matchId) ?? Number.MAX_SAFE_INTEGER));
+      const rightIndex = Math.min(...rightGroup.map((matchId) => matchIndex.get(matchId) ?? Number.MAX_SAFE_INTEGER));
+      return leftIndex - rightIndex;
+    });
   }
 }

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
@@ -1,11 +1,10 @@
-import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
 import { analyzeMatchGroupings } from "@guilty-spark/shared/halo/match-enrichment";
+import type { IndividualTrackerService , TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
 import type { IndividualTrackerSeriesGroup } from "../series-group-metadata";
 import { alignSeriesGroupsToGroupings } from "../series-group-metadata";
 import { applyAddToAdjacentGroup, applyBreakFromGroup } from "../grouping-utils";
 import { shouldHideShortDurationMatch } from "../match-duration-filter";
 import type { GameSelectionDialogSnapshot, GameSelectionDialogStore } from "./game-selection-dialog-store";
-import type { TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
 
 interface Config {
   readonly store: GameSelectionDialogStore;
@@ -86,9 +85,7 @@ export class GameSelectionDialogPresenter {
         const reachedSearchBoundary =
           searchStartTimeMs === 0 ||
           response.matches.length === 0 ||
-          response.matches.some(
-            (match) => new Date(match.startTime).getTime() < searchStartTimeMs,
-          );
+          response.matches.some((match) => new Date(match.startTime).getTime() < searchStartTimeMs);
 
         // Stop early if all matches found AND we've reached the search boundary, or if we got fewer than pageSize (end of history)
         if ((allFound && reachedSearchBoundary) || response.matches.length < pageSize) {
@@ -353,9 +350,7 @@ export class GameSelectionDialogPresenter {
       return null;
     }
 
-    const sortedTeams = match.teams
-      .map((team) => [...team].sort().join(","))
-      .sort();
+    const sortedTeams = match.teams.map((team) => [...team].sort().join(",")).sort();
 
     return sortedTeams.join("|");
   }

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
@@ -1,4 +1,5 @@
 import { analyzeMatchGroupings } from "@guilty-spark/shared/halo/match-enrichment";
+import type { TrackerLiveView } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { IndividualTrackerService, TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
 import type { IndividualTrackerSeriesGroup } from "../series-group-metadata";
 import { alignSeriesGroupsToGroupings } from "../series-group-metadata";
@@ -15,11 +16,7 @@ interface Config {
   readonly initialGroupings: readonly (readonly string[])[];
   readonly initialSeriesGroups: readonly IndividualTrackerSeriesGroup[];
   readonly searchStartTime?: string;
-  readonly activeSeriesContext?: {
-    readonly title: string;
-    readonly subtitle: string | null;
-    readonly teams: readonly unknown[];
-  };
+  readonly activeSeriesContext?: NonNullable<TrackerLiveView["activeSeriesContext"]>;
   readonly onSynced: () => void;
 }
 
@@ -64,7 +61,8 @@ export class GameSelectionDialogPresenter {
       const maxPages = 4;
       const pageSize = 25;
       const targetMatchIds = new Set(initialSelectedMatchIds);
-      const searchStartTimeMs = searchStartTime != null ? new Date(searchStartTime).getTime() : 0;
+      const parsedSearchStartTime = searchStartTime != null ? new Date(searchStartTime).getTime() : NaN;
+      const searchStartTimeMs = Number.isFinite(parsedSearchStartTime) ? parsedSearchStartTime : 0;
 
       // Load pages until all initial matches are found, we've covered searchStartTime, or we reach max pages
       for (let pageIndex = 0; pageIndex < maxPages; pageIndex++) {
@@ -85,7 +83,11 @@ export class GameSelectionDialogPresenter {
         const reachedSearchBoundary =
           searchStartTimeMs === 0 ||
           response.matches.length === 0 ||
-          response.matches.some((match) => new Date(match.startTime).getTime() < searchStartTimeMs);
+          response.matches.some((match) => {
+            const isoTime = match.startTimeIso != null ? new Date(match.startTimeIso).getTime() : NaN;
+            const matchTimeMs = Number.isFinite(isoTime) ? isoTime : new Date(match.startTime).getTime();
+            return Number.isFinite(matchTimeMs) && matchTimeMs < searchStartTimeMs;
+          });
 
         // Stop early if all matches found AND we've reached the search boundary, or if we got fewer than pageSize (end of history)
         if ((allFound && reachedSearchBoundary) || response.matches.length < pageSize) {

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
@@ -17,10 +17,12 @@ interface Config {
   readonly initialSeriesGroups: readonly IndividualTrackerSeriesGroup[];
   readonly searchStartTime?: string;
   readonly activeSeriesContext?: NonNullable<TrackerLiveView["activeSeriesContext"]>;
+  readonly hasActiveSeriesWarning?: boolean;
   readonly onSynced: () => void;
 }
 
 export class GameSelectionDialogPresenter {
+  private static readonly PAGE_SIZE = 25;
   private readonly config: Config;
   private isDisposed = false;
 
@@ -37,7 +39,8 @@ export class GameSelectionDialogPresenter {
       return;
     }
 
-    const { store, initialSelectedMatchIds, initialGroupings, initialSeriesGroups } = this.config;
+    const { store, initialSelectedMatchIds, initialGroupings, initialSeriesGroups, hasActiveSeriesWarning } =
+      this.config;
 
     store.batchUpdate({
       matches: null,
@@ -47,7 +50,7 @@ export class GameSelectionDialogPresenter {
       hasMore: false,
       hideShortGames: true,
       isSyncing: false,
-      hasActiveSeriesWarning: false,
+      hasActiveSeriesWarning: hasActiveSeriesWarning ?? false,
       errorMessage: null,
     });
 
@@ -59,15 +62,14 @@ export class GameSelectionDialogPresenter {
     try {
       const allLoadedMatches: TrackerMatchHistoryEntry[] = [];
       const maxPages = 4;
-      const pageSize = 25;
       const targetMatchIds = new Set(initialSelectedMatchIds);
       const parsedSearchStartTime = searchStartTime != null ? new Date(searchStartTime).getTime() : NaN;
       const searchStartTimeMs = Number.isFinite(parsedSearchStartTime) ? parsedSearchStartTime : 0;
 
       // Load pages until we've found all initial matches AND covered the searchStartTime boundary, or we reach max pages/end of history
       for (let pageIndex = 0; pageIndex < maxPages; pageIndex++) {
-        const offset = pageIndex * pageSize;
-        const response = await service.getMatchHistory(xuid, offset, pageSize);
+        const offset = pageIndex * GameSelectionDialogPresenter.PAGE_SIZE;
+        const response = await service.getMatchHistory(xuid, offset, GameSelectionDialogPresenter.PAGE_SIZE);
 
         if (this.isDisposed) {
           return;
@@ -83,21 +85,22 @@ export class GameSelectionDialogPresenter {
         const reachedSearchBoundary =
           searchStartTimeMs === 0 ||
           response.matches.length === 0 ||
+          response.matches.length < GameSelectionDialogPresenter.PAGE_SIZE ||
           response.matches.some((match) => {
             const isoTime = match.startTimeIso != null ? new Date(match.startTimeIso).getTime() : NaN;
             const matchTimeMs = Number.isFinite(isoTime) ? isoTime : new Date(match.startTime).getTime();
             return Number.isFinite(matchTimeMs) && matchTimeMs < searchStartTimeMs;
           });
 
-        // Stop early if all matches found AND we've reached the search boundary, or if we got fewer than pageSize (end of history)
-        if ((allFound && reachedSearchBoundary) || response.matches.length < pageSize) {
+        // Stop early if all matches found AND we've reached the search boundary, or if we got fewer than PAGE_SIZE (end of history)
+        if ((allFound && reachedSearchBoundary) || response.matches.length < GameSelectionDialogPresenter.PAGE_SIZE) {
           const snapshot = store.getSnapshot();
           const groupings = this.mergeSuggestedGroupings(snapshot.groupings, allLoadedMatches, 0);
           store.batchUpdate({
             matches: allLoadedMatches,
             groupings,
             seriesGroups: alignSeriesGroupsToGroupings(groupings, Array.from(snapshot.seriesGroups)),
-            hasMore: response.matches.length >= pageSize,
+            hasMore: response.matches.length >= GameSelectionDialogPresenter.PAGE_SIZE,
             hasActiveSeriesWarning: activeSeriesContext !== undefined,
           });
           return;
@@ -141,7 +144,7 @@ export class GameSelectionDialogPresenter {
   private async loadMoreAsync(start: number): Promise<void> {
     const { store, service, xuid } = this.config;
     try {
-      const response = await service.getMatchHistory(xuid, start, 25);
+      const response = await service.getMatchHistory(xuid, start, GameSelectionDialogPresenter.PAGE_SIZE);
       if (this.isDisposed) {
         return;
       }
@@ -153,7 +156,7 @@ export class GameSelectionDialogPresenter {
         matches: allMatches,
         groupings: nextGroupings,
         seriesGroups: nextSeriesGroups,
-        hasMore: response.matches.length >= 25,
+        hasMore: response.matches.length >= GameSelectionDialogPresenter.PAGE_SIZE,
       });
     } catch {
       /* keep existing data visible */
@@ -295,8 +298,7 @@ export class GameSelectionDialogPresenter {
     allMatches: readonly TrackerMatchHistoryEntry[],
     previousMatchCount: number,
   ): readonly (readonly string[])[] {
-    const pageSize = 25;
-    const lookbackStart = Math.max(0, previousMatchCount - pageSize);
+    const lookbackStart = Math.max(0, previousMatchCount - GameSelectionDialogPresenter.PAGE_SIZE);
     const boundaryMatches = allMatches.slice(lookbackStart);
     const newMatchIds = new Set(allMatches.slice(previousMatchCount).map((match) => match.matchId));
     const suggestedGroupings = this.computeSuggestedGroupings(boundaryMatches).filter((group) =>

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
@@ -58,7 +58,7 @@ export class GameSelectionDialogPresenter {
   }
 
   private async loadMatchesAsync(): Promise<void> {
-    const { store, service, xuid, initialSelectedMatchIds, searchStartTime, activeSeriesContext } = this.config;
+    const { store, service, xuid, initialSelectedMatchIds, searchStartTime } = this.config;
     try {
       const allLoadedMatches: TrackerMatchHistoryEntry[] = [];
       const maxPages = 4;
@@ -101,7 +101,6 @@ export class GameSelectionDialogPresenter {
             groupings,
             seriesGroups: alignSeriesGroupsToGroupings(groupings, Array.from(snapshot.seriesGroups)),
             hasMore: response.matches.length >= GameSelectionDialogPresenter.PAGE_SIZE,
-            hasActiveSeriesWarning: activeSeriesContext !== undefined,
           });
           return;
         }
@@ -115,7 +114,6 @@ export class GameSelectionDialogPresenter {
         groupings,
         seriesGroups: alignSeriesGroupsToGroupings(groupings, Array.from(snapshot.seriesGroups)),
         hasMore: true,
-        hasActiveSeriesWarning: activeSeriesContext !== undefined,
       });
     } catch (err: unknown) {
       if (this.isDisposed) {

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
@@ -93,7 +93,7 @@ export class GameSelectionDialogPresenter {
         // Stop early if all matches found AND we've reached the search boundary, or if we got fewer than pageSize (end of history)
         if ((allFound && reachedSearchBoundary) || response.matches.length < pageSize) {
           const snapshot = store.getSnapshot();
-          const groupings = snapshot.groupings.length > 0 ? snapshot.groupings : [...response.suggestedGroupings];
+          const groupings = this.mergeSuggestedGroupings(snapshot.groupings, allLoadedMatches, 0);
           store.batchUpdate({
             matches: allLoadedMatches,
             groupings,
@@ -107,7 +107,7 @@ export class GameSelectionDialogPresenter {
 
       // Reached max pages without finding all (rare edge case, but acceptable per requirements)
       const snapshot = store.getSnapshot();
-      const groupings = snapshot.groupings.length > 0 ? snapshot.groupings : [];
+      const groupings = this.mergeSuggestedGroupings(snapshot.groupings, allLoadedMatches, 0);
       store.batchUpdate({
         matches: allLoadedMatches,
         groupings,
@@ -303,18 +303,36 @@ export class GameSelectionDialogPresenter {
     const suggestedGroupings = this.computeSuggestedGroupings(boundaryMatches).filter((group) =>
       group.some((matchId) => newMatchIds.has(matchId)),
     );
-    const usedMatchIds = new Set(currentGroupings.flatMap((group) => group));
     const nextGroupings = currentGroupings.map((group) => [...group]);
+    const timelineOrderedMatchIds = allMatches.map((match) => match.matchId);
 
     for (const suggestedGroup of suggestedGroupings) {
-      if (suggestedGroup.some((matchId) => usedMatchIds.has(matchId))) {
+      const suggestedMatchIds = new Set(suggestedGroup);
+      const overlappingGroupIndexes: number[] = [];
+
+      for (const [index, existingGroup] of nextGroupings.entries()) {
+        if (existingGroup.some((matchId) => suggestedMatchIds.has(matchId))) {
+          overlappingGroupIndexes.push(index);
+        }
+      }
+
+      if (overlappingGroupIndexes.length === 0) {
+        nextGroupings.push([...suggestedGroup]);
         continue;
       }
 
-      nextGroupings.push([...suggestedGroup]);
-      for (const matchId of suggestedGroup) {
-        usedMatchIds.add(matchId);
+      const mergedMatchIds = new Set<string>(suggestedGroup);
+      for (const index of overlappingGroupIndexes) {
+        for (const matchId of nextGroupings[index] ?? []) {
+          mergedMatchIds.add(matchId);
+        }
       }
+
+      const overlappingIndexesSet = new Set(overlappingGroupIndexes);
+      const groupsWithoutOverlaps = nextGroupings.filter((_, index) => !overlappingIndexesSet.has(index));
+      const mergedGroup = timelineOrderedMatchIds.filter((matchId) => mergedMatchIds.has(matchId));
+      nextGroupings.length = 0;
+      nextGroupings.push(...groupsWithoutOverlaps, mergedGroup);
     }
 
     return this.sortGroupingsByTimeline(nextGroupings, allMatches);

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
@@ -1,5 +1,4 @@
 import { analyzeMatchGroupings } from "@guilty-spark/shared/halo/match-enrichment";
-import type { TrackerLiveView } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { IndividualTrackerService, TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
 import type { IndividualTrackerSeriesGroup } from "../series-group-metadata";
 import { alignSeriesGroupsToGroupings } from "../series-group-metadata";
@@ -16,7 +15,6 @@ interface Config {
   readonly initialGroupings: readonly (readonly string[])[];
   readonly initialSeriesGroups: readonly IndividualTrackerSeriesGroup[];
   readonly searchStartTime?: string;
-  readonly activeSeriesContext?: NonNullable<TrackerLiveView["activeSeriesContext"]>;
   readonly hasActiveSeriesWarning?: boolean;
   readonly onSynced: () => void;
 }

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
@@ -335,9 +335,11 @@ export class GameSelectionDialogPresenter {
       return null;
     }
 
-    return match.teams
-      .map((team, index) => `${index.toString()}:${[...team].sort().join(",")}`)
-      .join("|");
+    const sortedTeams = match.teams
+      .map((team) => [...team].sort().join(","))
+      .sort();
+
+    return sortedTeams.join("|");
   }
 
   private sortGroupingsByTimeline(

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
@@ -64,7 +64,7 @@ export class GameSelectionDialogPresenter {
       const parsedSearchStartTime = searchStartTime != null ? new Date(searchStartTime).getTime() : NaN;
       const searchStartTimeMs = Number.isFinite(parsedSearchStartTime) ? parsedSearchStartTime : 0;
 
-      // Load pages until all initial matches are found, we've covered searchStartTime, or we reach max pages
+      // Load pages until we've found all initial matches AND covered the searchStartTime boundary, or we reach max pages/end of history
       for (let pageIndex = 0; pageIndex < maxPages; pageIndex++) {
         const offset = pageIndex * pageSize;
         const response = await service.getMatchHistory(xuid, offset, pageSize);

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
@@ -96,7 +96,7 @@ export class GameSelectionDialogPresenter {
             matches: allLoadedMatches as never,
             groupings,
             seriesGroups: alignSeriesGroupsToGroupings(groupings, Array.from(snapshot.seriesGroups)),
-            hasMore: false,
+            hasMore: response.matches.length >= pageSize,
             hasActiveSeriesWarning: activeSeriesContext !== undefined,
           });
           return;

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-presenter.ts
@@ -1,5 +1,5 @@
 import { analyzeMatchGroupings } from "@guilty-spark/shared/halo/match-enrichment";
-import type { IndividualTrackerService , TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
+import type { IndividualTrackerService, TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
 import type { IndividualTrackerSeriesGroup } from "../series-group-metadata";
 import { alignSeriesGroupsToGroupings } from "../series-group-metadata";
 import { applyAddToAdjacentGroup, applyBreakFromGroup } from "../grouping-utils";

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-store.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog-store.ts
@@ -9,6 +9,7 @@ export interface GameSelectionDialogSnapshot {
   readonly hasMore: boolean;
   readonly hideShortGames: boolean;
   readonly isSyncing: boolean;
+  readonly hasActiveSeriesWarning: boolean;
   readonly errorMessage: string | null;
 }
 
@@ -25,6 +26,7 @@ export class GameSelectionDialogStore {
       hasMore: false,
       hideShortGames: true,
       isSyncing: false,
+      hasActiveSeriesWarning: false,
       errorMessage: null,
     };
   }

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog.tsx
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog.tsx
@@ -21,6 +21,7 @@ export interface GameSelectionDialogProps {
   readonly selectedMatchIds: ReadonlySet<string>;
   readonly hasMore: boolean;
   readonly hideShortGames: boolean;
+  readonly hasActiveSeriesWarning: boolean;
   readonly onClose: () => void;
   readonly onSyncAndClose: () => void;
   readonly onMatchToggle: (matchId: string) => void;
@@ -45,6 +46,7 @@ export function GameSelectionDialog({
   selectedMatchIds,
   hasMore,
   hideShortGames,
+  hasActiveSeriesWarning,
   onClose,
   onSyncAndClose,
   onMatchToggle,
@@ -80,6 +82,13 @@ export function GameSelectionDialog({
       </div>
 
       {errorMessage != null && <Alert variant="error">{errorMessage}</Alert>}
+
+      {hasActiveSeriesWarning && (
+        <Alert variant="info">
+          An active series is in progress. Use the series controls in the main tracker view to modify the active series.
+          Your selections here will update the overall match history.
+        </Alert>
+      )}
 
       {errorMessage == null && visibleMatches == null ? (
         <div className={styles.matchesContainer}>

--- a/pages/src/components/individual-tracker/game-selection-dialog/tests/game-selection-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/tests/game-selection-dialog-presenter.test.ts
@@ -40,7 +40,10 @@ function aMatch(matchId: string): TrackerMatchHistoryResponse["matches"][number]
     resultString: "Win - 50:40",
     isMatchmaking: false,
     category: "custom",
-    teams: [["alpha", "bravo"], ["charlie", "delta"]],
+    teams: [
+      ["alpha", "bravo"],
+      ["charlie", "delta"],
+    ],
     mapThumbnailUrl: "data:,",
   };
 }
@@ -288,12 +291,10 @@ describe("GameSelectionDialogPresenter", () => {
       };
 
       const service = aFakeService({
-        getMatchHistory: vi
-          .fn<IndividualTrackerService["getMatchHistory"]>()
-          .mockResolvedValue({
-            matches: [match2],
-            suggestedGroupings: [],
-          }),
+        getMatchHistory: vi.fn<IndividualTrackerService["getMatchHistory"]>().mockResolvedValue({
+          matches: [match2],
+          suggestedGroupings: [],
+        }),
       });
 
       store.batchUpdate({

--- a/pages/src/components/individual-tracker/game-selection-dialog/tests/game-selection-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/tests/game-selection-dialog-presenter.test.ts
@@ -40,7 +40,7 @@ function aMatch(matchId: string): TrackerMatchHistoryResponse["matches"][number]
     resultString: "Win - 50:40",
     isMatchmaking: false,
     category: "custom",
-    teams: [],
+    teams: [["alpha", "bravo"], ["charlie", "delta"]],
     mapThumbnailUrl: "data:,",
   };
 }
@@ -200,6 +200,57 @@ describe("GameSelectionDialogPresenter", () => {
       presenter.setHideShortGames(false);
 
       expect(store.getSnapshot().hideShortGames).toBe(false);
+    });
+  });
+
+  describe("loadMore()", () => {
+    it("recomputes and merges suggestions using new page plus prior-page boundary", async () => {
+      const firstPageTail = [aMatch("old-1"), aMatch("old-2")];
+      const service = aFakeService({
+        getMatchHistory: vi.fn<IndividualTrackerService["getMatchHistory"]>().mockResolvedValue({
+          matches: [aMatch("new-1"), aMatch("new-2")],
+          suggestedGroupings: [],
+        }),
+      });
+
+      store.batchUpdate({
+        matches: firstPageTail,
+        groupings: [],
+        seriesGroups: [],
+      });
+
+      const presenter = buildPresenter(service, store);
+      await presenter.loadMore();
+
+      expect(store.getSnapshot().groupings).toEqual([["old-1", "old-2", "new-1", "new-2"]]);
+    });
+
+    it("does not create new groups from older non-boundary data", async () => {
+      const oldMatches = [aMatch("old-a"), aMatch("old-b")];
+      const fillerMatches = Array.from({ length: 24 }, (_, index) => ({
+        ...aMatch(`filler-${index.toString()}`),
+        isMatchmaking: true,
+        category: "matchmaking" as const,
+      }));
+      const boundaryMatch = aMatch("old-tail");
+      const service = aFakeService({
+        getMatchHistory: vi.fn<IndividualTrackerService["getMatchHistory"]>().mockResolvedValue({
+          matches: [aMatch("new-1")],
+          suggestedGroupings: [],
+        }),
+      });
+
+      store.batchUpdate({
+        matches: [...oldMatches, ...fillerMatches, boundaryMatch],
+        groupings: [],
+        seriesGroups: [],
+      });
+
+      const presenter = buildPresenter(service, store);
+      await presenter.loadMore();
+
+      expect(store.getSnapshot().groupings).toEqual([["old-tail", "new-1"]]);
+      expect(store.getSnapshot().groupings).not.toContainEqual(["old-a", "old-b"]);
     });
   });
 

--- a/pages/src/components/individual-tracker/game-selection-dialog/tests/game-selection-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/tests/game-selection-dialog-presenter.test.ts
@@ -93,6 +93,22 @@ describe("GameSelectionDialogPresenter", () => {
       expect(service.getMatchHistory).toHaveBeenCalledWith("xuid-1", 0, 25);
     });
 
+    it("keeps hasMore true when auto-preload stops on a full page", async () => {
+      const page = Array.from({ length: 25 }, (_, index) => aMatch(`m-${index.toString()}`));
+      const service = aFakeService({
+        getMatchHistory: vi.fn<IndividualTrackerService["getMatchHistory"]>().mockResolvedValue({
+          matches: page,
+          suggestedGroupings: [],
+        }),
+      });
+
+      const presenter = buildPresenter(service, store);
+      presenter.loadMatches();
+
+      await flushPromises();
+      expect(store.getSnapshot().hasMore).toBe(true);
+    });
+
     it("sets suggested groupings when no initial groupings", async () => {
       const service = aFakeService({
         getMatchHistory: vi.fn<IndividualTrackerService["getMatchHistory"]>().mockResolvedValue({

--- a/pages/src/components/individual-tracker/game-selection-dialog/tests/game-selection-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/tests/game-selection-dialog-presenter.test.ts
@@ -124,7 +124,7 @@ describe("GameSelectionDialogPresenter", () => {
       expect(store.getSnapshot().groupings).toEqual([["m1", "m2"]]);
     });
 
-    it("preserves initial groupings over suggested groupings", async () => {
+    it("extends initial groupings when suggestions overlap", async () => {
       const service = aFakeService({
         getMatchHistory: vi.fn<IndividualTrackerService["getMatchHistory"]>().mockResolvedValue({
           matches: [aMatch("m1"), aMatch("m2"), aMatch("m3")],
@@ -137,7 +137,7 @@ describe("GameSelectionDialogPresenter", () => {
 
       await flushPromises();
       expect(store.getSnapshot().matches).not.toBeNull();
-      expect(store.getSnapshot().groupings).toEqual([["m1", "m2"]]);
+      expect(store.getSnapshot().groupings).toEqual([["m1", "m2", "m3"]]);
     });
 
     it("sets error message on failure", async () => {
@@ -223,6 +223,27 @@ describe("GameSelectionDialogPresenter", () => {
       await presenter.loadMore();
 
       expect(store.getSnapshot().groupings).toEqual([["old-1", "old-2", "new-1", "new-2"]]);
+    });
+
+    it("extends an existing grouping when load-more suggestions overlap", async () => {
+      const existingGroupMatches = [aMatch("old-1"), aMatch("old-2")];
+      const service = aFakeService({
+        getMatchHistory: vi.fn<IndividualTrackerService["getMatchHistory"]>().mockResolvedValue({
+          matches: [aMatch("new-1")],
+          suggestedGroupings: [],
+        }),
+      });
+
+      store.batchUpdate({
+        matches: existingGroupMatches,
+        groupings: [["old-1", "old-2"]],
+        seriesGroups: [],
+      });
+
+      const presenter = buildPresenter(service, store);
+      await presenter.loadMore();
+
+      expect(store.getSnapshot().groupings).toEqual([["old-1", "old-2", "new-1"]]);
     });
 
     it("does not create new groups from older non-boundary data", async () => {

--- a/pages/src/components/individual-tracker/game-selection-dialog/tests/game-selection-dialog-presenter.test.ts
+++ b/pages/src/components/individual-tracker/game-selection-dialog/tests/game-selection-dialog-presenter.test.ts
@@ -252,6 +252,40 @@ describe("GameSelectionDialogPresenter", () => {
       expect(store.getSnapshot().groupings).toEqual([["old-tail", "new-1"]]);
       expect(store.getSnapshot().groupings).not.toContainEqual(["old-a", "old-b"]);
     });
+
+    it("groups matches with same team rosters regardless of team order", async () => {
+      const teamAlpha = ["alpha", "bravo"];
+      const teamBeta = ["charlie", "delta"];
+
+      const match1 = {
+        ...aMatch("m1"),
+        teams: [teamAlpha, teamBeta],
+      };
+      const match2 = {
+        ...aMatch("m2"),
+        teams: [teamBeta, teamAlpha],
+      };
+
+      const service = aFakeService({
+        getMatchHistory: vi
+          .fn<IndividualTrackerService["getMatchHistory"]>()
+          .mockResolvedValue({
+            matches: [match2],
+            suggestedGroupings: [],
+          }),
+      });
+
+      store.batchUpdate({
+        matches: [match1],
+        groupings: [],
+        seriesGroups: [],
+      });
+
+      const presenter = buildPresenter(service, store);
+      await presenter.loadMore();
+
+      expect(store.getSnapshot().groupings).toEqual([["m1", "m2"]]);
+    });
   });
 
   describe("syncAndClose()", () => {

--- a/shared/src/contracts/individual-tracker/view.ts
+++ b/shared/src/contracts/individual-tracker/view.ts
@@ -53,6 +53,7 @@ export const trackerLiveViewSchema = z.object({
   lastMatchDiscoveredAt: z.string().nullable(),
   hasActiveSeries: z.boolean(),
   hasRecentCompletedSeries: z.boolean(),
+  searchStartTime: z.string().optional(),
   activeSeriesContext: z
     .object({
       title: z.string(),


### PR DESCRIPTION
## Summary
- add game selection dialog auto-preload and active-series warning UX
- wire searchStartTime through shared contract, API mapper, and pages dialog state
- keep load-more visible when preload stops on a full page
- recompute and merge suggested groupings on pagination using boundary-scoped windowing
- make team roster signatures order-independent for custom game grouping
- merge suggested groupings with existing dialog groupings on initial load
- add and update presenter test coverage for overlap and grouping regressions

## Validation
- npm run done
- targeted dialog presenter and component tests
- local browser validation of game selection grouping behavior
