### PR TITLE
feat(nudge): evolve endpoint to support series substitution events

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1689,78 +1689,11 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
   private async getState(): Promise<IndividualTrackerInternalState | null> {
     const state = await this.state.storage.get<IndividualTrackerInternalState>(STATE_STORAGE_KEY);
-    if (state == null) {
-      return null;
-    }
-
-    const { normalized, changed } = this.normalizeLegacySeriesState(state);
-    if (changed) {
-      await this.setState(normalized);
-    }
-
-    return normalized;
+    return state ?? null;
   }
 
   private async setState(state: IndividualTrackerInternalState): Promise<void> {
     await this.state.storage.put(STATE_STORAGE_KEY, state);
-  }
-
-  private normalizeLegacySeriesState(state: IndividualTrackerInternalState): {
-    normalized: IndividualTrackerInternalState;
-    changed: boolean;
-  } {
-    let changed = false;
-
-    const normalizeSeries = (series: ActiveSeries): ActiveSeries => {
-      for (const [teamIndex, team] of series.teams.entries()) {
-        if (team.id !== teamIndex) {
-          const teams = series.teams.map((t, index) => ({
-            ...t,
-            id: index,
-          }));
-          return {
-            ...series,
-            teams,
-          };
-        }
-      }
-
-      return series;
-    };
-
-    const normalized: IndividualTrackerInternalState = { ...state };
-
-    if (state.activeSeries == null) {
-      delete normalized.activeSeries;
-    } else {
-      const normalizedActiveSeries = normalizeSeries(state.activeSeries);
-      if (normalizedActiveSeries !== state.activeSeries) {
-        changed = true;
-      }
-      normalized.activeSeries = normalizedActiveSeries;
-    }
-
-    if (state.completedSeries == null) {
-      delete normalized.completedSeries;
-    } else {
-      const normalizedCompletedSeries = state.completedSeries.map((series) => normalizeSeries(series));
-      for (const [index, series] of normalizedCompletedSeries.entries()) {
-        if (series !== state.completedSeries[index]) {
-          changed = true;
-          break;
-        }
-      }
-      normalized.completedSeries = normalizedCompletedSeries;
-    }
-
-    if (!changed) {
-      return { normalized: state, changed: false };
-    }
-
-    return {
-      normalized,
-      changed: true,
-    };
   }
 
   private applySubstitutionToSeries(series: ActiveSeries, payload: SeriesSubstitutedPayload): ActiveSeries {

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1551,7 +1551,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
         break;
       }
