### PR TITLE
Fix follow viewer refresh and active series status

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -232,6 +232,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           "IndividualTracker: idle timeout reached, stopping tracker",
           new Map<string, JsonAny>([
             ["trackerId", trackerState.trackerId],
+            ["gamertag", trackerState.gamertag],
             ["idleTimeoutHours", trackerState.idleTimeoutHours],
           ]),
         );
@@ -274,6 +275,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       "IndividualTracker: polling for new matches with marker strategy",
       new Map([
         ["trackerId", trackerState.trackerId],
+        ["gamertag", trackerState.gamertag],
         ["lastSeenMatchId", trackerState.lastSeenMatchId ?? "none"],
       ]),
     );
@@ -344,6 +346,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         "IndividualTracker: added new match to tracker",
         new Map([
           ["trackerId", trackerState.trackerId],
+          ["gamertag", trackerState.gamertag],
           ["matchId", matchId],
           ["mapName", summary.mapName],
           ["score", summary.score],
@@ -359,6 +362,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       "IndividualTracker: poll marker filter summary",
       new Map<string, JsonAny>([
         ["trackerId", trackerState.trackerId],
+        ["gamertag", trackerState.gamertag],
         ["strategy", strategy],
         ["totalFetched", allMatches.length],
         ["processedRange", matchesToProcess.length],
@@ -434,6 +438,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       "IndividualTracker: poll with marker complete",
       new Map<string, JsonAny>([
         ["trackerId", trackerState.trackerId],
+        ["gamertag", trackerState.gamertag],
         ["newMatches", newlyDiscovered.size],
         ["totalMatches", trackerState.matchIds.length],
         ["checkCount", trackerState.checkCount],
@@ -481,6 +486,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           new Map<string, JsonAny>([
             ["context", "IndividualTracker failed to retrieve player matches page"],
             ["trackerId", trackerState.trackerId],
+            ["gamertag", trackerState.gamertag],
             ["page", page],
           ]),
         );
@@ -495,6 +501,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       "IndividualTracker: fetched matches with marker scan",
       new Map<string, JsonAny>([
         ["trackerId", trackerState.trackerId],
+        ["gamertag", trackerState.gamertag],
         ["totalFetched", allMatches.length],
         ["markerFound", markerFound],
         ["markerFoundAtIndex", markerFoundAtIndex],
@@ -660,6 +667,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         new Map([
           ["context", "IndividualTracker: failed to mark registry stopped on idle timeout"],
           ["trackerId", trackerState.trackerId],
+          ["gamertag", trackerState.gamertag],
         ]),
       );
     }
@@ -815,7 +823,13 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     await this.setState(trackerState);
     this.broadcastViewState(trackerState);
 
-    this.logService.info("IndividualTracker: tracker paused", new Map([["trackerId", trackerState.trackerId]]));
+    this.logService.info(
+      "IndividualTracker: tracker paused",
+      new Map([
+        ["trackerId", trackerState.trackerId],
+        ["gamertag", trackerState.gamertag],
+      ]),
+    );
 
     return individualTrackerPauseContract.toResponse({ success: true, state: this.sanitizeState(trackerState) });
   }
@@ -834,7 +848,13 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     await this.state.storage.setAlarm(addMilliseconds(new Date(), resumeAlarmDelay).getTime());
     this.broadcastViewState(trackerState);
 
-    this.logService.info("IndividualTracker: tracker resumed", new Map([["trackerId", trackerState.trackerId]]));
+    this.logService.info(
+      "IndividualTracker: tracker resumed",
+      new Map([
+        ["trackerId", trackerState.trackerId],
+        ["gamertag", trackerState.gamertag],
+      ]),
+    );
 
     return individualTrackerResumeContract.toResponse({ success: true, state: this.sanitizeState(trackerState) });
   }
@@ -850,7 +870,13 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       trackerState.lastUpdateTime = new Date().toISOString();
       this.broadcastViewState(trackerState);
       this.closeWebSockets("Tracker stopped");
-      this.logService.info("IndividualTracker: tracker stopped", new Map([["trackerId", trackerState.trackerId]]));
+      this.logService.info(
+        "IndividualTracker: tracker stopped",
+        new Map([
+          ["trackerId", trackerState.trackerId],
+          ["gamertag", trackerState.gamertag],
+        ]),
+      );
     }
 
     return individualTrackerStopContract.toResponse({ success: true });
@@ -905,6 +931,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       "IndividualTracker: match selection updated",
       new Map<string, JsonAny>([
         ["trackerId", trackerState.trackerId],
+        ["gamertag", trackerState.gamertag],
         ["selectedCount", incoming.length],
         ["seriesGroupCount", body.seriesGroups.length],
       ]),
@@ -1280,7 +1307,13 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     await this.setState(trackerState);
     this.broadcastViewState(trackerState);
 
-    this.logService.info("IndividualTracker: series started", new Map([["trackerId", trackerState.trackerId]]));
+    this.logService.info(
+      "IndividualTracker: series started",
+      new Map([
+        ["trackerId", trackerState.trackerId],
+        ["gamertag", trackerState.gamertag],
+      ]),
+    );
 
     return startSeriesContract.toResponse({ success: true });
   }
@@ -1301,7 +1334,13 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     await this.setState(trackerState);
     this.broadcastViewState(trackerState);
 
-    this.logService.info("IndividualTracker: series ended", new Map([["trackerId", trackerState.trackerId]]));
+    this.logService.info(
+      "IndividualTracker: series ended",
+      new Map([
+        ["trackerId", trackerState.trackerId],
+        ["gamertag", trackerState.gamertag],
+      ]),
+    );
 
     return endSeriesContract.toResponse({ success: true });
   }
@@ -1362,7 +1401,13 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     await this.setState(trackerState);
     this.broadcastViewState(trackerState);
 
-    this.logService.info("IndividualTracker: series resumed", new Map([["trackerId", trackerState.trackerId]]));
+    this.logService.info(
+      "IndividualTracker: series resumed",
+      new Map([
+        ["trackerId", trackerState.trackerId],
+        ["gamertag", trackerState.gamertag],
+      ]),
+    );
 
     return resumeSeriesContract.toResponse({ success: true });
   }
