### PR TITLE
feat(overlay): show active-series team details in top bar

### DIFF
--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -2,7 +2,12 @@ import React, { useCallback, useMemo } from "react";
 import { StreamerOverlay } from "../../streamer-overlay/streamer-overlay";
 import { TopSection } from "../../streamer-overlay/top-section";
 import { StatsPanel } from "../viewer/stats-panel";
-import type { IndividualTrackerViewerRenderModel, MatchDetailsState, ViewerSeriesTeam } from "../viewer/types";
+import type {
+  IndividualTrackerViewerRenderModel,
+  MatchDetailsState,
+  ViewerSeriesTeam,
+  ViewerSeriesTeamPlayer,
+} from "../viewer/types";
 import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
 import {
   buildTabs,
@@ -25,22 +30,16 @@ interface IndividualTrackerOverlayProps {
   readonly onDeselect: () => void;
 }
 
-function getSeriesPlayerDisplayName(player: {
-  readonly discordName: string | null;
-  readonly gamertag: string | null;
-}): string {
+function getSeriesPlayerDisplayName(player: ViewerSeriesTeamPlayer): string {
   return player.discordName ?? player.gamertag ?? "Unknown";
 }
 
-function renderTeamDetails(team: {
-  readonly name: string;
-  readonly players: readonly { readonly discordName: string | null; readonly gamertag: string | null }[];
-}): React.ReactElement {
+function renderTeamDetails(team: ViewerSeriesTeam): React.ReactElement {
   return (
     <>
       <div>{team.name}</div>
       {team.players.map((player, index) => (
-        <div key={`${team.name}-${index.toString()}`}>{getSeriesPlayerDisplayName(player)}</div>
+        <div key={`${team.id.toString()}-${index.toString()}`}>{getSeriesPlayerDisplayName(player)}</div>
       ))}
     </>
   );

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -51,11 +51,12 @@ function getTopSectionTeamDetails(teams: readonly ViewerSeriesTeam[]): {
   readonly teamLeft: React.ReactNode;
   readonly teamRight: React.ReactNode;
 } {
-  if (teams.length < 2) {
+  const teamLeft = teams.find((team) => team.id === 0);
+  const teamRight = teams.find((team) => team.id === 1);
+
+  if (teamLeft == null || teamRight == null) {
     return { showTeamDetails: false, teamLeft: null, teamRight: null };
   }
-
-  const [teamLeft, teamRight] = teams;
 
   return {
     showTeamDetails: true,

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from "react";
 import { StreamerOverlay } from "../../streamer-overlay/streamer-overlay";
 import { TopSection } from "../../streamer-overlay/top-section";
 import { StatsPanel } from "../viewer/stats-panel";
-import type { IndividualTrackerViewerRenderModel, MatchDetailsState } from "../viewer/types";
+import type { IndividualTrackerViewerRenderModel, MatchDetailsState, ViewerSeriesTeam } from "../viewer/types";
 import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
 import {
   buildTabs,
@@ -25,6 +25,45 @@ interface IndividualTrackerOverlayProps {
   readonly onDeselect: () => void;
 }
 
+function getSeriesPlayerDisplayName(player: {
+  readonly discordName: string | null;
+  readonly gamertag: string | null;
+}): string {
+  return player.discordName ?? player.gamertag ?? "Unknown";
+}
+
+function renderTeamDetails(team: {
+  readonly name: string;
+  readonly players: readonly { readonly discordName: string | null; readonly gamertag: string | null }[];
+}): React.ReactElement {
+  return (
+    <>
+      <div>{team.name}</div>
+      {team.players.map((player, index) => (
+        <div key={`${team.name}-${index.toString()}`}>{getSeriesPlayerDisplayName(player)}</div>
+      ))}
+    </>
+  );
+}
+
+function getTopSectionTeamDetails(teams: readonly ViewerSeriesTeam[]): {
+  readonly showTeamDetails: boolean;
+  readonly teamLeft: React.ReactNode;
+  readonly teamRight: React.ReactNode;
+} {
+  if (teams.length < 2) {
+    return { showTeamDetails: false, teamLeft: null, teamRight: null };
+  }
+
+  const [teamLeft, teamRight] = teams;
+
+  return {
+    showTeamDetails: true,
+    teamLeft: renderTeamDetails(teamLeft),
+    teamRight: renderTeamDetails(teamRight),
+  };
+}
+
 export function IndividualTrackerOverlay({
   renderModel,
   matchStatsState,
@@ -41,6 +80,8 @@ export function IndividualTrackerOverlay({
 
   const topSection = useMemo(() => {
     if (activeSeries != null) {
+      const { showTeamDetails, teamLeft, teamRight } = getTopSectionTeamDetails(activeSeries.teams);
+
       return (
         <TopSection
           title={activeSeries.title}
@@ -48,10 +89,10 @@ export function IndividualTrackerOverlay({
           iconUrl={null}
           showScore={true}
           seriesScore={activeSeries.score}
-          showTeamDetails={false}
+          showTeamDetails={showTeamDetails}
           teamColors={teamColors}
-          teamLeft={null}
-          teamRight={null}
+          teamLeft={teamLeft}
+          teamRight={teamRight}
         />
       );
     }

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -30,6 +30,7 @@ function aSeriesWith(overrides: Partial<ViewerSeriesTab> = {}): ViewerSeriesTab 
     title: overrides.title ?? "Eagle vs Cobra",
     subtitle: overrides.subtitle ?? "Best of 3",
     isActive: overrides.isActive ?? false,
+    teams: overrides.teams ?? [],
     matchBackgroundUrls: overrides.matchBackgroundUrls ?? matches.map(() => "data:,"),
     score: overrides.score ?? "2:1",
     duration: overrides.duration ?? "30m",

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -198,4 +198,59 @@ describe("IndividualTrackerOverlay", () => {
     expect(screen.getByText("Beta")).toBeInTheDocument();
     expect(screen.getByText("Unknown")).toBeInTheDocument();
   });
+
+  it("maps team details by team id regardless of active-series team order", () => {
+    render(
+      <IndividualTrackerOverlay
+        renderModel={aRenderModel({
+          matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" }), aFakeTrackerMatchSummaryWith({ matchId: "m-2" })],
+          series: [
+            aFakeTrackerSeriesGroupWith({
+              id: "series-1",
+              title: "Alpha vs Beta",
+              subtitle: "Bo3",
+              matchIds: ["m-1", "m-2"],
+              score: "1:0",
+            }),
+          ],
+          hasActiveSeries: true,
+          activeSeriesContext: {
+            title: "Alpha vs Beta",
+            subtitle: "Bo3",
+            teams: [
+              {
+                id: 1,
+                name: "Beta",
+                players: [{ discordId: null, discordName: null, gamertag: "Beta Player", xboxId: null }],
+              },
+              {
+                id: 2,
+                name: "Gamma",
+                players: [{ discordId: null, discordName: null, gamertag: "Ignored Player", xboxId: null }],
+              },
+              {
+                id: 0,
+                name: "Alpha",
+                players: [{ discordId: null, discordName: null, gamertag: "Alpha Player", xboxId: null }],
+              },
+            ],
+          },
+        })}
+        matchStatsState={null}
+        matchStatsPanelState={null}
+        selectedMatchId={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
+
+    const leftTeamContainer = screen.getByTestId("team-icon-0").parentElement;
+    const rightTeamContainer = screen.getByTestId("team-icon-1").parentElement;
+
+    expect(leftTeamContainer?.textContent).toContain("Alpha");
+    expect(leftTeamContainer?.textContent).toContain("Alpha Player");
+    expect(rightTeamContainer?.textContent).toContain("Beta");
+    expect(rightTeamContainer?.textContent).toContain("Beta Player");
+    expect(screen.queryByText("Ignored Player")).not.toBeInTheDocument();
+  });
 });

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -14,6 +14,7 @@ vi.mock("../../../icons/medal-icon", () => ({
 }));
 import {
   aFakeTrackerMatchSummaryWith,
+  aFakeTrackerSeriesGroupWith,
   aFakeTrackerViewStateWith,
 } from "../../../../services/individual-tracker/fakes/view.fake";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
@@ -146,5 +147,55 @@ describe("IndividualTrackerOverlay", () => {
     await userEvent.click(screen.getByRole("button", { name: "Close" }));
 
     expect(onDeselect).toHaveBeenCalledOnce();
+  });
+
+  it("renders active series team details using display-name fallbacks", () => {
+    render(
+      <IndividualTrackerOverlay
+        renderModel={aRenderModel({
+          matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" }), aFakeTrackerMatchSummaryWith({ matchId: "m-2" })],
+          series: [
+            aFakeTrackerSeriesGroupWith({
+              id: "series-1",
+              title: "Alpha vs Beta",
+              subtitle: "Bo3",
+              matchIds: ["m-1", "m-2"],
+              score: "1:0",
+            }),
+          ],
+          hasActiveSeries: true,
+          activeSeriesContext: {
+            title: "Alpha vs Beta",
+            subtitle: "Bo3",
+            teams: [
+              {
+                id: 0,
+                name: "Alpha",
+                players: [
+                  { discordId: null, discordName: "Discord Name", gamertag: "Gamertag Name", xboxId: null },
+                  { discordId: null, discordName: null, gamertag: "Xbox Only", xboxId: null },
+                ],
+              },
+              {
+                id: 1,
+                name: "Beta",
+                players: [{ discordId: null, discordName: null, gamertag: null, xboxId: null }],
+              },
+            ],
+          },
+        })}
+        matchStatsState={null}
+        matchStatsPanelState={null}
+        selectedMatchId={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Discord Name")).toBeInTheDocument();
+    expect(screen.getByText("Xbox Only")).toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
   });
 });

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
@@ -310,4 +310,46 @@ describe("buildViewerRenderModel", () => {
       expect(seriesItem.series.teams[1]?.players[0]?.gamertag).toBe("B-Xbox");
     }
   });
+
+  it("maps active series teams when active context subtitle is missing but title uniquely matches", () => {
+    const view = aFakeTrackerViewStateWith({
+      matches: [aFakeTrackerMatchSummaryWith({ matchId: "m1" }), aFakeTrackerMatchSummaryWith({ matchId: "m2" })],
+      series: [
+        aFakeTrackerSeriesGroupWith({
+          id: "series-1",
+          title: "Alpha vs Beta",
+          subtitle: "Bo3",
+          matchIds: ["m1", "m2"],
+        }),
+      ],
+      hasActiveSeries: true,
+      activeSeriesContext: {
+        title: "Alpha vs Beta",
+        subtitle: null,
+        teams: [
+          {
+            id: 0,
+            name: "Alpha",
+            players: [{ discordId: null, discordName: "A-Discord", gamertag: "A-Xbox", xboxId: null }],
+          },
+          {
+            id: 1,
+            name: "Beta",
+            players: [{ discordId: null, discordName: null, gamertag: "B-Xbox", xboxId: null }],
+          },
+        ],
+      },
+    });
+
+    const model = buildViewerRenderModel({ view });
+    const seriesItem = model.timeline.find((item) => item.type === "series");
+
+    expect(seriesItem?.type).toBe("series");
+    if (seriesItem?.type === "series") {
+      expect(seriesItem.series.isActive).toBe(true);
+      expect(seriesItem.series.teams).toHaveLength(2);
+      expect(seriesItem.series.teams[0]?.name).toBe("Alpha");
+      expect(seriesItem.series.teams[1]?.name).toBe("Beta");
+    }
+  });
 });

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
@@ -268,4 +268,46 @@ describe("buildViewerRenderModel", () => {
     expect(seriesItems.find((item) => item.series.id === "series-older")?.series.isActive).toBe(false);
     expect(seriesItems.find((item) => item.series.id === "series-recent")?.series.isActive).toBe(true);
   });
+
+  it("maps active series context teams onto the active series tab", () => {
+    const view = aFakeTrackerViewStateWith({
+      matches: [aFakeTrackerMatchSummaryWith({ matchId: "m1" }), aFakeTrackerMatchSummaryWith({ matchId: "m2" })],
+      series: [
+        aFakeTrackerSeriesGroupWith({
+          id: "series-1",
+          title: "Alpha vs Beta",
+          subtitle: "Bo3",
+          matchIds: ["m1", "m2"],
+        }),
+      ],
+      hasActiveSeries: true,
+      activeSeriesContext: {
+        title: "Alpha vs Beta",
+        subtitle: "Bo3",
+        teams: [
+          {
+            id: 0,
+            name: "Alpha",
+            players: [{ discordId: null, discordName: "A-Discord", gamertag: "A-Xbox", xboxId: null }],
+          },
+          {
+            id: 1,
+            name: "Beta",
+            players: [{ discordId: null, discordName: null, gamertag: "B-Xbox", xboxId: null }],
+          },
+        ],
+      },
+    });
+
+    const model = buildViewerRenderModel({ view });
+    const seriesItem = model.timeline.find((item) => item.type === "series");
+
+    expect(seriesItem?.type).toBe("series");
+    if (seriesItem?.type === "series") {
+      expect(seriesItem.series.teams).toHaveLength(2);
+      expect(seriesItem.series.teams[0]?.name).toBe("Alpha");
+      expect(seriesItem.series.teams[0]?.players[0]?.discordName).toBe("A-Discord");
+      expect(seriesItem.series.teams[1]?.players[0]?.gamertag).toBe("B-Xbox");
+    }
+  });
 });

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -27,6 +27,7 @@ export interface ViewerSeriesTab {
   readonly title: string;
   readonly subtitle: string;
   readonly isActive: boolean;
+  readonly teams: readonly ViewerSeriesTeam[];
   readonly matchBackgroundUrls: readonly string[];
   readonly score: string;
   readonly duration: string;
@@ -34,6 +35,17 @@ export interface ViewerSeriesTab {
   readonly endTime: string;
   readonly matches: readonly ViewerMatchTab[];
   readonly colorHex: string | undefined;
+}
+
+export interface ViewerSeriesTeamPlayer {
+  readonly discordName: string | null;
+  readonly gamertag: string | null;
+}
+
+export interface ViewerSeriesTeam {
+  readonly id: number;
+  readonly name: string;
+  readonly players: readonly ViewerSeriesTeamPlayer[];
 }
 
 export type ViewerTimelineItem =

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -24,42 +24,45 @@ export interface BuildViewerRenderModelOptions {
   readonly preferredEnemyColorId?: string;
 }
 
-function isActiveSeriesGroup(view: TrackerViewState, series: TrackerSeriesGroup): boolean {
-  if (!view.hasActiveSeries || view.activeSeriesContext == null) {
-    return false;
-  }
-
-  const activeSubtitle = view.activeSeriesContext.subtitle ?? "";
-  return series.title === view.activeSeriesContext.title && series.subtitle === activeSubtitle;
-}
-
 function findActiveSeriesId(view: TrackerViewState): string | null {
-  if (!view.hasActiveSeries) {
+  if (!view.hasActiveSeries || view.activeSeriesContext == null) {
     return null;
   }
 
+  const activeTitle = view.activeSeriesContext.title;
+  const activeSubtitle = view.activeSeriesContext.subtitle ?? "";
+
   for (const series of view.series) {
-    if (isActiveSeriesGroup(view, series)) {
+    if (series.title === activeTitle && series.subtitle === activeSubtitle) {
       return series.id;
     }
+  }
+
+  const titleMatches = view.series.filter((series) => series.title === activeTitle);
+  if (titleMatches.length === 1) {
+    return titleMatches[0]?.id ?? null;
   }
 
   return null;
 }
 
-function getSeriesTeams(view: TrackerViewState, series: TrackerSeriesGroup): readonly ViewerSeriesTeam[] {
-  if (isActiveSeriesGroup(view, series) && view.activeSeriesContext != null) {
-    return view.activeSeriesContext.teams.map((team) => ({
-      id: team.id,
-      name: team.name,
-      players: team.players.map((player) => ({
-        discordName: player.discordName,
-        gamertag: player.gamertag,
-      })),
-    }));
+function getSeriesTeams(
+  view: TrackerViewState,
+  series: TrackerSeriesGroup,
+  activeSeriesId: string | null,
+): readonly ViewerSeriesTeam[] {
+  if (view.activeSeriesContext == null || activeSeriesId == null || series.id !== activeSeriesId) {
+    return [];
   }
 
-  return [];
+  return view.activeSeriesContext.teams.map((team) => ({
+    id: team.id,
+    name: team.name,
+    players: team.players.map((player) => ({
+      discordName: player.discordName,
+      gamertag: player.gamertag,
+    })),
+  }));
 }
 
 function toReadableDurationOrUnknown(startTime: string, endTime: string): string {
@@ -215,7 +218,7 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
         title: anchoredSeries.title,
         subtitle: anchoredSeries.subtitle,
         isActive: activeSeriesId != null ? anchoredSeries.id === activeSeriesId : false,
-        teams: getSeriesTeams(view, anchoredSeries),
+        teams: getSeriesTeams(view, anchoredSeries, activeSeriesId),
         matchBackgroundUrls:
           anchoredSeries.matchBackgroundUrls ?? seriesSummaries.map((summary) => summary.mapBackgroundUrl ?? "data:,"),
         score: anchoredSeries.score,

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -13,6 +13,7 @@ import type {
   IndividualTrackerViewerRenderModel,
   ViewerAccumulatedStats,
   ViewerMatchTab,
+  ViewerSeriesTeam,
   ViewerSeriesTab,
   ViewerTimelineItem,
 } from "./types";
@@ -44,6 +45,21 @@ function findActiveSeriesId(view: TrackerViewState): string | null {
   }
 
   return null;
+}
+
+function getSeriesTeams(view: TrackerViewState, series: TrackerSeriesGroup): readonly ViewerSeriesTeam[] {
+  if (isActiveSeriesGroup(view, series) && view.activeSeriesContext != null) {
+    return view.activeSeriesContext.teams.map((team) => ({
+      id: team.id,
+      name: team.name,
+      players: team.players.map((player) => ({
+        discordName: player.discordName,
+        gamertag: player.gamertag,
+      })),
+    }));
+  }
+
+  return [];
 }
 
 function toReadableDurationOrUnknown(startTime: string, endTime: string): string {
@@ -199,6 +215,7 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
         title: anchoredSeries.title,
         subtitle: anchoredSeries.subtitle,
         isActive: activeSeriesId != null ? anchoredSeries.id === activeSeriesId : false,
+        teams: getSeriesTeams(view, anchoredSeries),
         matchBackgroundUrls:
           anchoredSeries.matchBackgroundUrls ?? seriesSummaries.map((summary) => summary.mapBackgroundUrl ?? "data:,"),
         score: anchoredSeries.score,


### PR DESCRIPTION
## Context
The stream overlay feature has been landing in small slices to support correct in-series vs matchmaking behavior driven by IndividualTrackerDO data. With routing, mode switching, and ticker/panel wiring already merged, the remaining top-bar parity gap was rendering team details during an active series.

## This PR
This PR implements PR6 by wiring active-series team data into the overlay top section and rendering team names/player names there while preserving existing top-section exclusivity behavior.

- Extend viewer render-model types with series team/player data.
- Map activeSeriesContext.teams onto the active timeline series entry.
- Render team details in the overlay top section when two teams are available.
- Apply display fallback for players: discordName ?? gamertag ?? "Unknown".
- Add test coverage for render-model mapping and overlay fallback rendering.
- Update affected overlay presenter fixture typing.

## Subsequent Work
- Land the next overlay slices from the stream-overlay plan after PR6 merges (if any remaining), keeping the same small-scope PR strategy and Copilot review loop discipline.