-      case undefined:
       case "started": {
         this.retireActiveSeries(trackerState);
         trackerState.activeSeries = {

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -75,6 +75,7 @@ import type {
   IndividualTrackerSeriesGroupOverride,
   IndividualTrackerViewState,
   ActiveSeries,
+  SeriesPlayer,
   SeriesTeam,
   StatsHighlightItem,
 } from "./types";
@@ -1758,15 +1759,25 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   }
 
   private applySubstitutionToSeries(series: ActiveSeries, payload: SeriesSubstitutedPayload): ActiveSeries {
+    const matchesPlayerOut = (player: SeriesPlayer): boolean => {
+      if (payload.playerOut.xboxId != null && player.xboxId != null) {
+        return player.xboxId === payload.playerOut.xboxId;
+      }
+
+      if (payload.playerOut.discordId != null && player.discordId != null) {
+        return player.discordId === payload.playerOut.discordId;
+      }
+
+      return player.gamertag != null && player.gamertag === payload.playerOut.gamertag;
+    };
+
     const updatedTeams = series.teams.map((team, teamIndex) => {
       const normalizedTeamId = teamIndex;
       if (normalizedTeamId === payload.teamId || team.id === payload.teamId) {
         return {
           ...team,
           id: normalizedTeamId,
-          players: team.players.map((player) =>
-            player.gamertag === payload.playerOut.gamertag ? payload.playerIn : player,
-          ),
+          players: team.players.map((player) => (matchesPlayerOut(player) ? payload.playerIn : player)),
         };
       }
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -35,7 +35,7 @@ import {
 } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/management";
 import {
   individualTrackerNudgeContract,
-  seriesContextNullablePayloadSchema,
+  nudgePayloadSchema,
 } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
 import {
   analyzeMatchGroupings,
@@ -1337,7 +1337,8 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
     const body = parsed.data;
 
-    const teams: SeriesTeam[] = body.teams.map((team) => ({
+    const teams: SeriesTeam[] = body.teams.map((team, teamIndex) => ({
+      id: teamIndex,
       name: team.name,
       players: team.members.map((gamertag) => ({ discordId: null, discordName: null, gamertag, xboxId: null })),
     }));
@@ -1413,7 +1414,8 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       trackerState.activeSeries.subtitle = body.subtitleOverride;
     }
     if (body.teams !== undefined) {
-      trackerState.activeSeries.teams = body.teams.map((team) => ({
+      trackerState.activeSeries.teams = body.teams.map((team, teamIndex) => ({
+        id: teamIndex,
         name: team.name,
         players: team.members.map((gamertag) => ({ discordId: null, discordName: null, gamertag, xboxId: null })),
       }));
@@ -1468,20 +1470,118 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return new Response("Not Found", { status: 404 });
     }
 
-    const parsed = await parseJsonBody(request, seriesContextNullablePayloadSchema, "Invalid nudge request");
+    const parsed = await parseJsonBody(request, nudgePayloadSchema, "Invalid nudge request");
     if (!parsed.success) {
       return parsed.response;
     }
     const payload = parsed.data;
 
-    this.retireActiveSeries(trackerState);
-    if (payload != null) {
+    // Handle three types of nudge events: started, ended, substituted (+ null for legacy ended)
+    if (payload === null) {
+      // Legacy: null = ended
+      this.retireActiveSeries(trackerState);
+    } else if (payload.type === "ended") {
+      // New: explicit ended event
+      this.retireActiveSeries(trackerState);
+    } else if (payload.type === "substituted") {
+      // Substitution event
+      const trackedGamertag = trackerState.gamertag;
+      const playerOutGamertag = payload.playerOut.gamertag;
+      const playerInGamertag = payload.playerIn.gamertag;
+
+      if (trackedGamertag === playerOutGamertag) {
+        // Tracked player is leaving the series
+        this.retireActiveSeries(trackerState);
+        this.logService.info(
+          "IndividualTracker: series retired (tracked player subbed out via nudge)",
+          new Map([
+            ["trackerId", trackerState.trackerId],
+            ["gamertag", trackerState.gamertag],
+          ]),
+        );
+      } else if (trackedGamertag === playerInGamertag && trackerState.activeSeries == null) {
+        // Tracked player is joining; try to resume a completed series
+        const completedSeries = trackerState.completedSeries ?? [];
+        let resumedSeries = null;
+
+        if (completedSeries.length > 0) {
+          resumedSeries = completedSeries[completedSeries.length - 1];
+        }
+
+        if (resumedSeries != null) {
+          trackerState.activeSeries = {
+            ...resumedSeries,
+            matchIds: [],
+            startedAt: new Date().toISOString(),
+            isActive: true,
+          };
+          trackerState.completedSeries = completedSeries.filter((s) => s !== resumedSeries);
+        } else {
+          // Create minimal series
+          trackerState.activeSeries = {
+            title: "Series",
+            subtitle: null,
+            guildIconUrl: null,
+            teams: [],
+            matchIds: [],
+            startedAt: new Date().toISOString(),
+            isActive: true,
+          };
+        }
+
+        this.logService.info(
+          "IndividualTracker: series resumed/created (tracked player subbed in via nudge)",
+          new Map([
+            ["trackerId", trackerState.trackerId],
+            ["gamertag", trackerState.gamertag],
+          ]),
+        );
+      } else if (trackerState.activeSeries != null) {
+        // Update team roster (neither in nor out is tracked player)
+        const updatedTeams = trackerState.activeSeries.teams.map((team) => {
+          if (team.id === payload.teamId) {
+            return {
+              ...team,
+              players: team.players.map((p) => (p.gamertag === playerOutGamertag ? payload.playerIn : p)),
+            };
+          }
+          return team;
+        });
+
+        trackerState.activeSeries = {
+          ...trackerState.activeSeries,
+          teams: updatedTeams,
+        };
+
+        this.logService.debug(
+          "IndividualTracker: team roster updated via nudge substitution",
+          new Map([
+            ["trackerId", trackerState.trackerId],
+            ["teamId", String(payload.teamId)],
+          ]),
+        );
+      }
+    } else {
+      // Default/started event (payload.type is undefined or "started")
+      this.retireActiveSeries(trackerState);
       trackerState.activeSeries = {
-        ...payload,
+        title: payload.title,
+        subtitle: payload.subtitle,
+        guildIconUrl: payload.guildIconUrl,
+        teams: payload.teams,
         matchIds: [],
         startedAt: new Date().toISOString(),
         isActive: true,
       };
+
+      this.logService.info(
+        "IndividualTracker: series started via nudge",
+        new Map([
+          ["trackerId", trackerState.trackerId],
+          ["gamertag", trackerState.gamertag],
+          ["title", payload.title],
+        ]),
+      );
     }
 
     trackerState.lastUpdateTime = new Date().toISOString();

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -36,6 +36,7 @@ import {
 import {
   individualTrackerNudgeContract,
   nudgePayloadSchema,
+  type SeriesSubstitutedPayload,
 } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
 import {
   analyzeMatchGroupings,
@@ -53,6 +54,7 @@ import {
 import { getDurationInSeconds } from "@guilty-spark/shared/halo/duration";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { parseJsonBody } from "@guilty-spark/shared/base/request-parsing";
+import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import {
   INDIVIDUAL_STATS_HIGHLIGHTS_MAX_SLOT_COUNT,
   INDIVIDUAL_STATS_HIGHLIGHTS_STAT_OPTIONS,
@@ -1470,126 +1472,106 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return new Response("Not Found", { status: 404 });
     }
 
-    if (trackerState.activeSeries != null) {
-      trackerState.activeSeries = {
-        ...trackerState.activeSeries,
-        teams: trackerState.activeSeries.teams.map((team, teamIndex) => ({
-          ...team,
-          id: teamIndex,
-        })),
-      };
-    }
-
     const parsed = await parseJsonBody(request, nudgePayloadSchema, "Invalid nudge request");
     if (!parsed.success) {
       return parsed.response;
     }
     const payload = parsed.data;
 
-    // Handle three types of nudge events: started, ended, substituted
-    if (payload.type === "ended") {
-      // Series ended event
-      this.retireActiveSeries(trackerState);
-    } else if (payload.type === "substituted") {
-      // Substitution event
-      const trackedGamertag = trackerState.gamertag;
-      const playerOutGamertag = payload.playerOut.gamertag;
-      const playerInGamertag = payload.playerIn.gamertag;
-
-      if (trackedGamertag === playerOutGamertag) {
-        // Tracked player is leaving the series
+    switch (payload.type) {
+      case "ended": {
         this.retireActiveSeries(trackerState);
-        this.logService.info(
-          "IndividualTracker: series retired (tracked player subbed out via nudge)",
-          new Map([
-            ["trackerId", trackerState.trackerId],
-            ["gamertag", trackerState.gamertag],
-          ]),
-        );
-      } else if (trackedGamertag === playerInGamertag && trackerState.activeSeries == null) {
-        // Tracked player is joining; try to resume a completed series
-        const completedSeries = trackerState.completedSeries ?? [];
-        const resumedSeries: ActiveSeries | null = completedSeries.at(-1) ?? null;
+        break;
+      }
+      case "substituted": {
+        const trackedGamertag = trackerState.gamertag;
+        const playerOutGamertag = payload.playerOut.gamertag;
+        const playerInGamertag = payload.playerIn.gamertag;
 
-        if (resumedSeries != null) {
-          trackerState.activeSeries = {
-            ...resumedSeries,
-            matchIds: [],
-            startedAt: new Date().toISOString(),
-            isActive: true,
-          };
-          trackerState.completedSeries = completedSeries.filter((s) => s !== resumedSeries);
-        } else {
-          // Create minimal series
-          trackerState.activeSeries = {
-            title: "Series",
-            subtitle: null,
-            guildIconUrl: null,
-            teams: [],
-            matchIds: [],
-            startedAt: new Date().toISOString(),
-            isActive: true,
-          };
-        }
+        if (trackedGamertag === playerOutGamertag) {
+          this.retireActiveSeries(trackerState);
+          this.logService.info(
+            "IndividualTracker: series retired (tracked player subbed out via nudge)",
+            new Map([
+              ["trackerId", trackerState.trackerId],
+              ["gamertag", trackerState.gamertag],
+            ]),
+          );
+        } else if (trackedGamertag === playerInGamertag && trackerState.activeSeries == null) {
+          const completedSeries = trackerState.completedSeries ?? [];
+          const resumedSeries: ActiveSeries | null = completedSeries.at(-1) ?? null;
 
-        this.logService.info(
-          "IndividualTracker: series resumed/created (tracked player subbed in via nudge)",
-          new Map([
-            ["trackerId", trackerState.trackerId],
-            ["gamertag", trackerState.gamertag],
-          ]),
-        );
-      } else if (trackerState.activeSeries != null) {
-        // Update team roster (neither in nor out is tracked player)
-        const updatedTeams = trackerState.activeSeries.teams.map((team, teamIndex) => {
-          const normalizedTeamId = teamIndex;
-          if (normalizedTeamId === payload.teamId || team.id === payload.teamId) {
-            return {
-              ...team,
-              id: normalizedTeamId,
-              players: team.players.map((p) => (p.gamertag === playerOutGamertag ? payload.playerIn : p)),
+          if (resumedSeries != null) {
+            trackerState.activeSeries = this.applySubstitutionToSeries(
+              {
+                ...resumedSeries,
+                matchIds: [],
+                startedAt: new Date().toISOString(),
+                isActive: true,
+              },
+              payload,
+            );
+            trackerState.completedSeries = completedSeries.filter((s) => s !== resumedSeries);
+          } else {
+            trackerState.activeSeries = {
+              title: "Series",
+              subtitle: null,
+              guildIconUrl: null,
+              teams: [],
+              matchIds: [],
+              startedAt: new Date().toISOString(),
+              isActive: true,
             };
           }
-          return {
-            ...team,
-            id: normalizedTeamId,
-          };
-        });
 
+          this.logService.info(
+            "IndividualTracker: series resumed/created (tracked player subbed in via nudge)",
+            new Map([
+              ["trackerId", trackerState.trackerId],
+              ["gamertag", trackerState.gamertag],
+            ]),
+          );
+        } else if (trackerState.activeSeries != null) {
+          trackerState.activeSeries = this.applySubstitutionToSeries(trackerState.activeSeries, payload);
+
+          this.logService.debug(
+            "IndividualTracker: team roster updated via nudge substitution",
+            new Map([
+              ["trackerId", trackerState.trackerId],
+              ["teamId", String(payload.teamId)],
+            ]),
+          );
+        }
+
+        break;
+      }
+      case undefined:
+      case "started": {
+        this.retireActiveSeries(trackerState);
         trackerState.activeSeries = {
-          ...trackerState.activeSeries,
-          teams: updatedTeams,
+          title: payload.title,
+          subtitle: payload.subtitle,
+          guildIconUrl: payload.guildIconUrl,
+          teams: payload.teams,
+          matchIds: [],
+          startedAt: new Date().toISOString(),
+          isActive: true,
         };
 
-        this.logService.debug(
-          "IndividualTracker: team roster updated via nudge substitution",
+        this.logService.info(
+          "IndividualTracker: series started via nudge",
           new Map([
             ["trackerId", trackerState.trackerId],
-            ["teamId", String(payload.teamId)],
+            ["gamertag", trackerState.gamertag],
+            ["title", payload.title],
           ]),
         );
-      }
-    } else {
-      // Default/started event (payload.type is undefined or "started")
-      this.retireActiveSeries(trackerState);
-      trackerState.activeSeries = {
-        title: payload.title,
-        subtitle: payload.subtitle,
-        guildIconUrl: payload.guildIconUrl,
-        teams: payload.teams,
-        matchIds: [],
-        startedAt: new Date().toISOString(),
-        isActive: true,
-      };
 
-      this.logService.info(
-        "IndividualTracker: series started via nudge",
-        new Map([
-          ["trackerId", trackerState.trackerId],
-          ["gamertag", trackerState.gamertag],
-          ["title", payload.title],
-        ]),
-      );
+        break;
+      }
+      default: {
+        throw new UnreachableError(payload);
+      }
     }
 
     trackerState.lastUpdateTime = new Date().toISOString();
@@ -1701,11 +1683,103 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
   private async getState(): Promise<IndividualTrackerInternalState | null> {
     const state = await this.state.storage.get<IndividualTrackerInternalState>(STATE_STORAGE_KEY);
-    return state ?? null;
+    if (state == null) {
+      return null;
+    }
+
+    const { normalized, changed } = this.normalizeLegacySeriesState(state);
+    if (changed) {
+      await this.setState(normalized);
+    }
+
+    return normalized;
   }
 
   private async setState(state: IndividualTrackerInternalState): Promise<void> {
     await this.state.storage.put(STATE_STORAGE_KEY, state);
+  }
+
+  private normalizeLegacySeriesState(state: IndividualTrackerInternalState): {
+    normalized: IndividualTrackerInternalState;
+    changed: boolean;
+  } {
+    let changed = false;
+
+    const normalizeSeries = (series: ActiveSeries): ActiveSeries => {
+      for (const [teamIndex, team] of series.teams.entries()) {
+        if (team.id !== teamIndex) {
+          const teams = series.teams.map((t, index) => ({
+            ...t,
+            id: index,
+          }));
+          return {
+            ...series,
+            teams,
+          };
+        }
+      }
+
+      return series;
+    };
+
+    const normalized: IndividualTrackerInternalState = { ...state };
+
+    if (state.activeSeries == null) {
+      delete normalized.activeSeries;
+    } else {
+      const normalizedActiveSeries = normalizeSeries(state.activeSeries);
+      if (normalizedActiveSeries !== state.activeSeries) {
+        changed = true;
+      }
+      normalized.activeSeries = normalizedActiveSeries;
+    }
+
+    if (state.completedSeries == null) {
+      delete normalized.completedSeries;
+    } else {
+      const normalizedCompletedSeries = state.completedSeries.map((series) => normalizeSeries(series));
+      for (const [index, series] of normalizedCompletedSeries.entries()) {
+        if (series !== state.completedSeries[index]) {
+          changed = true;
+          break;
+        }
+      }
+      normalized.completedSeries = normalizedCompletedSeries;
+    }
+
+    if (!changed) {
+      return { normalized: state, changed: false };
+    }
+
+    return {
+      normalized,
+      changed: true,
+    };
+  }
+
+  private applySubstitutionToSeries(series: ActiveSeries, payload: SeriesSubstitutedPayload): ActiveSeries {
+    const updatedTeams = series.teams.map((team, teamIndex) => {
+      const normalizedTeamId = teamIndex;
+      if (normalizedTeamId === payload.teamId || team.id === payload.teamId) {
+        return {
+          ...team,
+          id: normalizedTeamId,
+          players: team.players.map((player) =>
+            player.gamertag === payload.playerOut.gamertag ? payload.playerIn : player,
+          ),
+        };
+      }
+
+      return {
+        ...team,
+        id: normalizedTeamId,
+      };
+    });
+
+    return {
+      ...series,
+      teams: updatedTeams,
+    };
   }
 
   private retireActiveSeries(state: IndividualTrackerInternalState): void {

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1470,6 +1470,16 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return new Response("Not Found", { status: 404 });
     }
 
+    if (trackerState.activeSeries != null) {
+      trackerState.activeSeries = {
+        ...trackerState.activeSeries,
+        teams: trackerState.activeSeries.teams.map((team, teamIndex) => ({
+          ...team,
+          id: teamIndex,
+        })),
+      };
+    }
+
     const parsed = await parseJsonBody(request, nudgePayloadSchema, "Invalid nudge request");
     if (!parsed.success) {
       return parsed.response;

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1485,11 +1485,16 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         break;
       }
       case "substituted": {
+        const trackedXuid = trackerState.xuid;
         const trackedGamertag = trackerState.gamertag;
-        const playerOutGamertag = payload.playerOut.gamertag;
-        const playerInGamertag = payload.playerIn.gamertag;
+        const isTrackedPlayerOut =
+          (payload.playerOut.xboxId != null && trackedXuid === payload.playerOut.xboxId) ||
+          trackedGamertag === payload.playerOut.gamertag;
+        const isTrackedPlayerIn =
+          (payload.playerIn.xboxId != null && trackedXuid === payload.playerIn.xboxId) ||
+          trackedGamertag === payload.playerIn.gamertag;
 
-        if (trackedGamertag === playerOutGamertag) {
+        if (isTrackedPlayerOut) {
           this.retireActiveSeries(trackerState);
           this.logService.info(
             "IndividualTracker: series retired (tracked player subbed out via nudge)",
@@ -1498,7 +1503,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
               ["gamertag", trackerState.gamertag],
             ]),
           );
-        } else if (trackedGamertag === playerInGamertag && trackerState.activeSeries == null) {
+        } else if (isTrackedPlayerIn && trackerState.activeSeries == null) {
           const completedSeries = trackerState.completedSeries ?? [];
           const resumedSeries: ActiveSeries | null = completedSeries.at(-1) ?? null;
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1476,12 +1476,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
     const payload = parsed.data;
 
-    // Handle three types of nudge events: started, ended, substituted (+ null for legacy ended)
-    if (payload === null) {
-      // Legacy: null = ended
-      this.retireActiveSeries(trackerState);
-    } else if (payload.type === "ended") {
-      // New: explicit ended event
+    // Handle three types of nudge events: started, ended, substituted
+    if (payload.type === "ended") {
+      // Series ended event
       this.retireActiveSeries(trackerState);
     } else if (payload.type === "substituted") {
       // Substitution event

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1499,11 +1499,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       } else if (trackedGamertag === playerInGamertag && trackerState.activeSeries == null) {
         // Tracked player is joining; try to resume a completed series
         const completedSeries = trackerState.completedSeries ?? [];
-        let resumedSeries = null;
-
-        if (completedSeries.length > 0) {
-          resumedSeries = completedSeries[completedSeries.length - 1];
-        }
+        const resumedSeries: ActiveSeries | null = completedSeries.at(-1) ?? null;
 
         if (resumedSeries != null) {
           trackerState.activeSeries = {
@@ -1535,14 +1531,19 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         );
       } else if (trackerState.activeSeries != null) {
         // Update team roster (neither in nor out is tracked player)
-        const updatedTeams = trackerState.activeSeries.teams.map((team) => {
-          if (team.id === payload.teamId) {
+        const updatedTeams = trackerState.activeSeries.teams.map((team, teamIndex) => {
+          const normalizedTeamId = teamIndex;
+          if (normalizedTeamId === payload.teamId || team.id === payload.teamId) {
             return {
               ...team,
+              id: normalizedTeamId,
               players: team.players.map((p) => (p.gamertag === playerOutGamertag ? payload.playerIn : p)),
             };
           }
-          return team;
+          return {
+            ...team,
+            id: normalizedTeamId,
+          };
         });
 
         trackerState.activeSeries = {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2294,10 +2294,12 @@ describe("IndividualTrackerDO", () => {
       guildIconUrl: "https://cdn.discordapp.com/icons/guild-id/icon.webp",
       teams: [
         {
+          id: 0,
           name: "Eagle",
           players: [{ discordId: "discord-1", discordName: "PlayerOne", gamertag: "GT1", xboxId: "xuid-1" }],
         },
         {
+          id: 1,
           name: "Cobra",
           players: [{ discordId: "discord-2", discordName: "PlayerTwo", gamertag: "GT2", xboxId: "xuid-2" }],
         },
@@ -2424,8 +2426,12 @@ describe("IndividualTrackerDO", () => {
     it("applies activeSeries title, subtitle, guildIconUrl, and teams to the matching series group", async () => {
       const ids = ["match-nq-1", "match-nq-2"];
       const teams = [
-        { name: "Eagle", players: [{ discordId: "d-1", discordName: "Alice", gamertag: "AliceGT", xboxId: "x-1" }] },
-        { name: "Cobra", players: [{ discordId: "d-2", discordName: "Bob", gamertag: "BobGT", xboxId: "x-2" }] },
+        {
+          id: 0,
+          name: "Eagle",
+          players: [{ discordId: "d-1", discordName: "Alice", gamertag: "AliceGT", xboxId: "x-1" }],
+        },
+        { id: 1, name: "Cobra", players: [{ discordId: "d-2", discordName: "Bob", gamertag: "BobGT", xboxId: "x-2" }] },
       ];
       const activeSeries: ActiveSeries = {
         title: "Guilty Spark",
@@ -2670,6 +2676,7 @@ describe("IndividualTrackerDO", () => {
       const persisted = lastPersistedState(storagePutSpy);
       expect(persisted.activeSeries?.teams).toEqual([
         {
+          id: 0,
           name: "Team A",
           players: [
             { discordId: null, discordName: null, gamertag: "Player1", xboxId: null },
@@ -2677,6 +2684,7 @@ describe("IndividualTrackerDO", () => {
           ],
         },
         {
+          id: 1,
           name: "Team B",
           players: [{ discordId: null, discordName: null, gamertag: "Player3", xboxId: null }],
         },
@@ -2909,7 +2917,7 @@ describe("IndividualTrackerDO", () => {
 
     it("activeSeriesContext is present with correct data when activeSeries exists", async () => {
       const teams = [
-        { name: "Eagle", players: [{ discordId: null, discordName: null, gamertag: "GT1", xboxId: null }] },
+        { id: 0, name: "Eagle", players: [{ discordId: null, discordName: null, gamertag: "GT1", xboxId: null }] },
       ];
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2292,6 +2292,7 @@ describe("IndividualTrackerDO", () => {
 
   describe("handleNudge()", () => {
     const aSeriesPayload = (): SeriesStartedPayload => ({
+      type: "started",
       title: "Guilty Spark",
       subtitle: "Queue #1",
       guildIconUrl: "https://cdn.discordapp.com/icons/guild-id/icon.webp",

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -19,7 +19,7 @@ import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 import type { IndividualTrackerStartRequest } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/lifecycle";
 import type {
-  SeriesContextPayload,
+  SeriesStartedPayload,
   SeriesSubstitutedPayload,
 } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
 import { IndividualTrackerDO } from "../individual-tracker-do";
@@ -2291,7 +2291,7 @@ describe("IndividualTrackerDO", () => {
   });
 
   describe("handleNudge()", () => {
-    const aSeriesPayload = (): SeriesContextPayload => ({
+    const aSeriesPayload = (): SeriesStartedPayload => ({
       title: "Guilty Spark",
       subtitle: "Queue #1",
       guildIconUrl: "https://cdn.discordapp.com/icons/guild-id/icon.webp",
@@ -2651,45 +2651,6 @@ describe("IndividualTrackerDO", () => {
       expect(group?.subtitle).toBe("Queue #5");
       expect(group?.guildIconUrl).toBe("https://cdn.discordapp.com/icons/guild-id/icon.webp");
       expect(group?.teams).toEqual(teams);
-    });
-
-    it("normalizes legacy activeSeries team ids on read so view-state remains valid", async () => {
-      const ids = ["match-nq-1", "match-nq-2"];
-      const teams = [
-        {
-          id: 0,
-          name: "Eagle",
-          players: [{ discordId: "d-1", discordName: "Alice", gamertag: "AliceGT", xboxId: "x-1" }],
-        },
-      ];
-      const activeSeries: ActiveSeries = {
-        title: "Guilty Spark",
-        subtitle: "Queue #5",
-        guildIconUrl: "https://cdn.discordapp.com/icons/guild-id/icon.webp",
-        matchIds: ids,
-        teams,
-        startedAt: new Date().toISOString(),
-        isActive: true,
-      };
-
-      const state = aFakeIndividualTrackerInternalStateWith({
-        ...makeSeriesMatches(ids),
-        activeSeries,
-      });
-      Reflect.deleteProperty(state.activeSeries?.teams[0] ?? {}, "id");
-      storageGetSpy.mockResolvedValue(state);
-
-      const response = await individualTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
-
-      expect(response.status).toBe(200);
-      const body = await response.json<{
-        state: { series: { teams?: { id: number; name: string }[] }[] };
-      }>();
-      const [group] = body.state.series;
-      expect(group?.teams?.[0]?.id).toBe(0);
-
-      const persisted = lastPersistedState(storagePutSpy);
-      expect(persisted.activeSeries?.teams[0]?.id).toBe(0);
     });
 
     it("applies completedSeries metadata to a matching group after the series ends", async () => {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2462,6 +2462,31 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.completedSeries).toHaveLength(0);
     });
 
+    it("creates a new minimal active series when tracked player is subbed in with no completed series", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          gamertag: "GT3",
+          completedSeries: [],
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", { method: "POST", body: JSON.stringify(aSubstitutionPayload()) }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries).toMatchObject({
+        title: "Series",
+        subtitle: null,
+        guildIconUrl: null,
+        teams: [],
+        matchIds: [],
+        isActive: true,
+      });
+      expect(persisted.completedSeries).toHaveLength(0);
+    });
+
     it("resumes completed series when tracked player is subbed in by xboxId and gamertag is null", async () => {
       const completedSeries: ActiveSeries = {
         ...anActiveSeries(),

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2366,7 +2366,7 @@ describe("IndividualTrackerDO", () => {
       expect(response.status).toBe(400);
     });
 
-    it("moves existing activeSeries to completedSeries when nudging with null", async () => {
+    it("moves existing activeSeries to completedSeries when nudging with ended event", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
           activeSeries: anActiveSeries({ matchIds: ["match-1"] }),
@@ -2374,7 +2374,7 @@ describe("IndividualTrackerDO", () => {
       );
 
       const response = await individualTrackerDO.fetch(
-        new Request("http://do/nudge", { method: "POST", body: JSON.stringify(null) }),
+        new Request("http://do/nudge", { method: "POST", body: JSON.stringify({ type: "ended" }) }),
       );
 
       expect(response.status).toBe(200);

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2486,6 +2486,48 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.activeSeries?.teams[0]?.players[0]?.gamertag).toBe("GT3");
     });
 
+    it("updates active team roster by xboxId when player gamertag is null", async () => {
+      const payloadWithNullGamertags: SeriesSubstitutedPayload = {
+        type: "substituted",
+        teamId: 0,
+        playerOut: {
+          discordId: "discord-1",
+          discordName: "PlayerOne",
+          gamertag: null,
+          xboxId: "xuid-1",
+        },
+        playerIn: {
+          discordId: "discord-3",
+          discordName: "PlayerThree",
+          gamertag: null,
+          xboxId: "xuid-3",
+        },
+      };
+
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          gamertag: "GTX",
+          activeSeries: anActiveSeries({
+            teams: [
+              {
+                id: 0,
+                name: "Eagle",
+                players: [{ discordId: "discord-1", discordName: "PlayerOne", gamertag: null, xboxId: "xuid-1" }],
+              },
+            ],
+          }),
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", { method: "POST", body: JSON.stringify(payloadWithNullGamertags) }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries?.teams[0]?.players[0]?.xboxId).toBe("xuid-3");
+    });
+
     it("moves existing activeSeries to completedSeries when starting a new one via nudge", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -18,7 +18,10 @@ import {
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 import type { IndividualTrackerStartRequest } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/lifecycle";
-import type { SeriesContextPayload } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
+import type {
+  SeriesContextPayload,
+  SeriesSubstitutedPayload,
+} from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
 import { IndividualTrackerDO } from "../individual-tracker-do";
 import { aFakeMapAssetWith } from "../../../services/halo/fakes/data";
 import { installFakeServicesWith } from "../../../services/fakes/services";
@@ -2317,6 +2320,23 @@ describe("IndividualTrackerDO", () => {
       ...overrides,
     });
 
+    const aSubstitutionPayload = (): SeriesSubstitutedPayload => ({
+      type: "substituted",
+      teamId: 0,
+      playerOut: {
+        discordId: "discord-1",
+        discordName: "PlayerOne",
+        gamertag: "GT1",
+        xboxId: "xuid-1",
+      },
+      playerIn: {
+        discordId: "discord-3",
+        discordName: "PlayerThree",
+        gamertag: "GT3",
+        xboxId: "xuid-3",
+      },
+    });
+
     it("returns 404 when no state exists", async () => {
       storageGetSpy.mockResolvedValue(null);
 
@@ -2383,6 +2403,87 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.activeSeries).toBeUndefined();
       expect(persisted.completedSeries).toHaveLength(1);
       expect(storageSetAlarmSpy).toHaveBeenCalledWith(Date.now());
+    });
+
+    it("retires active series when tracked player is subbed out", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          gamertag: "GT1",
+          activeSeries: anActiveSeries({
+            teams: [
+              {
+                id: 0,
+                name: "Eagle",
+                players: [{ discordId: "discord-1", discordName: "PlayerOne", gamertag: "GT1", xboxId: "xuid-1" }],
+              },
+            ],
+          }),
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", { method: "POST", body: JSON.stringify(aSubstitutionPayload()) }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries).toBeUndefined();
+      expect(persisted.completedSeries).toHaveLength(1);
+    });
+
+    it("resumes completed series and applies substitution when tracked player is subbed in", async () => {
+      const completedSeries: ActiveSeries = {
+        ...anActiveSeries(),
+        isActive: false,
+        teams: [
+          {
+            id: 0,
+            name: "Eagle",
+            players: [{ discordId: "discord-1", discordName: "PlayerOne", gamertag: "GT1", xboxId: "xuid-1" }],
+          },
+        ],
+      };
+
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          gamertag: "GT3",
+          completedSeries: [completedSeries],
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", { method: "POST", body: JSON.stringify(aSubstitutionPayload()) }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries?.teams[0]?.players[0]?.gamertag).toBe("GT3");
+      expect(persisted.completedSeries).toHaveLength(0);
+    });
+
+    it("updates active team roster when tracked player is neither subbed in nor subbed out", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          gamertag: "GTX",
+          activeSeries: anActiveSeries({
+            teams: [
+              {
+                id: 0,
+                name: "Eagle",
+                players: [{ discordId: "discord-1", discordName: "PlayerOne", gamertag: "GT1", xboxId: "xuid-1" }],
+              },
+            ],
+          }),
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", { method: "POST", body: JSON.stringify(aSubstitutionPayload()) }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries?.teams[0]?.players[0]?.gamertag).toBe("GT3");
     });
 
     it("moves existing activeSeries to completedSeries when starting a new one via nudge", async () => {
@@ -2461,6 +2562,45 @@ describe("IndividualTrackerDO", () => {
       expect(group?.subtitle).toBe("Queue #5");
       expect(group?.guildIconUrl).toBe("https://cdn.discordapp.com/icons/guild-id/icon.webp");
       expect(group?.teams).toEqual(teams);
+    });
+
+    it("normalizes legacy activeSeries team ids on read so view-state remains valid", async () => {
+      const ids = ["match-nq-1", "match-nq-2"];
+      const teams = [
+        {
+          id: 0,
+          name: "Eagle",
+          players: [{ discordId: "d-1", discordName: "Alice", gamertag: "AliceGT", xboxId: "x-1" }],
+        },
+      ];
+      const activeSeries: ActiveSeries = {
+        title: "Guilty Spark",
+        subtitle: "Queue #5",
+        guildIconUrl: "https://cdn.discordapp.com/icons/guild-id/icon.webp",
+        matchIds: ids,
+        teams,
+        startedAt: new Date().toISOString(),
+        isActive: true,
+      };
+
+      const state = aFakeIndividualTrackerInternalStateWith({
+        ...makeSeriesMatches(ids),
+        activeSeries,
+      });
+      Reflect.deleteProperty(state.activeSeries?.teams[0] ?? {}, "id");
+      storageGetSpy.mockResolvedValue(state);
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
+
+      expect(response.status).toBe(200);
+      const body = await response.json<{
+        state: { series: { teams?: { id: number; name: string }[] }[] };
+      }>();
+      const [group] = body.state.series;
+      expect(group?.teams?.[0]?.id).toBe(0);
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries?.teams[0]?.id).toBe(0);
     });
 
     it("applies completedSeries metadata to a matching group after the series ends", async () => {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2461,6 +2461,53 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.completedSeries).toHaveLength(0);
     });
 
+    it("resumes completed series when tracked player is subbed in by xboxId and gamertag is null", async () => {
+      const completedSeries: ActiveSeries = {
+        ...anActiveSeries(),
+        isActive: false,
+        teams: [
+          {
+            id: 0,
+            name: "Eagle",
+            players: [{ discordId: "discord-1", discordName: "PlayerOne", gamertag: null, xboxId: "xuid-1" }],
+          },
+        ],
+      };
+      const payloadWithNullGamertags: SeriesSubstitutedPayload = {
+        type: "substituted",
+        teamId: 0,
+        playerOut: {
+          discordId: "discord-1",
+          discordName: "PlayerOne",
+          gamertag: null,
+          xboxId: "xuid-1",
+        },
+        playerIn: {
+          discordId: "discord-3",
+          discordName: "PlayerThree",
+          gamertag: null,
+          xboxId: "xuid-3",
+        },
+      };
+
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          xuid: "xuid-3",
+          gamertag: "TrackedPlayer",
+          completedSeries: [completedSeries],
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", { method: "POST", body: JSON.stringify(payloadWithNullGamertags) }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries?.teams[0]?.players[0]?.xboxId).toBe("xuid-3");
+      expect(persisted.completedSeries).toHaveLength(0);
+    });
+
     it("updates active team roster when tracked player is neither subbed in nor subbed out", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -55,6 +55,7 @@ export interface SeriesPlayer {
 }
 
 export interface SeriesTeam {
+  id: number;
   name: string;
   players: SeriesPlayer[];
 }

--- a/api/services/individual-tracker/individual-tracker.ts
+++ b/api/services/individual-tracker/individual-tracker.ts
@@ -1,7 +1,7 @@
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { parseStreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
-import type { SeriesContextPayload } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
+import type { NudgePayload } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
 import type { DatabaseService } from "../database/database";
 import type { IndividualTrackerProfilesRow } from "../database/types/individual_tracker_profiles";
 import type { IndividualTrackerStatus, IndividualTrackersRow } from "../database/types/individual_trackers";
@@ -170,7 +170,7 @@ export class IndividualTrackerService {
     return parseStreamerViewSettings(storedRow);
   }
 
-  async nudgeTrackers(xuids: string[], payload: SeriesContextPayload | null): Promise<void> {
+  async nudgeTrackers(xuids: string[], payload: NudgePayload): Promise<void> {
     const trackers = await this.databaseService.findIndividualTrackersByXuids(xuids);
     const nonStoppedTrackers = trackers.filter((t) => t.Status !== "stopped");
     await Promise.all(

--- a/api/services/individual-tracker/tests/individual-tracker.test.ts
+++ b/api/services/individual-tracker/tests/individual-tracker.test.ts
@@ -408,6 +408,7 @@ describe("IndividualTrackerService", () => {
       });
       vi.spyOn(databaseService, "findIndividualTrackersByXuids").mockResolvedValue([tracker]);
       const payload: SeriesStartedPayload = {
+        type: "started",
         title: "Test Server",
         subtitle: "Queue #1",
         guildIconUrl: null,

--- a/api/services/individual-tracker/tests/individual-tracker.test.ts
+++ b/api/services/individual-tracker/tests/individual-tracker.test.ts
@@ -435,10 +435,10 @@ describe("IndividualTrackerService", () => {
         aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1", Status: "active" }),
       ]);
 
-      await localService.nudgeTrackers(["xuid-1"], null);
+      await localService.nudgeTrackers(["xuid-1"], { type: "ended" });
 
       const [, init] = localFetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(JSON.parse(init.body as string)).toBeNull();
+      expect(JSON.parse(init.body as string)).toEqual({ type: "ended" });
     });
 
     it("skips stopped trackers and nudges active and paused ones", async () => {
@@ -448,7 +448,7 @@ describe("IndividualTrackerService", () => {
         aFakeIndividualTrackersRow({ TrackerId: "t3", UserId: "user-1", Status: "paused" }),
       ]);
 
-      await nudgeService.nudgeTrackers(["xuid-1", "xuid-2", "xuid-3"], null);
+      await nudgeService.nudgeTrackers(["xuid-1", "xuid-2", "xuid-3"], { type: "ended" });
 
       expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
@@ -458,7 +458,7 @@ describe("IndividualTrackerService", () => {
         aFakeIndividualTrackersRow({ Status: "stopped" }),
       ]);
 
-      await nudgeService.nudgeTrackers(["xuid-1"], null);
+      await nudgeService.nudgeTrackers(["xuid-1"], { type: "ended" });
 
       expect(fetchSpy).not.toHaveBeenCalled();
     });
@@ -471,7 +471,7 @@ describe("IndividualTrackerService", () => {
       const warnSpy: MockInstance<LogService["warn"]> = vi.spyOn(logService, "warn");
       fetchSpy.mockRejectedValueOnce(new Error("DO unavailable")).mockResolvedValueOnce(new Response("ok"));
 
-      await expect(nudgeService.nudgeTrackers(["xuid-1", "xuid-2"], null)).resolves.toBeUndefined();
+      await expect(nudgeService.nudgeTrackers(["xuid-1", "xuid-2"], { type: "ended" })).resolves.toBeUndefined();
       expect(warnSpy).toHaveBeenCalledOnce();
       expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
@@ -481,7 +481,7 @@ describe("IndividualTrackerService", () => {
         .spyOn(databaseService, "findIndividualTrackersByXuids")
         .mockResolvedValue([]);
 
-      await nudgeService.nudgeTrackers([], null);
+      await nudgeService.nudgeTrackers([], { type: "ended" });
 
       expect(findSpy).toHaveBeenCalledWith([]);
       expect(fetchSpy).not.toHaveBeenCalled();

--- a/api/services/individual-tracker/tests/individual-tracker.test.ts
+++ b/api/services/individual-tracker/tests/individual-tracker.test.ts
@@ -1,6 +1,6 @@
 import type { MockInstance } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { SeriesContextPayload } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
+import type { SeriesStartedPayload } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
 import {
   aFakeDatabaseServiceWith,
   aFakeIndividualTrackerProfilesRow,
@@ -407,7 +407,7 @@ describe("IndividualTrackerService", () => {
         Status: "active",
       });
       vi.spyOn(databaseService, "findIndividualTrackersByXuids").mockResolvedValue([tracker]);
-      const payload: SeriesContextPayload = {
+      const payload: SeriesStartedPayload = {
         title: "Test Server",
         subtitle: "Queue #1",
         guildIconUrl: null,

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -670,6 +670,7 @@ export class NeatQueueService {
       const { title, guildIconUrl } = await this.fetchGuildDisplayInfo(request.guild);
 
       const seriesTeams: SeriesTeam[] = request.teams.map((team, teamIndex) => ({
+        id: teamIndex,
         name: team[0]?.team_name ?? getTeamName(teamIndex),
         players: team.map((player) =>
           this.buildSeriesPlayer(queueState.playersAssociationData[player.id], player.id, player.name),
@@ -820,24 +821,49 @@ export class NeatQueueService {
     try {
       const subOutXuid = state.playersAssociationData[request.player_subbed_out.id]?.xboxId ?? null;
       const subInAssoc = state.playersAssociationData[request.player_subbed_in.id];
-      const updatedTeams = state.seriesContext.teams.map((team) => ({
-        ...team,
-        players: team.players.map((player) =>
-          player.discordId === request.player_subbed_out.id
-            ? this.buildSeriesPlayer(subInAssoc, request.player_subbed_in.id, request.player_subbed_in.name)
-            : player,
-        ),
-      }));
+      const subInXuid = subInAssoc?.xboxId ?? null;
+
+      // Find the team where substitution occurred
+      let teamId = -1;
+      const updatedTeams = state.seriesContext.teams.map((team) => {
+        const hasSubbedOutPlayer = team.players.some((p) => p.discordId === request.player_subbed_out.id);
+        if (hasSubbedOutPlayer) {
+          teamId = team.id;
+        }
+
+        return {
+          ...team,
+          players: team.players.map((player) =>
+            player.discordId === request.player_subbed_out.id
+              ? this.buildSeriesPlayer(subInAssoc, request.player_subbed_in.id, request.player_subbed_in.name)
+              : player,
+          ),
+        };
+      });
+
+      const playerOut = this.buildSeriesPlayer(
+        state.playersAssociationData[request.player_subbed_out.id],
+        request.player_subbed_out.id,
+        request.player_subbed_out.name,
+      );
+      const playerIn = this.buildSeriesPlayer(subInAssoc, request.player_subbed_in.id, request.player_subbed_in.name);
+
       const updatedContext: SeriesContextPayload = { ...state.seriesContext, teams: updatedTeams };
       state.seriesContext = updatedContext;
       this.setQueueState(neatQueueConfig.GuildId, matchNumber, state);
-      const subInXuid = subInAssoc?.xboxId ?? null;
-      await Promise.all([
-        subOutXuid != null ? this.individualTrackerService.nudgeTrackers([subOutXuid], null) : Promise.resolve(),
-        subInXuid != null
-          ? this.individualTrackerService.nudgeTrackers([subInXuid], updatedContext)
-          : Promise.resolve(),
-      ]);
+
+      // Send substitution event to both affected players
+      if (teamId >= 0) {
+        const substitutionPayload = { type: "substituted" as const, teamId, playerOut, playerIn };
+        await Promise.all([
+          subOutXuid != null
+            ? this.individualTrackerService.nudgeTrackers([subOutXuid], substitutionPayload)
+            : Promise.resolve(),
+          subInXuid != null
+            ? this.individualTrackerService.nudgeTrackers([subInXuid], substitutionPayload)
+            : Promise.resolve(),
+        ]);
+      }
     } catch (nudgeError) {
       this.logService.warn(
         "Failed to nudge individual trackers for substitution",

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -823,14 +823,16 @@ export class NeatQueueService {
 
       // Find the team where substitution occurred
       let teamId = -1;
-      const updatedTeams = state.seriesContext.teams.map((team) => {
+      const updatedTeams = state.seriesContext.teams.map((team, teamIndex) => {
+        const normalizedTeamId = teamIndex;
         const hasSubbedOutPlayer = team.players.some((p) => p.discordId === request.player_subbed_out.id);
         if (hasSubbedOutPlayer) {
-          teamId = team.id;
+          teamId = normalizedTeamId;
         }
 
         return {
           ...team,
+          id: normalizedTeamId,
           players: team.players.map((player) =>
             player.discordId === request.player_subbed_out.id
               ? this.buildSeriesPlayer(subInAssoc, request.player_subbed_in.id, request.player_subbed_in.name)
@@ -862,24 +864,30 @@ export class NeatQueueService {
         const playerXuidSet = new Set<string>();
 
         // Add XUIDs from original teams (includes player being subbed out)
-        originalTeams.forEach((team) => {
-          team.players.forEach((player) => {
-            const xuid = state.playersAssociationData[player.discordId ?? ""]?.xboxId;
+        for (const team of originalTeams) {
+          for (const player of team.players) {
+            if (player.discordId == null) {
+              continue;
+            }
+            const xuid = state.playersAssociationData[player.discordId]?.xboxId;
             if (xuid != null) {
               playerXuidSet.add(xuid);
             }
-          });
-        });
+          }
+        }
 
         // Add XUIDs from updated teams (includes player being subbed in)
-        updatedTeams.forEach((team) => {
-          team.players.forEach((player) => {
-            const xuid = state.playersAssociationData[player.discordId ?? ""]?.xboxId;
+        for (const team of updatedTeams) {
+          for (const player of team.players) {
+            if (player.discordId == null) {
+              continue;
+            }
+            const xuid = state.playersAssociationData[player.discordId]?.xboxId;
             if (xuid != null) {
               playerXuidSet.add(xuid);
             }
-          });
-        });
+          }
+        }
 
         if (playerXuidSet.size > 0) {
           await this.individualTrackerService

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -890,18 +890,18 @@ export class NeatQueueService {
         }
 
         if (playerXuidSet.size > 0) {
-          await this.individualTrackerService
-            .nudgeTrackers(Array.from(playerXuidSet), substitutionPayload)
-            .catch((error: unknown) => {
-              this.logService.warn(
-                "Failed to nudge individual trackers for substitution",
-                new Map([
-                  ["guildId", request.guild],
-                  ["queueNumber", matchNumber.toString()],
-                  ["error", String(error)],
-                ]),
-              );
-            });
+          try {
+            await this.individualTrackerService.nudgeTrackers(Array.from(playerXuidSet), substitutionPayload);
+          } catch (error: unknown) {
+            this.logService.warn(
+              "Failed to nudge individual trackers for substitution",
+              new Map([
+                ["guildId", request.guild],
+                ["queueNumber", matchNumber.toString()],
+                ["error", String(error)],
+              ]),
+            );
+          }
         }
       }
     } catch (nudgeError) {

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -677,6 +677,7 @@ export class NeatQueueService {
         ),
       }));
       const seriesContext: SeriesStartedPayload = {
+        type: "started",
         title: getSeriesGroupTitleFromTeams(seriesTeams) ?? title,
         subtitle: `Queue #${request.match_number.toString()}`,
         guildIconUrl,

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -17,7 +17,7 @@ import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { getTeamName } from "@guilty-spark/shared/halo/team";
 import { getSeriesGroupTitleFromTeams } from "@guilty-spark/shared/individual-tracker/series-grouping";
-import type { SeriesContextPayload } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
+import type { SeriesStartedPayload } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
 import type { DatabaseService } from "../database/database";
 import type { NeatQueueConfigRow } from "../database/types/neat_queue_config";
 import { NeatQueuePostSeriesDisplayMode } from "../database/types/neat_queue_config";
@@ -676,7 +676,7 @@ export class NeatQueueService {
           this.buildSeriesPlayer(queueState.playersAssociationData[player.id], player.id, player.name),
         ),
       }));
-      const seriesContext: SeriesContextPayload = {
+      const seriesContext: SeriesStartedPayload = {
         title: getSeriesGroupTitleFromTeams(seriesTeams) ?? title,
         subtitle: `Queue #${request.match_number.toString()}`,
         guildIconUrl,
@@ -861,7 +861,7 @@ export class NeatQueueService {
         return;
       }
 
-      const updatedContext: SeriesContextPayload = { ...state.seriesContext, teams: updatedTeams };
+      const updatedContext: SeriesStartedPayload = { ...state.seriesContext, teams: updatedTeams };
 
       // Save original teams before updating state for xuid collection
       const originalTeams = state.seriesContext.teams;

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -819,9 +819,7 @@ export class NeatQueueService {
       return;
     }
     try {
-      const subOutXuid = state.playersAssociationData[request.player_subbed_out.id]?.xboxId ?? null;
       const subInAssoc = state.playersAssociationData[request.player_subbed_in.id];
-      const subInXuid = subInAssoc?.xboxId ?? null;
 
       // Find the team where substitution occurred
       let teamId = -1;
@@ -849,20 +847,54 @@ export class NeatQueueService {
       const playerIn = this.buildSeriesPlayer(subInAssoc, request.player_subbed_in.id, request.player_subbed_in.name);
 
       const updatedContext: SeriesContextPayload = { ...state.seriesContext, teams: updatedTeams };
+
+      // Save original teams before updating state for xuid collection
+      const originalTeams = state.seriesContext.teams;
+
       state.seriesContext = updatedContext;
       this.setQueueState(neatQueueConfig.GuildId, matchNumber, state);
 
-      // Send substitution event to both affected players
+      // Send substitution event to all players in the series
       if (teamId >= 0) {
         const substitutionPayload = { type: "substituted" as const, teamId, playerOut, playerIn };
-        await Promise.all([
-          subOutXuid != null
-            ? this.individualTrackerService.nudgeTrackers([subOutXuid], substitutionPayload)
-            : Promise.resolve(),
-          subInXuid != null
-            ? this.individualTrackerService.nudgeTrackers([subInXuid], substitutionPayload)
-            : Promise.resolve(),
-        ]);
+
+        // Collect all XUIDs from both original and updated teams to get both subbed-out and subbed-in players
+        const playerXuidSet = new Set<string>();
+
+        // Add XUIDs from original teams (includes player being subbed out)
+        originalTeams.forEach((team) => {
+          team.players.forEach((player) => {
+            const xuid = state.playersAssociationData[player.discordId ?? ""]?.xboxId;
+            if (xuid != null) {
+              playerXuidSet.add(xuid);
+            }
+          });
+        });
+
+        // Add XUIDs from updated teams (includes player being subbed in)
+        updatedTeams.forEach((team) => {
+          team.players.forEach((player) => {
+            const xuid = state.playersAssociationData[player.discordId ?? ""]?.xboxId;
+            if (xuid != null) {
+              playerXuidSet.add(xuid);
+            }
+          });
+        });
+
+        if (playerXuidSet.size > 0) {
+          await this.individualTrackerService
+            .nudgeTrackers(Array.from(playerXuidSet), substitutionPayload)
+            .catch((error: unknown) => {
+              this.logService.warn(
+                "Failed to nudge individual trackers for substitution",
+                new Map([
+                  ["guildId", request.guild],
+                  ["queueNumber", matchNumber.toString()],
+                  ["error", String(error)],
+                ]),
+              );
+            });
+        }
       }
     } catch (nudgeError) {
       this.logService.warn(

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -848,6 +848,19 @@ export class NeatQueueService {
       );
       const playerIn = this.buildSeriesPlayer(subInAssoc, request.player_subbed_in.id, request.player_subbed_in.name);
 
+      if (teamId < 0) {
+        this.logService.warn(
+          "Failed to locate substitution team in series context",
+          new Map([
+            ["guildId", request.guild],
+            ["queueNumber", matchNumber.toString()],
+            ["playerOutId", request.player_subbed_out.id],
+            ["playerInId", request.player_subbed_in.id],
+          ]),
+        );
+        return;
+      }
+
       const updatedContext: SeriesContextPayload = { ...state.seriesContext, teams: updatedTeams };
 
       // Save original teams before updating state for xuid collection
@@ -857,51 +870,49 @@ export class NeatQueueService {
       this.setQueueState(neatQueueConfig.GuildId, matchNumber, state);
 
       // Send substitution event to all players in the series
-      if (teamId >= 0) {
-        const substitutionPayload = { type: "substituted" as const, teamId, playerOut, playerIn };
+      const substitutionPayload = { type: "substituted" as const, teamId, playerOut, playerIn };
 
-        // Collect all XUIDs from both original and updated teams to get both subbed-out and subbed-in players
-        const playerXuidSet = new Set<string>();
+      // Collect all XUIDs from both original and updated teams to get both subbed-out and subbed-in players
+      const playerXuidSet = new Set<string>();
 
-        // Add XUIDs from original teams (includes player being subbed out)
-        for (const team of originalTeams) {
-          for (const player of team.players) {
-            if (player.discordId == null) {
-              continue;
-            }
-            const xuid = state.playersAssociationData[player.discordId]?.xboxId;
-            if (xuid != null) {
-              playerXuidSet.add(xuid);
-            }
+      // Add XUIDs from original teams (includes player being subbed out)
+      for (const team of originalTeams) {
+        for (const player of team.players) {
+          if (player.discordId == null) {
+            continue;
+          }
+          const xuid = state.playersAssociationData[player.discordId]?.xboxId;
+          if (xuid != null) {
+            playerXuidSet.add(xuid);
           }
         }
+      }
 
-        // Add XUIDs from updated teams (includes player being subbed in)
-        for (const team of updatedTeams) {
-          for (const player of team.players) {
-            if (player.discordId == null) {
-              continue;
-            }
-            const xuid = state.playersAssociationData[player.discordId]?.xboxId;
-            if (xuid != null) {
-              playerXuidSet.add(xuid);
-            }
+      // Add XUIDs from updated teams (includes player being subbed in)
+      for (const team of updatedTeams) {
+        for (const player of team.players) {
+          if (player.discordId == null) {
+            continue;
+          }
+          const xuid = state.playersAssociationData[player.discordId]?.xboxId;
+          if (xuid != null) {
+            playerXuidSet.add(xuid);
           }
         }
+      }
 
-        if (playerXuidSet.size > 0) {
-          try {
-            await this.individualTrackerService.nudgeTrackers(Array.from(playerXuidSet), substitutionPayload);
-          } catch (error: unknown) {
-            this.logService.warn(
-              "Failed to nudge individual trackers for substitution",
-              new Map([
-                ["guildId", request.guild],
-                ["queueNumber", matchNumber.toString()],
-                ["error", String(error)],
-              ]),
-            );
-          }
+      if (playerXuidSet.size > 0) {
+        try {
+          await this.individualTrackerService.nudgeTrackers(Array.from(playerXuidSet), substitutionPayload);
+        } catch (error: unknown) {
+          this.logService.warn(
+            "Failed to nudge individual trackers for substitution",
+            new Map([
+              ["guildId", request.guild],
+              ["queueNumber", matchNumber.toString()],
+              ["error", String(error)],
+            ]),
+          );
         }
       }
     } catch (nudgeError) {
@@ -1087,21 +1098,31 @@ export class NeatQueueService {
     const allPlayerXuids = this.extractXuids(completedQueueState.playersAssociationData);
 
     await Promise.all([
-      this.individualTrackerService.nudgeTrackers(allPlayerXuids, { type: "ended" }).catch((error: unknown) => {
-        this.logService.warn(
-          "Failed to nudge individual trackers for match completion",
-          new Map([
-            ["guildId", neatQueueConfig.GuildId],
-            ["queueNumber", request.match_number.toString()],
-            ["error", String(error)],
-          ]),
-        );
-      }),
+      this.nudgeIndividualTrackersForMatchCompletion(request, neatQueueConfig, allPlayerXuids),
       this.stopLiveTrackingIfActive(request, neatQueueConfig),
       this.clearTimeline(request, neatQueueConfig),
       this.deletePlayersMessageId(request, neatQueueConfig),
       this.haloService.updateDiscordAssociations(),
     ]);
+  }
+
+  private async nudgeIndividualTrackersForMatchCompletion(
+    request: NeatQueueMatchCompletedRequest,
+    neatQueueConfig: NeatQueueConfigRow,
+    allPlayerXuids: string[],
+  ): Promise<void> {
+    try {
+      await this.individualTrackerService.nudgeTrackers(allPlayerXuids, { type: "ended" });
+    } catch (error: unknown) {
+      this.logService.warn(
+        "Failed to nudge individual trackers for match completion",
+        new Map([
+          ["guildId", neatQueueConfig.GuildId],
+          ["queueNumber", request.match_number.toString()],
+          ["error", String(error)],
+        ]),
+      );
+    }
   }
 
   private async resolveSeriesFromLiveTracker(request: NeatQueueMatchCompletedRequest): Promise<MatchStats[] | null> {

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -873,16 +873,25 @@ export class NeatQueueService {
       // Send substitution event to all players in the series
       const substitutionPayload = { type: "substituted" as const, teamId, playerOut, playerIn };
 
+      const getPlayerXuid = (player: SeriesPlayer): string | null => {
+        if (player.xboxId != null) {
+          return player.xboxId;
+        }
+
+        if (player.discordId == null) {
+          return null;
+        }
+
+        return state.playersAssociationData[player.discordId]?.xboxId ?? null;
+      };
+
       // Collect all XUIDs from both original and updated teams to get both subbed-out and subbed-in players
       const playerXuidSet = new Set<string>();
 
       // Add XUIDs from original teams (includes player being subbed out)
       for (const team of originalTeams) {
         for (const player of team.players) {
-          if (player.discordId == null) {
-            continue;
-          }
-          const xuid = state.playersAssociationData[player.discordId]?.xboxId;
+          const xuid = getPlayerXuid(player);
           if (xuid != null) {
             playerXuidSet.add(xuid);
           }
@@ -892,10 +901,7 @@ export class NeatQueueService {
       // Add XUIDs from updated teams (includes player being subbed in)
       for (const team of updatedTeams) {
         for (const player of team.players) {
-          if (player.discordId == null) {
-            continue;
-          }
-          const xuid = state.playersAssociationData[player.discordId]?.xboxId;
+          const xuid = getPlayerXuid(player);
           if (xuid != null) {
             playerXuidSet.add(xuid);
           }

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -1047,7 +1047,7 @@ export class NeatQueueService {
     const allPlayerXuids = this.extractXuids(completedQueueState.playersAssociationData);
 
     await Promise.all([
-      this.individualTrackerService.nudgeTrackers(allPlayerXuids, null).catch((error: unknown) => {
+      this.individualTrackerService.nudgeTrackers(allPlayerXuids, { type: "ended" }).catch((error: unknown) => {
         this.logService.warn(
           "Failed to nudge individual trackers for match completion",
           new Map([

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -11,7 +11,7 @@ import { ChannelType } from "discord-api-types/v10";
 import { sub } from "date-fns";
 import type { LiveTrackerMatchSummary } from "@guilty-spark/shared/live-tracker/types";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
-import type { SeriesContextPayload } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
+import type { SeriesStartedPayload } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
 import type { SeriesPlayer, SeriesTeam } from "../../../durable-objects/individual-tracker/types";
 import { NeatQueueService } from "../neatqueue";
 import type { DatabaseService } from "../../database/database";
@@ -2064,7 +2064,7 @@ describe("NeatQueueService", () => {
         await jobToComplete?.();
 
         expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
-        const [, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], SeriesContextPayload];
+        const [, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], SeriesStartedPayload];
         expect(payload.title).toBe("Eagles vs Cobras");
       });
 
@@ -2081,7 +2081,7 @@ describe("NeatQueueService", () => {
         const { jobToComplete } = neatQueueService.handleRequest(teamsCreatedRequest, neatQueueConfig);
         await expect(jobToComplete?.()).resolves.toBeUndefined();
         expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
-        const [, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], SeriesContextPayload];
+        const [, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], SeriesStartedPayload];
         expect(payload.title).toBe(teamsCreatedRequest.guild);
         expect(payload.guildIconUrl).toBeNull();
       });

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -2111,6 +2111,7 @@ describe("NeatQueueService", () => {
         };
         const playersAssociationData = {
           discord_user_01: createSamplePlayerAssociationData("discord_user_01", "soundmanD", "SoundmanD"),
+          discord_user_03: createSamplePlayerAssociationData("discord_user_03", "newPlayer", "NewPlayer"),
         };
         (vi.spyOn(env.APP_DATA, "get") as MockInstance).mockResolvedValue(
           aFakeNeatQueueStateWith({ seriesContext, playersAssociationData }),
@@ -2136,16 +2137,11 @@ describe("NeatQueueService", () => {
         const { jobToComplete } = neatQueueService.handleRequest(substitutionRequest, neatQueueConfig);
         await jobToComplete?.();
 
-        expect(nudgeTrackersSpy).toHaveBeenCalledTimes(2);
-        const calls = nudgeTrackersSpy.mock.calls as [string[], unknown][];
-        const subOutCall = calls.find(
-          ([, payload]: [string[], unknown]) =>
-            payload !== null && typeof payload === "object" && "type" in payload && payload.type === "substituted",
-        );
-        const subInCall = calls.find(([xuids]) => xuids.includes("xuid_discord_user_03"));
-        expect(subOutCall?.[0]).toEqual(["xuid_discord_user_01"]);
-        expect(subInCall?.[0]).toEqual(["xuid_discord_user_03"]);
-        expect(subInCall?.[1]).toMatchObject({
+        expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
+        const [xuids, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], unknown];
+        expect(xuids).toContain("xuid_discord_user_01");
+        expect(xuids).toContain("xuid_discord_user_03");
+        expect(payload).toMatchObject({
           type: "substituted",
           teamId: 0,
           playerOut: expect.objectContaining({ discordId: "discord_user_01" }) as SeriesPlayer,
@@ -2176,6 +2172,7 @@ describe("NeatQueueService", () => {
         };
         const playersAssociationData = {
           discord_user_01: createSamplePlayerAssociationData("discord_user_01", "soundmanD", "SoundmanD"),
+          discord_user_03: createSamplePlayerAssociationData("discord_user_03", "newPlayer", "NewPlayer"),
         };
         (vi.spyOn(env.APP_DATA, "get") as MockInstance).mockResolvedValue(
           aFakeNeatQueueStateWith({ seriesContext, playersAssociationData }),
@@ -2197,15 +2194,11 @@ describe("NeatQueueService", () => {
         const { jobToComplete } = neatQueueService.handleRequest(substitutionRequest, neatQueueConfig);
         await jobToComplete?.();
 
-        expect(nudgeTrackersSpy).toHaveBeenCalledTimes(2);
-        const calls = nudgeTrackersSpy.mock.calls as [string[], unknown][];
-        const subOutCall = calls.find(
-          ([, payload]: [string[], unknown]) =>
-            payload !== null && typeof payload === "object" && "type" in payload && payload.type === "substituted",
-        );
-        const subInCall = calls.find(([xuids]) => xuids.includes("xuid_discord_user_03"));
-        expect(subOutCall?.[0]).toEqual(["xuid_discord_user_01"]);
-        expect(subInCall?.[0]).toEqual(["xuid_discord_user_03"]);
+        expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
+        const [xuids, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], unknown];
+        expect(xuids).toContain("xuid_discord_user_01");
+        expect(xuids).toContain("xuid_discord_user_03");
+        expect(payload).toMatchObject({ type: "substituted" });
       });
 
       it("skips nudge when seriesContext is not set", async () => {

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -2260,11 +2260,11 @@ describe("NeatQueueService", () => {
         await jobToComplete?.();
 
         expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
-        const [xuids, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], null];
+        const [xuids, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], { type: "ended" }];
         expect(xuids).toHaveLength(2);
         expect(xuids).toContain("xuid_discord_user_01");
         expect(xuids).toContain("xuid_discord_user_02");
-        expect(payload).toBeNull();
+        expect(payload).toEqual({ type: "ended" });
       });
 
       it("nudges with empty array when no players have XUIDs", async () => {
@@ -2283,7 +2283,7 @@ describe("NeatQueueService", () => {
         await jobToComplete?.();
 
         expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
-        expect(nudgeTrackersSpy).toHaveBeenCalledWith([], null);
+        expect(nudgeTrackersSpy).toHaveBeenCalledWith([], { type: "ended" });
       });
     });
   });

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -2203,6 +2203,58 @@ describe("NeatQueueService", () => {
         expect(payload).toMatchObject({ type: "substituted" });
       });
 
+      it("collects XUIDs from series players when association data is missing", async () => {
+        const substitutionRequest = getFakeNeatQueueData("substitution");
+        const seriesContext = {
+          type: "started" as const,
+          title: "Test Server",
+          subtitle: "Queue #3",
+          guildIconUrl: null,
+          teams: [
+            {
+              id: 0,
+              name: "Team 1",
+              players: [
+                {
+                  discordId: "discord_user_01",
+                  discordName: "soundmanD",
+                  gamertag: "SoundmanD",
+                  xboxId: "xuid_discord_user_01",
+                },
+              ],
+            },
+          ],
+        };
+        const playersAssociationData = {
+          discord_user_03: createSamplePlayerAssociationData("discord_user_03", "newPlayer", "NewPlayer"),
+        };
+
+        (vi.spyOn(env.APP_DATA, "get") as MockInstance).mockResolvedValue(
+          aFakeNeatQueueStateWith({ seriesContext, playersAssociationData }),
+        );
+        vi.spyOn(env.APP_DATA, "put").mockResolvedValue();
+        vi.spyOn(databaseService, "getDiscordAssociations").mockResolvedValue([
+          aFakeDiscordAssociationsRow({ DiscordId: "discord_user_03", XboxId: "xuid_discord_user_03" }),
+        ]);
+        vi.spyOn(haloService, "getUsersByXuids").mockResolvedValue([]);
+        vi.spyOn(haloService, "getRankedArenaCsrs").mockResolvedValue(new Map());
+        vi.spyOn(haloService, "getPlayersEsras").mockResolvedValue(new Map());
+        vi.spyOn(liveTrackerService, "getTrackerStatus").mockResolvedValue({
+          state: aFakeLiveTrackerStateWith({ status: "stopped" }),
+        });
+        vi.spyOn(databaseService, "getGuildConfig").mockResolvedValue(
+          aFakeGuildConfigRow({ NeatQueueInformerPlayerConnections: "N" }),
+        );
+
+        const { jobToComplete } = neatQueueService.handleRequest(substitutionRequest, neatQueueConfig);
+        await jobToComplete?.();
+
+        expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
+        const [xuids] = nudgeTrackersSpy.mock.calls[0] as [string[], unknown];
+        expect(xuids).toContain("xuid_discord_user_01");
+        expect(xuids).toContain("xuid_discord_user_03");
+      });
+
       it("skips nudge when seriesContext is not set", async () => {
         const substitutionRequest = getFakeNeatQueueData("substitution");
         (vi.spyOn(env.APP_DATA, "get") as MockInstance).mockResolvedValue(aFakeNeatQueueStateWith());

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -2096,6 +2096,7 @@ describe("NeatQueueService", () => {
           guildIconUrl: null,
           teams: [
             {
+              id: 0,
               name: "Team 1",
               players: [
                 {
@@ -2137,20 +2138,18 @@ describe("NeatQueueService", () => {
 
         expect(nudgeTrackersSpy).toHaveBeenCalledTimes(2);
         const calls = nudgeTrackersSpy.mock.calls as [string[], unknown][];
-        const nullCall = calls.find(([, payload]) => payload === null);
-        const contextCall = calls.find(([, payload]) => payload !== null);
-        expect(nullCall?.[0]).toEqual(["xuid_discord_user_01"]);
-        expect(contextCall?.[0]).toEqual(["xuid_discord_user_03"]);
-        expect(contextCall?.[1]).toMatchObject({
-          title: "Test Server",
-          subtitle: "Queue #3",
-          teams: [
-            expect.objectContaining<Partial<SeriesTeam>>({
-              players: expect.arrayContaining<SeriesPlayer>([
-                expect.objectContaining<Partial<SeriesPlayer>>({ discordId: "discord_user_03" }) as SeriesPlayer,
-              ]) as SeriesPlayer[],
-            }) as SeriesTeam,
-          ],
+        const subOutCall = calls.find(
+          ([, payload]: [string[], unknown]) =>
+            payload !== null && typeof payload === "object" && "type" in payload && payload.type === "substituted",
+        );
+        const subInCall = calls.find(([xuids]) => xuids.includes("xuid_discord_user_03"));
+        expect(subOutCall?.[0]).toEqual(["xuid_discord_user_01"]);
+        expect(subInCall?.[0]).toEqual(["xuid_discord_user_03"]);
+        expect(subInCall?.[1]).toMatchObject({
+          type: "substituted",
+          teamId: 0,
+          playerOut: expect.objectContaining({ discordId: "discord_user_01" }) as SeriesPlayer,
+          playerIn: expect.objectContaining({ discordId: "discord_user_03" }) as SeriesPlayer,
         });
       });
 
@@ -2162,6 +2161,7 @@ describe("NeatQueueService", () => {
           guildIconUrl: null,
           teams: [
             {
+              id: 0,
               name: "Team 1",
               players: [
                 {
@@ -2199,10 +2199,13 @@ describe("NeatQueueService", () => {
 
         expect(nudgeTrackersSpy).toHaveBeenCalledTimes(2);
         const calls = nudgeTrackersSpy.mock.calls as [string[], unknown][];
-        const nullCall = calls.find(([, payload]) => payload === null);
-        const contextCall = calls.find(([, payload]) => payload !== null);
-        expect(nullCall?.[0]).toEqual(["xuid_discord_user_01"]);
-        expect(contextCall?.[0]).toEqual(["xuid_discord_user_03"]);
+        const subOutCall = calls.find(
+          ([, payload]: [string[], unknown]) =>
+            payload !== null && typeof payload === "object" && "type" in payload && payload.type === "substituted",
+        );
+        const subInCall = calls.find(([xuids]) => xuids.includes("xuid_discord_user_03"));
+        expect(subOutCall?.[0]).toEqual(["xuid_discord_user_01"]);
+        expect(subInCall?.[0]).toEqual(["xuid_discord_user_03"]);
       });
 
       it("skips nudge when seriesContext is not set", async () => {

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -2091,6 +2091,7 @@ describe("NeatQueueService", () => {
       it("nudges sub-out with null and sub-in with updated context when seriesContext exists", async () => {
         const substitutionRequest = getFakeNeatQueueData("substitution");
         const seriesContext = {
+          type: "started" as const,
           title: "Test Server",
           subtitle: "Queue #3",
           guildIconUrl: null,
@@ -2152,6 +2153,7 @@ describe("NeatQueueService", () => {
       it("nudges even when live tracker is not active", async () => {
         const substitutionRequest = getFakeNeatQueueData("substitution");
         const seriesContext = {
+          type: "started" as const,
           title: "Test Server",
           subtitle: "Queue #3",
           guildIconUrl: null,

--- a/api/services/neatqueue/types.ts
+++ b/api/services/neatqueue/types.ts
@@ -1,5 +1,5 @@
 import type { PlayerAssociationData } from "@guilty-spark/shared/live-tracker/types";
-import type { SeriesContextPayload } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
+import type { SeriesStartedPayload } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
 import type { DiscordAssociationsRow } from "../database/types/discord_associations";
 import type { NeatQueueConfigRow } from "../database/types/neat_queue_config";
 
@@ -122,7 +122,7 @@ export interface NeatQueueState {
   timeline: NeatQueueTimelineEvent[];
   playersMessageId: string | null;
   playersAssociationData: Record<string, PlayerAssociationData>;
-  seriesContext?: SeriesContextPayload;
+  seriesContext?: SeriesStartedPayload;
 }
 
 export interface FetchedPlayersData {

--- a/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
@@ -34,20 +34,17 @@ export const seriesSubstitutedPayloadSchema = z.object({
 });
 export type SeriesSubstitutedPayload = z.infer<typeof seriesSubstitutedPayloadSchema>;
 
-// Union of all nudge payloads (backward compat: SeriesStartedPayload can omit type)
+// Union of all nudge payloads
 export const nudgePayloadSchema = z.union([
   seriesStartedPayloadSchema,
   seriesEndedPayloadSchema,
   seriesSubstitutedPayloadSchema,
-  z.null(),
 ]);
 export type NudgePayload = z.infer<typeof nudgePayloadSchema>;
 
-// Legacy aliases for backward compat
+// Legacy aliases for backward compat (now point to started payload)
 export const seriesContextPayloadSchema = seriesStartedPayloadSchema;
 export type SeriesContextPayload = SeriesStartedPayload;
-export const seriesContextNullablePayloadSchema = z.union([seriesContextPayloadSchema, z.null()]);
-export type SeriesContextNullablePayload = z.infer<typeof seriesContextNullablePayloadSchema>;
 
 export const individualTrackerNudgeContract = defineContract(z.object({ success: z.literal(true) }));
 export type IndividualTrackerNudgeResponse = z.infer<typeof individualTrackerNudgeContract.schema>;

--- a/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
@@ -1,14 +1,51 @@
 import { z } from "zod";
 import { defineContract } from "../../base";
-import { trackerSeriesTeamSchema } from "../../individual-tracker/view";
+import { trackerSeriesTeamSchema, trackerSeriesPlayerSchema } from "../../individual-tracker/view";
 
-export const seriesContextPayloadSchema = z.object({
+// Reuse player schema from view
+export const seriesPlayerSchema = trackerSeriesPlayerSchema;
+export type SeriesPlayer = z.infer<typeof seriesPlayerSchema>;
+
+export const seriesTeamSchema = trackerSeriesTeamSchema;
+export type SeriesTeam = z.infer<typeof seriesTeamSchema>;
+
+// Event: Series started (set new context)
+export const seriesStartedPayloadSchema = z.object({
+  type: z.literal("started").optional(),
   title: z.string(),
   subtitle: z.string(),
   guildIconUrl: z.string().nullable(),
-  teams: z.array(trackerSeriesTeamSchema),
+  teams: z.array(seriesTeamSchema),
 });
-export type SeriesContextPayload = z.infer<typeof seriesContextPayloadSchema>;
+export type SeriesStartedPayload = z.infer<typeof seriesStartedPayloadSchema>;
+
+// Event: Series ended (clear active series)
+export const seriesEndedPayloadSchema = z.object({
+  type: z.literal("ended"),
+});
+export type SeriesEndedPayload = z.infer<typeof seriesEndedPayloadSchema>;
+
+// Event: Player substitution (swap player in team)
+export const seriesSubstitutedPayloadSchema = z.object({
+  type: z.literal("substituted"),
+  teamId: z.number(),
+  playerOut: seriesPlayerSchema,
+  playerIn: seriesPlayerSchema,
+});
+export type SeriesSubstitutedPayload = z.infer<typeof seriesSubstitutedPayloadSchema>;
+
+// Union of all nudge payloads (backward compat: SeriesStartedPayload can omit type)
+export const nudgePayloadSchema = z.union([
+  seriesStartedPayloadSchema,
+  seriesEndedPayloadSchema,
+  seriesSubstitutedPayloadSchema,
+  z.null(),
+]);
+export type NudgePayload = z.infer<typeof nudgePayloadSchema>;
+
+// Legacy aliases for backward compat
+export const seriesContextPayloadSchema = seriesStartedPayloadSchema;
+export type SeriesContextPayload = SeriesStartedPayload;
 export const seriesContextNullablePayloadSchema = z.union([seriesContextPayloadSchema, z.null()]);
 export type SeriesContextNullablePayload = z.infer<typeof seriesContextNullablePayloadSchema>;
 

--- a/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
@@ -25,13 +25,34 @@ export const seriesEndedPayloadSchema = z.object({
 });
 export type SeriesEndedPayload = z.infer<typeof seriesEndedPayloadSchema>;
 
+const hasStablePlayerIdentifier = (player: SeriesPlayer): boolean =>
+  player.xboxId != null || player.discordId != null || player.gamertag != null;
+
 // Event: Player substitution (swap player in team)
-export const seriesSubstitutedPayloadSchema = z.object({
-  type: z.literal("substituted"),
-  teamId: z.number().int().min(0),
-  playerOut: seriesPlayerSchema,
-  playerIn: seriesPlayerSchema,
-});
+export const seriesSubstitutedPayloadSchema = z
+  .object({
+    type: z.literal("substituted"),
+    teamId: z.number().int().min(0),
+    playerOut: seriesPlayerSchema,
+    playerIn: seriesPlayerSchema,
+  })
+  .superRefine((payload, context) => {
+    if (!hasStablePlayerIdentifier(payload.playerOut)) {
+      context.addIssue({
+        code: "custom",
+        path: ["playerOut"],
+        message: "playerOut must include at least one identifier (xboxId, discordId, or gamertag)",
+      });
+    }
+
+    if (!hasStablePlayerIdentifier(payload.playerIn)) {
+      context.addIssue({
+        code: "custom",
+        path: ["playerIn"],
+        message: "playerIn must include at least one identifier (xboxId, discordId, or gamertag)",
+      });
+    }
+  });
 export type SeriesSubstitutedPayload = z.infer<typeof seriesSubstitutedPayloadSchema>;
 
 // Union of all nudge payloads

--- a/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
@@ -11,7 +11,7 @@ export type SeriesTeam = z.infer<typeof seriesTeamSchema>;
 
 // Event: Series started (set new context)
 export const seriesStartedPayloadSchema = z.object({
-  type: z.literal("started").optional(),
+  type: z.literal("started"),
   title: z.string(),
   subtitle: z.string(),
   guildIconUrl: z.string().nullable(),
@@ -35,7 +35,7 @@ export const seriesSubstitutedPayloadSchema = z.object({
 export type SeriesSubstitutedPayload = z.infer<typeof seriesSubstitutedPayloadSchema>;
 
 // Union of all nudge payloads
-export const nudgePayloadSchema = z.union([
+export const nudgePayloadSchema = z.discriminatedUnion("type", [
   seriesStartedPayloadSchema,
   seriesEndedPayloadSchema,
   seriesSubstitutedPayloadSchema,

--- a/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
@@ -42,9 +42,5 @@ export const nudgePayloadSchema = z.union([
 ]);
 export type NudgePayload = z.infer<typeof nudgePayloadSchema>;
 
-// Legacy aliases for backward compat (now point to started payload)
-export const seriesContextPayloadSchema = seriesStartedPayloadSchema;
-export type SeriesContextPayload = SeriesStartedPayload;
-
 export const individualTrackerNudgeContract = defineContract(z.object({ success: z.literal(true) }));
 export type IndividualTrackerNudgeResponse = z.infer<typeof individualTrackerNudgeContract.schema>;

--- a/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
@@ -28,7 +28,7 @@ export type SeriesEndedPayload = z.infer<typeof seriesEndedPayloadSchema>;
 // Event: Player substitution (swap player in team)
 export const seriesSubstitutedPayloadSchema = z.object({
   type: z.literal("substituted"),
-  teamId: z.number(),
+  teamId: z.number().int().min(0),
   playerOut: seriesPlayerSchema,
   playerIn: seriesPlayerSchema,
 });

--- a/shared/src/contracts/durable-objects/individual-tracker/tests/it-do.test.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/tests/it-do.test.ts
@@ -121,6 +121,7 @@ describe("individualTrackerViewStateContract", () => {
 
 describe("seriesStartedPayloadSchema", () => {
   const validPayload: SeriesStartedPayload = {
+    type: "started",
     title: "Eagles vs Cobras",
     subtitle: "Best of 3",
     guildIconUrl: null,
@@ -130,7 +131,7 @@ describe("seriesStartedPayloadSchema", () => {
     ],
   };
 
-  it("parses a valid series context payload", () => {
+  it("parses a valid started payload", () => {
     expect(seriesStartedPayloadSchema.parse(validPayload)).toEqual(validPayload);
   });
 

--- a/shared/src/contracts/durable-objects/individual-tracker/tests/it-do.test.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/tests/it-do.test.ts
@@ -125,8 +125,8 @@ describe("seriesContextPayloadSchema", () => {
     subtitle: "Best of 3",
     guildIconUrl: null,
     teams: [
-      { name: "Eagles", players: [{ discordId: "d1", discordName: "Player1", gamertag: "Tag1", xboxId: "x1" }] },
-      { name: "Cobras", players: [] },
+      { id: 0, name: "Eagles", players: [{ discordId: "d1", discordName: "Player1", gamertag: "Tag1", xboxId: "x1" }] },
+      { id: 1, name: "Cobras", players: [] },
     ],
   };
 

--- a/shared/src/contracts/durable-objects/individual-tracker/tests/it-do.test.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/tests/it-do.test.ts
@@ -7,7 +7,7 @@ import {
   type IndividualTrackerStartResponse,
 } from "../lifecycle";
 import { individualTrackerStatusContract, individualTrackerViewStateContract } from "../management";
-import { seriesContextPayloadSchema, type SeriesContextPayload } from "../nudge";
+import { seriesStartedPayloadSchema, type SeriesStartedPayload } from "../nudge";
 import {
   editSeriesContract,
   endSeriesContract,
@@ -119,8 +119,8 @@ describe("individualTrackerViewStateContract", () => {
   });
 });
 
-describe("seriesContextPayloadSchema", () => {
-  const validPayload: SeriesContextPayload = {
+describe("seriesStartedPayloadSchema", () => {
+  const validPayload: SeriesStartedPayload = {
     title: "Eagles vs Cobras",
     subtitle: "Best of 3",
     guildIconUrl: null,
@@ -131,12 +131,12 @@ describe("seriesContextPayloadSchema", () => {
   };
 
   it("parses a valid series context payload", () => {
-    expect(seriesContextPayloadSchema.parse(validPayload)).toEqual(validPayload);
+    expect(seriesStartedPayloadSchema.parse(validPayload)).toEqual(validPayload);
   });
 
   it("rejects a missing title", () => {
     expect(
-      seriesContextPayloadSchema.safeParse({
+      seriesStartedPayloadSchema.safeParse({
         subtitle: "Best of 3",
         guildIconUrl: null,
         teams: [],

--- a/shared/src/contracts/durable-objects/individual-tracker/tests/it-do.test.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/tests/it-do.test.ts
@@ -7,7 +7,7 @@ import {
   type IndividualTrackerStartResponse,
 } from "../lifecycle";
 import { individualTrackerStatusContract, individualTrackerViewStateContract } from "../management";
-import { seriesStartedPayloadSchema, type SeriesStartedPayload } from "../nudge";
+import { seriesStartedPayloadSchema, seriesSubstitutedPayloadSchema, type SeriesStartedPayload } from "../nudge";
 import {
   editSeriesContract,
   endSeriesContract,
@@ -141,6 +141,19 @@ describe("seriesStartedPayloadSchema", () => {
         subtitle: "Best of 3",
         guildIconUrl: null,
         teams: [],
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("seriesSubstitutedPayloadSchema", () => {
+  it("rejects substitution payload when both players have no identifiers", () => {
+    expect(
+      seriesSubstitutedPayloadSchema.safeParse({
+        type: "substituted",
+        teamId: 0,
+        playerOut: { discordId: null, discordName: null, gamertag: null, xboxId: null },
+        playerIn: { discordId: null, discordName: null, gamertag: null, xboxId: null },
       }).success,
     ).toBe(false);
   });

--- a/shared/src/contracts/individual-tracker/view.ts
+++ b/shared/src/contracts/individual-tracker/view.ts
@@ -31,6 +31,7 @@ export const trackerSeriesPlayerSchema = z.object({
 export type TrackerSeriesPlayer = z.infer<typeof trackerSeriesPlayerSchema>;
 
 export const trackerSeriesTeamSchema = z.object({
+  id: z.number(),
   name: z.string(),
   players: z.array(trackerSeriesPlayerSchema),
 });

--- a/shared/src/contracts/individual-tracker/view.ts
+++ b/shared/src/contracts/individual-tracker/view.ts
@@ -31,7 +31,7 @@ export const trackerSeriesPlayerSchema = z.object({
 export type TrackerSeriesPlayer = z.infer<typeof trackerSeriesPlayerSchema>;
 
 export const trackerSeriesTeamSchema = z.object({
-  id: z.number(),
+  id: z.number().int().min(0),
   name: z.string(),
   players: z.array(trackerSeriesPlayerSchema),
 });


### PR DESCRIPTION
## Context

The individual tracker nudge flow was expanded to support explicit lifecycle events (`started`, `ended`, `substituted`) so NeatQueue can drive tracker state transitions safely and deterministically. Since this feature is not live yet, we are simplifying the implementation by removing transitional backward-compatibility paths and keeping only the canonical payload contracts and runtime behavior.

## This PR

- Uses canonical nudge contract names only (`SeriesStartedPayload` / `seriesStartedPayloadSchema`) across API and shared tests.
- Removes legacy compatibility aliases from nudge contracts.
- Removes runtime legacy normalization on read in `IndividualTrackerDO` (`normalizeLegacySeriesState` path).
- Removes obsolete legacy-normalization test coverage and keeps behavior focused on current-state invariants.
- Keeps substitution handling robust with xuid-first detection and gamertag fallback from prior commits in this branch.

## Subsequent Work

- Continue the Copilot review loop for any new feedback on PR #613.