@@ -1674,7 +1719,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     const trackerState = await this.getState();
     this.logService.info(
       "IndividualTracker: WebSocket connection requested",
-      new Map([["trackerId", trackerState?.trackerId ?? "unknown"]]),
+      new Map([
+        ["trackerId", trackerState?.trackerId ?? "unknown"],
+        ["gamertag", trackerState?.gamertag ?? "unknown"],
+      ]),
     );
     try {
       const response = this.webSocketAdapter.upgrade(
@@ -1683,7 +1731,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       );
       this.logService.info(
         "IndividualTracker: WebSocket connection established",
-        new Map([["trackerId", trackerState?.trackerId ?? "unknown"]]),
+        new Map([
+          ["trackerId", trackerState?.trackerId ?? "unknown"],
+          ["gamertag", trackerState?.gamertag ?? "unknown"],
+        ]),
       );
       return response;
     } catch (error) {

--- a/api/routes/individual-tracker/follow.ts
+++ b/api/routes/individual-tracker/follow.ts
@@ -12,6 +12,7 @@ import type { RoutesRegisterHandler } from "../base/types";
 import { fetchTrackerDoViewState, toTrackerView } from "./mapper";
 
 const gamertagParamsSchema = z.object({ gamertag: z.string().min(1) });
+const FOLLOW_WS_POLL_INTERVAL_MS = 3000;
 
 function isNonStopped(row: IndividualTrackersRow): boolean {
   return row.Status !== "stopped";
@@ -93,10 +94,34 @@ export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       const { 0: client, 1: server } = new WebSocketPair();
       server.accept();
-      server.send(trackerDirectoryMessageContract.serialize({ type: "directory", directory }));
-      // Push-on-change (tracker goes live, new tracker added) is deferred to a future PR
-      // that subscribes to individual tracker DOs. For now clients get the snapshot on
-      // connect and can reconnect to refresh.
+      let lastPayload = trackerDirectoryMessageContract.serialize({ type: "directory", directory });
+      server.send(lastPayload);
+
+      const pollInterval = setInterval(() => {
+        void (async (): Promise<void> => {
+          try {
+            const nextDirectory = await buildDirectory(env, identity.UserId, services);
+            const nextPayload = trackerDirectoryMessageContract.serialize({
+              type: "directory",
+              directory: nextDirectory,
+            });
+            if (nextPayload === lastPayload) {
+              return;
+            }
+            lastPayload = nextPayload;
+            server.send(nextPayload);
+          } catch (pollError) {
+            logService.error(pollError, new Map([["context", "Follow WebSocket poll error"]]));
+          }
+        })();
+      }, FOLLOW_WS_POLL_INTERVAL_MS);
+
+      const stopPolling = (): void => {
+        clearInterval(pollInterval);
+      };
+
+      server.addEventListener("close", stopPolling);
+      server.addEventListener("error", stopPolling);
 
       return new Response(null, { status: 101, webSocket: client });
     } catch (error) {

--- a/api/routes/individual-tracker/tests/follow.test.ts
+++ b/api/routes/individual-tracker/tests/follow.test.ts
@@ -278,6 +278,92 @@ describe("/u/:gamertag follow routes", () => {
   });
 
   describe("GET /u/:gamertag/ws", () => {
+    it("pushes updated directory messages when live tracker changes", async () => {
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "LiveSwitchTag" });
+      const trackerOneLive = aFakeIndividualTrackersRow({
+        TrackerId: "t1",
+        UserId: "user-1",
+        Status: "active",
+        IsLive: 1,
+      });
+      const trackerTwo = aFakeIndividualTrackersRow({
+        TrackerId: "t2",
+        UserId: "user-1",
+        Status: "active",
+        IsLive: 0,
+      });
+      const trackerTwoLive = aFakeIndividualTrackersRow({
+        TrackerId: "t2",
+        UserId: "user-1",
+        Status: "active",
+        IsLive: 1,
+      });
+
+      let capturedServer: WebSocket | undefined;
+      const client = makeFakeWebSocket();
+      const server = makeFakeWebSocket();
+      vi.stubGlobal("WebSocketPair", function () {
+        capturedServer = server;
+        return { 0: client, 1: server };
+      });
+
+      const OriginalResponse = globalThis.Response;
+      vi.stubGlobal(
+        "Response",
+        class FakeResponse extends OriginalResponse {
+          constructor(body: BodyInit | null, init?: ResponseInit & { webSocket?: WebSocket }) {
+            super(body, { ...init, status: init?.status === 101 ? 200 : (init?.status ?? 200) });
+            if (init?.status === 101) {
+              Object.defineProperty(this, "status", { value: 101 });
+            }
+          }
+        },
+      );
+
+      let pollCallback: (() => void) | undefined;
+      vi.spyOn(globalThis, "setInterval").mockImplementation((callback) => {
+        pollCallback = callback;
+        return 1 as unknown as NodeJS.Timeout;
+      });
+
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
+        // First call returns t1 live, second call returns t2 live
+        vi.spyOn(services.databaseService, "findIndividualTrackersByUserId")
+          .mockResolvedValueOnce([trackerOneLive, trackerTwo])
+          .mockResolvedValueOnce([trackerTwo, trackerTwoLive]);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(wsRequest("/u/LiveSwitchTag/ws"), env)) as Response;
+      expect(res.status).toBe(101);
+
+      const serverMocks = capturedServer as unknown as Record<string, ReturnType<typeof vi.fn>> | undefined;
+      const sendMock = serverMocks?.["send"];
+      expect(sendMock).toHaveBeenCalledOnce();
+
+      // Check that initial state has t1 as live
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const firstPayload = sendMock?.mock.calls[0]?.[0];
+      const firstMessage = trackerDirectoryMessageContract.parse(firstPayload as string);
+      expect(firstMessage.directory.liveTrackerId).toBe("t1");
+
+      expect(pollCallback).toBeDefined();
+      pollCallback?.();
+      await vi.waitFor(() => {
+        expect(sendMock).toHaveBeenCalledTimes(2);
+      });
+
+      // Should now have 2 sends (initial + updated)
+      expect(sendMock).toHaveBeenCalledTimes(2);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const secondPayload = sendMock?.mock.calls[1]?.[0];
+      const secondMessage = trackerDirectoryMessageContract.parse(secondPayload as string);
+      expect(secondMessage.directory.liveTrackerId).toBe("t2");
+    });
+
     it("returns 404 when gamertag is not found", async () => {
       const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
         const services = installFakeServicesWith({ env });

--- a/api/worker.ts
+++ b/api/worker.ts
@@ -15,12 +15,12 @@ const server = new Server({
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: "https://76d3531a8ad7eb47ae6e8574e5fd9f9d@o4509134330462208.ingest.us.sentry.io/4509134352285696",
+    enabled: env.MODE === "production",
     environment: env.MODE === "development" ? "development" : "production",
     // Set tracesSampleRate to 1.0 to capture 100% of spans for tracing.
     // Learn more at
     // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
     tracesSampleRate: 1.0,
-    debug: env.MODE === "development",
     beforeSend: (
       event: Sentry.ErrorEvent,
       hint: Sentry.EventHint,

--- a/pages/src/apps/individual-tracker-viewer/create.tsx
+++ b/pages/src/apps/individual-tracker-viewer/create.tsx
@@ -84,6 +84,7 @@ export function IndividualTrackerViewerApp({ apiHost, trackerId }: IndividualTra
             seriesMatchesService={services.seriesMatchesService}
             haloClient={services.haloClient}
             trackerId={trackerId}
+            pageTitleVariant="tracker"
           />
         ) : (
           <ErrorState message="Services failed to load" />

--- a/pages/src/components/follow/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer.tsx
@@ -83,6 +83,8 @@ export function FollowLiveViewer({
     gamertag,
   });
   const connectionStatusOverride = toTrackerConnectionStatus(directoryStatus);
+  const selectedTracker =
+    selectedTrackerId == null ? null : directory?.trackers.find((tracker) => tracker.trackerId === selectedTrackerId);
 
   React.useEffect(() => {
     document.title = getViewerTitle(gamertag, directory);
@@ -98,14 +100,14 @@ export function FollowLiveViewer({
         />
       )}
       <div className={styles.trackerContent}>
-        {selectedTrackerId !== null ? (
+        {selectedTracker != null ? (
           <IndividualTrackerViewerPage
-            key={selectedTrackerId}
+            key={`${selectedTracker.trackerId}:${selectedTracker.lastUpdateTime}`}
             individualTrackerViewService={individualTrackerViewService}
             matchAnalyticsService={matchAnalyticsService}
             seriesMatchesService={seriesMatchesService}
             haloClient={haloClient}
-            trackerId={selectedTrackerId}
+            trackerId={selectedTracker.trackerId}
             streamerSettings={directory?.streamerSettings}
             connectionStatusOverride={connectionStatusOverride}
           />

--- a/pages/src/components/follow/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 import type { HaloInfiniteClient } from "halo-infinite-api";
+import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
 import { ErrorState } from "../error-state/error-state";
 import { LoadingState } from "../loading-state/loading-state";
 import { IndividualTrackerViewerPage } from "../individual-tracker/viewer/create";
 import type { FollowLiveService } from "../../services/follow/follow-types";
-import type { TrackerViewConnectionStatus , IndividualTrackerViewService } from "../../services/individual-tracker/view-types";
+import type {
+  TrackerViewConnectionStatus,
+  IndividualTrackerViewService,
+} from "../../services/individual-tracker/view-types";
 import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import type { SeriesMatchesService } from "../../services/stats/series-matches-types";
 import { FollowTrackerTabs } from "./follow-tracker-tabs";
@@ -33,6 +37,30 @@ function toTrackerConnectionStatus(
   }
 }
 
+function getLiveTracker(directory: TrackerDirectory | null): TrackerDirectory["trackers"][number] | null {
+  if (directory == null) {
+    return null;
+  }
+
+  if (directory.liveTrackerId != null) {
+    const liveTracker = directory.trackers.find((tracker) => tracker.trackerId === directory.liveTrackerId);
+    if (liveTracker != null) {
+      return liveTracker;
+    }
+  }
+
+  return directory.trackers.find((tracker) => tracker.isLive) ?? null;
+}
+
+function getViewerTitle(gamertag: string, directory: TrackerDirectory | null): string {
+  const liveTracker = getLiveTracker(directory);
+  if (liveTracker == null) {
+    return `${gamertag} live view - Guilty Spark`;
+  }
+
+  return `${gamertag} live view - ${liveTracker.gamertag} live - Guilty Spark`;
+}
+
 export interface FollowLiveViewerProps {
   readonly gamertag: string;
   readonly followLiveService: FollowLiveService;
@@ -55,6 +83,10 @@ export function FollowLiveViewer({
     gamertag,
   });
   const connectionStatusOverride = toTrackerConnectionStatus(directoryStatus);
+
+  React.useEffect(() => {
+    document.title = getViewerTitle(gamertag, directory);
+  }, [directory, gamertag]);
 
   return (
     <div className={styles.container}>

--- a/pages/src/components/follow/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer.tsx
@@ -1,16 +1,37 @@
 import React from "react";
 import type { HaloInfiniteClient } from "halo-infinite-api";
-import { Alert } from "../alert/alert";
 import { ErrorState } from "../error-state/error-state";
 import { LoadingState } from "../loading-state/loading-state";
 import { IndividualTrackerViewerPage } from "../individual-tracker/viewer/create";
 import type { FollowLiveService } from "../../services/follow/follow-types";
-import type { IndividualTrackerViewService } from "../../services/individual-tracker/view-types";
+import type { TrackerViewConnectionStatus , IndividualTrackerViewService } from "../../services/individual-tracker/view-types";
 import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import type { SeriesMatchesService } from "../../services/stats/series-matches-types";
 import { FollowTrackerTabs } from "./follow-tracker-tabs";
 import { useFollowLiveDirectory } from "./use-follow-live-directory";
 import styles from "./follow-live-viewer.module.css";
+
+function toTrackerConnectionStatus(
+  directoryStatus: "connecting" | "connected" | "error" | "disconnected",
+): TrackerViewConnectionStatus | undefined {
+  switch (directoryStatus) {
+    case "connected": {
+      return undefined;
+    }
+    case "connecting": {
+      return undefined;
+    }
+    case "disconnected": {
+      return "disconnected";
+    }
+    case "error": {
+      return "error";
+    }
+    default: {
+      return undefined;
+    }
+  }
+}
 
 export interface FollowLiveViewerProps {
   readonly gamertag: string;
@@ -33,20 +54,10 @@ export function FollowLiveViewer({
     followLiveService,
     gamertag,
   });
-
-  const showBanner = (directoryStatus === "error" && directory !== null) || directoryStatus === "disconnected";
+  const connectionStatusOverride = toTrackerConnectionStatus(directoryStatus);
 
   return (
     <div className={styles.container}>
-      {showBanner && (
-        <Alert variant={directoryStatus === "disconnected" ? "warning" : "error"}>
-          {directoryStatus === "error"
-            ? directory !== null
-              ? "Connection error — data may be stale"
-              : "Failed to load tracker directory"
-            : "Disconnected — reload to refresh"}
-        </Alert>
-      )}
       {directory !== null && directory.trackers.length > 1 && (
         <FollowTrackerTabs
           directory={directory}
@@ -64,6 +75,7 @@ export function FollowLiveViewer({
             haloClient={haloClient}
             trackerId={selectedTrackerId}
             streamerSettings={directory?.streamerSettings}
+            connectionStatusOverride={connectionStatusOverride}
           />
         ) : directoryStatus === "error" && directory === null ? (
           <ErrorState message="Failed to load tracker directory" onRetry={onRetry} />

--- a/pages/src/components/follow/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer.tsx
@@ -29,8 +29,10 @@ export function FollowLiveViewer({
   seriesMatchesService,
   haloClient,
 }: FollowLiveViewerProps): React.ReactElement {
-  const { directory, directoryStatus, selectedTrackerId, isFollowingLive, onSelectTracker, onFollowLive, onRetry } =
-    useFollowLiveDirectory({ followLiveService, gamertag });
+  const { directory, directoryStatus, selectedTrackerId, onSelectTracker, onRetry } = useFollowLiveDirectory({
+    followLiveService,
+    gamertag,
+  });
 
   const showBanner = (directoryStatus === "error" && directory !== null) || directoryStatus === "disconnected";
 
@@ -49,9 +51,7 @@ export function FollowLiveViewer({
         <FollowTrackerTabs
           directory={directory}
           selectedTrackerId={selectedTrackerId}
-          isFollowingLive={isFollowingLive}
           onSelectTracker={onSelectTracker}
-          onFollowLive={onFollowLive}
         />
       )}
       <div className={styles.trackerContent}>

--- a/pages/src/components/follow/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer.tsx
@@ -23,7 +23,7 @@ function toTrackerConnectionStatus(
       return undefined;
     }
     case "connecting": {
-      return undefined;
+      return "connecting";
     }
     case "disconnected": {
       return "disconnected";

--- a/pages/src/components/follow/follow-tracker-tabs.module.css
+++ b/pages/src/components/follow/follow-tracker-tabs.module.css
@@ -1,9 +1,3 @@
-.tabBar {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-}
-
 .tabs {
   display: flex;
   flex-wrap: wrap;
@@ -25,12 +19,6 @@
   font-weight: 600;
 }
 
-.tabRecord {
-  color: var(--halo-gray);
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-}
-
 .liveBadge {
   background: var(--color-live, #e53935);
   border-radius: 2px;
@@ -41,31 +29,4 @@
   letter-spacing: 0.08em;
   padding: 1px 4px;
   text-transform: uppercase;
-}
-
-.followLiveButton {
-  align-self: flex-start;
-  background: transparent;
-  border: 1px solid var(--halo-teal-primary);
-  color: var(--halo-teal-primary);
-  cursor: pointer;
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  padding: var(--space-1) var(--space-3);
-  text-transform: uppercase;
-  transition:
-    background 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.followLiveButton:hover {
-  background: rgb(93 212 216 / 10%);
-  box-shadow: 0 0 12px rgb(93 212 216 / 25%);
-}
-
-.followLiveButton:focus-visible {
-  outline: 2px solid var(--halo-teal-primary);
-  outline-offset: 2px;
 }

--- a/pages/src/components/follow/follow-tracker-tabs.module.css
+++ b/pages/src/components/follow/follow-tracker-tabs.module.css
@@ -7,10 +7,9 @@
 .tabLabel {
   align-items: center;
   display: flex;
-  flex-direction: column;
   font-family: var(--font-body);
   font-size: var(--text-sm);
-  gap: var(--space-1);
+  gap: var(--space-2);
   min-width: 120px;
 }
 
@@ -20,13 +19,14 @@
 }
 
 .liveBadge {
-  background: var(--color-live, #e53935);
-  border-radius: 2px;
-  color: #fff;
-  font-family: var(--font-mono);
+  background: color-mix(in srgb, var(--halo-teal-primary) 20%, transparent);
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 60%, transparent);
+  border-radius: var(--radius-full);
+  color: var(--halo-teal-primary);
+  font-family: var(--font-heading);
   font-size: var(--text-xs);
   font-weight: 700;
-  letter-spacing: 0.08em;
-  padding: 1px 4px;
+  letter-spacing: 0.1em;
+  padding: 2px var(--space-2);
   text-transform: uppercase;
 }

--- a/pages/src/components/follow/follow-tracker-tabs.tsx
+++ b/pages/src/components/follow/follow-tracker-tabs.tsx
@@ -1,41 +1,12 @@
 import React from "react";
 import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
-import type { TrackerMatchSummary } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import { TabbedSection } from "../tabbed-section/tabbed-section";
 import styles from "./follow-tracker-tabs.module.css";
 
 export interface FollowTrackerTabsProps {
   readonly directory: TrackerDirectory;
   readonly selectedTrackerId: string | null;
-  readonly isFollowingLive: boolean;
   readonly onSelectTracker: (trackerId: string) => void;
-  readonly onFollowLive: () => void;
-}
-
-function hasLiveTracker(directory: TrackerDirectory): boolean {
-  for (const entry of directory.trackers) {
-    if (entry.isLive) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function toWinLossRecord(matches: readonly TrackerMatchSummary[]): string {
-  let wins = 0;
-  let losses = 0;
-  for (const match of matches) {
-    if (match.outcome === "Win") {
-      wins += 1;
-      continue;
-    }
-
-    if (match.outcome === "Loss") {
-      losses += 1;
-    }
-  }
-
-  return `${wins.toString()}:${losses.toString()}`;
 }
 
 function getSelectedTabId(directory: TrackerDirectory, selectedTrackerId: string | null): string | null {
@@ -55,20 +26,14 @@ function getSelectedTabId(directory: TrackerDirectory, selectedTrackerId: string
 export function FollowTrackerTabs({
   directory,
   selectedTrackerId,
-  isFollowingLive,
   onSelectTracker,
-  onFollowLive,
 }: FollowTrackerTabsProps): React.ReactElement {
-  const showFollowLive = !isFollowingLive && hasLiveTracker(directory);
   const selectedTabId = getSelectedTabId(directory, selectedTrackerId);
   const tabs = directory.trackers.map((entry) => ({
     id: entry.trackerId,
     label: (
       <span className={styles.tabLabel}>
         <span className={styles.tabGamertag}>{entry.gamertag}</span>
-        <span className={styles.tabRecord} data-testid="tab-record">
-          {toWinLossRecord(entry.matches)}
-        </span>
         {entry.isLive && (
           <span className={styles.liveBadge} data-testid="live-badge">
             Live
@@ -80,7 +45,7 @@ export function FollowTrackerTabs({
   }));
 
   return (
-    <div className={styles.tabBar}>
+    <>
       {tabs.length > 0 && (
         <TabbedSection
           tabs={tabs}
@@ -91,11 +56,6 @@ export function FollowTrackerTabs({
           tabsClassName={styles.tabs}
         />
       )}
-      {showFollowLive && (
-        <button type="button" className={styles.followLiveButton} onClick={onFollowLive} data-testid="follow-live-btn">
-          Follow live
-        </button>
-      )}
-    </div>
+    </>
   );
 }

--- a/pages/src/components/follow/tests/follow-live-viewer.test.tsx
+++ b/pages/src/components/follow/tests/follow-live-viewer.test.tsx
@@ -18,9 +18,11 @@ vi.mock("../../individual-tracker/viewer/create", () => ({
   IndividualTrackerViewerPage: ({
     trackerId,
     streamerSettings,
+    connectionStatusOverride,
   }: {
     trackerId: string;
     streamerSettings?: TrackerDirectory["streamerSettings"];
+    connectionStatusOverride?: string;
   }): React.ReactElement => {
     const [instanceId] = React.useState(() => {
       mockViewerInstanceCount += 1;
@@ -33,6 +35,7 @@ vi.mock("../../individual-tracker/viewer/create", () => ({
         <span data-testid="mock-streamer-settings">
           {streamerSettings?.styleFlags?.showMatchmakingStatsOnly === true ? "true" : "false"}
         </span>
+        <span data-testid="mock-connection-status-override">{connectionStatusOverride ?? "none"}</span>
       </div>
     );
   },
@@ -182,6 +185,44 @@ describe("FollowLiveViewer", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("mock-viewer")).toHaveAttribute("data-instance-id", "2");
+    });
+  });
+
+  it("passes connecting status override when follow directory is reconnecting", async () => {
+    const initialDirectory: TrackerDirectory = aDirectoryWith({
+      trackers: [
+        aTrackerWith({
+          trackerId: "tracker-1",
+          gamertag: "Spartan One",
+          isLive: true,
+          status: "active",
+        }),
+      ],
+      liveTrackerId: "tracker-1",
+    });
+    const followLiveService = aFakeFollowLiveServiceWith({ directory: initialDirectory });
+
+    render(
+      <FollowLiveViewer
+        gamertag="Spartan One"
+        followLiveService={followLiveService}
+        individualTrackerViewService={aFakeIndividualTrackerViewServiceWith()}
+        matchAnalyticsService={aFakeMatchAnalyticsServiceWith()}
+        seriesMatchesService={aFakeSeriesMatchesServiceWith()}
+        haloClient={aFakeHaloClientWith()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-connection-status-override")).toHaveTextContent("none");
+    });
+
+    act(() => {
+      followLiveService.lastConnection?.emitStatus("connecting");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-connection-status-override")).toHaveTextContent("connecting");
     });
   });
 });

--- a/pages/src/components/follow/tests/follow-live-viewer.test.tsx
+++ b/pages/src/components/follow/tests/follow-live-viewer.test.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom/vitest";
 
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
 import { aDirectoryWith, aTrackerWith } from "@guilty-spark/shared/contracts/individual-tracker/fakes/follow.fake";
 import { aFakeHaloClientWith } from "../../../services/fakes/halo-client.fake";
@@ -12,6 +12,8 @@ import { aFakeMatchAnalyticsServiceWith } from "../../../services/stats/fakes/ma
 import { aFakeSeriesMatchesServiceWith } from "../../../services/stats/fakes/series-matches.fake";
 import { FollowLiveViewer, type FollowLiveViewerProps } from "../follow-live-viewer";
 
+let mockViewerInstanceCount = 0;
+
 vi.mock("../../individual-tracker/viewer/create", () => ({
   IndividualTrackerViewerPage: ({
     trackerId,
@@ -19,14 +21,21 @@ vi.mock("../../individual-tracker/viewer/create", () => ({
   }: {
     trackerId: string;
     streamerSettings?: TrackerDirectory["streamerSettings"];
-  }): React.ReactElement => (
-    <div data-testid="mock-viewer">
-      {trackerId}
-      <span data-testid="mock-streamer-settings">
-        {streamerSettings?.styleFlags?.showMatchmakingStatsOnly === true ? "true" : "false"}
-      </span>
-    </div>
-  ),
+  }): React.ReactElement => {
+    const [instanceId] = React.useState(() => {
+      mockViewerInstanceCount += 1;
+      return mockViewerInstanceCount;
+    });
+
+    return (
+      <div data-testid="mock-viewer" data-instance-id={instanceId.toString()}>
+        {trackerId}
+        <span data-testid="mock-streamer-settings">
+          {streamerSettings?.styleFlags?.showMatchmakingStatsOnly === true ? "true" : "false"}
+        </span>
+      </div>
+    );
+  },
 }));
 
 function aViewerPropsWith(directory: TrackerDirectory): FollowLiveViewerProps {
@@ -44,6 +53,7 @@ describe("FollowLiveViewer", () => {
   afterEach(() => {
     cleanup();
     document.title = "";
+    mockViewerInstanceCount = 0;
   });
 
   it("shows tracker navigation when directory has multiple trackers", async () => {
@@ -123,6 +133,55 @@ describe("FollowLiveViewer", () => {
 
     await waitFor(() => {
       expect(document.title).toBe("Spartan One live view - Spartan Two live - Guilty Spark");
+    });
+  });
+
+  it("remounts the selected viewer when only the selected tracker last update time changes", async () => {
+    const initialDirectory: TrackerDirectory = aDirectoryWith({
+      trackers: [
+        aTrackerWith({
+          trackerId: "tracker-1",
+          gamertag: "Spartan One",
+          isLive: true,
+          status: "active",
+          lastUpdateTime: "2026-01-01T00:00:00.000Z",
+        }),
+      ],
+      liveTrackerId: "tracker-1",
+    });
+    const followLiveService = aFakeFollowLiveServiceWith({ directory: initialDirectory });
+
+    render(
+      <FollowLiveViewer
+        gamertag="Spartan One"
+        followLiveService={followLiveService}
+        individualTrackerViewService={aFakeIndividualTrackerViewServiceWith()}
+        matchAnalyticsService={aFakeMatchAnalyticsServiceWith()}
+        seriesMatchesService={aFakeSeriesMatchesServiceWith()}
+        haloClient={aFakeHaloClientWith()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-viewer")).toHaveAttribute("data-instance-id", "1");
+    });
+
+    const updatedDirectory: TrackerDirectory = {
+      ...initialDirectory,
+      trackers: [
+        {
+          ...initialDirectory.trackers[0],
+          lastUpdateTime: "2026-01-01T00:01:00.000Z",
+        },
+      ],
+    };
+
+    act(() => {
+      followLiveService.lastConnection?.emitDirectory(updatedDirectory);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-viewer")).toHaveAttribute("data-instance-id", "2");
     });
   });
 });

--- a/pages/src/components/follow/tests/follow-live-viewer.test.tsx
+++ b/pages/src/components/follow/tests/follow-live-viewer.test.tsx
@@ -43,6 +43,7 @@ function aViewerPropsWith(directory: TrackerDirectory): FollowLiveViewerProps {
 describe("FollowLiveViewer", () => {
   afterEach(() => {
     cleanup();
+    document.title = "";
   });
 
   it("shows tracker navigation when directory has multiple trackers", async () => {
@@ -107,5 +108,21 @@ describe("FollowLiveViewer", () => {
     });
 
     expect(screen.getByTestId("mock-streamer-settings")).toHaveTextContent("true");
+  });
+
+  it("updates the document title to mention the current live tracker", async () => {
+    const liveDirectory: TrackerDirectory = aDirectoryWith({
+      trackers: [
+        aTrackerWith({ trackerId: "tracker-1", gamertag: "Spartan One", isLive: false, status: "active" }),
+        aTrackerWith({ trackerId: "tracker-2", gamertag: "Spartan Two", isLive: true, status: "active" }),
+      ],
+      liveTrackerId: "tracker-2",
+    });
+
+    render(<FollowLiveViewer {...aViewerPropsWith(liveDirectory)} />);
+
+    await waitFor(() => {
+      expect(document.title).toBe("Spartan One live view - Spartan Two live - Guilty Spark");
+    });
   });
 });

--- a/pages/src/components/follow/tests/follow-tracker-tabs.test.tsx
+++ b/pages/src/components/follow/tests/follow-tracker-tabs.test.tsx
@@ -50,9 +50,7 @@ describe("FollowTrackerTabs", () => {
       <FollowTrackerTabs
         directory={aTabsDirectoryWithWinsAndLosses()}
         selectedTrackerId="tracker-1"
-        isFollowingLive={true}
         onSelectTracker={vi.fn<(trackerId: string) => void>()}
-        onFollowLive={vi.fn<() => void>()}
       />,
     );
 
@@ -62,30 +60,12 @@ describe("FollowTrackerTabs", () => {
     expect(trackerButtons[1]).toHaveTextContent("Spartan Two");
   });
 
-  it("shows the win-loss record for each tracker", () => {
-    render(
-      <FollowTrackerTabs
-        directory={aTabsDirectoryWithWinsAndLosses()}
-        selectedTrackerId="tracker-1"
-        isFollowingLive={true}
-        onSelectTracker={vi.fn<(trackerId: string) => void>()}
-        onFollowLive={vi.fn<() => void>()}
-      />,
-    );
-
-    const records = screen.getAllByTestId("tab-record");
-    expect(records[0]).toHaveTextContent("3:2");
-    expect(records[1]).toHaveTextContent("1:3");
-  });
-
   it("shows Live badge on the live tracker", () => {
     render(
       <FollowTrackerTabs
         directory={aTabsDirectoryWithWinsAndLosses()}
         selectedTrackerId="tracker-1"
-        isFollowingLive={true}
         onSelectTracker={vi.fn<(trackerId: string) => void>()}
-        onFollowLive={vi.fn<() => void>()}
       />,
     );
 
@@ -111,9 +91,7 @@ describe("FollowTrackerTabs", () => {
       <FollowTrackerTabs
         directory={dir}
         selectedTrackerId="tracker-1"
-        isFollowingLive={true}
         onSelectTracker={vi.fn<(trackerId: string) => void>()}
-        onFollowLive={vi.fn<() => void>()}
       />,
     );
 
@@ -127,9 +105,7 @@ describe("FollowTrackerTabs", () => {
       <FollowTrackerTabs
         directory={aTabsDirectoryWithWinsAndLosses()}
         selectedTrackerId="tracker-1"
-        isFollowingLive={true}
         onSelectTracker={onSelectTracker}
-        onFollowLive={vi.fn<() => void>()}
       />,
     );
 
@@ -138,78 +114,6 @@ describe("FollowTrackerTabs", () => {
 
     expect(onSelectTracker).toHaveBeenCalledOnce();
     expect(onSelectTracker).toHaveBeenCalledWith("tracker-2");
-  });
-
-  it("shows Follow live button when isFollowingLive is false and there is a live tracker", () => {
-    render(
-      <FollowTrackerTabs
-        directory={aTabsDirectoryWithWinsAndLosses()}
-        selectedTrackerId="tracker-2"
-        isFollowingLive={false}
-        onSelectTracker={vi.fn<(trackerId: string) => void>()}
-        onFollowLive={vi.fn<() => void>()}
-      />,
-    );
-
-    expect(screen.getByTestId("follow-live-btn")).toBeInTheDocument();
-  });
-
-  it("does not show Follow live button when isFollowingLive is true", () => {
-    render(
-      <FollowTrackerTabs
-        directory={aTabsDirectoryWithWinsAndLosses()}
-        selectedTrackerId="tracker-1"
-        isFollowingLive={true}
-        onSelectTracker={vi.fn<(trackerId: string) => void>()}
-        onFollowLive={vi.fn<() => void>()}
-      />,
-    );
-
-    expect(screen.queryByTestId("follow-live-btn")).toBeNull();
-  });
-
-  it("does not show Follow live button when no tracker is live", () => {
-    const dir: TrackerDirectory = {
-      trackers: [
-        aTrackerWith({
-          trackerId: "tracker-1",
-          gamertag: "Spartan One",
-          status: "active",
-          isLive: false,
-        }),
-      ],
-      liveTrackerId: null,
-    };
-
-    render(
-      <FollowTrackerTabs
-        directory={dir}
-        selectedTrackerId="tracker-1"
-        isFollowingLive={false}
-        onSelectTracker={vi.fn<(trackerId: string) => void>()}
-        onFollowLive={vi.fn<() => void>()}
-      />,
-    );
-
-    expect(screen.queryByTestId("follow-live-btn")).toBeNull();
-  });
-
-  it("calls onFollowLive when the Follow live button is clicked", async () => {
-    const onFollowLive = vi.fn<() => void>();
-
-    render(
-      <FollowTrackerTabs
-        directory={aDirectoryWith()}
-        selectedTrackerId="tracker-2"
-        isFollowingLive={false}
-        onSelectTracker={vi.fn<(trackerId: string) => void>()}
-        onFollowLive={onFollowLive}
-      />,
-    );
-
-    await userEvent.click(screen.getByTestId("follow-live-btn"));
-
-    expect(onFollowLive).toHaveBeenCalledOnce();
   });
 
   it("renders no tabs when directory is empty", () => {
@@ -222,15 +126,12 @@ describe("FollowTrackerTabs", () => {
       <FollowTrackerTabs
         directory={emptyDirectory}
         selectedTrackerId={null}
-        isFollowingLive={false}
         onSelectTracker={vi.fn<(trackerId: string) => void>()}
-        onFollowLive={vi.fn<() => void>()}
       />,
     );
 
     expect(screen.queryAllByRole("tab")).toHaveLength(0);
     expect(screen.queryByRole("tablist")).toBeNull();
-    expect(screen.queryByTestId("follow-live-btn")).toBeNull();
   });
 
   it("renders tracker navigation even when selectedTrackerId is null", async () => {
@@ -240,9 +141,7 @@ describe("FollowTrackerTabs", () => {
       <FollowTrackerTabs
         directory={aTabsDirectoryWithWinsAndLosses()}
         selectedTrackerId={null}
-        isFollowingLive={false}
         onSelectTracker={onSelectTracker}
-        onFollowLive={vi.fn<() => void>()}
       />,
     );
 

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-presenter.ts
@@ -248,29 +248,6 @@ export class LiveTrackersPresenter {
       });
     }
 
-    if (status === "active" || status === "paused") {
-      actions.push({
-        label: "Stop tracker",
-        disabled: snapshot.busy || trackerId == null,
-        onClick: (): void => {
-          if (trackerId != null) {
-            void this.stopTracker(trackerId);
-          }
-        },
-      });
-      if (item.hasActiveSeries) {
-        actions.push({
-          label: "End series",
-          disabled: snapshot.busy || trackerId == null,
-          onClick: (): void => {
-            if (trackerId != null) {
-              void this.endSeries(trackerId);
-            }
-          },
-        });
-      }
-    }
-
     if (status === "active" && trackerId != null) {
       actions.push({
         label: "Game selection",
@@ -307,6 +284,29 @@ export class LiveTrackersPresenter {
           },
         });
       }
+    }
+
+    if (status === "active" || status === "paused") {
+      if (item.hasActiveSeries) {
+        actions.push({
+          label: "End series",
+          disabled: snapshot.busy || trackerId == null,
+          onClick: (): void => {
+            if (trackerId != null) {
+              void this.endSeries(trackerId);
+            }
+          },
+        });
+      }
+      actions.push({
+        label: "Stop tracker",
+        disabled: snapshot.busy || trackerId == null,
+        onClick: (): void => {
+          if (trackerId != null) {
+            void this.stopTracker(trackerId);
+          }
+        },
+      });
     }
 
     if (!isPinned) {

--- a/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.module.css
+++ b/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.module.css
@@ -17,28 +17,6 @@
   margin: 0;
 }
 
-.addButton {
-  background: transparent;
-  border: 1px solid var(--halo-teal-primary);
-  border-radius: var(--radius-sm);
-  color: var(--halo-teal-primary);
-  cursor: pointer;
-  font-family: var(--font-heading);
-  font-size: var(--text-xs);
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  padding: var(--space-2) var(--space-3);
-  text-transform: uppercase;
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.addButton:hover {
-  background: color-mix(in srgb, var(--halo-teal-primary) 14%, transparent);
-  color: var(--halo-white);
-}
-
 .list {
   border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 25%, transparent);
   border-radius: var(--radius-md);

--- a/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import classNames from "classnames";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { Alert } from "../../alert/alert";
+import { Button } from "../../button/button";
 import { Dropdown } from "../../dropdown/dropdown";
 import styles from "./tracker-list.module.css";
 
@@ -150,9 +151,9 @@ export function TrackerList({ items, onAddTracker, getActions }: TrackerListProp
     <div className={styles.listContainer}>
       <div className={styles.listHeader}>
         <h2 className={styles.listTitle}>Live Trackers</h2>
-        <button type="button" className={styles.addButton} onClick={onAddTracker} aria-label="Add tracker">
-          + Add tracker
-        </button>
+        <Button type="button" size="small" variant="secondary" onClick={onAddTracker}>
+          Add tracker
+        </Button>
       </div>
 
       {!hasItems ? (

--- a/pages/src/components/individual-tracker/viewer/create.tsx
+++ b/pages/src/components/individual-tracker/viewer/create.tsx
@@ -5,7 +5,10 @@ import { ComponentLoader } from "../../component-loader/component-loader";
 import { ErrorState } from "../../error-state/error-state";
 import { LoadingState } from "../../loading-state/loading-state";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
-import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
+import type {
+  IndividualTrackerViewService,
+  TrackerViewConnectionStatus,
+} from "../../../services/individual-tracker/view-types";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { SeriesMatchesService } from "../../../services/stats/series-matches-types";
 import { IndividualTrackerViewer } from "./individual-tracker-viewer";
@@ -19,6 +22,7 @@ interface IndividualTrackerViewerPageProps {
   readonly haloClient: HaloInfiniteClient;
   readonly trackerId: string;
   readonly streamerSettings?: StreamerViewSettings;
+  readonly connectionStatusOverride?: TrackerViewConnectionStatus;
 }
 
 export function IndividualTrackerViewerPage({
@@ -29,6 +33,7 @@ export function IndividualTrackerViewerPage({
   haloClient,
   trackerId,
   streamerSettings,
+  connectionStatusOverride,
 }: IndividualTrackerViewerPageProps): React.ReactElement {
   const canManage = individualTrackerService != null;
 
@@ -51,7 +56,7 @@ export function IndividualTrackerViewerPage({
         model.renderModel != null ? (
           <IndividualTrackerViewer
             renderModel={model.renderModel}
-            connectionStatus={model.connectionStatus}
+            connectionStatus={connectionStatusOverride ?? model.connectionStatus}
             expandedEntryKeys={model.expandedEntryKeys}
             entryStates={model.entryStates}
             canManage={canManage}

--- a/pages/src/components/individual-tracker/viewer/create.tsx
+++ b/pages/src/components/individual-tracker/viewer/create.tsx
@@ -23,6 +23,7 @@ interface IndividualTrackerViewerPageProps {
   readonly trackerId: string;
   readonly streamerSettings?: StreamerViewSettings;
   readonly connectionStatusOverride?: TrackerViewConnectionStatus;
+  readonly pageTitleVariant?: "tracker";
 }
 
 export function IndividualTrackerViewerPage({
@@ -34,6 +35,7 @@ export function IndividualTrackerViewerPage({
   trackerId,
   streamerSettings,
   connectionStatusOverride,
+  pageTitleVariant,
 }: IndividualTrackerViewerPageProps): React.ReactElement {
   const canManage = individualTrackerService != null;
 
@@ -46,6 +48,19 @@ export function IndividualTrackerViewerPage({
     trackerId,
     streamerSettings,
   });
+
+  React.useEffect(() => {
+    if (pageTitleVariant !== "tracker") {
+      return;
+    }
+
+    const gamertag = model.renderModel?.gamertag;
+    if (gamertag == null || gamertag === "") {
+      return;
+    }
+
+    document.title = `${gamertag} tracker - Guilty Spark`;
+  }, [model.renderModel?.gamertag, pageTitleVariant]);
 
   return (
     <ComponentLoader

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.module.css
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.module.css
@@ -76,6 +76,18 @@
   color: var(--halo-gray);
 }
 
+.statusSyncing {
+  background: color-mix(in srgb, var(--halo-teal-primary) 20%, transparent);
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 55%, transparent);
+  color: var(--halo-teal-primary);
+}
+
+.statusDegraded {
+  background: color-mix(in srgb, var(--color-warning) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-warning) 50%, transparent);
+  color: var(--color-warning);
+}
+
 .liveBadge {
   background: color-mix(in srgb, var(--halo-teal-primary) 20%, transparent);
   border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 60%, transparent);
@@ -91,12 +103,6 @@
 
 .lastUpdated {
   font-size: var(--text-sm);
-}
-
-.connectionNotice {
-  color: var(--halo-gray);
-  font-size: var(--text-sm);
-  margin: 0 0 var(--space-4);
 }
 
 .accumulatedSection,

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
@@ -604,7 +604,11 @@ export function IndividualTrackerViewer({
                               ))}
                             </div>
                             <OutcomeBadge
-                              outcome={summarizeSeriesOutcome(series.matches.map((seriesMatch) => seriesMatch.outcome))}
+                              outcome={
+                                series.isActive
+                                  ? "In progress"
+                                  : summarizeSeriesOutcome(series.matches.map((seriesMatch) => seriesMatch.outcome))
+                              }
                             />
                           </div>
                           <span

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
@@ -64,6 +64,51 @@ function statusLabel(status: TrackerStatus): string {
   }
 }
 
+type ViewerStatusTone = "active" | "paused" | "stopped" | "syncing" | "degraded";
+
+function getViewerStatusBadge(
+  trackerStatus: TrackerStatus,
+  connectionStatus: TrackerViewConnectionStatus,
+): { label: string; tone: ViewerStatusTone } {
+  if (trackerStatus !== "active") {
+    switch (trackerStatus) {
+      case "paused": {
+        return { label: statusLabel(trackerStatus), tone: "paused" };
+      }
+      case "stopped": {
+        return { label: statusLabel(trackerStatus), tone: "stopped" };
+      }
+      default: {
+        throw new UnreachableError(trackerStatus);
+      }
+    }
+  }
+
+  switch (connectionStatus) {
+    case "connected": {
+      return { label: "Active", tone: "active" };
+    }
+    case "connecting": {
+      return { label: "Connecting", tone: "syncing" };
+    }
+    case "disconnected": {
+      return { label: "Reconnecting", tone: "syncing" };
+    }
+    case "error": {
+      return { label: "Connection issue", tone: "degraded" };
+    }
+    case "not_found": {
+      return { label: "Not found", tone: "degraded" };
+    }
+    case "stopped": {
+      return { label: "Stopped", tone: "stopped" };
+    }
+    default: {
+      throw new UnreachableError(connectionStatus);
+    }
+  }
+}
+
 function parseDate(value: string | null): Date | null {
   if (value == null) {
     return null;
@@ -117,30 +162,19 @@ function nextUpdateContent(renderModel: IndividualTrackerViewerRenderModel): Rea
   return <ReactTimeAgo date={addMinutes(lastUpdatedDate, 3)} locale="en" />;
 }
 
-function connectionNotice(connectionStatus: TrackerViewConnectionStatus): string | null {
-  switch (connectionStatus) {
-    case "connected": {
-      return null;
-    }
-    case "connecting": {
-      return "Connecting...";
-    }
-    case "disconnected": {
-      return "Reconnecting...";
-    }
-    case "error": {
-      return "Connection error. Retrying...";
-    }
-    case "not_found": {
-      return "Tracker not found.";
-    }
-    case "stopped": {
-      return "Tracker stopped.";
-    }
-    default: {
-      throw new UnreachableError(connectionStatus);
-    }
+function connectionAwareNextUpdate(
+  renderModel: IndividualTrackerViewerRenderModel,
+  statusBadge: { label: string; tone: ViewerStatusTone },
+): React.ReactNode {
+  if (statusBadge.tone === "syncing") {
+    return "reconnecting";
   }
+
+  if (statusBadge.tone === "degraded") {
+    return "connection issue";
+  }
+
+  return nextUpdateContent(renderModel);
 }
 
 function summarizeSeriesOutcome(outcomes: readonly NormalizedMatchOutcome[]): NormalizedMatchOutcome {
@@ -345,10 +379,11 @@ export function IndividualTrackerViewer({
     };
   }, []);
 
-  const notice = connectionNotice(connectionStatus);
+  const statusBadge = getViewerStatusBadge(renderModel.status, connectionStatus);
+  const canRefresh = statusBadge.tone === "active";
   const refreshHint = (
     <>
-      Last update: {lastUpdateContent(renderModel)} | Next update: {nextUpdateContent(renderModel)}
+      Last update: {lastUpdateContent(renderModel)} | Next update: {connectionAwareNextUpdate(renderModel, statusBadge)}
     </>
   );
 
@@ -368,7 +403,7 @@ export function IndividualTrackerViewer({
                 size="small"
                 loading={refreshPending}
                 onClick={onRefresh}
-                disabled={refreshPending || renderModel.status !== "active"}
+                disabled={refreshPending || !canRefresh}
               >
                 Refresh
               </Button>
@@ -383,22 +418,18 @@ export function IndividualTrackerViewer({
           <div className={styles.badges}>
             <span
               className={classNames(styles.statusBadge, {
-                [styles.statusActive]: renderModel.status === "active",
-                [styles.statusPaused]: renderModel.status === "paused",
-                [styles.statusStopped]: renderModel.status === "stopped",
+                [styles.statusActive]: statusBadge.tone === "active",
+                [styles.statusPaused]: statusBadge.tone === "paused",
+                [styles.statusStopped]: statusBadge.tone === "stopped",
+                [styles.statusSyncing]: statusBadge.tone === "syncing",
+                [styles.statusDegraded]: statusBadge.tone === "degraded",
               })}
             >
-              {statusLabel(renderModel.status)}
+              {statusBadge.label}
             </span>
             {renderModel.isLive && <span className={styles.liveBadge}>Live</span>}
           </div>
         </div>
-
-        {notice != null && (
-          <p className={styles.connectionNotice} data-testid="connection-notice">
-            {notice}
-          </p>
-        )}
 
         {renderModel.topBarStats != null && renderModel.topBarStats.length > 0 && (
           <section className={styles.accumulatedSection}>

--- a/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
@@ -108,7 +108,9 @@ describe("IndividualTrackerViewer", () => {
         aFakeTrackerMatchSummaryWith({ matchId: "m-1", outcome: "Win" }),
         aFakeTrackerMatchSummaryWith({ matchId: "m-2", outcome: "Loss" }),
       ],
-      series: [aFakeTrackerSeriesGroupWith({ matchIds: ["m-1", "m-2"], title: "Ranked Series", subtitle: "Best of 3" })],
+      series: [
+        aFakeTrackerSeriesGroupWith({ matchIds: ["m-1", "m-2"], title: "Ranked Series", subtitle: "Best of 3" }),
+      ],
       hasActiveSeries: true,
       activeSeriesContext: {
         title: "Ranked Series",

--- a/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
@@ -118,12 +118,21 @@ describe("IndividualTrackerViewer", () => {
     expect(screen.getByText("No matches tracked yet.")).toBeInTheDocument();
   });
 
-  it("renders a connection notice for non-connected states", () => {
+  it("renders reconnecting status in the badge for disconnected state", () => {
     const view = aFakeTrackerViewStateWith({ gamertag: "Spartan One" });
 
     renderViewer(view, "disconnected");
 
-    expect(screen.getByTestId("connection-notice")).toHaveTextContent("Reconnecting...");
+    expect(screen.getByText("Reconnecting")).toBeInTheDocument();
+  });
+
+  it("disables refresh when connection is disconnected", () => {
+    const view = aFakeTrackerViewStateWith({ gamertag: "Spartan One", status: "active" });
+
+    renderViewer(view, "disconnected");
+
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeDisabled();
+    expect(screen.getByText(/Next update:\s*reconnecting/i)).toBeInTheDocument();
   });
 
   it("renders without crashing when timestamps are not valid dates", () => {

--- a/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
@@ -102,6 +102,48 @@ describe("IndividualTrackerViewer", () => {
     expect(screen.getByText("2 matches")).toBeInTheDocument();
   });
 
+  it("renders In progress for an active series", () => {
+    const view = aFakeTrackerViewStateWith({
+      matches: [
+        aFakeTrackerMatchSummaryWith({ matchId: "m-1", outcome: "Win" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m-2", outcome: "Loss" }),
+      ],
+      series: [aFakeTrackerSeriesGroupWith({ matchIds: ["m-1", "m-2"], title: "Ranked Series", subtitle: "Best of 3" })],
+      hasActiveSeries: true,
+      activeSeriesContext: {
+        title: "Ranked Series",
+        subtitle: "Best of 3",
+        teams: [],
+      },
+    });
+
+    renderViewer(view);
+
+    expect(screen.getByText("In progress")).toBeInTheDocument();
+  });
+
+  it("marks only the most recent series as In progress when active context is missing", () => {
+    const view = aFakeTrackerViewStateWith({
+      matches: [
+        aFakeTrackerMatchSummaryWith({ matchId: "m-1", outcome: "Win" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m-2", outcome: "Loss" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m-3", outcome: "Win" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m-4", outcome: "Win" }),
+      ],
+      series: [
+        aFakeTrackerSeriesGroupWith({ id: "series-1", title: "Current Series", matchIds: ["m-1", "m-2"] }),
+        aFakeTrackerSeriesGroupWith({ id: "series-2", title: "Previous Series", matchIds: ["m-3", "m-4"] }),
+      ],
+      hasActiveSeries: true,
+      activeSeriesContext: undefined,
+    });
+
+    renderViewer(view);
+
+    expect(screen.getAllByText("In progress")).toHaveLength(1);
+    expect(screen.getByText("Win")).toBeInTheDocument();
+  });
+
   it("renders a Live badge when the tracker is live", () => {
     const view = aFakeTrackerViewStateWith({ isLive: true });
 

--- a/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
@@ -128,13 +128,13 @@ describe("IndividualTrackerViewer", () => {
     const view = aFakeTrackerViewStateWith({
       matches: [
         aFakeTrackerMatchSummaryWith({ matchId: "m-1", outcome: "Win" }),
-        aFakeTrackerMatchSummaryWith({ matchId: "m-2", outcome: "Loss" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m-2", outcome: "Win" }),
         aFakeTrackerMatchSummaryWith({ matchId: "m-3", outcome: "Win" }),
-        aFakeTrackerMatchSummaryWith({ matchId: "m-4", outcome: "Win" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m-4", outcome: "Loss" }),
       ],
       series: [
-        aFakeTrackerSeriesGroupWith({ id: "series-1", title: "Current Series", matchIds: ["m-1", "m-2"] }),
-        aFakeTrackerSeriesGroupWith({ id: "series-2", title: "Previous Series", matchIds: ["m-3", "m-4"] }),
+        aFakeTrackerSeriesGroupWith({ id: "series-older", title: "Older Series", matchIds: ["m-1", "m-2"] }),
+        aFakeTrackerSeriesGroupWith({ id: "series-recent", title: "Recent Series", matchIds: ["m-3", "m-4"] }),
       ],
       hasActiveSeries: true,
       activeSeriesContext: undefined,
@@ -143,7 +143,8 @@ describe("IndividualTrackerViewer", () => {
     renderViewer(view);
 
     expect(screen.getAllByText("In progress")).toHaveLength(1);
-    expect(screen.getByText("Win")).toBeInTheDocument();
+    expect(screen.getByLabelText("Series Recent Series")).toHaveTextContent("In progress");
+    expect(screen.getByLabelText("Series Older Series")).not.toHaveTextContent("In progress");
   });
 
   it("renders a Live badge when the tracker is live", () => {

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -153,6 +153,31 @@ describe("useIndividualTrackerViewer", () => {
     expect(getMatchStatsSpy).not.toHaveBeenCalled();
   });
 
+  it("treats the public viewer path as connected after the initial view loads", async () => {
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
+      view: aFakeTrackerViewStateWith({ trackerId: "tracker-1", status: "active" }),
+    });
+    const connectSpy = vi.spyOn(individualTrackerViewService, "connect");
+    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+
+    const { result } = renderHook(() =>
+      useIndividualTrackerViewer({
+        individualTrackerViewService,
+        matchAnalyticsService,
+        seriesMatchesService,
+        haloClient,
+        trackerId: "tracker-1",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.snapshot.status).toBe(ComponentLoaderStatus.LOADED);
+      expect(result.current.snapshot.connectionStatus).toBe("connected");
+    });
+
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+
   it("loads long series in a single request when a series entry expands", async () => {
     const matchIds = Array.from({ length: 13 }, (_, index) => `m-${(index + 1).toString()}`);
     const matches = matchIds.map((matchId) => aFakeTrackerMatchSummaryWith({ matchId }));

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -36,6 +36,7 @@ function aViewerTestDependenciesWith(): ViewerTestDependencies {
 
 describe("useIndividualTrackerViewer", () => {
   it("does not recreate presenter when streamer settings values are unchanged", async () => {
+    const individualTrackerService = aFakeIndividualTrackerServiceWith();
     const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
       view: aFakeTrackerViewStateWith({ trackerId: "tracker-1", status: "active" }),
     });
@@ -51,6 +52,7 @@ describe("useIndividualTrackerViewer", () => {
     const { rerender } = renderHook(
       ({ settings }: { settings: StreamerViewSettings }) =>
         useIndividualTrackerViewer({
+          individualTrackerService,
           individualTrackerViewService,
           matchAnalyticsService,
           seriesMatchesService,

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
@@ -244,4 +244,28 @@ describe("buildViewerRenderModel", () => {
       expect(first.series.duration).toBe("unknown");
     }
   });
+
+  it("marks only the most recent timeline series active when active context is missing", () => {
+    const view = aFakeTrackerViewStateWith({
+      matches: [
+        aFakeTrackerMatchSummaryWith({ matchId: "m1" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m2" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m3" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m4" }),
+      ],
+      series: [
+        aFakeTrackerSeriesGroupWith({ id: "series-older", matchIds: ["m1", "m2"] }),
+        aFakeTrackerSeriesGroupWith({ id: "series-recent", matchIds: ["m3", "m4"] }),
+      ],
+      hasActiveSeries: true,
+      activeSeriesContext: undefined,
+    });
+
+    const model = buildViewerRenderModel({ view });
+    const seriesItems = model.timeline.filter((item) => item.type === "series");
+
+    expect(seriesItems).toHaveLength(2);
+    expect(seriesItems.find((item) => item.series.id === "series-older")?.series.isActive).toBe(false);
+    expect(seriesItems.find((item) => item.series.id === "series-recent")?.series.isActive).toBe(true);
+  });
 });

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -26,6 +26,7 @@ export interface ViewerSeriesTab {
   readonly id: string;
   readonly title: string;
   readonly subtitle: string;
+  readonly isActive: boolean;
   readonly matchBackgroundUrls: readonly string[];
   readonly score: string;
   readonly duration: string;

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -530,6 +530,7 @@ export class IndividualTrackerViewerPresenter {
     // Only establish individual-tracker WS connection in managed context (when individualTrackerService is available).
     // Public pages (follow viewer) should not connect to per-tracker endpoints.
     if (this.config.individualTrackerService == null) {
+      this.config.store.setConnectionStatus("connected");
       return;
     }
 

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -260,8 +260,8 @@ export class IndividualTrackerViewerPresenter {
   }
 
   public refresh(): void {
+    // Refresh is only available in managed context.
     if (this.config.individualTrackerService == null) {
-      void this.load();
       return;
     }
 
@@ -483,7 +483,11 @@ export class IndividualTrackerViewerPresenter {
 
   private async refreshAsync(): Promise<void> {
     try {
-      await this.config.individualTrackerService?.refreshTracker(this.config.trackerId);
+      // Only refresh in managed context when individual tracker service is available.
+      if (this.config.individualTrackerService == null) {
+        return;
+      }
+      await this.config.individualTrackerService.refreshTracker(this.config.trackerId);
       if (this.isDisposed) {
         return;
       }
@@ -522,6 +526,12 @@ export class IndividualTrackerViewerPresenter {
     this.viewSubscription?.unsubscribe();
     this.statusSubscription?.unsubscribe();
     this.connection?.disconnect();
+
+    // Only establish individual-tracker WS connection in managed context (when individualTrackerService is available).
+    // Public pages (follow viewer) should not connect to per-tracker endpoints.
+    if (this.config.individualTrackerService == null) {
+      return;
+    }
 
     const connection = this.config.individualTrackerViewService.connect(this.config.trackerId);
     this.connection = connection;

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -132,7 +132,7 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
   const seriesByAnchor = new Map<string, TrackerSeriesGroup>();
   const seriesMemberIds = new Set<string>();
   const activeSeriesId = findActiveSeriesId(view);
-  let seenSeriesCount = 0;
+  let fallbackActiveSeriesId: string | null = null;
   for (const series of view.series) {
     const knownIds = series.matchIds.filter((id) => matchesById.has(id));
     if (knownIds.length < 2) {
@@ -198,8 +198,7 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
         id: anchoredSeries.id,
         title: anchoredSeries.title,
         subtitle: anchoredSeries.subtitle,
-        isActive:
-          activeSeriesId != null ? anchoredSeries.id === activeSeriesId : view.hasActiveSeries && seenSeriesCount === 0,
+        isActive: activeSeriesId != null ? anchoredSeries.id === activeSeriesId : false,
         matchBackgroundUrls:
           anchoredSeries.matchBackgroundUrls ?? seriesSummaries.map((summary) => summary.mapBackgroundUrl ?? "data:,"),
         score: anchoredSeries.score,
@@ -209,8 +208,10 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
         matches: seriesMatches,
         colorHex: undefined,
       };
+      if (activeSeriesId == null && view.hasActiveSeries) {
+        fallbackActiveSeriesId = anchoredSeries.id;
+      }
       timeline.push({ type: "series", series });
-      seenSeriesCount += 1;
       continue;
     }
 
@@ -221,6 +222,23 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
     timeline.push({ type: "match", match: toMatchTab(match, teamHex, enemyHex) });
   }
 
+  const timelineWithFallback =
+    activeSeriesId == null && fallbackActiveSeriesId != null
+      ? timeline.map((item) => {
+          if (item.type === "match") {
+            return item;
+          }
+
+          return {
+            type: "series" as const,
+            series: {
+              ...item.series,
+              isActive: item.series.id === fallbackActiveSeriesId,
+            },
+          };
+        })
+      : timeline;
+
   const accumulated = accumulate(view.matches);
 
   return {
@@ -229,7 +247,7 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
     status: view.status,
     isLive: view.isLive,
     lastUpdateTime: view.lastUpdateTime,
-    timeline: [...timeline],
+    timeline: [...timelineWithFallback],
     accumulated,
     topBarStats: view.topBarStats,
     teamColors: [getTeamColorOrDefault(preferredTeamColorId, 0), getTeamColorOrDefault(preferredEnemyColorId, 1)],

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -23,6 +23,29 @@ export interface BuildViewerRenderModelOptions {
   readonly preferredEnemyColorId?: string;
 }
 
+function isActiveSeriesGroup(view: TrackerViewState, series: TrackerSeriesGroup): boolean {
+  if (!view.hasActiveSeries || view.activeSeriesContext == null) {
+    return false;
+  }
+
+  const activeSubtitle = view.activeSeriesContext.subtitle ?? "";
+  return series.title === view.activeSeriesContext.title && series.subtitle === activeSubtitle;
+}
+
+function findActiveSeriesId(view: TrackerViewState): string | null {
+  if (!view.hasActiveSeries) {
+    return null;
+  }
+
+  for (const series of view.series) {
+    if (isActiveSeriesGroup(view, series)) {
+      return series.id;
+    }
+  }
+
+  return null;
+}
+
 function toReadableDurationOrUnknown(startTime: string, endTime: string): string {
   const startDate = parseISO(startTime);
   const endDate = parseISO(endTime);
@@ -108,6 +131,8 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
 
   const seriesByAnchor = new Map<string, TrackerSeriesGroup>();
   const seriesMemberIds = new Set<string>();
+  const activeSeriesId = findActiveSeriesId(view);
+  let seenSeriesCount = 0;
   for (const series of view.series) {
     const knownIds = series.matchIds.filter((id) => matchesById.has(id));
     if (knownIds.length < 2) {
@@ -173,6 +198,10 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
         id: anchoredSeries.id,
         title: anchoredSeries.title,
         subtitle: anchoredSeries.subtitle,
+        isActive:
+          activeSeriesId != null
+            ? anchoredSeries.id === activeSeriesId
+            : view.hasActiveSeries && seenSeriesCount === 0,
         matchBackgroundUrls:
           anchoredSeries.matchBackgroundUrls ?? seriesSummaries.map((summary) => summary.mapBackgroundUrl ?? "data:,"),
         score: anchoredSeries.score,
@@ -183,6 +212,7 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
         colorHex: undefined,
       };
       timeline.push({ type: "series", series });
+      seenSeriesCount += 1;
       continue;
     }
 

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -199,9 +199,7 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
         title: anchoredSeries.title,
         subtitle: anchoredSeries.subtitle,
         isActive:
-          activeSeriesId != null
-            ? anchoredSeries.id === activeSeriesId
-            : view.hasActiveSeries && seenSeriesCount === 0,
+          activeSeriesId != null ? anchoredSeries.id === activeSeriesId : view.hasActiveSeries && seenSeriesCount === 0,
         matchBackgroundUrls:
           anchoredSeries.matchBackgroundUrls ?? seriesSummaries.map((summary) => summary.mapBackgroundUrl ?? "data:,"),
         score: anchoredSeries.score,

--- a/pages/src/components/outcome-badge/outcome-badge.module.css
+++ b/pages/src/components/outcome-badge/outcome-badge.module.css
@@ -41,3 +41,9 @@
   border-color: rgb(148 163 184 / 55%);
   color: rgb(203 213 225);
 }
+
+.outcomeBadge[data-outcome="In progress"] {
+  background: rgb(10 24 35 / 88%);
+  border-color: rgb(93 212 216 / 60%);
+  color: rgb(93 212 216);
+}

--- a/pages/src/components/outcome-badge/outcome-badge.tsx
+++ b/pages/src/components/outcome-badge/outcome-badge.tsx
@@ -3,7 +3,7 @@ import type { NormalizedMatchOutcome } from "@guilty-spark/shared/halo/match-enr
 import styles from "./outcome-badge.module.css";
 
 interface OutcomeBadgeProps {
-  readonly outcome: NormalizedMatchOutcome;
+  readonly outcome: NormalizedMatchOutcome | "In progress";
 }
 
 export function OutcomeBadge({ outcome }: OutcomeBadgeProps): ReactElement {

--- a/pages/src/pages/u/[gamertag]/view.astro
+++ b/pages/src/pages/u/[gamertag]/view.astro
@@ -6,6 +6,6 @@ import { FollowLiveApp } from "../../../apps/follow-live/create";
 const { gamertag } = Astro.params;
 ---
 
-<Layout title={`${gamertag ?? ""} — Guilty Spark`} description="Follow this player live">
+<Layout title={`${gamertag ?? ""} live view - Guilty Spark`} description="Follow this player live">
   <FollowLiveApp client:only="react" apiHost={API_HOST} gamertag={gamertag ?? ""} />
 </Layout>


### PR DESCRIPTION
## Summary
- refresh the selected public follow viewer when directory updates keep the same tracker id but change last update time
- mark active series as "In progress" instead of summarizing outcomes while the series is still active
- identify active series from active context, with a fallback that marks only the most recent series when context is missing
- add badge styling and type support for the new "In progress" outcome

## Test coverage
- add a follow viewer regression test that emits a directory update and verifies the selected viewer remounts when only lastUpdateTime changes
- add viewer tests for active-series display behavior, including the fallback path

## Validation
- npx vitest run pages/src/components/follow/tests/follow-live-viewer.test.tsx
