### PR TITLE
feat: forward follow directory streamer settings into public viewer

### DIFF
--- a/pages/src/components/follow/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer.tsx
@@ -63,6 +63,7 @@ export function FollowLiveViewer({
             seriesMatchesService={seriesMatchesService}
             haloClient={haloClient}
             trackerId={selectedTrackerId}
+            streamerSettings={directory?.streamerSettings}
           />
         ) : directoryStatus === "error" && directory === null ? (
           <ErrorState message="Failed to load tracker directory" onRetry={onRetry} />

--- a/pages/src/components/follow/tests/follow-live-viewer.test.tsx
+++ b/pages/src/components/follow/tests/follow-live-viewer.test.tsx
@@ -18,7 +18,7 @@ vi.mock("../../individual-tracker/viewer/create", () => ({
     streamerSettings,
   }: {
     trackerId: string;
-    streamerSettings?: { styleFlags?: { showMatchmakingStatsOnly?: boolean } };
+    streamerSettings?: TrackerDirectory["streamerSettings"];
   }): React.ReactElement => (
     <div data-testid="mock-viewer">
       {trackerId}

--- a/pages/src/components/follow/tests/follow-live-viewer.test.tsx
+++ b/pages/src/components/follow/tests/follow-live-viewer.test.tsx
@@ -13,8 +13,19 @@ import { aFakeSeriesMatchesServiceWith } from "../../../services/stats/fakes/ser
 import { FollowLiveViewer, type FollowLiveViewerProps } from "../follow-live-viewer";
 
 vi.mock("../../individual-tracker/viewer/create", () => ({
-  IndividualTrackerViewerPage: ({ trackerId }: { trackerId: string }): React.ReactElement => (
-    <div data-testid="mock-viewer">{trackerId}</div>
+  IndividualTrackerViewerPage: ({
+    trackerId,
+    streamerSettings,
+  }: {
+    trackerId: string;
+    streamerSettings?: { styleFlags?: { showMatchmakingStatsOnly?: boolean } };
+  }): React.ReactElement => (
+    <div data-testid="mock-viewer">
+      {trackerId}
+      <span data-testid="mock-streamer-settings">
+        {streamerSettings?.styleFlags?.showMatchmakingStatsOnly === true ? "true" : "false"}
+      </span>
+    </div>
   ),
 }));
 
@@ -78,5 +89,23 @@ describe("FollowLiveViewer", () => {
     const trackerButtons = screen.getAllByRole("button", { name: /Spartan/ });
     expect(trackerButtons).toHaveLength(2);
     expect(screen.queryByTestId("mock-viewer")).toBeNull();
+  });
+
+  it("passes directory streamer settings into the viewer page", async () => {
+    const directoryWithSettings: TrackerDirectory = aDirectoryWith({
+      streamerSettings: {
+        styleFlags: {
+          showMatchmakingStatsOnly: true,
+        },
+      },
+    });
+
+    render(<FollowLiveViewer {...aViewerPropsWith(directoryWithSettings)} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-viewer")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("mock-streamer-settings")).toHaveTextContent("true");
   });
 });

--- a/pages/src/components/individual-tracker/viewer/create.tsx
+++ b/pages/src/components/individual-tracker/viewer/create.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { HaloInfiniteClient } from "halo-infinite-api";
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { ComponentLoader } from "../../component-loader/component-loader";
 import { ErrorState } from "../../error-state/error-state";
 import { LoadingState } from "../../loading-state/loading-state";
@@ -17,6 +18,7 @@ interface IndividualTrackerViewerPageProps {
   readonly seriesMatchesService: SeriesMatchesService;
   readonly haloClient: HaloInfiniteClient;
   readonly trackerId: string;
+  readonly streamerSettings?: StreamerViewSettings;
 }
 
 export function IndividualTrackerViewerPage({
@@ -26,6 +28,7 @@ export function IndividualTrackerViewerPage({
   seriesMatchesService,
   haloClient,
   trackerId,
+  streamerSettings,
 }: IndividualTrackerViewerPageProps): React.ReactElement {
   const canManage = individualTrackerService != null;
 
@@ -36,6 +39,7 @@ export function IndividualTrackerViewerPage({
     seriesMatchesService,
     haloClient,
     trackerId,
+    streamerSettings,
   });
 
   return (

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { HaloInfiniteClient } from "halo-infinite-api";
 import type { SeriesMatchesResponse } from "@guilty-spark/shared/contracts/stats/series-matches";
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import { aFakeIndividualTrackerServiceWith } from "../../../../services/individual-tracker/fakes/individual-tracker.fake";
@@ -34,6 +35,51 @@ function aViewerTestDependenciesWith(): ViewerTestDependencies {
 }
 
 describe("useIndividualTrackerViewer", () => {
+  it("does not recreate presenter when streamer settings values are unchanged", async () => {
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
+      view: aFakeTrackerViewStateWith({ trackerId: "tracker-1", status: "active" }),
+    });
+    const connectSpy = vi.spyOn(individualTrackerViewService, "connect");
+    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+
+    const initialSettings: StreamerViewSettings = {
+      styleFlags: {
+        showMatchmakingStatsOnly: true,
+      },
+    };
+
+    const { rerender } = renderHook(
+      ({ settings }: { settings: StreamerViewSettings }) =>
+        useIndividualTrackerViewer({
+          individualTrackerViewService,
+          matchAnalyticsService,
+          seriesMatchesService,
+          haloClient,
+          trackerId: "tracker-1",
+          streamerSettings: settings,
+        }),
+      {
+        initialProps: { settings: initialSettings },
+      },
+    );
+
+    await waitFor(() => {
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const nextSettings: StreamerViewSettings = {
+      styleFlags: {
+        showMatchmakingStatsOnly: true,
+      },
+    };
+
+    rerender({ settings: nextSettings });
+
+    await waitFor(() => {
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("clears refreshPending after the websocket view update arrives", async () => {
     const individualTrackerService = aFakeIndividualTrackerServiceWith();
     const refreshSpy = vi.spyOn(individualTrackerService, "refreshTracker").mockResolvedValue(undefined);

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -73,11 +73,12 @@ describe("useIndividualTrackerViewer", () => {
       },
     };
 
-    rerender({ settings: nextSettings });
-
-    await waitFor(() => {
-      expect(connectSpy).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      rerender({ settings: nextSettings });
+      await Promise.resolve();
     });
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
   });
 
   it("clears refreshPending after the websocket view update arrives", async () => {

--- a/pages/src/components/individual-tracker/viewer/use-individual-tracker-viewer.ts
+++ b/pages/src/components/individual-tracker/viewer/use-individual-tracker-viewer.ts
@@ -38,8 +38,6 @@ export function useIndividualTrackerViewer({
   streamerSettings,
 }: UseIndividualTrackerViewerOpts): IndividualTrackerViewerHookResult {
   const store = useMemo(() => new IndividualTrackerViewerStore(), []);
-  const streamerSettingsKey = useMemo(() => JSON.stringify(streamerSettings ?? null), [streamerSettings]);
-  const stableStreamerSettings = useMemo(() => streamerSettings, [streamerSettingsKey]);
 
   const presenter = useMemo(
     () =>
@@ -51,7 +49,6 @@ export function useIndividualTrackerViewer({
         haloClient,
         store,
         trackerId,
-        streamerSettings: stableStreamerSettings,
       }),
     [
       individualTrackerService,
@@ -61,9 +58,12 @@ export function useIndividualTrackerViewer({
       haloClient,
       store,
       trackerId,
-      stableStreamerSettings,
     ],
   );
+
+  useEffect(() => {
+    presenter.setStreamerSettings(streamerSettings);
+  }, [presenter, streamerSettings]);
 
   useEffect(() => {
     presenter.start();

--- a/pages/src/components/individual-tracker/viewer/use-individual-tracker-viewer.ts
+++ b/pages/src/components/individual-tracker/viewer/use-individual-tracker-viewer.ts
@@ -38,6 +38,8 @@ export function useIndividualTrackerViewer({
   streamerSettings,
 }: UseIndividualTrackerViewerOpts): IndividualTrackerViewerHookResult {
   const store = useMemo(() => new IndividualTrackerViewerStore(), []);
+  const streamerSettingsKey = useMemo(() => JSON.stringify(streamerSettings ?? null), [streamerSettings]);
+  const stableStreamerSettings = useMemo(() => streamerSettings, [streamerSettingsKey]);
 
   const presenter = useMemo(
     () =>
@@ -49,7 +51,7 @@ export function useIndividualTrackerViewer({
         haloClient,
         store,
         trackerId,
-        streamerSettings,
+        streamerSettings: stableStreamerSettings,
       }),
     [
       individualTrackerService,
@@ -59,7 +61,7 @@ export function useIndividualTrackerViewer({
       haloClient,
       store,
       trackerId,
-      streamerSettings,
+      stableStreamerSettings,
     ],
   );
 

--- a/pages/src/components/individual-tracker/viewer/use-individual-tracker-viewer.ts
+++ b/pages/src/components/individual-tracker/viewer/use-individual-tracker-viewer.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
 import type { HaloInfiniteClient } from "halo-infinite-api";
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
@@ -16,6 +17,7 @@ interface UseIndividualTrackerViewerOpts {
   readonly seriesMatchesService: SeriesMatchesService;
   readonly haloClient: HaloInfiniteClient;
   readonly trackerId: string;
+  readonly streamerSettings?: StreamerViewSettings;
 }
 
 export interface IndividualTrackerViewerHookResult {
@@ -33,6 +35,7 @@ export function useIndividualTrackerViewer({
   seriesMatchesService,
   haloClient,
   trackerId,
+  streamerSettings,
 }: UseIndividualTrackerViewerOpts): IndividualTrackerViewerHookResult {
   const store = useMemo(() => new IndividualTrackerViewerStore(), []);
 
@@ -46,6 +49,7 @@ export function useIndividualTrackerViewer({
         haloClient,
         store,
         trackerId,
+        streamerSettings,
       }),
     [
       individualTrackerService,
@@ -55,6 +59,7 @@ export function useIndividualTrackerViewer({
       haloClient,
       store,
       trackerId,
+      streamerSettings,
     ],
   );
 

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -481,7 +481,7 @@ export class IndividualTrackerViewerPresenter {
         return;
       }
       const view =
-        this.config.streamerSettings !== undefined
+        response.view.streamerSettings === undefined && this.config.streamerSettings !== undefined
           ? { ...response.view, streamerSettings: this.config.streamerSettings }
           : response.view;
       this.config.store.setLoaded(view);

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -4,6 +4,7 @@ import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
 import { getTeamName } from "@guilty-spark/shared/halo/team";
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { SeriesMatchesResponse } from "@guilty-spark/shared/contracts/stats/series-matches";
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { SeriesMatchesService } from "../../../services/stats/series-matches-types";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
@@ -51,6 +52,7 @@ interface Config {
   readonly haloClient: HaloInfiniteClient;
   readonly store: IndividualTrackerViewerStore;
   readonly trackerId: string;
+  readonly streamerSettings?: StreamerViewSettings;
 }
 
 const WIN_OUTCOME = 2;
@@ -478,7 +480,11 @@ export class IndividualTrackerViewerPresenter {
       if (this.isDisposed) {
         return;
       }
-      this.config.store.setLoaded(response.view);
+      const view =
+        this.config.streamerSettings !== undefined
+          ? { ...response.view, streamerSettings: this.config.streamerSettings }
+          : response.view;
+      this.config.store.setLoaded(view);
       this.openConnection();
     } catch (error) {
       if (this.isDisposed) {

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -52,7 +52,6 @@ interface Config {
   readonly haloClient: HaloInfiniteClient;
   readonly store: IndividualTrackerViewerStore;
   readonly trackerId: string;
-  readonly streamerSettings?: StreamerViewSettings;
 }
 
 const WIN_OUTCOME = 2;
@@ -221,6 +220,9 @@ export class IndividualTrackerViewerPresenter {
   private viewSubscription: TrackerViewSubscription | null = null;
   private statusSubscription: TrackerViewSubscription | null = null;
   private awaitingRefresh = false;
+  private streamerSettings: StreamerViewSettings | undefined;
+  private streamerSettingsKey = "null";
+  private hasServerStreamerSettings = false;
 
   public constructor(config: Config) {
     this.config = config;
@@ -271,6 +273,27 @@ export class IndividualTrackerViewerPresenter {
     this.awaitingRefresh = true;
     this.config.store.setRefreshState(true);
     void this.refreshAsync();
+  }
+
+  public setStreamerSettings(streamerSettings: StreamerViewSettings | undefined): void {
+    const nextKey = JSON.stringify(streamerSettings ?? null);
+    if (nextKey === this.streamerSettingsKey) {
+      return;
+    }
+
+    this.streamerSettings = streamerSettings;
+    this.streamerSettingsKey = nextKey;
+
+    if (this.hasServerStreamerSettings) {
+      return;
+    }
+
+    const snapshot = this.config.store.getSnapshot();
+    if (snapshot.view == null) {
+      return;
+    }
+
+    this.config.store.setLoaded({ ...snapshot.view, streamerSettings: this.streamerSettings });
   }
 
   public toggleEntry(item: ViewerTimelineItem): void {
@@ -480,9 +503,10 @@ export class IndividualTrackerViewerPresenter {
       if (this.isDisposed) {
         return;
       }
+      this.hasServerStreamerSettings = response.view.streamerSettings !== undefined;
       const view =
-        response.view.streamerSettings === undefined && this.config.streamerSettings !== undefined
-          ? { ...response.view, streamerSettings: this.config.streamerSettings }
+        response.view.streamerSettings === undefined && this.streamerSettings !== undefined
+          ? { ...response.view, streamerSettings: this.streamerSettings }
           : response.view;
       this.config.store.setLoaded(view);
       this.openConnection();


### PR DESCRIPTION
## Context
This is the next finite increment for public viewer parity after the follow-viewer behavior test stage.

## This PR
- Wires directory-level streamer settings from follow payload into the public individual tracker viewer path
- Threads optional streamer settings through FollowLiveViewer -> IndividualTrackerViewerPage -> useIndividualTrackerViewer -> presenter
- Moves streamer settings update handling into the presenter so equivalent settings object churn does not recreate the presenter
- Preserves server-provided tracker view streamer settings precedence; directory settings are fallback only when the view response omits settings
- Adds FollowLiveViewer test coverage to verify settings are forwarded
- Adds viewer hook regression coverage to verify unchanged streamer settings values do not trigger reconnect/reload churn

## Validation
- npx vitest run pages/src/components/follow/tests/follow-live-viewer.test.tsx
- npx vitest run pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
- npm run done

## Subsequent Work
- Continue remaining public viewer UI parity gaps with another finite increment
- Add any additional edge tests discovered during review
