### PR TITLE
fix: align live tracker fallback behavior across follow and manager

### DIFF
--- a/pages/src/components/follow/tests/use-follow-live-directory.test.ts
+++ b/pages/src/components/follow/tests/use-follow-live-directory.test.ts
@@ -127,6 +127,68 @@ describe("useFollowLiveDirectory", () => {
     expect(result.current.selectedTrackerId).toBe("tracker-2");
   });
 
+  it("falls back to preferred live tracker when manually selected tracker disappears", async () => {
+    const service = aFakeFollowLiveServiceWith({ directory: aDirectoryWith() });
+    const { result } = renderHook(() =>
+      useFollowLiveDirectory({ followLiveService: service, gamertag: "Spartan One" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedTrackerId).toBe("tracker-1");
+    });
+
+    act(() => {
+      result.current.onSelectTracker("tracker-2");
+    });
+
+    expect(result.current.isFollowingLive).toBe(false);
+
+    const updatedDir: TrackerDirectory = {
+      trackers: [
+        aTrackerWith({ trackerId: "tracker-1", isLive: false, status: "active" }),
+        aTrackerWith({ trackerId: "tracker-3", gamertag: "Spartan Three", isLive: true, status: "active" }),
+      ],
+      liveTrackerId: "tracker-3",
+    };
+
+    act(() => {
+      service.lastConnection?.emitDirectory(updatedDir);
+    });
+
+    expect(result.current.selectedTrackerId).toBe("tracker-3");
+    expect(result.current.isFollowingLive).toBe(true);
+  });
+
+  it("clears selectedTrackerId when selected tracker disappears and no tracker is active", async () => {
+    const service = aFakeFollowLiveServiceWith({ directory: aDirectoryWith() });
+    const { result } = renderHook(() =>
+      useFollowLiveDirectory({ followLiveService: service, gamertag: "Spartan One" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedTrackerId).toBe("tracker-1");
+    });
+
+    act(() => {
+      result.current.onSelectTracker("tracker-2");
+    });
+
+    const updatedDir: TrackerDirectory = {
+      trackers: [
+        aTrackerWith({ trackerId: "tracker-1", isLive: false, status: "stopped" }),
+        aTrackerWith({ trackerId: "tracker-3", gamertag: "Spartan Three", isLive: false, status: "paused" }),
+      ],
+      liveTrackerId: null,
+    };
+
+    act(() => {
+      service.lastConnection?.emitDirectory(updatedDir);
+    });
+
+    expect(result.current.selectedTrackerId).toBeNull();
+    expect(result.current.isFollowingLive).toBe(true);
+  });
+
   it("onSelectTracker sets isFollowingLive to false when selecting a non-live tracker", async () => {
     const service = aFakeFollowLiveServiceWith({ directory: aDirectoryWith() });
     const { result } = renderHook(() =>

--- a/pages/src/components/follow/use-follow-live-directory.ts
+++ b/pages/src/components/follow/use-follow-live-directory.ts
@@ -50,6 +50,8 @@ export function useFollowLiveDirectory({
   isFollowingLiveRef.current = isFollowingLive;
   const directoryRef = useRef(directory);
   directoryRef.current = directory;
+  const selectedTrackerIdRef = useRef(selectedTrackerId);
+  selectedTrackerIdRef.current = selectedTrackerId;
 
   const prevLiveTrackerIdRef = useRef<string | null>(null);
   const initialLoadDoneRef = useRef(false);
@@ -96,6 +98,16 @@ export function useFollowLiveDirectory({
 
       const newLiveId = findPreferredTrackerId(updatedDirectory);
       const prevLiveId = prevLiveTrackerIdRef.current;
+      const selectedId = selectedTrackerIdRef.current;
+      const selectedExists =
+        selectedId != null && updatedDirectory.trackers.some((tracker) => tracker.trackerId === selectedId);
+
+      if (!selectedExists) {
+        setSelectedTrackerId(newLiveId);
+        setIsFollowingLive(true);
+        prevLiveTrackerIdRef.current = newLiveId;
+        return;
+      }
 
       if (isFollowingLiveRef.current && newLiveId !== prevLiveId) {
         setSelectedTrackerId(newLiveId);

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -64,6 +64,8 @@ export class LiveTrackersPresenter {
   private liveConnectionKey: string | null = null;
   private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
   private refreshInFlight = false;
+  private refreshRequested = false;
+  private refreshExecution: Promise<void> | null = null;
   private activeLiveView: TrackerLiveView | null = null;
 
   public constructor(config: Config) {
@@ -324,40 +326,59 @@ export class LiveTrackersPresenter {
   }
 
   public async refresh(): Promise<void> {
-    const snapshot = this.getSnapshot();
-    if (snapshot.userId == null) {
-      this.resetForUnauthenticated();
+    this.refreshRequested = true;
+    if (this.refreshExecution != null) {
+      await this.refreshExecution;
       return;
     }
 
-    this.refreshInFlight = true;
+    this.refreshExecution = this.runRefreshLoop();
     try {
-      const initialResponse = await this.config.individualTrackerService.listTrackers();
-      const desiredLive = findFallbackLiveTracker(initialResponse.trackers);
-      const currentLive = initialResponse.trackers.find((tracker) => tracker.isLive) ?? null;
+      await this.refreshExecution;
+    } finally {
+      this.refreshExecution = null;
+    }
+  }
 
-      let { trackers } = initialResponse;
-      if (desiredLive != null && desiredLive.trackerId !== currentLive?.trackerId) {
-        await this.config.individualTrackerService.selectActive(desiredLive.trackerId);
-        const refreshedResponse = await this.config.individualTrackerService.listTrackers();
-        ({ trackers } = refreshedResponse);
+  private async runRefreshLoop(): Promise<void> {
+    while (this.refreshRequested && !this.isDisposed) {
+      this.refreshRequested = false;
+
+      const snapshot = this.getSnapshot();
+      if (snapshot.userId == null) {
+        this.resetForUnauthenticated();
+        continue;
       }
 
-      const liveTracker = findFallbackLiveTracker(trackers);
+      this.refreshInFlight = true;
+      try {
+        const initialResponse = await this.config.individualTrackerService.listTrackers();
+        const desiredLive = findFallbackLiveTracker(initialResponse.trackers);
+        const currentLive = initialResponse.trackers.find((tracker) => tracker.isLive) ?? null;
 
-      this.updateSnapshot((current) => ({
-        ...current,
-        activeTracker: liveTracker?.state ?? null,
-        runningTrackers: trackers.map((t) => ({ trackerId: t.trackerId, gamertag: t.gamertag, xuid: t.xuid })),
-        trackerStatuses: Object.fromEntries<TrackerState | null>(trackers.map((t) => [t.trackerId, t.state ?? null])),
-      }));
-    } catch (error) {
-      this.updateSnapshot((current) => ({
-        ...current,
-        errorMessage: error instanceof Error ? error.message : "Failed to load individual tracker.",
-      }));
-    } finally {
-      this.refreshInFlight = false;
+        let { trackers } = initialResponse;
+        if (desiredLive != null && desiredLive.trackerId !== currentLive?.trackerId) {
+          await this.config.individualTrackerService.selectActive(desiredLive.trackerId);
+          const refreshedResponse = await this.config.individualTrackerService.listTrackers();
+          ({ trackers } = refreshedResponse);
+        }
+
+        const liveTracker = findFallbackLiveTracker(trackers);
+
+        this.updateSnapshot((current) => ({
+          ...current,
+          activeTracker: liveTracker?.state ?? null,
+          runningTrackers: trackers.map((t) => ({ trackerId: t.trackerId, gamertag: t.gamertag, xuid: t.xuid })),
+          trackerStatuses: Object.fromEntries<TrackerState | null>(trackers.map((t) => [t.trackerId, t.state ?? null])),
+        }));
+      } catch (error) {
+        this.updateSnapshot((current) => ({
+          ...current,
+          errorMessage: error instanceof Error ? error.message : "Failed to load individual tracker.",
+        }));
+      } finally {
+        this.refreshInFlight = false;
+      }
     }
   }
 

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -1,4 +1,4 @@
-import type { TrackerState, TrackerStatus } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
+import type { Tracker, TrackerState, TrackerStatus } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import type { TrackerLiveView } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import { getDefaultSeriesGroupTitle } from "@guilty-spark/shared/individual-tracker/series-grouping";
 import type {
@@ -22,6 +22,20 @@ interface Config {
 }
 
 const NON_LIVE_POLL_INTERVAL_MS = 30_000;
+
+function findFallbackLiveTracker(trackers: readonly Tracker[]): Tracker | null {
+  const currentLive = trackers.find((tracker) => tracker.isLive) ?? null;
+  const currentLiveStopped = currentLive?.state?.status === "stopped";
+
+  if (currentLive != null && !currentLiveStopped) {
+    return currentLive;
+  }
+
+  const fallback = trackers.find(
+    (tracker) => tracker.state?.status === "active" && tracker.trackerId !== currentLive?.trackerId,
+  );
+  return fallback ?? null;
+}
 
 function toOverrideOrNull(value: string, defaultValue: string): string | null {
   const normalizedValue = value.trim();
@@ -318,8 +332,18 @@ export class LiveTrackersPresenter {
 
     this.refreshInFlight = true;
     try {
-      const { trackers } = await this.config.individualTrackerService.listTrackers();
-      const liveTracker = trackers.find((t) => t.isLive);
+      const initialResponse = await this.config.individualTrackerService.listTrackers();
+      const desiredLive = findFallbackLiveTracker(initialResponse.trackers);
+      const currentLive = initialResponse.trackers.find((tracker) => tracker.isLive) ?? null;
+
+      let { trackers } = initialResponse;
+      if (desiredLive != null && desiredLive.trackerId !== currentLive?.trackerId) {
+        await this.config.individualTrackerService.selectActive(desiredLive.trackerId);
+        const refreshedResponse = await this.config.individualTrackerService.listTrackers();
+        ({ trackers } = refreshedResponse);
+      }
+
+      const liveTracker = findFallbackLiveTracker(trackers);
 
       this.updateSnapshot((current) => ({
         ...current,
@@ -427,8 +451,7 @@ export class LiveTrackersPresenter {
       if (status !== "stopped") {
         return;
       }
-      // Null activeTracker so that if the same tracker is restarted, syncRuntimeDependencies
-      // sees a key change and establishes a fresh WS connection.
+      // Null activeTracker immediately, then refresh to allow fallback live selection.
       this.updateSnapshot((snapshot) => {
         const existing = snapshot.trackerStatuses[trackerId] ?? null;
         return {
@@ -440,6 +463,7 @@ export class LiveTrackersPresenter {
               : { ...snapshot.trackerStatuses, [trackerId]: { ...existing, status: "stopped" as TrackerStatus } },
         };
       });
+      void this.refresh();
     });
   }
 

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -25,14 +25,14 @@ const NON_LIVE_POLL_INTERVAL_MS = 30_000;
 
 function findFallbackLiveTracker(trackers: readonly Tracker[]): Tracker | null {
   const currentLive = trackers.find((tracker) => tracker.isLive) ?? null;
-  const currentLiveStopped = currentLive?.state?.status === "stopped";
+  const currentLiveStopped = currentLive?.status === "stopped";
 
   if (currentLive != null && !currentLiveStopped) {
     return currentLive;
   }
 
   const fallback = trackers.find(
-    (tracker) => tracker.state?.status === "active" && tracker.trackerId !== currentLive?.trackerId,
+    (tracker) => tracker.status === "active" && tracker.trackerId !== currentLive?.trackerId,
   );
   return fallback ?? null;
 }

--- a/pages/src/components/individual-tracker-manager/live-trackers/tests/live-trackers-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/tests/live-trackers-presenter.test.ts
@@ -498,7 +498,7 @@ describe("LiveTrackersPresenter", () => {
       gamertag: "Chief",
       status: "stopped",
       isLive: true,
-      state: aFakeTrackerState({ trackerId: "t1", gamertag: "Chief", status: "stopped" }),
+      state: null,
     });
     const activeTracker = aFakeTrackerWith({
       trackerId: "t2",
@@ -526,7 +526,7 @@ describe("LiveTrackersPresenter", () => {
       gamertag: "Chief",
       status: "stopped",
       isLive: true,
-      state: aFakeTrackerState({ trackerId: "t1", gamertag: "Chief", status: "stopped" }),
+      state: null,
     });
     const pausedTracker = aFakeTrackerWith({
       trackerId: "t2",

--- a/pages/src/components/individual-tracker-manager/live-trackers/tests/live-trackers-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/tests/live-trackers-presenter.test.ts
@@ -492,6 +492,62 @@ describe("LiveTrackersPresenter", () => {
     presenter.dispose();
   });
 
+  it("promotes another active tracker when current live tracker is stopped", async () => {
+    const stoppedLiveTracker = aFakeTrackerWith({
+      trackerId: "t1",
+      gamertag: "Chief",
+      status: "stopped",
+      isLive: true,
+      state: aFakeTrackerState({ trackerId: "t1", gamertag: "Chief", status: "stopped" }),
+    });
+    const activeTracker = aFakeTrackerWith({
+      trackerId: "t2",
+      gamertag: "Arbiter",
+      status: "active",
+      isLive: false,
+      state: aFakeTrackerState({ trackerId: "t2", gamertag: "Arbiter", status: "active" }),
+    });
+    const { presenter, service } = aHarness({ trackers: [stoppedLiveTracker, activeTracker] });
+    const selectActiveSpy = vi.spyOn(service, "selectActive");
+
+    presenter.start();
+    presenter.setSessionContext("u1", null, null);
+    await presenter.refresh();
+
+    expect(selectActiveSpy).toHaveBeenCalledWith("t2");
+    expect(presenter.getSnapshot().activeTracker?.trackerId).toBe("t2");
+
+    presenter.dispose();
+  });
+
+  it("keeps activeTracker null when no active fallback exists", async () => {
+    const stoppedLiveTracker = aFakeTrackerWith({
+      trackerId: "t1",
+      gamertag: "Chief",
+      status: "stopped",
+      isLive: true,
+      state: aFakeTrackerState({ trackerId: "t1", gamertag: "Chief", status: "stopped" }),
+    });
+    const pausedTracker = aFakeTrackerWith({
+      trackerId: "t2",
+      gamertag: "Arbiter",
+      status: "paused",
+      isLive: false,
+      state: aFakeTrackerState({ trackerId: "t2", gamertag: "Arbiter", status: "paused" }),
+    });
+    const { presenter, service } = aHarness({ trackers: [stoppedLiveTracker, pausedTracker] });
+    const selectActiveSpy = vi.spyOn(service, "selectActive");
+
+    presenter.start();
+    presenter.setSessionContext("u1", null, null);
+    await presenter.refresh();
+
+    expect(selectActiveSpy).not.toHaveBeenCalled();
+    expect(presenter.getSnapshot().activeTracker).toBeNull();
+
+    presenter.dispose();
+  });
+
   it("resetForUnauthenticated clears all session state", async () => {
     const tracker = aFakeTrackerWith({ trackerId: "t1", gamertag: "Chief" });
     const { presenter, store } = aHarness({ trackers: [tracker] });


### PR DESCRIPTION
## Context
This finite increment aligns live-tracker fallback behavior across follow/public viewer and user manager flows after PR #607.

## This PR
- Follow directory hook now reconciles stale manual selection when the selected tracker disappears from incoming directory updates
- Follow mode falls back to preferred live/active tracker and re-enables follow-live when stale selection is removed
- Follow mode clears selection when no active/live tracker exists, allowing the viewer to present the no-active state
- Manager live-trackers presenter now auto-promotes another active tracker when the current live tracker is stopped/missing
- Manager snapshot keeps `activeTracker` null when no active fallback exists

## Validation
- npx vitest run pages/src/components/follow/tests/use-follow-live-directory.test.ts pages/src/components/individual-tracker-manager/live-trackers/tests/live-trackers-presenter.test.ts
- npm run done

## Subsequent Work
- Continue remaining individual tracker UI parity gaps in a new finite increment
