### PR TITLE
refactor(overlay): adopt SPC for overlay match-state orchestration

### DIFF
--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -1,12 +1,19 @@
 import React from "react";
 import type { HaloInfiniteClient } from "halo-infinite-api";
+import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
+import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
 import { ComponentLoader } from "../../component-loader/component-loader";
 import { ErrorState } from "../../error-state/error-state";
 import { LoadingState } from "../../loading-state/loading-state";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { SeriesMatchesService } from "../../../services/stats/series-matches-types";
+import { StatsController } from "../../../controllers/stats/stats-controller";
+import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPlayer } from "../../../controllers/stats/kill-matrix/types";
 import { useIndividualTrackerViewer } from "../viewer/use-individual-tracker-viewer";
+import type { MatchDetailsState } from "../viewer/types";
+import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
 import { IndividualTrackerOverlay } from "./individual-tracker-overlay";
 
 interface IndividualTrackerOverlayPageProps {
@@ -24,6 +31,9 @@ export function IndividualTrackerOverlayPage({
   haloClient,
   trackerId,
 }: IndividualTrackerOverlayPageProps): React.ReactElement {
+  const [selectedMatchId, setSelectedMatchId] = React.useState<string | null>(null);
+  const [matchStatsByMatchId, setMatchStatsByMatchId] = React.useState<ReadonlyMap<string, MatchStatsState>>(new Map());
+
   const { snapshot, model, onRetry } = useIndividualTrackerViewer({
     individualTrackerViewService,
     matchAnalyticsService,
@@ -31,6 +41,125 @@ export function IndividualTrackerOverlayPage({
     haloClient,
     trackerId,
   });
+
+  React.useEffect(() => {
+    setSelectedMatchId(null);
+    setMatchStatsByMatchId(new Map());
+  }, [trackerId]);
+
+  const setMatchStatsState = React.useCallback((matchId: string, state: MatchStatsState): void => {
+    setMatchStatsByMatchId((previous) => {
+      const next = new Map(previous);
+      next.set(matchId, state);
+      return next;
+    });
+  }, []);
+
+  const loadMatchStats = React.useCallback(
+    async (matchId: string): Promise<void> => {
+      setMatchStatsState(matchId, { status: "loading" });
+      try {
+        const stats = await haloClient.getMatchStats(matchId);
+        const xuids = stats.Players.filter((player) => player.PlayerType === 1).map((player) => getPlayerXuid(player));
+
+        const [users, analyticsByMatchId] = await Promise.all([
+          haloClient.getUsers(xuids),
+          matchAnalyticsService.getBatchMatchAnalytics([matchId]),
+        ]);
+        const medalMetadata: MedalMetadata = {};
+
+        const playerMap = new Map(users.map((user) => [user.xuid, user.gamertag]));
+        for (const xuid of xuids) {
+          if (!playerMap.has(xuid)) {
+            playerMap.set(xuid, xuid);
+          }
+        }
+
+        setMatchStatsState(matchId, {
+          status: "loaded",
+          stats,
+          playerMap,
+          medalMetadata,
+          analytics: analyticsByMatchId[matchId] ?? null,
+        });
+      } catch {
+        setMatchStatsState(matchId, {
+          status: "error",
+          message: "Failed to load match stats",
+        });
+      }
+    },
+    [haloClient, matchAnalyticsService, setMatchStatsState],
+  );
+
+  const onSelectMatch = React.useCallback(
+    (matchId: string): void => {
+      setSelectedMatchId(matchId);
+
+      const existingState = matchStatsByMatchId.get(matchId);
+      if (existingState?.status === "loaded" || existingState?.status === "loading") {
+        return;
+      }
+
+      void loadMatchStats(matchId);
+    },
+    [loadMatchStats, matchStatsByMatchId],
+  );
+
+  const onDeselect = React.useCallback((): void => {
+    setSelectedMatchId(null);
+  }, []);
+
+  const matchStatsState = selectedMatchId == null ? null : (matchStatsByMatchId.get(selectedMatchId) ?? null);
+
+  const matchStatsPanelState = React.useMemo<MatchDetailsState | null>(() => {
+    if (selectedMatchId == null || matchStatsState == null) {
+      return null;
+    }
+
+    if (matchStatsState.status === "loading") {
+      return { status: "loading" };
+    }
+
+    if (matchStatsState.status === "error") {
+      return { status: "error", message: matchStatsState.message };
+    }
+
+    const { stats, playerMap, medalMetadata, analytics } = matchStatsState;
+    const controller = new StatsController();
+    controller.loadMatch(stats, playerMap, medalMetadata);
+    if (analytics != null) {
+      controller.loadAnalytics(analytics, playerMap);
+    }
+
+    const killMatrixRows = analytics != null ? controller.getKillMatrix() : null;
+    const players = controller.getPlayers();
+    const playersByGamertag = new Map(players.map((player) => [player.gamertag, player]));
+    const data = controller.getMatchStats();
+    const resolvedPlayers = data
+      .flatMap((teamData) => teamData.players.map((player) => playersByGamertag.get(player.name)))
+      .filter((player): player is KillMatrixPlayer => player != null);
+    const orderedPlayers = resolvedPlayers.length === players.length ? resolvedPlayers : players;
+
+    return {
+      status: "loaded",
+      matchId: stats.MatchId,
+      gameVariantCategory: stats.MatchInfo.GameVariantCategory,
+      gameMapThumbnailUrl: "",
+      duration: stats.MatchInfo.Duration,
+      startTime: stats.MatchInfo.StartTime,
+      endTime: stats.MatchInfo.EndTime,
+      data,
+      killMatrixPivotData:
+        killMatrixRows != null
+          ? KillMatrixFormatter.pivot(killMatrixRows, orderedPlayers)
+          : EMPTY_KILL_MATRIX_PIVOT_DATA,
+      transposedKillMatrixPivotData:
+        killMatrixRows != null
+          ? KillMatrixFormatter.transpose(killMatrixRows, orderedPlayers)
+          : EMPTY_KILL_MATRIX_PIVOT_DATA,
+    };
+  }, [matchStatsState, selectedMatchId]);
 
   return (
     <ComponentLoader
@@ -41,11 +170,11 @@ export function IndividualTrackerOverlayPage({
         model.renderModel != null ? (
           <IndividualTrackerOverlay
             renderModel={model.renderModel}
-            matchStatsState={null}
-            matchStatsPanelState={null}
-            selectedMatchId={null}
-            onSelectMatch={(): void => undefined}
-            onDeselect={(): void => undefined}
+            matchStatsState={matchStatsState}
+            matchStatsPanelState={matchStatsPanelState}
+            selectedMatchId={selectedMatchId}
+            onSelectMatch={onSelectMatch}
+            onDeselect={onDeselect}
           />
         ) : (
           <LoadingState />

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -1,20 +1,15 @@
-import React from "react";
+import React, { useEffect, useMemo, useSyncExternalStore } from "react";
 import type { HaloInfiniteClient } from "halo-infinite-api";
-import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
-import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
 import { ComponentLoader } from "../../component-loader/component-loader";
 import { ErrorState } from "../../error-state/error-state";
 import { LoadingState } from "../../loading-state/loading-state";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { SeriesMatchesService } from "../../../services/stats/series-matches-types";
-import { StatsController } from "../../../controllers/stats/stats-controller";
-import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
-import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPlayer } from "../../../controllers/stats/kill-matrix/types";
 import { useIndividualTrackerViewer } from "../viewer/use-individual-tracker-viewer";
-import type { MatchDetailsState } from "../viewer/types";
-import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
 import { IndividualTrackerOverlay } from "./individual-tracker-overlay";
+import { OverlayPagePresenter } from "./overlay-page-presenter";
+import { OverlayPageStore } from "./overlay-page-store";
 
 interface IndividualTrackerOverlayPageProps {
   readonly individualTrackerViewService: IndividualTrackerViewService;
@@ -31,8 +26,17 @@ export function IndividualTrackerOverlayPage({
   haloClient,
   trackerId,
 }: IndividualTrackerOverlayPageProps): React.ReactElement {
-  const [selectedMatchId, setSelectedMatchId] = React.useState<string | null>(null);
-  const [matchStatsByMatchId, setMatchStatsByMatchId] = React.useState<ReadonlyMap<string, MatchStatsState>>(new Map());
+  const store = useMemo(() => new OverlayPageStore(), []);
+
+  const presenter = useMemo(
+    () =>
+      new OverlayPagePresenter({
+        store,
+        haloClient,
+        matchAnalyticsService,
+      }),
+    [haloClient, matchAnalyticsService, store],
+  );
 
   const { snapshot, model, onRetry } = useIndividualTrackerViewer({
     individualTrackerViewService,
@@ -42,124 +46,20 @@ export function IndividualTrackerOverlayPage({
     trackerId,
   });
 
-  React.useEffect(() => {
-    setSelectedMatchId(null);
-    setMatchStatsByMatchId(new Map());
-  }, [trackerId]);
-
-  const setMatchStatsState = React.useCallback((matchId: string, state: MatchStatsState): void => {
-    setMatchStatsByMatchId((previous) => {
-      const next = new Map(previous);
-      next.set(matchId, state);
-      return next;
-    });
-  }, []);
-
-  const loadMatchStats = React.useCallback(
-    async (matchId: string): Promise<void> => {
-      setMatchStatsState(matchId, { status: "loading" });
-      try {
-        const stats = await haloClient.getMatchStats(matchId);
-        const xuids = stats.Players.filter((player) => player.PlayerType === 1).map((player) => getPlayerXuid(player));
-
-        const [users, analyticsByMatchId] = await Promise.all([
-          haloClient.getUsers(xuids),
-          matchAnalyticsService.getBatchMatchAnalytics([matchId]),
-        ]);
-        const medalMetadata: MedalMetadata = {};
-
-        const playerMap = new Map(users.map((user) => [user.xuid, user.gamertag]));
-        for (const xuid of xuids) {
-          if (!playerMap.has(xuid)) {
-            playerMap.set(xuid, xuid);
-          }
-        }
-
-        setMatchStatsState(matchId, {
-          status: "loaded",
-          stats,
-          playerMap,
-          medalMetadata,
-          analytics: analyticsByMatchId[matchId] ?? null,
-        });
-      } catch {
-        setMatchStatsState(matchId, {
-          status: "error",
-          message: "Failed to load match stats",
-        });
-      }
-    },
-    [haloClient, matchAnalyticsService, setMatchStatsState],
-  );
-
-  const onSelectMatch = React.useCallback(
-    (matchId: string): void => {
-      setSelectedMatchId(matchId);
-
-      const existingState = matchStatsByMatchId.get(matchId);
-      if (existingState?.status === "loaded" || existingState?.status === "loading") {
-        return;
-      }
-
-      void loadMatchStats(matchId);
-    },
-    [loadMatchStats, matchStatsByMatchId],
-  );
-
-  const onDeselect = React.useCallback((): void => {
-    setSelectedMatchId(null);
-  }, []);
-
-  const matchStatsState = selectedMatchId == null ? null : (matchStatsByMatchId.get(selectedMatchId) ?? null);
-
-  const matchStatsPanelState = React.useMemo<MatchDetailsState | null>(() => {
-    if (selectedMatchId == null || matchStatsState == null) {
-      return null;
-    }
-
-    if (matchStatsState.status === "loading") {
-      return { status: "loading" };
-    }
-
-    if (matchStatsState.status === "error") {
-      return { status: "error", message: matchStatsState.message };
-    }
-
-    const { stats, playerMap, medalMetadata, analytics } = matchStatsState;
-    const controller = new StatsController();
-    controller.loadMatch(stats, playerMap, medalMetadata);
-    if (analytics != null) {
-      controller.loadAnalytics(analytics, playerMap);
-    }
-
-    const killMatrixRows = analytics != null ? controller.getKillMatrix() : null;
-    const players = controller.getPlayers();
-    const playersByGamertag = new Map(players.map((player) => [player.gamertag, player]));
-    const data = controller.getMatchStats();
-    const resolvedPlayers = data
-      .flatMap((teamData) => teamData.players.map((player) => playersByGamertag.get(player.name)))
-      .filter((player): player is KillMatrixPlayer => player != null);
-    const orderedPlayers = resolvedPlayers.length === players.length ? resolvedPlayers : players;
-
-    return {
-      status: "loaded",
-      matchId: stats.MatchId,
-      gameVariantCategory: stats.MatchInfo.GameVariantCategory,
-      gameMapThumbnailUrl: "",
-      duration: stats.MatchInfo.Duration,
-      startTime: stats.MatchInfo.StartTime,
-      endTime: stats.MatchInfo.EndTime,
-      data,
-      killMatrixPivotData:
-        killMatrixRows != null
-          ? KillMatrixFormatter.pivot(killMatrixRows, orderedPlayers)
-          : EMPTY_KILL_MATRIX_PIVOT_DATA,
-      transposedKillMatrixPivotData:
-        killMatrixRows != null
-          ? KillMatrixFormatter.transpose(killMatrixRows, orderedPlayers)
-          : EMPTY_KILL_MATRIX_PIVOT_DATA,
+  useEffect(() => {
+    presenter.reset();
+    return (): void => {
+      presenter.dispose();
     };
-  }, [matchStatsState, selectedMatchId]);
+  }, [presenter, trackerId]);
+
+  const overlaySnapshot = useSyncExternalStore(
+    (listener) => store.subscribe(listener),
+    () => store.getSnapshot(),
+    () => store.getSnapshot(),
+  );
+
+  const overlayModel = useMemo(() => presenter.present(overlaySnapshot), [overlaySnapshot, presenter]);
 
   return (
     <ComponentLoader
@@ -170,11 +70,15 @@ export function IndividualTrackerOverlayPage({
         model.renderModel != null ? (
           <IndividualTrackerOverlay
             renderModel={model.renderModel}
-            matchStatsState={matchStatsState}
-            matchStatsPanelState={matchStatsPanelState}
-            selectedMatchId={selectedMatchId}
-            onSelectMatch={onSelectMatch}
-            onDeselect={onDeselect}
+            matchStatsState={overlayModel.matchStatsState}
+            matchStatsPanelState={overlayModel.matchStatsPanelState}
+            selectedMatchId={overlayModel.selectedMatchId}
+            onSelectMatch={(matchId): void => {
+              presenter.selectMatch(matchId);
+            }}
+            onDeselect={(): void => {
+              presenter.deselect();
+            }}
           />
         ) : (
           <LoadingState />

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -26,7 +26,7 @@ export function IndividualTrackerOverlayPage({
   haloClient,
   trackerId,
 }: IndividualTrackerOverlayPageProps): React.ReactElement {
-  const store = useMemo(() => new OverlayPageStore(), []);
+  const store = useMemo(() => new OverlayPageStore(), [trackerId]);
 
   const presenter = useMemo(
     () =>
@@ -35,7 +35,7 @@ export function IndividualTrackerOverlayPage({
         haloClient,
         matchAnalyticsService,
       }),
-    [haloClient, matchAnalyticsService, store, trackerId],
+    [haloClient, matchAnalyticsService, store],
   );
 
   const { snapshot, model, onRetry } = useIndividualTrackerViewer({

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -35,7 +35,7 @@ export function IndividualTrackerOverlayPage({
         haloClient,
         matchAnalyticsService,
       }),
-    [haloClient, matchAnalyticsService, store],
+    [haloClient, matchAnalyticsService, store, trackerId],
   );
 
   const { snapshot, model, onRetry } = useIndividualTrackerViewer({
@@ -51,7 +51,7 @@ export function IndividualTrackerOverlayPage({
     return (): void => {
       presenter.dispose();
     };
-  }, [presenter, trackerId]);
+  }, [presenter]);
 
   const overlaySnapshot = useSyncExternalStore(
     (listener) => store.subscribe(listener),

--- a/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
@@ -1,0 +1,160 @@
+import type { HaloInfiniteClient } from "halo-infinite-api";
+import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
+import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
+import { StatsController } from "../../../controllers/stats/stats-controller";
+import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPlayer } from "../../../controllers/stats/kill-matrix/types";
+import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
+import type { MatchDetailsState } from "../viewer/types";
+import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
+import type { OverlayPageSnapshot, OverlayPageStore } from "./overlay-page-store";
+
+interface OverlayPagePresenterConfig {
+  readonly store: OverlayPageStore;
+  readonly haloClient: HaloInfiniteClient;
+  readonly matchAnalyticsService: MatchAnalyticsService;
+}
+
+export interface OverlayPageViewModel {
+  readonly selectedMatchId: string | null;
+  readonly matchStatsState: MatchStatsState | null;
+  readonly matchStatsPanelState: MatchDetailsState | null;
+}
+
+export class OverlayPagePresenter {
+  private readonly config: OverlayPagePresenterConfig;
+  private isDisposed = false;
+
+  public constructor(config: OverlayPagePresenterConfig) {
+    this.config = config;
+  }
+
+  public dispose(): void {
+    this.isDisposed = true;
+  }
+
+  public reset(): void {
+    this.config.store.reset();
+  }
+
+  public selectMatch(matchId: string): void {
+    this.config.store.setSelectedMatchId(matchId);
+
+    const existingState = this.config.store.getSnapshot().matchStatsByMatchId.get(matchId);
+    if (existingState?.status === "loaded" || existingState?.status === "loading") {
+      return;
+    }
+
+    void this.loadMatchStatsAsync(matchId);
+  }
+
+  public deselect(): void {
+    this.config.store.setSelectedMatchId(null);
+  }
+
+  public present(snapshot: OverlayPageSnapshot): OverlayPageViewModel {
+    const matchStatsState =
+      snapshot.selectedMatchId == null ? null : (snapshot.matchStatsByMatchId.get(snapshot.selectedMatchId) ?? null);
+
+    return {
+      selectedMatchId: snapshot.selectedMatchId,
+      matchStatsState,
+      matchStatsPanelState: this.toMatchStatsPanelState(snapshot.selectedMatchId, matchStatsState),
+    };
+  }
+
+  private async loadMatchStatsAsync(matchId: string): Promise<void> {
+    this.config.store.setMatchStatsState(matchId, { status: "loading" });
+
+    try {
+      const stats = await this.config.haloClient.getMatchStats(matchId);
+      const xuids = stats.Players.filter((player) => player.PlayerType === 1).map((player) => getPlayerXuid(player));
+
+      const [users, analyticsByMatchId] = await Promise.all([
+        this.config.haloClient.getUsers(xuids),
+        this.config.matchAnalyticsService.getBatchMatchAnalytics([matchId]),
+      ]);
+      const medalMetadata: MedalMetadata = {};
+
+      if (this.isDisposed) {
+        return;
+      }
+
+      const playerMap = new Map(users.map((user) => [user.xuid, user.gamertag]));
+      for (const xuid of xuids) {
+        if (!playerMap.has(xuid)) {
+          playerMap.set(xuid, xuid);
+        }
+      }
+
+      this.config.store.setMatchStatsState(matchId, {
+        status: "loaded",
+        stats,
+        playerMap,
+        medalMetadata,
+        analytics: analyticsByMatchId[matchId] ?? null,
+      });
+    } catch {
+      if (this.isDisposed) {
+        return;
+      }
+
+      this.config.store.setMatchStatsState(matchId, {
+        status: "error",
+        message: "Failed to load match stats",
+      });
+    }
+  }
+
+  private toMatchStatsPanelState(
+    selectedMatchId: string | null,
+    matchStatsState: MatchStatsState | null,
+  ): MatchDetailsState | null {
+    if (selectedMatchId == null || matchStatsState == null) {
+      return null;
+    }
+
+    if (matchStatsState.status === "loading") {
+      return { status: "loading" };
+    }
+
+    if (matchStatsState.status === "error") {
+      return { status: "error", message: matchStatsState.message };
+    }
+
+    const { stats, playerMap, medalMetadata, analytics } = matchStatsState;
+    const controller = new StatsController();
+    controller.loadMatch(stats, playerMap, medalMetadata);
+    if (analytics != null) {
+      controller.loadAnalytics(analytics, playerMap);
+    }
+
+    const killMatrixRows = analytics != null ? controller.getKillMatrix() : null;
+    const players = controller.getPlayers();
+    const playersByGamertag = new Map(players.map((player) => [player.gamertag, player]));
+    const data = controller.getMatchStats();
+    const resolvedPlayers = data
+      .flatMap((teamData) => teamData.players.map((player) => playersByGamertag.get(player.name)))
+      .filter((player): player is KillMatrixPlayer => player != null);
+    const orderedPlayers = resolvedPlayers.length === players.length ? resolvedPlayers : players;
+
+    return {
+      status: "loaded",
+      matchId: stats.MatchId,
+      gameVariantCategory: stats.MatchInfo.GameVariantCategory,
+      gameMapThumbnailUrl: "",
+      duration: stats.MatchInfo.Duration,
+      startTime: stats.MatchInfo.StartTime,
+      endTime: stats.MatchInfo.EndTime,
+      data,
+      killMatrixPivotData:
+        killMatrixRows != null
+          ? KillMatrixFormatter.pivot(killMatrixRows, orderedPlayers)
+          : EMPTY_KILL_MATRIX_PIVOT_DATA,
+      transposedKillMatrixPivotData:
+        killMatrixRows != null
+          ? KillMatrixFormatter.transpose(killMatrixRows, orderedPlayers)
+          : EMPTY_KILL_MATRIX_PIVOT_DATA,
+    };
+  }
+}

--- a/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
@@ -1,6 +1,7 @@
 import type { HaloInfiniteClient } from "halo-infinite-api";
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
 import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { StatsController } from "../../../controllers/stats/stats-controller";
 import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPlayer } from "../../../controllers/stats/kill-matrix/types";
@@ -71,8 +72,10 @@ export class OverlayPagePresenter {
       const xuids = stats.Players.filter((player) => player.PlayerType === 1).map((player) => getPlayerXuid(player));
 
       const [users, analyticsByMatchId] = await Promise.all([
-        this.config.haloClient.getUsers(xuids),
-        this.config.matchAnalyticsService.getBatchMatchAnalytics([matchId]),
+        this.config.haloClient.getUsers(xuids).catch(() => []),
+        this.config.matchAnalyticsService
+          .getBatchMatchAnalytics([matchId])
+          .catch((): Record<string, MatchAnalytics | null> => ({})),
       ]);
       const medalMetadata: MedalMetadata = {};
 

--- a/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
@@ -26,6 +26,10 @@ export class OverlayPagePresenter {
   private readonly config: OverlayPagePresenterConfig;
   private isDisposed = false;
 
+  private shouldAbort(): boolean {
+    return this.isDisposed;
+  }
+
   public constructor(config: OverlayPagePresenterConfig) {
     this.config = config;
   }
@@ -69,6 +73,10 @@ export class OverlayPagePresenter {
 
     try {
       const stats = await this.config.haloClient.getMatchStats(matchId);
+      if (this.shouldAbort()) {
+        return;
+      }
+
       const xuids = stats.Players.filter((player) => player.PlayerType === 1).map((player) => getPlayerXuid(player));
 
       const [users, analyticsByMatchId] = await Promise.all([
@@ -79,7 +87,7 @@ export class OverlayPagePresenter {
       ]);
       const medalMetadata: MedalMetadata = {};
 
-      if (this.isDisposed) {
+      if (this.shouldAbort()) {
         return;
       }
 
@@ -98,7 +106,7 @@ export class OverlayPagePresenter {
         analytics: analyticsByMatchId[matchId] ?? null,
       });
     } catch {
-      if (this.isDisposed) {
+      if (this.shouldAbort()) {
         return;
       }
 

--- a/pages/src/components/individual-tracker/overlay/overlay-page-store.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-store.ts
@@ -1,0 +1,50 @@
+import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
+
+export interface OverlayPageSnapshot {
+  readonly selectedMatchId: string | null;
+  readonly matchStatsByMatchId: ReadonlyMap<string, MatchStatsState>;
+}
+
+export class OverlayPageStore {
+  private snapshot: OverlayPageSnapshot = {
+    selectedMatchId: null,
+    matchStatsByMatchId: new Map(),
+  };
+
+  private readonly subscribers = new Set<() => void>();
+
+  public subscribe(listener: () => void): () => void {
+    this.subscribers.add(listener);
+    return (): void => {
+      this.subscribers.delete(listener);
+    };
+  }
+
+  public getSnapshot(): OverlayPageSnapshot {
+    return this.snapshot;
+  }
+
+  public reset(): void {
+    this.update({
+      selectedMatchId: null,
+      matchStatsByMatchId: new Map(),
+    });
+  }
+
+  public setSelectedMatchId(selectedMatchId: string | null): void {
+    this.update({ selectedMatchId });
+  }
+
+  public setMatchStatsState(matchId: string, state: MatchStatsState): void {
+    const next = new Map(this.snapshot.matchStatsByMatchId);
+    next.set(matchId, state);
+    this.update({ matchStatsByMatchId: next });
+  }
+
+  private update(partial: Partial<OverlayPageSnapshot>): void {
+    this.snapshot = { ...this.snapshot, ...partial };
+    for (const subscriber of this.subscribers) {
+      subscriber();
+    }
+  }
+}

--- a/pages/src/components/individual-tracker/overlay/tests/create.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/create.test.tsx
@@ -146,4 +146,62 @@ describe("IndividualTrackerOverlayPage", () => {
       expect(screen.getByTestId("panel-state")).toHaveTextContent("error");
     });
   });
+
+  it("loads again after tracker id changes", async () => {
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
+      view: aFakeTrackerViewStateWith({
+        trackerId: "tracker-1",
+        status: "active",
+        matches: [aFakeTrackerMatchSummaryWith({ matchId: "match-1" })],
+      }),
+    });
+
+    const getMatchStats = vi.fn(
+      async (): Promise<ReturnType<typeof aFakeMatchStatsWith>> =>
+        Promise.resolve(aFakeMatchStatsWith({ MatchId: "match-1" })),
+    );
+    const haloClient = aFakeHaloClientWith({ getMatchStats });
+
+    const { rerender } = render(
+      <IndividualTrackerOverlayPage
+        individualTrackerViewService={individualTrackerViewService}
+        matchAnalyticsService={aFakeMatchAnalyticsServiceWith()}
+        seriesMatchesService={aFakeSeriesMatchesServiceWith()}
+        haloClient={haloClient}
+        trackerId="tracker-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("select")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("select"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("match-stats-state")).toHaveTextContent("loaded");
+    });
+
+    rerender(
+      <IndividualTrackerOverlayPage
+        individualTrackerViewService={individualTrackerViewService}
+        matchAnalyticsService={aFakeMatchAnalyticsServiceWith()}
+        seriesMatchesService={aFakeSeriesMatchesServiceWith()}
+        haloClient={haloClient}
+        trackerId="tracker-2"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("select")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("select"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("match-stats-state")).toHaveTextContent("loaded");
+    });
+
+    expect(getMatchStats).toHaveBeenCalledTimes(2);
+  });
 });

--- a/pages/src/components/individual-tracker/overlay/tests/create.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/create.test.tsx
@@ -1,0 +1,149 @@
+import "@testing-library/jest-dom/vitest";
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
+import { aFakeHaloClientWith } from "../../../../services/fakes/halo-client.fake";
+import {
+  aFakeTrackerMatchSummaryWith,
+  aFakeTrackerViewStateWith,
+  aFakeIndividualTrackerViewServiceWith,
+} from "../../../../services/individual-tracker/fakes/view.fake";
+import { aFakeMatchAnalyticsServiceWith } from "../../../../services/stats/fakes/match-analytics.fake";
+import { aFakeSeriesMatchesServiceWith } from "../../../../services/stats/fakes/series-matches.fake";
+import { IndividualTrackerOverlayPage } from "../create";
+
+vi.mock("../individual-tracker-overlay", () => ({
+  IndividualTrackerOverlay: (props: {
+    selectedMatchId: string | null;
+    matchStatsState: { status: string } | null;
+    matchStatsPanelState: { status: string } | null;
+    onSelectMatch: (matchId: string) => void;
+    onDeselect: () => void;
+  }): React.ReactElement => {
+    return (
+      <div>
+        <div data-testid="selected-match">{props.selectedMatchId ?? "none"}</div>
+        <div data-testid="match-stats-state">{props.matchStatsState?.status ?? "none"}</div>
+        <div data-testid="panel-state">{props.matchStatsPanelState?.status ?? "none"}</div>
+        <button
+          type="button"
+          onClick={(): void => {
+            props.onSelectMatch("match-1");
+          }}
+        >
+          select
+        </button>
+        <button type="button" onClick={props.onDeselect}>
+          deselect
+        </button>
+      </div>
+    );
+  },
+}));
+
+describe("IndividualTrackerOverlayPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("loads match stats on select and reuses cached state", async () => {
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
+      view: aFakeTrackerViewStateWith({
+        trackerId: "tracker-1",
+        status: "active",
+        matches: [aFakeTrackerMatchSummaryWith({ matchId: "match-1" })],
+      }),
+    });
+
+    const getMatchStats = vi.fn(
+      async (): Promise<ReturnType<typeof aFakeMatchStatsWith>> =>
+        Promise.resolve(aFakeMatchStatsWith({ MatchId: "match-1" })),
+    );
+    const getUsers = vi.fn(async (xuids: string[]) =>
+      Promise.resolve(
+        xuids.map((xuid) => ({
+          xuid,
+          gamertag: xuid,
+          gamerpic: { small: "", medium: "", large: "", xlarge: "" },
+        })),
+      ),
+    );
+    const haloClient = aFakeHaloClientWith({ getMatchStats, getUsers });
+
+    const matchAnalyticsService = aFakeMatchAnalyticsServiceWith();
+    const getBatchMatchAnalytics = vi.spyOn(matchAnalyticsService, "getBatchMatchAnalytics");
+
+    render(
+      <IndividualTrackerOverlayPage
+        individualTrackerViewService={individualTrackerViewService}
+        matchAnalyticsService={matchAnalyticsService}
+        seriesMatchesService={aFakeSeriesMatchesServiceWith()}
+        haloClient={haloClient}
+        trackerId="tracker-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("select")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("select"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-match")).toHaveTextContent("match-1");
+      expect(screen.getByTestId("match-stats-state")).toHaveTextContent("loaded");
+      expect(screen.getByTestId("panel-state")).toHaveTextContent("loaded");
+    });
+
+    await userEvent.click(screen.getByText("deselect"));
+    await userEvent.click(screen.getByText("select"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-match")).toHaveTextContent("match-1");
+      expect(screen.getByTestId("match-stats-state")).toHaveTextContent("loaded");
+      expect(screen.getByTestId("panel-state")).toHaveTextContent("loaded");
+    });
+
+    expect(getMatchStats).toHaveBeenCalledTimes(1);
+    expect(getBatchMatchAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps failed match load to error states", async () => {
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
+      view: aFakeTrackerViewStateWith({
+        trackerId: "tracker-1",
+        status: "active",
+        matches: [aFakeTrackerMatchSummaryWith({ matchId: "match-1" })],
+      }),
+    });
+
+    const haloClient = aFakeHaloClientWith({
+      getMatchStats: vi.fn(async () => Promise.reject(new Error("boom"))),
+    });
+
+    render(
+      <IndividualTrackerOverlayPage
+        individualTrackerViewService={individualTrackerViewService}
+        matchAnalyticsService={aFakeMatchAnalyticsServiceWith()}
+        seriesMatchesService={aFakeSeriesMatchesServiceWith()}
+        haloClient={haloClient}
+        trackerId="tracker-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("select")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("select"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-match")).toHaveTextContent("match-1");
+      expect(screen.getByTestId("match-stats-state")).toHaveTextContent("error");
+      expect(screen.getByTestId("panel-state")).toHaveTextContent("error");
+    });
+  });
+});

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
@@ -69,4 +69,31 @@ describe("OverlayPagePresenter", () => {
     expect(model.matchStatsState?.status).toBe("error");
     expect(model.matchStatsPanelState?.status).toBe("error");
   });
+
+  it("keeps loaded state when users and analytics lookups fail", async () => {
+    const store = new OverlayPageStore();
+    const haloClient = aFakeHaloClientWith({
+      getMatchStats: vi.fn(async () => Promise.resolve(aFakeMatchStatsWith({ MatchId: "match-1" }))),
+      getUsers: vi.fn(async () => Promise.reject(new Error("users down"))),
+    });
+
+    const matchAnalyticsService = aFakeMatchAnalyticsServiceWith();
+    vi.spyOn(matchAnalyticsService, "getBatchMatchAnalytics").mockRejectedValue(new Error("analytics down"));
+
+    const presenter = new OverlayPagePresenter({
+      store,
+      haloClient,
+      matchAnalyticsService,
+    });
+
+    presenter.selectMatch("match-1");
+
+    await waitFor(() => {
+      expect(store.getSnapshot().matchStatsByMatchId.get("match-1")?.status).toBe("loaded");
+    });
+
+    const model = presenter.present(store.getSnapshot());
+    expect(model.matchStatsState?.status).toBe("loaded");
+    expect(model.matchStatsPanelState?.status).toBe("loaded");
+  });
 });

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { waitFor } from "@testing-library/react";
+import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
+import { aFakeHaloClientWith } from "../../../../services/fakes/halo-client.fake";
+import { aFakeMatchAnalyticsServiceWith } from "../../../../services/stats/fakes/match-analytics.fake";
+import { OverlayPagePresenter } from "../overlay-page-presenter";
+import { OverlayPageStore } from "../overlay-page-store";
+
+function aUsersFor(
+  xuids: readonly string[],
+): { xuid: string; gamertag: string; gamerpic: { small: string; medium: string; large: string; xlarge: string } }[] {
+  return xuids.map((xuid) => ({
+    xuid,
+    gamertag: `Spartan ${xuid}`,
+    gamerpic: { small: "", medium: "", large: "", xlarge: "" },
+  }));
+}
+
+describe("OverlayPagePresenter", () => {
+  it("loads match stats and builds loaded panel state", async () => {
+    const store = new OverlayPageStore();
+    const getMatchStats = vi.fn(async () => Promise.resolve(aFakeMatchStatsWith({ MatchId: "match-1" })));
+    const haloClient = aFakeHaloClientWith({
+      getMatchStats,
+      getUsers: vi.fn(async (xuids: string[]) => Promise.resolve(aUsersFor(xuids))),
+    });
+
+    const presenter = new OverlayPagePresenter({
+      store,
+      haloClient,
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+    });
+
+    presenter.selectMatch("match-1");
+
+    await waitFor(() => {
+      expect(store.getSnapshot().matchStatsByMatchId.get("match-1")?.status).toBe("loaded");
+    });
+
+    const model = presenter.present(store.getSnapshot());
+    expect(model.selectedMatchId).toBe("match-1");
+    expect(model.matchStatsState?.status).toBe("loaded");
+    expect(model.matchStatsPanelState?.status).toBe("loaded");
+
+    presenter.selectMatch("match-1");
+    expect(getMatchStats).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps load failures to error states", async () => {
+    const store = new OverlayPageStore();
+    const haloClient = aFakeHaloClientWith({
+      getMatchStats: vi.fn(async () => Promise.reject(new Error("boom"))),
+    });
+
+    const presenter = new OverlayPagePresenter({
+      store,
+      haloClient,
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+    });
+
+    presenter.selectMatch("match-1");
+
+    await waitFor(() => {
+      expect(store.getSnapshot().matchStatsByMatchId.get("match-1")?.status).toBe("error");
+    });
+
+    const model = presenter.present(store.getSnapshot());
+    expect(model.selectedMatchId).toBe("match-1");
+    expect(model.matchStatsState?.status).toBe("error");
+    expect(model.matchStatsPanelState?.status).toBe("error");
+  });
+});

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-page-store.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-page-store.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
+import { OverlayPageStore } from "../overlay-page-store";
+
+describe("OverlayPageStore", () => {
+  it("updates selected match and stores match states", () => {
+    const store = new OverlayPageStore();
+
+    store.setSelectedMatchId("match-1");
+    store.setMatchStatsState("match-1", {
+      status: "loaded",
+      stats: aFakeMatchStatsWith({ MatchId: "match-1" }),
+      playerMap: new Map([["xuid-1", "Spartan"]]),
+      medalMetadata: {},
+      analytics: null,
+    });
+
+    const snapshot = store.getSnapshot();
+    expect(snapshot.selectedMatchId).toBe("match-1");
+    expect(snapshot.matchStatsByMatchId.get("match-1")?.status).toBe("loaded");
+  });
+
+  it("resets to empty snapshot", () => {
+    const store = new OverlayPageStore();
+
+    store.setSelectedMatchId("match-1");
+    store.setMatchStatsState("match-1", { status: "error", message: "boom" });
+
+    store.reset();
+
+    const snapshot = store.getSnapshot();
+    expect(snapshot.selectedMatchId).toBeNull();
+    expect(snapshot.matchStatsByMatchId.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Context
The stream overlay PR5 work introduces tab-driven match stats loading so ticker and stats panel can share one loaded match-stats source. To keep this incremental and low risk, we are first aligning the overlay page with the repository SPC pattern (Store -> Presenter -> Component) before continuing with additional sub-steps.

## This PR
This PR is tightly scoped to SPC refactoring for overlay page match-state orchestration.

- Moves overlay page state from component-local hooks into a dedicated store:
  - `OverlayPageStore` holds selected match + per-match load/cache states.
- Moves async loading and view-model mapping logic into a dedicated presenter:
  - `OverlayPagePresenter` owns select/deselect/reset flows, cache-aware loading, and panel-state mapping.
- Simplifies `IndividualTrackerOverlayPage` to orchestration only:
  - instantiate store/presenter
  - subscribe via `useSyncExternalStore`
  - render overlay with presenter output
- Adds focused unit tests for the new SPC layers:
  - presenter success/error/caching behavior
  - store update/reset behavior

Validation:
- `npm run done` passes (format, typecheck, lint, related tests).
- Added tests:
  - `pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts`
  - `pages/src/components/individual-tracker/overlay/tests/overlay-page-store.test.ts`

## Subsequent Work
- Continue PR5 sub-step work by wiring any remaining tab/ticker/panel refinements on top of this SPC baseline.
- Keep follow-up changes focused on behavior enhancements, with presenter tests extended for each new branch.
