### PR TITLE
refactor: use shared TabbedSection in follow tracker tabs

### DIFF
--- a/pages/src/components/follow/follow-tracker-tabs.module.css
+++ b/pages/src/components/follow/follow-tracker-tabs.module.css
@@ -10,35 +10,14 @@
   gap: var(--space-2);
 }
 
-.tab {
+.tabLabel {
   align-items: center;
-  background: transparent;
-  border: 1px solid var(--halo-gray-dark, #444);
-  color: var(--halo-gray, #aaa);
-  cursor: pointer;
   display: flex;
   flex-direction: column;
   font-family: var(--font-body);
   font-size: var(--text-sm);
   gap: var(--space-1);
   min-width: 120px;
-  padding: var(--space-2) var(--space-4);
-  transition:
-    background 0.2s ease,
-    border-color 0.2s ease,
-    color 0.2s ease;
-}
-
-.tab:hover {
-  background: rgb(255 255 255 / 5%);
-  border-color: var(--halo-teal-primary);
-  color: var(--halo-white);
-}
-
-.tab.selected {
-  background: rgb(93 212 216 / 10%);
-  border-color: var(--halo-teal-primary);
-  color: var(--halo-white);
 }
 
 .tabGamertag {
@@ -52,10 +31,6 @@
   font-size: var(--text-xs);
 }
 
-.tab.selected .tabRecord {
-  color: var(--halo-gray-light, #ccc);
-}
-
 .liveBadge {
   background: var(--color-live, #e53935);
   border-radius: 2px;
@@ -66,6 +41,10 @@
   letter-spacing: 0.08em;
   padding: 1px 4px;
   text-transform: uppercase;
+}
+
+.tabPanel {
+  display: none;
 }
 
 .followLiveButton {

--- a/pages/src/components/follow/follow-tracker-tabs.module.css
+++ b/pages/src/components/follow/follow-tracker-tabs.module.css
@@ -43,10 +43,6 @@
   text-transform: uppercase;
 }
 
-.tabPanel {
-  display: none;
-}
-
 .followLiveButton {
   align-self: flex-start;
   background: transparent;

--- a/pages/src/components/follow/follow-tracker-tabs.tsx
+++ b/pages/src/components/follow/follow-tracker-tabs.tsx
@@ -47,6 +47,10 @@ function getSelectedTabId(directory: TrackerDirectory, selectedTrackerId: string
     }
   }
 
+  if (directory.trackers.length === 0) {
+    return null;
+  }
+
   const [firstTracker] = directory.trackers;
   return firstTracker.trackerId;
 }
@@ -87,7 +91,6 @@ export function FollowTrackerTabs({
           tabListAriaLabel="Followed trackers"
           onTabChange={onSelectTracker}
           tabsClassName={styles.tabs}
-          tabContainerClassName={styles.tabPanel}
         />
       )}
       {showFollowLive && (

--- a/pages/src/components/follow/follow-tracker-tabs.tsx
+++ b/pages/src/components/follow/follow-tracker-tabs.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import cn from "classnames";
 import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
 import type { TrackerMatchSummary } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import { TabbedSection } from "../tabbed-section/tabbed-section";
 import styles from "./follow-tracker-tabs.module.css";
 
 export interface FollowTrackerTabsProps {
@@ -38,6 +38,19 @@ function toWinLossRecord(matches: readonly TrackerMatchSummary[]): string {
   return `${wins.toString()}:${losses.toString()}`;
 }
 
+function getSelectedTabId(directory: TrackerDirectory, selectedTrackerId: string | null): string | null {
+  if (selectedTrackerId != null) {
+    for (const tracker of directory.trackers) {
+      if (tracker.trackerId === selectedTrackerId) {
+        return selectedTrackerId;
+      }
+    }
+  }
+
+  const [firstTracker] = directory.trackers;
+  return firstTracker.trackerId;
+}
+
 export function FollowTrackerTabs({
   directory,
   selectedTrackerId,
@@ -46,33 +59,37 @@ export function FollowTrackerTabs({
   onFollowLive,
 }: FollowTrackerTabsProps): React.ReactElement {
   const showFollowLive = !isFollowingLive && hasLiveTracker(directory);
+  const selectedTabId = getSelectedTabId(directory, selectedTrackerId);
+  const tabs = directory.trackers.map((entry) => ({
+    id: entry.trackerId,
+    label: (
+      <span className={styles.tabLabel}>
+        <span className={styles.tabGamertag}>{entry.gamertag}</span>
+        <span className={styles.tabRecord} data-testid="tab-record">
+          {toWinLossRecord(entry.matches)}
+        </span>
+        {entry.isLive && (
+          <span className={styles.liveBadge} data-testid="live-badge">
+            Live
+          </span>
+        )}
+      </span>
+    ),
+    content: null,
+  }));
 
   return (
     <div className={styles.tabBar}>
-      <div className={styles.tabs} role="tablist">
-        {directory.trackers.map((entry) => (
-          <button
-            key={entry.trackerId}
-            type="button"
-            role="tab"
-            aria-selected={entry.trackerId === selectedTrackerId}
-            className={cn(styles.tab, { [styles.selected]: entry.trackerId === selectedTrackerId })}
-            onClick={(): void => {
-              onSelectTracker(entry.trackerId);
-            }}
-          >
-            <span className={styles.tabGamertag}>{entry.gamertag}</span>
-            <span className={styles.tabRecord} data-testid="tab-record">
-              {toWinLossRecord(entry.matches)}
-            </span>
-            {entry.isLive && (
-              <span className={styles.liveBadge} data-testid="live-badge">
-                Live
-              </span>
-            )}
-          </button>
-        ))}
-      </div>
+      {selectedTabId != null && (
+        <TabbedSection
+          tabs={tabs}
+          selectedTabId={selectedTabId}
+          tabListAriaLabel="Followed trackers"
+          onTabChange={onSelectTracker}
+          tabsClassName={styles.tabs}
+          tabContainerClassName={styles.tabPanel}
+        />
+      )}
       {showFollowLive && (
         <button type="button" className={styles.followLiveButton} onClick={onFollowLive} data-testid="follow-live-btn">
           Follow live

--- a/pages/src/components/follow/follow-tracker-tabs.tsx
+++ b/pages/src/components/follow/follow-tracker-tabs.tsx
@@ -39,20 +39,17 @@ function toWinLossRecord(matches: readonly TrackerMatchSummary[]): string {
 }
 
 function getSelectedTabId(directory: TrackerDirectory, selectedTrackerId: string | null): string | null {
-  if (selectedTrackerId != null) {
-    for (const tracker of directory.trackers) {
-      if (tracker.trackerId === selectedTrackerId) {
-        return selectedTrackerId;
-      }
-    }
-  }
-
-  if (directory.trackers.length === 0) {
+  if (selectedTrackerId == null) {
     return null;
   }
 
-  const [firstTracker] = directory.trackers;
-  return firstTracker.trackerId;
+  for (const tracker of directory.trackers) {
+    if (tracker.trackerId === selectedTrackerId) {
+      return selectedTrackerId;
+    }
+  }
+
+  return null;
 }
 
 export function FollowTrackerTabs({
@@ -84,12 +81,13 @@ export function FollowTrackerTabs({
 
   return (
     <div className={styles.tabBar}>
-      {selectedTabId != null && (
+      {tabs.length > 0 && (
         <TabbedSection
           tabs={tabs}
           selectedTabId={selectedTabId}
           tabListAriaLabel="Followed trackers"
           onTabChange={onSelectTracker}
+          variant="navigation"
           tabsClassName={styles.tabs}
         />
       )}

--- a/pages/src/components/follow/tests/follow-tracker-tabs.test.tsx
+++ b/pages/src/components/follow/tests/follow-tracker-tabs.test.tsx
@@ -56,10 +56,10 @@ describe("FollowTrackerTabs", () => {
       />,
     );
 
-    const tabs = screen.getAllByRole("tab");
-    expect(tabs).toHaveLength(2);
-    expect(tabs[0]).toHaveTextContent("Spartan One");
-    expect(tabs[1]).toHaveTextContent("Spartan Two");
+    const trackerButtons = screen.getAllByRole("button", { name: /Spartan/ });
+    expect(trackerButtons).toHaveLength(2);
+    expect(trackerButtons[0]).toHaveTextContent("Spartan One");
+    expect(trackerButtons[1]).toHaveTextContent("Spartan Two");
   });
 
   it("shows the win-loss record for each tracker", () => {
@@ -133,8 +133,8 @@ describe("FollowTrackerTabs", () => {
       />,
     );
 
-    const tabs = screen.getAllByRole("tab");
-    await userEvent.click(tabs[1]);
+    const trackerButtons = screen.getAllByRole("button", { name: /Spartan/ });
+    await userEvent.click(trackerButtons[1]);
 
     expect(onSelectTracker).toHaveBeenCalledOnce();
     expect(onSelectTracker).toHaveBeenCalledWith("tracker-2");
@@ -231,5 +231,24 @@ describe("FollowTrackerTabs", () => {
     expect(screen.queryAllByRole("tab")).toHaveLength(0);
     expect(screen.queryByRole("tablist")).toBeNull();
     expect(screen.queryByTestId("follow-live-btn")).toBeNull();
+  });
+
+  it("renders tracker navigation even when selectedTrackerId is null", async () => {
+    const onSelectTracker = vi.fn<(trackerId: string) => void>();
+
+    render(
+      <FollowTrackerTabs
+        directory={aTabsDirectoryWithWinsAndLosses()}
+        selectedTrackerId={null}
+        isFollowingLive={false}
+        onSelectTracker={onSelectTracker}
+        onFollowLive={vi.fn<() => void>()}
+      />,
+    );
+
+    const trackerButtons = screen.getAllByRole("button", { name: /Spartan/ });
+    await userEvent.click(trackerButtons[0]);
+
+    expect(onSelectTracker).toHaveBeenCalledWith("tracker-1");
   });
 });

--- a/pages/src/components/follow/tests/follow-tracker-tabs.test.tsx
+++ b/pages/src/components/follow/tests/follow-tracker-tabs.test.tsx
@@ -211,4 +211,25 @@ describe("FollowTrackerTabs", () => {
 
     expect(onFollowLive).toHaveBeenCalledOnce();
   });
+
+  it("renders no tabs when directory is empty", () => {
+    const emptyDirectory: TrackerDirectory = {
+      trackers: [],
+      liveTrackerId: null,
+    };
+
+    render(
+      <FollowTrackerTabs
+        directory={emptyDirectory}
+        selectedTrackerId={null}
+        isFollowingLive={false}
+        onSelectTracker={vi.fn<(trackerId: string) => void>()}
+        onFollowLive={vi.fn<() => void>()}
+      />,
+    );
+
+    expect(screen.queryAllByRole("tab")).toHaveLength(0);
+    expect(screen.queryByRole("tablist")).toBeNull();
+    expect(screen.queryByTestId("follow-live-btn")).toBeNull();
+  });
 });

--- a/pages/src/components/tabbed-section/tabbed-section.tsx
+++ b/pages/src/components/tabbed-section/tabbed-section.tsx
@@ -6,9 +6,10 @@ import styles from "./tabbed-section.module.css";
 
 interface TabbedSectionProps<TId extends string> {
   readonly tabs: readonly TabbedSectionTab<TId>[];
-  readonly selectedTabId: TId;
+  readonly selectedTabId: TId | null;
   readonly tabListAriaLabel: string;
   readonly onTabChange: (tabId: TId) => void;
+  readonly variant?: "section" | "navigation";
   readonly tabsClassName?: string;
   readonly tabContainerClassName?: string;
 }
@@ -18,6 +19,7 @@ export function TabbedSection<TId extends string>({
   selectedTabId,
   tabListAriaLabel,
   onTabChange,
+  variant = "section",
   tabsClassName,
   tabContainerClassName,
 }: TabbedSectionProps<TId>): React.ReactElement {
@@ -42,19 +44,16 @@ export function TabbedSection<TId extends string>({
       if (event.ctrlKey || event.altKey || event.metaKey) {
         return;
       }
-      const currentIndex = tabs.findIndex((t) => t.id === selectedTabId);
-      if (currentIndex === -1) {
-        return;
-      }
+      const currentIndex = selectedTabId != null ? tabs.findIndex((t) => t.id === selectedTabId) : -1;
       let nextIndex: number | null = null;
 
       switch (event.key) {
         case "ArrowRight": {
-          nextIndex = (currentIndex + 1) % tabs.length;
+          nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % tabs.length;
           break;
         }
         case "ArrowLeft": {
-          nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+          nextIndex = currentIndex === -1 ? tabs.length - 1 : (currentIndex - 1 + tabs.length) % tabs.length;
           break;
         }
         case "Home": {
@@ -83,7 +82,7 @@ export function TabbedSection<TId extends string>({
       <div
         ref={tabListRef}
         className={classNames(styles.tabList, tabsClassName)}
-        role="tablist"
+        role={variant === "section" ? "tablist" : undefined}
         aria-label={tabListAriaLabel}
         onKeyDown={handleKeyDown}
       >
@@ -91,15 +90,17 @@ export function TabbedSection<TId extends string>({
           const tabDomId = `${tabSetId}-${tab.id}-tab`;
           const panelDomId = `${tabSetId}-${tab.id}-panel`;
           const isSelected = tab.id === selectedTabId;
+          const isFallbackFocusable = selectedTabId == null && tabs[0]?.id === tab.id;
           return (
             <button
               key={tab.id}
               id={tabDomId}
               type="button"
-              role="tab"
-              aria-selected={isSelected}
-              tabIndex={isSelected ? 0 : -1}
-              aria-controls={panelDomId}
+              role={variant === "section" ? "tab" : undefined}
+              aria-selected={variant === "section" ? isSelected : undefined}
+              aria-pressed={variant === "navigation" ? isSelected : undefined}
+              tabIndex={isSelected || isFallbackFocusable ? 0 : -1}
+              aria-controls={variant === "section" ? panelDomId : undefined}
               className={classNames(styles.tabButton, {
                 [styles.tabButtonActive]: isSelected,
               })}
@@ -113,23 +114,24 @@ export function TabbedSection<TId extends string>({
         })}
       </div>
 
-      {tabs.map((tab) => {
-        const tabDomId = `${tabSetId}-${tab.id}-tab`;
-        const panelDomId = `${tabSetId}-${tab.id}-panel`;
-        const isSelected = tab.id === selectedTabId;
-        return (
-          <div
-            key={tab.id}
-            id={panelDomId}
-            role="tabpanel"
-            aria-labelledby={tabDomId}
-            hidden={!isSelected}
-            className={classNames(styles.panel, tabContainerClassName)}
-          >
-            {tab.content}
-          </div>
-        );
-      })}
+      {variant === "section" &&
+        tabs.map((tab) => {
+          const tabDomId = `${tabSetId}-${tab.id}-tab`;
+          const panelDomId = `${tabSetId}-${tab.id}-panel`;
+          const isSelected = tab.id === selectedTabId;
+          return (
+            <div
+              key={tab.id}
+              id={panelDomId}
+              role="tabpanel"
+              aria-labelledby={tabDomId}
+              hidden={!isSelected}
+              className={classNames(styles.panel, tabContainerClassName)}
+            >
+              {tab.content}
+            </div>
+          );
+        })}
     </>
   );
 }

--- a/pages/src/components/tabbed-section/tabbed-section.tsx
+++ b/pages/src/components/tabbed-section/tabbed-section.tsx
@@ -6,13 +6,25 @@ import styles from "./tabbed-section.module.css";
 
 interface TabbedSectionProps<TId extends string> {
   readonly tabs: readonly TabbedSectionTab<TId>[];
-  readonly selectedTabId: TId | null;
   readonly tabListAriaLabel: string;
   readonly onTabChange: (tabId: TId) => void;
-  readonly variant?: "section" | "navigation";
   readonly tabsClassName?: string;
   readonly tabContainerClassName?: string;
 }
+
+interface TabbedSectionSectionProps<TId extends string> extends TabbedSectionProps<TId> {
+  readonly variant?: "section";
+  readonly selectedTabId: TId;
+}
+
+interface TabbedSectionNavigationProps<TId extends string> extends TabbedSectionProps<TId> {
+  readonly variant: "navigation";
+  readonly selectedTabId: TId | null;
+}
+
+type TabbedSectionComponentProps<TId extends string> =
+  | TabbedSectionSectionProps<TId>
+  | TabbedSectionNavigationProps<TId>;
 
 export function TabbedSection<TId extends string>({
   tabs,
@@ -22,7 +34,7 @@ export function TabbedSection<TId extends string>({
   variant = "section",
   tabsClassName,
   tabContainerClassName,
-}: TabbedSectionProps<TId>): React.ReactElement {
+}: TabbedSectionComponentProps<TId>): React.ReactElement {
   const tabSetId = React.useId();
   const tabListRef = React.useRef<HTMLDivElement>(null);
 

--- a/pages/src/components/tabbed-section/tests/tabbed-section.test.tsx
+++ b/pages/src/components/tabbed-section/tests/tabbed-section.test.tsx
@@ -168,7 +168,7 @@ describe("TabbedSection", () => {
     expect(onTabChange).not.toHaveBeenCalled();
   });
 
-  it("does not call onTabChange on ArrowRight when selectedTabId is not in tabs", () => {
+  it("falls back to first tab on ArrowRight when selectedTabId is not in tabs", () => {
     const onTabChange = vi.fn<(tabId: "players" | "kill-matrix") => void>();
 
     render(
@@ -185,7 +185,8 @@ describe("TabbedSection", () => {
 
     fireEvent.keyDown(screen.getByRole("tablist"), { key: "ArrowRight" });
 
-    expect(onTabChange).not.toHaveBeenCalled();
+    expect(onTabChange).toHaveBeenCalledOnce();
+    expect(onTabChange).toHaveBeenCalledWith("players");
   });
 
   it("moves focus to the newly selected tab button on ArrowRight", () => {
@@ -267,5 +268,50 @@ describe("TabbedSection", () => {
     fireEvent.keyDown(screen.getByRole("tablist"), { key: "ArrowRight", metaKey: true });
 
     expect(onTabChange).not.toHaveBeenCalled();
+  });
+
+  it("renders navigation variant without tabpanel ARIA wiring", () => {
+    render(
+      <TabbedSection
+        tabListAriaLabel="Demo tabs"
+        selectedTabId="players"
+        onTabChange={() => undefined}
+        variant="navigation"
+        tabs={[
+          { id: "players", label: "Players", content: <div>Players panel</div> },
+          { id: "kill-matrix", label: "Kill Matrix", content: <div>Kill matrix panel</div> },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByRole("tablist")).toBeNull();
+    expect(screen.queryByRole("tabpanel")).toBeNull();
+    expect(screen.getByRole("button", { name: "Players" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Kill Matrix" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("uses first tab as fallback focus target when selectedTabId is null", () => {
+    const onTabChange = vi.fn<(tabId: "players" | "kill-matrix") => void>();
+
+    render(
+      <TabbedSection
+        tabListAriaLabel="Demo tabs"
+        selectedTabId={null}
+        onTabChange={onTabChange}
+        variant="navigation"
+        tabs={[
+          { id: "players", label: "Players", content: <div>Players panel</div> },
+          { id: "kill-matrix", label: "Kill Matrix", content: <div>Kill matrix panel</div> },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Players" })).toHaveAttribute("tabindex", "0");
+    expect(screen.getByRole("button", { name: "Kill Matrix" })).toHaveAttribute("tabindex", "-1");
+
+    fireEvent.keyDown(screen.getByLabelText("Demo tabs"), { key: "ArrowRight" });
+
+    expect(onTabChange).toHaveBeenCalledOnce();
+    expect(onTabChange).toHaveBeenCalledWith("players");
   });
 });

--- a/pages/src/components/tabbed-section/types.ts
+++ b/pages/src/components/tabbed-section/types.ts
@@ -1,7 +1,9 @@
 import type { ReactNode } from "react";
 
+export type TabbedSectionLabel = Exclude<ReactNode, boolean | null | undefined>;
+
 export interface TabbedSectionTab<TId extends string> {
   readonly id: TId;
-  readonly label: NonNullable<ReactNode>;
+  readonly label: TabbedSectionLabel;
   readonly content: ReactNode;
 }

--- a/pages/src/components/tabbed-section/types.ts
+++ b/pages/src/components/tabbed-section/types.ts
@@ -2,6 +2,6 @@ import type { ReactNode } from "react";
 
 export interface TabbedSectionTab<TId extends string> {
   readonly id: TId;
-  readonly label: string;
+  readonly label: ReactNode;
   readonly content: ReactNode;
 }

--- a/pages/src/components/tabbed-section/types.ts
+++ b/pages/src/components/tabbed-section/types.ts
@@ -2,6 +2,6 @@ import type { ReactNode } from "react";
 
 export interface TabbedSectionTab<TId extends string> {
   readonly id: TId;
-  readonly label: ReactNode;
+  readonly label: NonNullable<ReactNode>;
   readonly content: ReactNode;
 }


### PR DESCRIPTION
## Context
The previous parity PR is merged, so this increment moves to the next planned step: refactor follow viewer tab navigation to reuse the shared tab component patterns already used across pages.

## This PR
- Refactors follow tracker tab rendering to use TabbedSection instead of bespoke tab button markup
- Preserves existing tab content semantics (gamertag, win/loss record, live badge, follow-live action)
- Expands TabbedSectionTab label typing to ReactNode so feature tabs can render richer labels while keeping existing string-label use cases
- Keeps selection behavior stable with fallback to the first tracker when needed

## Validation
- npm run done (format/typecheck/lint passed; test:changed had no related test files for the touched set)
- npx vitest run pages/src/components/follow/tests/follow-tracker-tabs.test.tsx pages/src/components/tabbed-section/tests/tabbed-section.test.tsx pages/src/components/follow/tests/use-follow-live-directory.test.ts

## Subsequent Work
- Continue public viewer parity implementation for individual tracker sections beyond tab container wiring
- Add focused multi/single tracker behavior coverage where missing as parity work expands
