### PR TITLE
feat(overlay): mirror live-tracker in-series start UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,14 @@ Each feature follows the SPC split: Store → Presenter → Component (view).
 - **Presenter**: owns all business logic and async work. `start()` drives fetches and pushes results to the store. `present(snapshot)` is a pure computation that converts a snapshot into a fully display-ready view model — all formatting, icon URLs, hex colour values, sorted arrays, and computed strings must be done here, not in the view.
 - **View (component)**: pure renderer. Receives specific named props only (see **View Props** below). No business logic, no utility calls, no `useMemo` for data derivation.
 
+**Presenter shape and ownership**:
+
+- Presenters should be class-based by default (for example, `FooPresenter`) rather than modules that expose many independent exported functions.
+- Front-load shared setup in the presenter constructor (defaults, static mappings, reusable options) so call sites remain thin and consistent.
+- Keep presenter public API small and intentional (for example, `present(...)` and a few UI state helpers), with helper logic implemented as private methods.
+- `create.tsx` owns presenter instantiation (`useMemo(() => new FooPresenter(...), [...])`) and orchestrates calls; components remain render-only.
+- Do not move business/data-shaping logic into components to satisfy short-term convenience. If logic is shared by multiple presenter methods, extract private presenter methods first.
+
 ```typescript
 // create.tsx — wires the three layers together
 const store = useMemo(() => new FooStore(), []);
@@ -96,6 +104,8 @@ return <FooView {...model} />;
 ```
 
 **View Props**: Views must receive specific named props — never a generic `model` object or raw contract types (e.g. `renderData: Contract["renderData"]`). The `create.tsx` file is the mapping layer between presenter output and view props; spreading the model is idiomatic: `<FooView {...model} />`. `useMemo` inside a view is acceptable only for pure view-layer derivations such as column definitions — never for business logic or data transformation.
+
+When a feature needs view-model computation beyond simple pass-through, prefer presenter methods invoked from `create.tsx` over ad hoc utility calls in the component.
 
 **Shared types between presenter and view**: If a type is used by both the presenter and the view, it lives in `types.ts` in the same folder. The presenter does not import from the view; the view does not import from the presenter. Both import from `types.ts`.
 
@@ -241,6 +251,13 @@ Prefer typed fake instances plus `vi.spyOn` over ad hoc test doubles. Avoid `as 
 - Pages presenter tests: construct `Store` + `Presenter` directly (no React), drive via public methods, assert on `store.getSnapshot()`
 - Pages component tests: `@testing-library/react` — `render`/`screen`/`userEvent`; mock icons/providers
 - Proxy client tests: `vi.spyOn(globalThis, "fetch")`
+
+**Post-review hardening expectations**:
+
+- If a code review uncovers a regression risk, add a focused regression test in the same PR before merge.
+- For list/detail mapping, prefer stable identifiers over positional assumptions (for example, team IDs over array order).
+- For memoized components (`React.memo`), comparators must include all render-affecting props.
+- Normalize display-boundary values in presenter/create layers (for example, treat empty subtitle values as absent) instead of encoding that logic in view rendering.
 
 ## Security
 

--- a/api/services/halo/tests/resilient-fetch.test.ts
+++ b/api/services/halo/tests/resilient-fetch.test.ts
@@ -201,25 +201,36 @@ describe("createResilientFetch", () => {
 
       await resilientFetch("https://halostats.svc.halowaypoint.com/test");
 
-      // Advance timers to trigger the debounced KV writes
-      await vi.advanceTimersByTimeAsync(1000);
+      // Flush all pending debounced KV writes.
+      await vi.runAllTimersAsync();
+
+      const errorWindowCalls = kvPutSpy.mock.calls.filter((call) => String(call[0]).startsWith(KV_KEYS.ERROR_WINDOW));
+      const circuitBreakerCalls = kvPutSpy.mock.calls.filter((call) => call[0] === KV_KEYS.CIRCUIT_BREAKER);
 
       // Should have tracked the error and activated circuit breaker
-      expect(kvPutSpy).toHaveBeenCalledWith(
-        expect.stringContaining(KV_KEYS.ERROR_WINDOW),
-        expect.any(String),
-        expect.objectContaining({
-          expirationTtl: CIRCUIT_BREAKER_CONFIG.ERROR_TRACKING_TTL_SECONDS,
-        }),
+      expect(errorWindowCalls).toEqual(
+        expect.arrayContaining([
+          [
+            expect.stringContaining(KV_KEYS.ERROR_WINDOW),
+            expect.any(String),
+            expect.objectContaining({
+              expirationTtl: CIRCUIT_BREAKER_CONFIG.ERROR_TRACKING_TTL_SECONDS,
+            }),
+          ],
+        ]),
       );
 
       // Circuit breaker should be activated
-      expect(kvPutSpy).toHaveBeenCalledWith(
-        KV_KEYS.CIRCUIT_BREAKER,
-        expect.any(String),
-        expect.objectContaining({
-          expirationTtl: expect.any(Number) as number,
-        }),
+      expect(circuitBreakerCalls).toEqual(
+        expect.arrayContaining([
+          [
+            KV_KEYS.CIRCUIT_BREAKER,
+            expect.any(String),
+            expect.objectContaining({
+              expirationTtl: expect.any(Number) as number,
+            }),
+          ],
+        ]),
       );
 
       expect(logServiceWarnSpy).toHaveBeenCalledWith(
@@ -658,17 +669,28 @@ describe("createResilientFetch", () => {
       });
 
       await resilientFetch("https://halostats.svc.halowaypoint.com/test");
-      await vi.advanceTimersByTimeAsync(1000);
+      await vi.runAllTimersAsync();
 
-      expect(kvPutSpy).toHaveBeenCalledWith(
-        expect.stringContaining("halo:film:errors"),
-        expect.any(String),
-        expect.objectContaining({ expirationTtl: CIRCUIT_BREAKER_CONFIG.ERROR_TRACKING_TTL_SECONDS }),
+      const errorWindowCalls = kvPutSpy.mock.calls.filter((call) => String(call[0]).startsWith("halo:film:errors"));
+      const circuitBreakerCalls = kvPutSpy.mock.calls.filter((call) => call[0] === "halo:film:circuit_breaker");
+
+      expect(errorWindowCalls).toEqual(
+        expect.arrayContaining([
+          [
+            expect.stringContaining("halo:film:errors"),
+            expect.any(String),
+            expect.objectContaining({ expirationTtl: CIRCUIT_BREAKER_CONFIG.ERROR_TRACKING_TTL_SECONDS }),
+          ],
+        ]),
       );
-      expect(kvPutSpy).toHaveBeenCalledWith(
-        "halo:film:circuit_breaker",
-        expect.any(String),
-        expect.objectContaining({ expirationTtl: expect.any(Number) as number }),
+      expect(circuitBreakerCalls).toEqual(
+        expect.arrayContaining([
+          [
+            "halo:film:circuit_breaker",
+            expect.any(String),
+            expect.objectContaining({ expirationTtl: expect.any(Number) as number }),
+          ],
+        ]),
       );
       expect(kvPutSpy).not.toHaveBeenCalledWith(KV_KEYS.CIRCUIT_BREAKER, expect.anything(), expect.anything());
     });

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -8,6 +8,7 @@ import type { MatchAnalyticsService } from "../../../services/stats/match-analyt
 import type { SeriesMatchesService } from "../../../services/stats/series-matches-types";
 import { useIndividualTrackerViewer } from "../viewer/use-individual-tracker-viewer";
 import { IndividualTrackerOverlay } from "./individual-tracker-overlay";
+import { buildOverlayViewModel, isPanelOpen as computeIsPanelOpen } from "./individual-tracker-overlay-presenter";
 import { OverlayPagePresenter } from "./overlay-page-presenter";
 import { OverlayPageStore } from "./overlay-page-store";
 
@@ -60,6 +61,22 @@ export function IndividualTrackerOverlayPage({
   );
 
   const overlayModel = useMemo(() => presenter.present(overlaySnapshot), [overlaySnapshot, presenter]);
+  const overlayViewModel = useMemo(
+    () =>
+      model.renderModel != null
+        ? buildOverlayViewModel({
+            renderModel: model.renderModel,
+            streamerSettings: model.streamerSettings,
+            matchStatsState: overlayModel.matchStatsState,
+            selectedMatchId: overlayModel.selectedMatchId,
+          })
+        : null,
+    [model.renderModel, model.streamerSettings, overlayModel.matchStatsState, overlayModel.selectedMatchId],
+  );
+  const isPanelOpen = useMemo(
+    () => computeIsPanelOpen(overlayModel.selectedMatchId, overlayModel.matchStatsState),
+    [overlayModel.matchStatsState, overlayModel.selectedMatchId],
+  );
 
   return (
     <ComponentLoader
@@ -67,11 +84,11 @@ export function IndividualTrackerOverlayPage({
       loading={<LoadingState text="Loading tracker..." />}
       error={<ErrorState message={snapshot.errorMessage ?? "Failed to load tracker"} onRetry={onRetry} />}
       loaded={
-        model.renderModel != null ? (
+        model.renderModel != null && overlayViewModel != null ? (
           <IndividualTrackerOverlay
-            renderModel={model.renderModel}
-            streamerSettings={model.streamerSettings}
-            matchStatsState={overlayModel.matchStatsState}
+            viewModel={overlayViewModel}
+            isPanelOpen={isPanelOpen}
+            matchesLength={model.renderModel.accumulated.total}
             matchStatsPanelState={overlayModel.matchStatsPanelState}
             selectedMatchId={overlayModel.selectedMatchId}
             onSelectMatch={(matchId): void => {

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -72,7 +72,13 @@ export function IndividualTrackerOverlayPage({
             selectedMatchId: overlayModel.selectedMatchId,
           })
         : null,
-    [model.renderModel, model.streamerSettings, overlayModel.matchStatsState, overlayModel.selectedMatchId, overlayPresenter],
+    [
+      model.renderModel,
+      model.streamerSettings,
+      overlayModel.matchStatsState,
+      overlayModel.selectedMatchId,
+      overlayPresenter,
+    ],
   );
   const isPanelOpen = useMemo(
     () => overlayPresenter.isPanelOpen(overlayModel.selectedMatchId, overlayModel.matchStatsState),

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -8,7 +8,7 @@ import type { MatchAnalyticsService } from "../../../services/stats/match-analyt
 import type { SeriesMatchesService } from "../../../services/stats/series-matches-types";
 import { useIndividualTrackerViewer } from "../viewer/use-individual-tracker-viewer";
 import { IndividualTrackerOverlay } from "./individual-tracker-overlay";
-import { buildOverlayViewModel, isPanelOpen as computeIsPanelOpen } from "./individual-tracker-overlay-presenter";
+import { IndividualTrackerOverlayPresenter } from "./individual-tracker-overlay-presenter";
 import { OverlayPagePresenter } from "./overlay-page-presenter";
 import { OverlayPageStore } from "./overlay-page-store";
 
@@ -61,21 +61,22 @@ export function IndividualTrackerOverlayPage({
   );
 
   const overlayModel = useMemo(() => presenter.present(overlaySnapshot), [overlaySnapshot, presenter]);
+  const overlayPresenter = useMemo(() => new IndividualTrackerOverlayPresenter(), []);
   const overlayViewModel = useMemo(
     () =>
       model.renderModel != null
-        ? buildOverlayViewModel({
+        ? overlayPresenter.present({
             renderModel: model.renderModel,
             streamerSettings: model.streamerSettings,
             matchStatsState: overlayModel.matchStatsState,
             selectedMatchId: overlayModel.selectedMatchId,
           })
         : null,
-    [model.renderModel, model.streamerSettings, overlayModel.matchStatsState, overlayModel.selectedMatchId],
+    [model.renderModel, model.streamerSettings, overlayModel.matchStatsState, overlayModel.selectedMatchId, overlayPresenter],
   );
   const isPanelOpen = useMemo(
-    () => computeIsPanelOpen(overlayModel.selectedMatchId, overlayModel.matchStatsState),
-    [overlayModel.matchStatsState, overlayModel.selectedMatchId],
+    () => overlayPresenter.isPanelOpen(overlayModel.selectedMatchId, overlayModel.matchStatsState),
+    [overlayModel.matchStatsState, overlayModel.selectedMatchId, overlayPresenter],
   );
 
   return (

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -70,6 +70,7 @@ export function IndividualTrackerOverlayPage({
         model.renderModel != null ? (
           <IndividualTrackerOverlay
             renderModel={model.renderModel}
+            streamerSettings={model.streamerSettings}
             matchStatsState={overlayModel.matchStatsState}
             matchStatsPanelState={overlayModel.matchStatsPanelState}
             selectedMatchId={overlayModel.selectedMatchId}

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -3,6 +3,7 @@ import { getTeamName } from "@guilty-spark/shared/halo/team";
 import type { MatchStats } from "halo-infinite-api";
 import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type { TickerMatchGroup } from "../../information-ticker/information-ticker";
@@ -10,6 +11,13 @@ import { createMatchStatsFormatter } from "../../../controllers/stats/create";
 import type { OverlayTab } from "../../streamer-overlay/tabs-bar";
 import type { IndividualTrackerViewerRenderModel, ViewerSeriesTab, ViewerTimelineItem } from "../viewer/types";
 import { gameModeIconSrc } from "../game-mode-icon";
+import type {
+  IndividualTrackerOverlayViewModel,
+  OverlayDisplaySettings,
+  OverlayTeamDetailsModel,
+  OverlayTopSectionModel,
+} from "./types";
+import { getOverlayDisplaySettings } from "./types";
 
 export type MatchStatsState =
   | { readonly status: "loading" }
@@ -26,6 +34,18 @@ export function getDefaultTeamColors(): [TeamColor, TeamColor] {
   return [getTeamColorOrDefault(undefined, 0), getTeamColorOrDefault(undefined, 1)];
 }
 
+function getFontSizeStyles(streamerSettings: StreamerViewSettings | undefined): React.CSSProperties {
+  const fontSizes = streamerSettings?.layoutOptions?.fontSizes;
+
+  return {
+    "--font-size-queue-info": ((fontSizes?.queueInfo ?? 100) / 100).toString(),
+    "--font-size-score": ((fontSizes?.score ?? 100) / 100).toString(),
+    "--font-size-teams": ((fontSizes?.teams ?? 100) / 100).toString(),
+    "--font-size-tabs": ((fontSizes?.tabs ?? 100) / 100).toString(),
+    "--font-size-ticker": ((fontSizes?.ticker ?? 100) / 100).toString(),
+  } as React.CSSProperties;
+}
+
 export function getActiveSeries(timeline: readonly ViewerTimelineItem[]): ViewerSeriesTab | null {
   for (const item of timeline) {
     if (item.type === "series" && item.series.isActive) {
@@ -34,6 +54,93 @@ export function getActiveSeries(timeline: readonly ViewerTimelineItem[]): Viewer
   }
 
   return null;
+}
+
+function getOverlayActiveSeries(renderModel: IndividualTrackerViewerRenderModel): ViewerSeriesTab | null {
+  const timelineSeries = getActiveSeries(renderModel.timeline);
+  if (timelineSeries != null) {
+    return timelineSeries;
+  }
+
+  if (!renderModel.hasActiveSeries || renderModel.activeSeriesContext == null) {
+    return null;
+  }
+
+  return {
+    id: "active-series-pre-match",
+    title: renderModel.activeSeriesContext.title,
+    subtitle: renderModel.activeSeriesContext.subtitle ?? "",
+    isActive: true,
+    teams: renderModel.activeSeriesContext.teams,
+    matchBackgroundUrls: [],
+    score: "0:0",
+    duration: "unknown",
+    startTime: "",
+    endTime: "",
+    matches: [],
+    colorHex: undefined,
+  };
+}
+
+function getSeriesPlayerDisplayNameForSettings(
+  player: { readonly discordName: string | null; readonly gamertag: string | null },
+  settings: Pick<OverlayDisplaySettings, "showDiscordNames" | "showXboxNames">,
+): string {
+  if (settings.showDiscordNames && settings.showXboxNames) {
+    return player.discordName ?? player.gamertag ?? "Unknown";
+  }
+
+  if (settings.showDiscordNames) {
+    return player.discordName ?? "Unknown";
+  }
+
+  if (settings.showXboxNames) {
+    return player.gamertag ?? "Unknown";
+  }
+
+  return player.discordName ?? player.gamertag ?? "Unknown";
+}
+
+function getTeamDetailsModel(
+  team: {
+    readonly name: string;
+    readonly players: readonly { readonly discordName: string | null; readonly gamertag: string | null }[];
+  },
+  settings: Pick<OverlayDisplaySettings, "showDiscordNames" | "showXboxNames">,
+): OverlayTeamDetailsModel {
+  const players =
+    !settings.showDiscordNames && !settings.showXboxNames
+      ? []
+      : team.players.map((player) => getSeriesPlayerDisplayNameForSettings(player, settings));
+
+  return {
+    name: team.name,
+    players,
+  };
+}
+
+function getTopSectionModel(activeSeries: ViewerSeriesTab, settings: OverlayDisplaySettings): OverlayTopSectionModel {
+  const teamLeft = activeSeries.teams.find((team) => team.id === 0);
+  const teamRight = activeSeries.teams.find((team) => team.id === 1);
+  const showTeamDetails = settings.showTeamDetails && teamLeft != null && teamRight != null;
+
+  return {
+    title: settings.showTitle ? activeSeries.title : null,
+    subtitle: settings.showSubtitle && activeSeries.subtitle !== "" ? activeSeries.subtitle : null,
+    showScore: settings.showScore,
+    seriesScore: activeSeries.score,
+    showTeamDetails,
+    teamLeft: showTeamDetails ? getTeamDetailsModel(teamLeft, settings) : null,
+    teamRight: showTeamDetails ? getTeamDetailsModel(teamRight, settings) : null,
+  };
+}
+
+function getTeamColors(renderModel: IndividualTrackerViewerRenderModel): TeamColor[] {
+  if (renderModel.teamColors.length >= 2) {
+    return [renderModel.teamColors[0], renderModel.teamColors[1]];
+  }
+
+  return getDefaultTeamColors();
 }
 
 export function buildTabs(
@@ -184,4 +291,43 @@ export function buildPreSeriesTickerGroup(options: {
 
 export function getShowTabs(renderModel: IndividualTrackerViewerRenderModel): boolean {
   return renderModel.timeline.length > 0 || renderModel.hasActiveSeries;
+}
+
+export function buildOverlayViewModel(options: {
+  readonly renderModel: IndividualTrackerViewerRenderModel;
+  readonly streamerSettings: StreamerViewSettings | undefined;
+  readonly matchStatsState: MatchStatsState | null;
+  readonly selectedMatchId: string | null;
+}): IndividualTrackerOverlayViewModel {
+  const { renderModel, streamerSettings, matchStatsState, selectedMatchId } = options;
+  const displaySettings = getOverlayDisplaySettings(streamerSettings);
+  const fontSizeStyles = getFontSizeStyles(streamerSettings);
+  const teamColors = getTeamColors(renderModel);
+  const activeSeries = getOverlayActiveSeries(renderModel);
+  const tabs = buildTabs(renderModel.timeline, activeSeries);
+  const selectedTabIndex = getSelectedTabIndex(tabs, selectedMatchId);
+  const loadedTickerGroups = buildTickerGroups(matchStatsState, selectedTabIndex);
+  const tickerMatchGroups =
+    loadedTickerGroups.length > 0
+      ? loadedTickerGroups
+      : buildPreSeriesTickerGroup({
+          showTicker: displaySettings.showTicker,
+          activeSeries,
+          playerName: renderModel.gamertag,
+          discordName: null,
+          gamertag: displaySettings.showXboxNames ? renderModel.gamertag : null,
+        });
+
+  return {
+    pinTopSection: activeSeries != null,
+    topSection: activeSeries != null ? getTopSectionModel(activeSeries, displaySettings) : null,
+    statsHighlights: renderModel.statsHighlights ?? [],
+    teamColors,
+    tabs,
+    tickerMatchGroups,
+    showTabs: displaySettings.showTabs && getShowTabs(renderModel),
+    showTicker: displaySettings.showTicker,
+    showPreSeriesInfo: tickerMatchGroups.length > 0 && activeSeries?.matches.length === 0,
+    fontSizeStyles,
+  };
 }

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -30,8 +30,271 @@ export type MatchStatsState =
     }
   | { readonly status: "error"; readonly message: string };
 
-export function getDefaultTeamColors(): [TeamColor, TeamColor] {
+function getDefaultTeamColors(): [TeamColor, TeamColor] {
   return [getTeamColorOrDefault(undefined, 0), getTeamColorOrDefault(undefined, 1)];
+}
+
+interface BuildOverlayViewModelOptions {
+  readonly renderModel: IndividualTrackerViewerRenderModel;
+  readonly streamerSettings: StreamerViewSettings | undefined;
+  readonly matchStatsState: MatchStatsState | null;
+  readonly selectedMatchId: string | null;
+}
+
+interface IndividualTrackerOverlayPresenterConfig {
+  readonly defaultTeamColors?: readonly [TeamColor, TeamColor];
+}
+
+export class IndividualTrackerOverlayPresenter {
+  private readonly defaultTeamColors: readonly [TeamColor, TeamColor];
+
+  public constructor(config?: IndividualTrackerOverlayPresenterConfig) {
+    this.defaultTeamColors = config?.defaultTeamColors ?? getDefaultTeamColors();
+  }
+
+  public getActiveSeries(timeline: readonly ViewerTimelineItem[]): ViewerSeriesTab | null {
+    for (const item of timeline) {
+      if (item.type === "series" && item.series.isActive) {
+        return item.series;
+      }
+    }
+
+    return null;
+  }
+
+  public buildTabs(
+    timeline: readonly ViewerTimelineItem[],
+    activeSeriesOverride: ViewerSeriesTab | null = null,
+  ): readonly OverlayTab[] {
+    const activeSeries = activeSeriesOverride ?? this.getActiveSeries(timeline);
+    if (activeSeries != null) {
+      if (activeSeries.matches.length === 0) {
+        return [
+          {
+            type: "series",
+            seriesId: activeSeries.id,
+            index: -1,
+            label: "Series score",
+            score: activeSeries.score,
+            teamColor: undefined,
+          },
+        ];
+      }
+
+      return activeSeries.matches.map(
+        (match, index): OverlayTab => ({
+          type: "match",
+          index,
+          matchId: match.matchId,
+          label: match.mapName,
+          score: match.score,
+          icon: gameModeIconSrc(match.gameVariantCategory),
+          teamColor: match.colorHex,
+        }),
+      );
+    }
+
+    let matchIdx = 0;
+    let seriesIdx = -1;
+    return timeline.map((item): OverlayTab => {
+      if (item.type === "series") {
+        return {
+          type: "series",
+          seriesId: item.series.id,
+          index: seriesIdx--,
+          label: item.series.title,
+          score: item.series.score,
+          teamColor: undefined,
+          icons: item.series.matches.map((match) => ({
+            src: gameModeIconSrc(match.gameVariantCategory),
+            dimmed: false,
+          })),
+        };
+      }
+      return {
+        type: "match",
+        index: matchIdx++,
+        matchId: item.match.matchId,
+        label: item.match.mapName,
+        score: item.match.score,
+        icon: gameModeIconSrc(item.match.gameVariantCategory),
+        teamColor: item.match.colorHex,
+      };
+    });
+  }
+
+  public isPanelOpen(selectedMatchId: string | null, matchStatsState: MatchStatsState | null): boolean {
+    return selectedMatchId != null && (matchStatsState?.status === "loaded" || matchStatsState?.status === "error");
+  }
+
+  public buildPreSeriesTickerGroup(options: {
+    readonly showTicker: boolean;
+    readonly activeSeries: ViewerSeriesTab | null;
+    readonly playerName: string;
+    readonly discordName: string | null;
+    readonly gamertag: string | null;
+  }): TickerMatchGroup[] {
+    if (!options.showTicker || options.activeSeries == null || options.activeSeries.matches.length > 0) {
+      return [];
+    }
+
+    return [
+      {
+        matchIndex: -1,
+        label: "Player Info",
+        rows: [
+          {
+            type: "player",
+            teamId: 0,
+            name: options.playerName,
+            discordName: options.discordName,
+            gamertag: options.gamertag,
+            showTeamIcon: false,
+            stats: [
+              {
+                name: "Status",
+                value: 0,
+                bestInTeam: false,
+                bestInMatch: false,
+                display: "Waiting for first match",
+              },
+            ],
+            medals: [],
+          },
+        ],
+      },
+    ];
+  }
+
+  public present(options: BuildOverlayViewModelOptions): IndividualTrackerOverlayViewModel {
+    const { renderModel, streamerSettings, matchStatsState, selectedMatchId } = options;
+    const displaySettings = getOverlayDisplaySettings(streamerSettings);
+    const fontSizeStyles = getFontSizeStyles(streamerSettings);
+    const teamColors = this.getTeamColors(renderModel);
+    const activeSeries = this.getOverlayActiveSeries(renderModel);
+    const tabs = this.buildTabs(renderModel.timeline, activeSeries);
+    const selectedTabIndex = this.getSelectedTabIndex(tabs, selectedMatchId);
+    const loadedTickerGroups = this.buildTickerGroups(matchStatsState, selectedTabIndex);
+    const tickerMatchGroups =
+      loadedTickerGroups.length > 0
+        ? loadedTickerGroups
+        : this.buildPreSeriesTickerGroup({
+            showTicker: displaySettings.showTicker,
+            activeSeries,
+            playerName: renderModel.gamertag,
+            discordName: null,
+            gamertag: displaySettings.showXboxNames ? renderModel.gamertag : null,
+          });
+
+    return {
+      pinTopSection: activeSeries != null,
+      topSection: activeSeries != null ? this.getTopSectionModel(activeSeries, displaySettings) : null,
+      statsHighlights: renderModel.statsHighlights ?? [],
+      teamColors,
+      tabs,
+      tickerMatchGroups,
+      showTabs: displaySettings.showTabs && this.getShowTabs(renderModel),
+      showTicker: displaySettings.showTicker,
+      showPreSeriesInfo: tickerMatchGroups.length > 0 && activeSeries?.matches.length === 0,
+      fontSizeStyles,
+    };
+  }
+
+  private getOverlayActiveSeries(renderModel: IndividualTrackerViewerRenderModel): ViewerSeriesTab | null {
+    const timelineSeries = this.getActiveSeries(renderModel.timeline);
+    if (timelineSeries != null) {
+      return timelineSeries;
+    }
+
+    if (!renderModel.hasActiveSeries || renderModel.activeSeriesContext == null) {
+      return null;
+    }
+
+    return {
+      id: "active-series-pre-match",
+      title: renderModel.activeSeriesContext.title,
+      subtitle: renderModel.activeSeriesContext.subtitle ?? "",
+      isActive: true,
+      teams: renderModel.activeSeriesContext.teams,
+      matchBackgroundUrls: [],
+      score: "0:0",
+      duration: "unknown",
+      startTime: "",
+      endTime: "",
+      matches: [],
+      colorHex: undefined,
+    };
+  }
+
+  private getTopSectionModel(activeSeries: ViewerSeriesTab, settings: OverlayDisplaySettings): OverlayTopSectionModel {
+    const teamLeft = activeSeries.teams.find((team) => team.id === 0);
+    const teamRight = activeSeries.teams.find((team) => team.id === 1);
+    const showTeamDetails = settings.showTeamDetails && teamLeft != null && teamRight != null;
+
+    return {
+      title: settings.showTitle ? activeSeries.title : null,
+      subtitle: settings.showSubtitle && activeSeries.subtitle !== "" ? activeSeries.subtitle : null,
+      showScore: settings.showScore,
+      seriesScore: activeSeries.score,
+      showTeamDetails,
+      teamLeft: showTeamDetails ? getTeamDetailsModel(teamLeft, settings) : null,
+      teamRight: showTeamDetails ? getTeamDetailsModel(teamRight, settings) : null,
+    };
+  }
+
+  private getTeamColors(renderModel: IndividualTrackerViewerRenderModel): TeamColor[] {
+    if (renderModel.teamColors.length >= 2) {
+      return [renderModel.teamColors[0], renderModel.teamColors[1]];
+    }
+
+    return [...this.defaultTeamColors];
+  }
+
+  private getSelectedTabIndex(tabs: readonly OverlayTab[], selectedMatchId: string | null): number {
+    if (selectedMatchId == null) {
+      return 0;
+    }
+    const tab = tabs.find((t) => t.type === "match" && t.matchId === selectedMatchId);
+    return tab?.type === "match" ? tab.index : 0;
+  }
+
+  private buildTickerGroups(matchStatsState: MatchStatsState | null, matchIndex: number): TickerMatchGroup[] {
+    if (matchStatsState?.status !== "loaded") {
+      return [];
+    }
+
+    const { stats } = matchStatsState;
+    const formatter = createMatchStatsFormatter(stats.MatchInfo.GameVariantCategory);
+    const playerMap = new Map(stats.Players.map((p) => [getPlayerXuid(p), getPlayerXuid(p)]));
+    const data = formatter.getData(stats, playerMap, {});
+
+    return [
+      {
+        matchIndex,
+        label: "",
+        rows: data.flatMap((teamData) => [
+          {
+            type: "team" as const,
+            teamId: teamData.teamId,
+            name: getTeamName(teamData.teamId),
+            stats: teamData.teamStats,
+            medals: teamData.teamMedals,
+          },
+          ...teamData.players.map((p) => ({
+            type: "player" as const,
+            teamId: teamData.teamId,
+            name: p.name,
+            stats: p.values,
+            medals: p.medals,
+          })),
+        ]),
+      },
+    ];
+  }
+
+  private getShowTabs(renderModel: IndividualTrackerViewerRenderModel): boolean {
+    return renderModel.timeline.length > 0 || renderModel.hasActiveSeries;
+  }
 }
 
 function getFontSizeStyles(streamerSettings: StreamerViewSettings | undefined): React.CSSProperties {
@@ -44,42 +307,6 @@ function getFontSizeStyles(streamerSettings: StreamerViewSettings | undefined): 
     "--font-size-tabs": ((fontSizes?.tabs ?? 100) / 100).toString(),
     "--font-size-ticker": ((fontSizes?.ticker ?? 100) / 100).toString(),
   } as React.CSSProperties;
-}
-
-export function getActiveSeries(timeline: readonly ViewerTimelineItem[]): ViewerSeriesTab | null {
-  for (const item of timeline) {
-    if (item.type === "series" && item.series.isActive) {
-      return item.series;
-    }
-  }
-
-  return null;
-}
-
-function getOverlayActiveSeries(renderModel: IndividualTrackerViewerRenderModel): ViewerSeriesTab | null {
-  const timelineSeries = getActiveSeries(renderModel.timeline);
-  if (timelineSeries != null) {
-    return timelineSeries;
-  }
-
-  if (!renderModel.hasActiveSeries || renderModel.activeSeriesContext == null) {
-    return null;
-  }
-
-  return {
-    id: "active-series-pre-match",
-    title: renderModel.activeSeriesContext.title,
-    subtitle: renderModel.activeSeriesContext.subtitle ?? "",
-    isActive: true,
-    teams: renderModel.activeSeriesContext.teams,
-    matchBackgroundUrls: [],
-    score: "0:0",
-    duration: "unknown",
-    startTime: "",
-    endTime: "",
-    matches: [],
-    colorHex: undefined,
-  };
 }
 
 function getSeriesPlayerDisplayNameForSettings(
@@ -119,215 +346,3 @@ function getTeamDetailsModel(
   };
 }
 
-function getTopSectionModel(activeSeries: ViewerSeriesTab, settings: OverlayDisplaySettings): OverlayTopSectionModel {
-  const teamLeft = activeSeries.teams.find((team) => team.id === 0);
-  const teamRight = activeSeries.teams.find((team) => team.id === 1);
-  const showTeamDetails = settings.showTeamDetails && teamLeft != null && teamRight != null;
-
-  return {
-    title: settings.showTitle ? activeSeries.title : null,
-    subtitle: settings.showSubtitle && activeSeries.subtitle !== "" ? activeSeries.subtitle : null,
-    showScore: settings.showScore,
-    seriesScore: activeSeries.score,
-    showTeamDetails,
-    teamLeft: showTeamDetails ? getTeamDetailsModel(teamLeft, settings) : null,
-    teamRight: showTeamDetails ? getTeamDetailsModel(teamRight, settings) : null,
-  };
-}
-
-function getTeamColors(renderModel: IndividualTrackerViewerRenderModel): TeamColor[] {
-  if (renderModel.teamColors.length >= 2) {
-    return [renderModel.teamColors[0], renderModel.teamColors[1]];
-  }
-
-  return getDefaultTeamColors();
-}
-
-export function buildTabs(
-  timeline: readonly ViewerTimelineItem[],
-  activeSeriesOverride: ViewerSeriesTab | null = null,
-): readonly OverlayTab[] {
-  const activeSeries = activeSeriesOverride ?? getActiveSeries(timeline);
-  if (activeSeries != null) {
-    if (activeSeries.matches.length === 0) {
-      return [
-        {
-          type: "series",
-          seriesId: activeSeries.id,
-          index: -1,
-          label: "Series score",
-          score: activeSeries.score,
-          teamColor: undefined,
-        },
-      ];
-    }
-
-    return activeSeries.matches.map(
-      (match, index): OverlayTab => ({
-        type: "match",
-        index,
-        matchId: match.matchId,
-        label: match.mapName,
-        score: match.score,
-        icon: gameModeIconSrc(match.gameVariantCategory),
-        teamColor: match.colorHex,
-      }),
-    );
-  }
-
-  let matchIdx = 0;
-  let seriesIdx = -1;
-  return timeline.map((item): OverlayTab => {
-    if (item.type === "series") {
-      return {
-        type: "series",
-        seriesId: item.series.id,
-        index: seriesIdx--,
-        label: item.series.title,
-        score: item.series.score,
-        teamColor: undefined,
-        icons: item.series.matches.map((match) => ({
-          src: gameModeIconSrc(match.gameVariantCategory),
-          dimmed: false,
-        })),
-      };
-    }
-    return {
-      type: "match",
-      index: matchIdx++,
-      matchId: item.match.matchId,
-      label: item.match.mapName,
-      score: item.match.score,
-      icon: gameModeIconSrc(item.match.gameVariantCategory),
-      teamColor: item.match.colorHex,
-    };
-  });
-}
-
-export function getSelectedTabIndex(tabs: readonly OverlayTab[], selectedMatchId: string | null): number {
-  if (selectedMatchId == null) {
-    return 0;
-  }
-  const tab = tabs.find((t) => t.type === "match" && t.matchId === selectedMatchId);
-  return tab?.type === "match" ? tab.index : 0;
-}
-
-export function isPanelOpen(selectedMatchId: string | null, matchStatsState: MatchStatsState | null): boolean {
-  return selectedMatchId != null && (matchStatsState?.status === "loaded" || matchStatsState?.status === "error");
-}
-
-export function buildTickerGroups(matchStatsState: MatchStatsState | null, matchIndex: number): TickerMatchGroup[] {
-  if (matchStatsState?.status !== "loaded") {
-    return [];
-  }
-
-  const { stats } = matchStatsState;
-  const formatter = createMatchStatsFormatter(stats.MatchInfo.GameVariantCategory);
-  const playerMap = new Map(stats.Players.map((p) => [getPlayerXuid(p), getPlayerXuid(p)]));
-  const data = formatter.getData(stats, playerMap, {});
-
-  return [
-    {
-      matchIndex,
-      label: "",
-      rows: data.flatMap((teamData) => [
-        {
-          type: "team" as const,
-          teamId: teamData.teamId,
-          name: getTeamName(teamData.teamId),
-          stats: teamData.teamStats,
-          medals: teamData.teamMedals,
-        },
-        ...teamData.players.map((p) => ({
-          type: "player" as const,
-          teamId: teamData.teamId,
-          name: p.name,
-          stats: p.values,
-          medals: p.medals,
-        })),
-      ]),
-    },
-  ];
-}
-
-export function buildPreSeriesTickerGroup(options: {
-  readonly showTicker: boolean;
-  readonly activeSeries: ViewerSeriesTab | null;
-  readonly playerName: string;
-  readonly discordName: string | null;
-  readonly gamertag: string | null;
-}): TickerMatchGroup[] {
-  if (!options.showTicker || options.activeSeries == null || options.activeSeries.matches.length > 0) {
-    return [];
-  }
-
-  return [
-    {
-      matchIndex: -1,
-      label: "Player Info",
-      rows: [
-        {
-          type: "player",
-          teamId: 0,
-          name: options.playerName,
-          discordName: options.discordName,
-          gamertag: options.gamertag,
-          showTeamIcon: false,
-          stats: [
-            {
-              name: "Status",
-              value: 0,
-              bestInTeam: false,
-              bestInMatch: false,
-              display: "Waiting for first match",
-            },
-          ],
-          medals: [],
-        },
-      ],
-    },
-  ];
-}
-
-export function getShowTabs(renderModel: IndividualTrackerViewerRenderModel): boolean {
-  return renderModel.timeline.length > 0 || renderModel.hasActiveSeries;
-}
-
-export function buildOverlayViewModel(options: {
-  readonly renderModel: IndividualTrackerViewerRenderModel;
-  readonly streamerSettings: StreamerViewSettings | undefined;
-  readonly matchStatsState: MatchStatsState | null;
-  readonly selectedMatchId: string | null;
-}): IndividualTrackerOverlayViewModel {
-  const { renderModel, streamerSettings, matchStatsState, selectedMatchId } = options;
-  const displaySettings = getOverlayDisplaySettings(streamerSettings);
-  const fontSizeStyles = getFontSizeStyles(streamerSettings);
-  const teamColors = getTeamColors(renderModel);
-  const activeSeries = getOverlayActiveSeries(renderModel);
-  const tabs = buildTabs(renderModel.timeline, activeSeries);
-  const selectedTabIndex = getSelectedTabIndex(tabs, selectedMatchId);
-  const loadedTickerGroups = buildTickerGroups(matchStatsState, selectedTabIndex);
-  const tickerMatchGroups =
-    loadedTickerGroups.length > 0
-      ? loadedTickerGroups
-      : buildPreSeriesTickerGroup({
-          showTicker: displaySettings.showTicker,
-          activeSeries,
-          playerName: renderModel.gamertag,
-          discordName: null,
-          gamertag: displaySettings.showXboxNames ? renderModel.gamertag : null,
-        });
-
-  return {
-    pinTopSection: activeSeries != null,
-    topSection: activeSeries != null ? getTopSectionModel(activeSeries, displaySettings) : null,
-    statsHighlights: renderModel.statsHighlights ?? [],
-    teamColors,
-    tabs,
-    tickerMatchGroups,
-    showTabs: displaySettings.showTabs && getShowTabs(renderModel),
-    showTicker: displaySettings.showTicker,
-    showPreSeriesInfo: tickerMatchGroups.length > 0 && activeSeries?.matches.length === 0,
-    fontSizeStyles,
-  };
-}

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -1,6 +1,7 @@
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
 import { getTeamName } from "@guilty-spark/shared/halo/team";
 import type { MatchStats } from "halo-infinite-api";
+import type { CSSProperties } from "react";
 import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
@@ -32,6 +33,55 @@ export type MatchStatsState =
 
 function getDefaultTeamColors(): [TeamColor, TeamColor] {
   return [getTeamColorOrDefault(undefined, 0), getTeamColorOrDefault(undefined, 1)];
+}
+
+function getFontSizeStyles(streamerSettings: StreamerViewSettings | undefined): CSSProperties {
+  const fontSizes = streamerSettings?.layoutOptions?.fontSizes;
+
+  return {
+    "--font-size-queue-info": ((fontSizes?.queueInfo ?? 100) / 100).toString(),
+    "--font-size-score": ((fontSizes?.score ?? 100) / 100).toString(),
+    "--font-size-teams": ((fontSizes?.teams ?? 100) / 100).toString(),
+    "--font-size-tabs": ((fontSizes?.tabs ?? 100) / 100).toString(),
+    "--font-size-ticker": ((fontSizes?.ticker ?? 100) / 100).toString(),
+  } as CSSProperties;
+}
+
+function getSeriesPlayerDisplayNameForSettings(
+  player: { readonly discordName: string | null; readonly gamertag: string | null },
+  settings: Pick<OverlayDisplaySettings, "showDiscordNames" | "showXboxNames">,
+): string {
+  if (settings.showDiscordNames && settings.showXboxNames) {
+    return player.discordName ?? player.gamertag ?? "Unknown";
+  }
+
+  if (settings.showDiscordNames) {
+    return player.discordName ?? "Unknown";
+  }
+
+  if (settings.showXboxNames) {
+    return player.gamertag ?? "Unknown";
+  }
+
+  return player.discordName ?? player.gamertag ?? "Unknown";
+}
+
+function getTeamDetailsModel(
+  team: {
+    readonly name: string;
+    readonly players: readonly { readonly discordName: string | null; readonly gamertag: string | null }[];
+  },
+  settings: Pick<OverlayDisplaySettings, "showDiscordNames" | "showXboxNames">,
+): OverlayTeamDetailsModel {
+  const players =
+    !settings.showDiscordNames && !settings.showXboxNames
+      ? []
+      : team.players.map((player) => getSeriesPlayerDisplayNameForSettings(player, settings));
+
+  return {
+    name: team.name,
+    players,
+  };
 }
 
 interface BuildOverlayViewModelOptions {
@@ -296,53 +346,3 @@ export class IndividualTrackerOverlayPresenter {
     return renderModel.timeline.length > 0 || renderModel.hasActiveSeries;
   }
 }
-
-function getFontSizeStyles(streamerSettings: StreamerViewSettings | undefined): React.CSSProperties {
-  const fontSizes = streamerSettings?.layoutOptions?.fontSizes;
-
-  return {
-    "--font-size-queue-info": ((fontSizes?.queueInfo ?? 100) / 100).toString(),
-    "--font-size-score": ((fontSizes?.score ?? 100) / 100).toString(),
-    "--font-size-teams": ((fontSizes?.teams ?? 100) / 100).toString(),
-    "--font-size-tabs": ((fontSizes?.tabs ?? 100) / 100).toString(),
-    "--font-size-ticker": ((fontSizes?.ticker ?? 100) / 100).toString(),
-  } as React.CSSProperties;
-}
-
-function getSeriesPlayerDisplayNameForSettings(
-  player: { readonly discordName: string | null; readonly gamertag: string | null },
-  settings: Pick<OverlayDisplaySettings, "showDiscordNames" | "showXboxNames">,
-): string {
-  if (settings.showDiscordNames && settings.showXboxNames) {
-    return player.discordName ?? player.gamertag ?? "Unknown";
-  }
-
-  if (settings.showDiscordNames) {
-    return player.discordName ?? "Unknown";
-  }
-
-  if (settings.showXboxNames) {
-    return player.gamertag ?? "Unknown";
-  }
-
-  return player.discordName ?? player.gamertag ?? "Unknown";
-}
-
-function getTeamDetailsModel(
-  team: {
-    readonly name: string;
-    readonly players: readonly { readonly discordName: string | null; readonly gamertag: string | null }[];
-  },
-  settings: Pick<OverlayDisplaySettings, "showDiscordNames" | "showXboxNames">,
-): OverlayTeamDetailsModel {
-  const players =
-    !settings.showDiscordNames && !settings.showXboxNames
-      ? []
-      : team.players.map((player) => getSeriesPlayerDisplayNameForSettings(player, settings));
-
-  return {
-    name: team.name,
-    players,
-  };
-}
-

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -36,9 +36,25 @@ export function getActiveSeries(timeline: readonly ViewerTimelineItem[]): Viewer
   return null;
 }
 
-export function buildTabs(timeline: readonly ViewerTimelineItem[]): readonly OverlayTab[] {
-  const activeSeries = getActiveSeries(timeline);
+export function buildTabs(
+  timeline: readonly ViewerTimelineItem[],
+  activeSeriesOverride: ViewerSeriesTab | null = null,
+): readonly OverlayTab[] {
+  const activeSeries = activeSeriesOverride ?? getActiveSeries(timeline);
   if (activeSeries != null) {
+    if (activeSeries.matches.length === 0) {
+      return [
+        {
+          type: "series",
+          seriesId: activeSeries.id,
+          index: -1,
+          label: "Series score",
+          score: activeSeries.score,
+          teamColor: undefined,
+        },
+      ];
+    }
+
     return activeSeries.matches.map(
       (match, index): OverlayTab => ({
         type: "match",
@@ -127,6 +143,45 @@ export function buildTickerGroups(matchStatsState: MatchStatsState | null, match
   ];
 }
 
+export function buildPreSeriesTickerGroup(options: {
+  readonly showTicker: boolean;
+  readonly activeSeries: ViewerSeriesTab | null;
+  readonly playerName: string;
+  readonly discordName: string | null;
+  readonly gamertag: string | null;
+}): TickerMatchGroup[] {
+  if (!options.showTicker || options.activeSeries == null || options.activeSeries.matches.length > 0) {
+    return [];
+  }
+
+  return [
+    {
+      matchIndex: -1,
+      label: "Player Info",
+      rows: [
+        {
+          type: "player",
+          teamId: 0,
+          name: options.playerName,
+          discordName: options.discordName,
+          gamertag: options.gamertag,
+          showTeamIcon: false,
+          stats: [
+            {
+              name: "Status",
+              value: 0,
+              bestInTeam: false,
+              bestInMatch: false,
+              display: "Waiting for first match",
+            },
+          ],
+          medals: [],
+        },
+      ],
+    },
+  ];
+}
+
 export function getShowTabs(renderModel: IndividualTrackerViewerRenderModel): boolean {
-  return renderModel.timeline.length > 0;
+  return renderModel.timeline.length > 0 || renderModel.hasActiveSeries;
 }

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -120,14 +120,27 @@ function getSeriesPlayerDisplayNameForSettings(
   return getSeriesPlayerDisplayName(player);
 }
 
+function getVisibleTeamPlayers(
+  players: readonly ViewerSeriesTeamPlayer[],
+  settings: Pick<OverlayDisplaySettings, "showDiscordNames" | "showXboxNames">,
+): readonly ViewerSeriesTeamPlayer[] {
+  if (!settings.showDiscordNames && !settings.showXboxNames) {
+    return [];
+  }
+
+  return players;
+}
+
 function renderTeamDetails(
   team: ViewerSeriesTeam,
   settings: Pick<OverlayDisplaySettings, "showDiscordNames" | "showXboxNames">,
 ): React.ReactElement {
+  const visiblePlayers = getVisibleTeamPlayers(team.players, settings);
+
   return (
     <>
       <div>{team.name}</div>
-      {team.players.map((player, index) => (
+      {visiblePlayers.map((player, index) => (
         <div key={`${team.id.toString()}-${index.toString()}`}>
           {getSeriesPlayerDisplayNameForSettings(player, settings)}
         </div>
@@ -192,7 +205,7 @@ export function IndividualTrackerOverlay({
       return (
         <TopSection
           title={displaySettings.showTitle ? activeSeries.title : null}
-          subtitle={displaySettings.showSubtitle ? activeSeries.subtitle : null}
+          subtitle={displaySettings.showSubtitle && activeSeries.subtitle !== "" ? activeSeries.subtitle : null}
           iconUrl={null}
           showScore={displaySettings.showScore}
           seriesScore={activeSeries.score}

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -1,15 +1,18 @@
 import React, { useCallback, useMemo } from "react";
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { StreamerOverlay } from "../../streamer-overlay/streamer-overlay";
 import { TopSection } from "../../streamer-overlay/top-section";
 import { StatsPanel } from "../viewer/stats-panel";
 import type {
   IndividualTrackerViewerRenderModel,
   MatchDetailsState,
+  ViewerSeriesTab,
   ViewerSeriesTeam,
   ViewerSeriesTeamPlayer,
 } from "../viewer/types";
 import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
 import {
+  buildPreSeriesTickerGroup,
   buildTabs,
   buildTickerGroups,
   getActiveSeries,
@@ -23,6 +26,7 @@ import styles from "./individual-tracker-overlay.module.css";
 
 interface IndividualTrackerOverlayProps {
   readonly renderModel: IndividualTrackerViewerRenderModel;
+  readonly streamerSettings: StreamerViewSettings | undefined;
   readonly matchStatsState: MatchStatsState | null;
   readonly matchStatsPanelState: MatchDetailsState | null;
   readonly selectedMatchId: string | null;
@@ -30,26 +34,120 @@ interface IndividualTrackerOverlayProps {
   readonly onDeselect: () => void;
 }
 
+interface OverlayDisplaySettings {
+  readonly showTicker: boolean;
+  readonly showTabs: boolean;
+  readonly showTitle: boolean;
+  readonly showSubtitle: boolean;
+  readonly showScore: boolean;
+  readonly showTeamDetails: boolean;
+  readonly showDiscordNames: boolean;
+  readonly showXboxNames: boolean;
+}
+
+function getOverlayDisplaySettings(streamerSettings: StreamerViewSettings | undefined): OverlayDisplaySettings {
+  const visibleSections = streamerSettings?.visibleSections;
+  return {
+    showTicker: visibleSections?.showTicker ?? true,
+    showTabs: visibleSections?.showTabs ?? true,
+    showTitle: visibleSections?.showTitle ?? true,
+    showSubtitle: visibleSections?.showSubtitle ?? true,
+    showScore: visibleSections?.showScore ?? true,
+    showTeamDetails: visibleSections?.showTeamDetails ?? true,
+    showDiscordNames: visibleSections?.showDiscordNames ?? true,
+    showXboxNames: visibleSections?.showXboxNames ?? true,
+  };
+}
+
+function getFontSizeStyles(streamerSettings: StreamerViewSettings | undefined): React.CSSProperties {
+  const fontSizes = streamerSettings?.layoutOptions?.fontSizes;
+
+  return {
+    "--font-size-queue-info": ((fontSizes?.queueInfo ?? 100) / 100).toString(),
+    "--font-size-score": ((fontSizes?.score ?? 100) / 100).toString(),
+    "--font-size-teams": ((fontSizes?.teams ?? 100) / 100).toString(),
+    "--font-size-tabs": ((fontSizes?.tabs ?? 100) / 100).toString(),
+    "--font-size-ticker": ((fontSizes?.ticker ?? 100) / 100).toString(),
+  } as React.CSSProperties;
+}
+
+function getOverlayActiveSeries(renderModel: IndividualTrackerViewerRenderModel): ViewerSeriesTab | null {
+  const timelineSeries = getActiveSeries(renderModel.timeline);
+  if (timelineSeries != null) {
+    return timelineSeries;
+  }
+
+  if (!renderModel.hasActiveSeries || renderModel.activeSeriesContext == null) {
+    return null;
+  }
+
+  return {
+    id: "active-series-pre-match",
+    title: renderModel.activeSeriesContext.title,
+    subtitle: renderModel.activeSeriesContext.subtitle ?? "",
+    isActive: true,
+    teams: renderModel.activeSeriesContext.teams,
+    matchBackgroundUrls: [],
+    score: "0:0",
+    duration: "unknown",
+    startTime: "",
+    endTime: "",
+    matches: [],
+    colorHex: undefined,
+  };
+}
+
 function getSeriesPlayerDisplayName(player: ViewerSeriesTeamPlayer): string {
   return player.discordName ?? player.gamertag ?? "Unknown";
 }
 
-function renderTeamDetails(team: ViewerSeriesTeam): React.ReactElement {
+function getSeriesPlayerDisplayNameForSettings(
+  player: ViewerSeriesTeamPlayer,
+  settings: Pick<OverlayDisplaySettings, "showDiscordNames" | "showXboxNames">,
+): string {
+  if (settings.showDiscordNames && settings.showXboxNames) {
+    return player.discordName ?? player.gamertag ?? "Unknown";
+  }
+
+  if (settings.showDiscordNames) {
+    return player.discordName ?? "Unknown";
+  }
+
+  if (settings.showXboxNames) {
+    return player.gamertag ?? "Unknown";
+  }
+
+  return getSeriesPlayerDisplayName(player);
+}
+
+function renderTeamDetails(
+  team: ViewerSeriesTeam,
+  settings: Pick<OverlayDisplaySettings, "showDiscordNames" | "showXboxNames">,
+): React.ReactElement {
   return (
     <>
       <div>{team.name}</div>
       {team.players.map((player, index) => (
-        <div key={`${team.id.toString()}-${index.toString()}`}>{getSeriesPlayerDisplayName(player)}</div>
+        <div key={`${team.id.toString()}-${index.toString()}`}>
+          {getSeriesPlayerDisplayNameForSettings(player, settings)}
+        </div>
       ))}
     </>
   );
 }
 
-function getTopSectionTeamDetails(teams: readonly ViewerSeriesTeam[]): {
+function getTopSectionTeamDetails(
+  teams: readonly ViewerSeriesTeam[],
+  settings: Pick<OverlayDisplaySettings, "showTeamDetails" | "showDiscordNames" | "showXboxNames">,
+): {
   readonly showTeamDetails: boolean;
   readonly teamLeft: React.ReactNode;
   readonly teamRight: React.ReactNode;
 } {
+  if (!settings.showTeamDetails) {
+    return { showTeamDetails: false, teamLeft: null, teamRight: null };
+  }
+
   const teamLeft = teams.find((team) => team.id === 0);
   const teamRight = teams.find((team) => team.id === 1);
 
@@ -59,13 +157,14 @@ function getTopSectionTeamDetails(teams: readonly ViewerSeriesTeam[]): {
 
   return {
     showTeamDetails: true,
-    teamLeft: renderTeamDetails(teamLeft),
-    teamRight: renderTeamDetails(teamRight),
+    teamLeft: renderTeamDetails(teamLeft, settings),
+    teamRight: renderTeamDetails(teamRight, settings),
   };
 }
 
 export function IndividualTrackerOverlay({
   renderModel,
+  streamerSettings,
   matchStatsState,
   matchStatsPanelState,
   selectedMatchId,
@@ -73,21 +172,29 @@ export function IndividualTrackerOverlay({
   onDeselect,
 }: IndividualTrackerOverlayProps): React.ReactElement {
   const isPanelOpen = computeIsPanelOpen(selectedMatchId, matchStatsState);
+  const displaySettings = useMemo(() => getOverlayDisplaySettings(streamerSettings), [streamerSettings]);
+  const fontSizeStyles = useMemo(() => getFontSizeStyles(streamerSettings), [streamerSettings]);
 
-  const teamColors = useMemo(() => getDefaultTeamColors(), []);
+  const teamColors = useMemo(() => {
+    if (renderModel.teamColors.length >= 2) {
+      return [renderModel.teamColors[0], renderModel.teamColors[1]];
+    }
 
-  const activeSeries = useMemo(() => getActiveSeries(renderModel.timeline), [renderModel.timeline]);
+    return getDefaultTeamColors();
+  }, [renderModel.teamColors]);
+
+  const activeSeries = useMemo(() => getOverlayActiveSeries(renderModel), [renderModel]);
 
   const topSection = useMemo(() => {
     if (activeSeries != null) {
-      const { showTeamDetails, teamLeft, teamRight } = getTopSectionTeamDetails(activeSeries.teams);
+      const { showTeamDetails, teamLeft, teamRight } = getTopSectionTeamDetails(activeSeries.teams, displaySettings);
 
       return (
         <TopSection
-          title={activeSeries.title}
-          subtitle={activeSeries.subtitle}
+          title={displaySettings.showTitle ? activeSeries.title : null}
+          subtitle={displaySettings.showSubtitle ? activeSeries.subtitle : null}
           iconUrl={null}
-          showScore={true}
+          showScore={displaySettings.showScore}
           seriesScore={activeSeries.score}
           showTeamDetails={showTeamDetails}
           teamColors={teamColors}
@@ -102,16 +209,36 @@ export function IndividualTrackerOverlay({
     }
 
     return <OverlayStatsHighlights items={renderModel.statsHighlights} />;
-  }, [activeSeries, teamColors, renderModel.statsHighlights]);
+  }, [activeSeries, displaySettings, teamColors, renderModel.statsHighlights]);
 
-  const tabs = useMemo(() => buildTabs(renderModel.timeline), [renderModel.timeline]);
+  const tabs = useMemo(() => buildTabs(renderModel.timeline, activeSeries), [activeSeries, renderModel.timeline]);
 
   const selectedTabIndex = useMemo(() => getSelectedTabIndex(tabs, selectedMatchId), [tabs, selectedMatchId]);
 
-  const tickerMatchGroups = useMemo(
-    () => buildTickerGroups(matchStatsState, selectedTabIndex),
-    [matchStatsState, selectedTabIndex],
-  );
+  const tickerMatchGroups = useMemo(() => {
+    const loadedGroups = buildTickerGroups(matchStatsState, selectedTabIndex);
+    if (loadedGroups.length > 0) {
+      return loadedGroups;
+    }
+
+    return buildPreSeriesTickerGroup({
+      showTicker: displaySettings.showTicker,
+      activeSeries,
+      playerName: renderModel.gamertag,
+      discordName: null,
+      gamertag: displaySettings.showXboxNames ? renderModel.gamertag : null,
+    });
+  }, [
+    activeSeries,
+    displaySettings.showDiscordNames,
+    displaySettings.showTicker,
+    displaySettings.showXboxNames,
+    matchStatsState,
+    renderModel.gamertag,
+    selectedTabIndex,
+  ]);
+
+  const showPreSeriesInfo = tickerMatchGroups.length > 0 && activeSeries?.matches.length === 0;
 
   const handleTabClick = useCallback(
     (tabIndex: number): void => {
@@ -154,13 +281,13 @@ export function IndividualTrackerOverlay({
         teamColors={teamColors}
         tabs={tabs}
         tickerMatchGroups={tickerMatchGroups}
-        showTabs={getShowTabs(renderModel)}
-        showTicker={true}
-        showPreSeriesInfo={false}
+        showTabs={displaySettings.showTabs && getShowTabs(renderModel)}
+        showTicker={displaySettings.showTicker}
+        showPreSeriesInfo={showPreSeriesInfo}
         matchesLength={renderModel.accumulated.total}
         showPreview={false}
         previewMode="observer"
-        fontSizeStyles={{}}
+        fontSizeStyles={fontSizeStyles}
         settingsUi={null}
         hasPanelContent={hasPanelContent}
         renderPanelContent={renderPanelContent}

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -1,257 +1,72 @@
 import React, { useCallback, useMemo } from "react";
-import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { StreamerOverlay } from "../../streamer-overlay/streamer-overlay";
 import { TopSection } from "../../streamer-overlay/top-section";
 import { StatsPanel } from "../viewer/stats-panel";
-import type {
-  IndividualTrackerViewerRenderModel,
-  MatchDetailsState,
-  ViewerSeriesTab,
-  ViewerSeriesTeam,
-  ViewerSeriesTeamPlayer,
-} from "../viewer/types";
-import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
-import {
-  buildPreSeriesTickerGroup,
-  buildTabs,
-  buildTickerGroups,
-  getActiveSeries,
-  getDefaultTeamColors,
-  getSelectedTabIndex,
-  getShowTabs,
-  isPanelOpen as computeIsPanelOpen,
-} from "./individual-tracker-overlay-presenter";
+import type { MatchDetailsState } from "../viewer/types";
 import { OverlayStatsHighlights } from "./overlay-stats-highlights";
+import type { IndividualTrackerOverlayViewModel } from "./types";
 import styles from "./individual-tracker-overlay.module.css";
 
 interface IndividualTrackerOverlayProps {
-  readonly renderModel: IndividualTrackerViewerRenderModel;
-  readonly streamerSettings: StreamerViewSettings | undefined;
-  readonly matchStatsState: MatchStatsState | null;
+  readonly viewModel: IndividualTrackerOverlayViewModel;
+  readonly isPanelOpen: boolean;
+  readonly matchesLength: number;
   readonly matchStatsPanelState: MatchDetailsState | null;
   readonly selectedMatchId: string | null;
   readonly onSelectMatch: (matchId: string) => void;
   readonly onDeselect: () => void;
 }
 
-interface OverlayDisplaySettings {
-  readonly showTicker: boolean;
-  readonly showTabs: boolean;
-  readonly showTitle: boolean;
-  readonly showSubtitle: boolean;
-  readonly showScore: boolean;
-  readonly showTeamDetails: boolean;
-  readonly showDiscordNames: boolean;
-  readonly showXboxNames: boolean;
-}
-
-function getOverlayDisplaySettings(streamerSettings: StreamerViewSettings | undefined): OverlayDisplaySettings {
-  const visibleSections = streamerSettings?.visibleSections;
-  return {
-    showTicker: visibleSections?.showTicker ?? true,
-    showTabs: visibleSections?.showTabs ?? true,
-    showTitle: visibleSections?.showTitle ?? true,
-    showSubtitle: visibleSections?.showSubtitle ?? true,
-    showScore: visibleSections?.showScore ?? true,
-    showTeamDetails: visibleSections?.showTeamDetails ?? true,
-    showDiscordNames: visibleSections?.showDiscordNames ?? true,
-    showXboxNames: visibleSections?.showXboxNames ?? true,
-  };
-}
-
-function getFontSizeStyles(streamerSettings: StreamerViewSettings | undefined): React.CSSProperties {
-  const fontSizes = streamerSettings?.layoutOptions?.fontSizes;
-
-  return {
-    "--font-size-queue-info": ((fontSizes?.queueInfo ?? 100) / 100).toString(),
-    "--font-size-score": ((fontSizes?.score ?? 100) / 100).toString(),
-    "--font-size-teams": ((fontSizes?.teams ?? 100) / 100).toString(),
-    "--font-size-tabs": ((fontSizes?.tabs ?? 100) / 100).toString(),
-    "--font-size-ticker": ((fontSizes?.ticker ?? 100) / 100).toString(),
-  } as React.CSSProperties;
-}
-
-function getOverlayActiveSeries(renderModel: IndividualTrackerViewerRenderModel): ViewerSeriesTab | null {
-  const timelineSeries = getActiveSeries(renderModel.timeline);
-  if (timelineSeries != null) {
-    return timelineSeries;
-  }
-
-  if (!renderModel.hasActiveSeries || renderModel.activeSeriesContext == null) {
-    return null;
-  }
-
-  return {
-    id: "active-series-pre-match",
-    title: renderModel.activeSeriesContext.title,
-    subtitle: renderModel.activeSeriesContext.subtitle ?? "",
-    isActive: true,
-    teams: renderModel.activeSeriesContext.teams,
-    matchBackgroundUrls: [],
-    score: "0:0",
-    duration: "unknown",
-    startTime: "",
-    endTime: "",
-    matches: [],
-    colorHex: undefined,
-  };
-}
-
-function getSeriesPlayerDisplayName(player: ViewerSeriesTeamPlayer): string {
-  return player.discordName ?? player.gamertag ?? "Unknown";
-}
-
-function getSeriesPlayerDisplayNameForSettings(
-  player: ViewerSeriesTeamPlayer,
-  settings: Pick<OverlayDisplaySettings, "showDiscordNames" | "showXboxNames">,
-): string {
-  if (settings.showDiscordNames && settings.showXboxNames) {
-    return player.discordName ?? player.gamertag ?? "Unknown";
-  }
-
-  if (settings.showDiscordNames) {
-    return player.discordName ?? "Unknown";
-  }
-
-  if (settings.showXboxNames) {
-    return player.gamertag ?? "Unknown";
-  }
-
-  return getSeriesPlayerDisplayName(player);
-}
-
-function getVisibleTeamPlayers(
-  players: readonly ViewerSeriesTeamPlayer[],
-  settings: Pick<OverlayDisplaySettings, "showDiscordNames" | "showXboxNames">,
-): readonly ViewerSeriesTeamPlayer[] {
-  if (!settings.showDiscordNames && !settings.showXboxNames) {
-    return [];
-  }
-
-  return players;
-}
-
-function renderTeamDetails(
-  team: ViewerSeriesTeam,
-  settings: Pick<OverlayDisplaySettings, "showDiscordNames" | "showXboxNames">,
-): React.ReactElement {
-  const visiblePlayers = getVisibleTeamPlayers(team.players, settings);
-
-  return (
-    <>
-      <div>{team.name}</div>
-      {visiblePlayers.map((player, index) => (
-        <div key={`${team.id.toString()}-${index.toString()}`}>
-          {getSeriesPlayerDisplayNameForSettings(player, settings)}
-        </div>
-      ))}
-    </>
-  );
-}
-
-function getTopSectionTeamDetails(
-  teams: readonly ViewerSeriesTeam[],
-  settings: Pick<OverlayDisplaySettings, "showTeamDetails" | "showDiscordNames" | "showXboxNames">,
-): {
-  readonly showTeamDetails: boolean;
-  readonly teamLeft: React.ReactNode;
-  readonly teamRight: React.ReactNode;
-} {
-  if (!settings.showTeamDetails) {
-    return { showTeamDetails: false, teamLeft: null, teamRight: null };
-  }
-
-  const teamLeft = teams.find((team) => team.id === 0);
-  const teamRight = teams.find((team) => team.id === 1);
-
-  if (teamLeft == null || teamRight == null) {
-    return { showTeamDetails: false, teamLeft: null, teamRight: null };
-  }
-
-  return {
-    showTeamDetails: true,
-    teamLeft: renderTeamDetails(teamLeft, settings),
-    teamRight: renderTeamDetails(teamRight, settings),
-  };
-}
-
 export function IndividualTrackerOverlay({
-  renderModel,
-  streamerSettings,
-  matchStatsState,
+  viewModel,
+  isPanelOpen,
+  matchesLength,
   matchStatsPanelState,
   selectedMatchId,
   onSelectMatch,
   onDeselect,
 }: IndividualTrackerOverlayProps): React.ReactElement {
-  const isPanelOpen = computeIsPanelOpen(selectedMatchId, matchStatsState);
-  const displaySettings = useMemo(() => getOverlayDisplaySettings(streamerSettings), [streamerSettings]);
-  const fontSizeStyles = useMemo(() => getFontSizeStyles(streamerSettings), [streamerSettings]);
-
-  const teamColors = useMemo(() => {
-    if (renderModel.teamColors.length >= 2) {
-      return [renderModel.teamColors[0], renderModel.teamColors[1]];
-    }
-
-    return getDefaultTeamColors();
-  }, [renderModel.teamColors]);
-
-  const activeSeries = useMemo(() => getOverlayActiveSeries(renderModel), [renderModel]);
-
   const topSection = useMemo(() => {
-    if (activeSeries != null) {
-      const { showTeamDetails, teamLeft, teamRight } = getTopSectionTeamDetails(activeSeries.teams, displaySettings);
-
+    if (viewModel.topSection != null) {
       return (
         <TopSection
-          title={displaySettings.showTitle ? activeSeries.title : null}
-          subtitle={displaySettings.showSubtitle && activeSeries.subtitle !== "" ? activeSeries.subtitle : null}
+          title={viewModel.topSection.title}
+          subtitle={viewModel.topSection.subtitle}
           iconUrl={null}
-          showScore={displaySettings.showScore}
-          seriesScore={activeSeries.score}
-          showTeamDetails={showTeamDetails}
-          teamColors={teamColors}
-          teamLeft={teamLeft}
-          teamRight={teamRight}
+          showScore={viewModel.topSection.showScore}
+          seriesScore={viewModel.topSection.seriesScore}
+          showTeamDetails={viewModel.topSection.showTeamDetails}
+          teamColors={viewModel.teamColors}
+          teamLeft={
+            viewModel.topSection.teamLeft != null ? (
+              <>
+                <div>{viewModel.topSection.teamLeft.name}</div>
+                {viewModel.topSection.teamLeft.players.map((player, index) => (
+                  <div key={`left-${index.toString()}`}>{player}</div>
+                ))}
+              </>
+            ) : null
+          }
+          teamRight={
+            viewModel.topSection.teamRight != null ? (
+              <>
+                <div>{viewModel.topSection.teamRight.name}</div>
+                {viewModel.topSection.teamRight.players.map((player, index) => (
+                  <div key={`right-${index.toString()}`}>{player}</div>
+                ))}
+              </>
+            ) : null
+          }
         />
       );
     }
 
-    if (renderModel.statsHighlights == null || renderModel.statsHighlights.length === 0) {
+    if (viewModel.statsHighlights.length === 0) {
       return null;
     }
 
-    return <OverlayStatsHighlights items={renderModel.statsHighlights} />;
-  }, [activeSeries, displaySettings, teamColors, renderModel.statsHighlights]);
-
-  const tabs = useMemo(() => buildTabs(renderModel.timeline, activeSeries), [activeSeries, renderModel.timeline]);
-
-  const selectedTabIndex = useMemo(() => getSelectedTabIndex(tabs, selectedMatchId), [tabs, selectedMatchId]);
-
-  const tickerMatchGroups = useMemo(() => {
-    const loadedGroups = buildTickerGroups(matchStatsState, selectedTabIndex);
-    if (loadedGroups.length > 0) {
-      return loadedGroups;
-    }
-
-    return buildPreSeriesTickerGroup({
-      showTicker: displaySettings.showTicker,
-      activeSeries,
-      playerName: renderModel.gamertag,
-      discordName: null,
-      gamertag: displaySettings.showXboxNames ? renderModel.gamertag : null,
-    });
-  }, [
-    activeSeries,
-    displaySettings.showDiscordNames,
-    displaySettings.showTicker,
-    displaySettings.showXboxNames,
-    matchStatsState,
-    renderModel.gamertag,
-    selectedTabIndex,
-  ]);
-
-  const showPreSeriesInfo = tickerMatchGroups.length > 0 && activeSeries?.matches.length === 0;
+    return <OverlayStatsHighlights items={viewModel.statsHighlights} />;
+  }, [viewModel]);
 
   const handleTabClick = useCallback(
     (tabIndex: number): void => {
@@ -259,7 +74,7 @@ export function IndividualTrackerOverlay({
         onDeselect();
         return;
       }
-      const tab = tabs.find((t) => t.type === "match" && t.index === tabIndex);
+      const tab = viewModel.tabs.find((t) => t.type === "match" && t.index === tabIndex);
       if (tab?.type === "match") {
         if (tab.matchId === selectedMatchId) {
           onDeselect();
@@ -268,7 +83,7 @@ export function IndividualTrackerOverlay({
         }
       }
     },
-    [onDeselect, onSelectMatch, selectedMatchId, tabs],
+    [onDeselect, onSelectMatch, selectedMatchId, viewModel.tabs],
   );
 
   const hasPanelContent = useCallback((): boolean => false, []);
@@ -283,24 +98,24 @@ export function IndividualTrackerOverlay({
       className={styles.overlayRoot}
       style={
         {
-          "--overlay-team-color": teamColors[0].hex,
-          "--overlay-enemy-color": teamColors[1].hex,
+          "--overlay-team-color": viewModel.teamColors[0]?.hex,
+          "--overlay-enemy-color": viewModel.teamColors[1]?.hex,
         } as React.CSSProperties
       }
     >
       <StreamerOverlay
         topSection={topSection}
-        pinTopSection={activeSeries != null}
-        teamColors={teamColors}
-        tabs={tabs}
-        tickerMatchGroups={tickerMatchGroups}
-        showTabs={displaySettings.showTabs && getShowTabs(renderModel)}
-        showTicker={displaySettings.showTicker}
-        showPreSeriesInfo={showPreSeriesInfo}
-        matchesLength={renderModel.accumulated.total}
+        pinTopSection={viewModel.pinTopSection}
+        teamColors={viewModel.teamColors}
+        tabs={viewModel.tabs}
+        tickerMatchGroups={viewModel.tickerMatchGroups}
+        showTabs={viewModel.showTabs}
+        showTicker={viewModel.showTicker}
+        showPreSeriesInfo={viewModel.showPreSeriesInfo}
+        matchesLength={matchesLength}
         showPreview={false}
         previewMode="observer"
-        fontSizeStyles={fontSizeStyles}
+        fontSizeStyles={viewModel.fontSizeStyles}
         settingsUi={null}
         hasPanelContent={hasPanelContent}
         renderPanelContent={renderPanelContent}

--- a/pages/src/components/individual-tracker/overlay/tests/create.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/create.test.tsx
@@ -17,16 +17,20 @@ import { IndividualTrackerOverlayPage } from "../create";
 
 vi.mock("../individual-tracker-overlay", () => ({
   IndividualTrackerOverlay: (props: {
+    viewModel: object;
+    isPanelOpen: boolean;
+    matchesLength: number;
     selectedMatchId: string | null;
-    matchStatsState: { status: string } | null;
     matchStatsPanelState: { status: string } | null;
     onSelectMatch: (matchId: string) => void;
     onDeselect: () => void;
   }): React.ReactElement => {
     return (
       <div>
+        <div data-testid="has-view-model">yes</div>
+        <div data-testid="panel-open">{props.isPanelOpen ? "yes" : "no"}</div>
+        <div data-testid="matches-length">{props.matchesLength.toString()}</div>
         <div data-testid="selected-match">{props.selectedMatchId ?? "none"}</div>
-        <div data-testid="match-stats-state">{props.matchStatsState?.status ?? "none"}</div>
         <div data-testid="panel-state">{props.matchStatsPanelState?.status ?? "none"}</div>
         <button
           type="button"
@@ -93,8 +97,9 @@ describe("IndividualTrackerOverlayPage", () => {
     await userEvent.click(screen.getByText("select"));
 
     await waitFor(() => {
+      expect(screen.getByTestId("has-view-model")).toHaveTextContent("yes");
       expect(screen.getByTestId("selected-match")).toHaveTextContent("match-1");
-      expect(screen.getByTestId("match-stats-state")).toHaveTextContent("loaded");
+      expect(screen.getByTestId("panel-open")).toHaveTextContent("yes");
       expect(screen.getByTestId("panel-state")).toHaveTextContent("loaded");
     });
 
@@ -103,7 +108,7 @@ describe("IndividualTrackerOverlayPage", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("selected-match")).toHaveTextContent("match-1");
-      expect(screen.getByTestId("match-stats-state")).toHaveTextContent("loaded");
+      expect(screen.getByTestId("panel-open")).toHaveTextContent("yes");
       expect(screen.getByTestId("panel-state")).toHaveTextContent("loaded");
     });
 
@@ -142,7 +147,7 @@ describe("IndividualTrackerOverlayPage", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("selected-match")).toHaveTextContent("match-1");
-      expect(screen.getByTestId("match-stats-state")).toHaveTextContent("error");
+      expect(screen.getByTestId("panel-open")).toHaveTextContent("yes");
       expect(screen.getByTestId("panel-state")).toHaveTextContent("error");
     });
   });
@@ -179,7 +184,8 @@ describe("IndividualTrackerOverlayPage", () => {
     await userEvent.click(screen.getByText("select"));
 
     await waitFor(() => {
-      expect(screen.getByTestId("match-stats-state")).toHaveTextContent("loaded");
+      expect(screen.getByTestId("panel-open")).toHaveTextContent("yes");
+      expect(screen.getByTestId("panel-state")).toHaveTextContent("loaded");
     });
 
     rerender(
@@ -199,7 +205,8 @@ describe("IndividualTrackerOverlayPage", () => {
     await userEvent.click(screen.getByText("select"));
 
     await waitFor(() => {
-      expect(screen.getByTestId("match-stats-state")).toHaveTextContent("loaded");
+      expect(screen.getByTestId("panel-open")).toHaveTextContent("yes");
+      expect(screen.getByTestId("panel-state")).toHaveTextContent("loaded");
     });
 
     expect(getMatchStats).toHaveBeenCalledTimes(2);

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { gameModeIconSrc } from "../../game-mode-icon";
 import type { ViewerMatchTab, ViewerSeriesTab, ViewerTimelineItem } from "../../viewer/types";
-import { buildTabs, getActiveSeries } from "../individual-tracker-overlay-presenter";
+import { buildPreSeriesTickerGroup, buildTabs, getActiveSeries } from "../individual-tracker-overlay-presenter";
 
 function aMatchWith(overrides: Partial<ViewerMatchTab> = {}): ViewerMatchTab {
   return {
@@ -123,5 +123,40 @@ describe("individual-tracker-overlay-presenter", () => {
       expect(seriesTabs[0].index).toBe(-1);
       expect(seriesTabs[1].index).toBe(-2);
     }
+  });
+
+  it("returns a series score tab when active series exists but has no matches", () => {
+    const activeSeries = aSeriesWith({
+      id: "series-active",
+      isActive: true,
+      score: "0:0",
+      matches: [],
+    });
+
+    const tabs = buildTabs([], activeSeries);
+
+    expect(tabs).toHaveLength(1);
+    const [seriesTab] = tabs;
+    expect(seriesTab.type).toBe("series");
+    if (seriesTab.type === "series") {
+      expect(seriesTab.label).toBe("Series score");
+      expect(seriesTab.score).toBe("0:0");
+      expect(seriesTab.index).toBe(-1);
+    }
+  });
+
+  it("builds pre-series ticker group only when ticker is enabled and active series has no matches", () => {
+    const groups = buildPreSeriesTickerGroup({
+      showTicker: true,
+      activeSeries: aSeriesWith({ matches: [], isActive: true }),
+      playerName: "TrackedPlayer",
+      discordName: null,
+      gamertag: "TrackedPlayer",
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe("Player Info");
+    expect(groups[0].rows[0].showTeamIcon).toBe(false);
+    expect(groups[0].rows[0].gamertag).toBe("TrackedPlayer");
   });
 });

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -7,12 +7,7 @@ import type {
   ViewerSeriesTab,
   ViewerTimelineItem,
 } from "../../viewer/types";
-import {
-  buildOverlayViewModel,
-  buildPreSeriesTickerGroup,
-  buildTabs,
-  getActiveSeries,
-} from "../individual-tracker-overlay-presenter";
+import { IndividualTrackerOverlayPresenter } from "../individual-tracker-overlay-presenter";
 
 function aRenderModelWith(
   overrides: Partial<IndividualTrackerViewerRenderModel> = {},
@@ -75,6 +70,8 @@ function aSeriesWith(overrides: Partial<ViewerSeriesTab> = {}): ViewerSeriesTab 
 }
 
 describe("individual-tracker-overlay-presenter", () => {
+  const presenter = new IndividualTrackerOverlayPresenter();
+
   it("finds the active series in timeline", () => {
     const timeline: ViewerTimelineItem[] = [
       { type: "series", series: aSeriesWith({ id: "series-old", isActive: false }) },
@@ -82,7 +79,7 @@ describe("individual-tracker-overlay-presenter", () => {
       { type: "series", series: aSeriesWith({ id: "series-active", isActive: true }) },
     ];
 
-    const activeSeries = getActiveSeries(timeline);
+    const activeSeries = presenter.getActiveSeries(timeline);
     expect(activeSeries?.id).toBe("series-active");
   });
 
@@ -101,7 +98,7 @@ describe("individual-tracker-overlay-presenter", () => {
       { type: "match", match: aMatchWith({ matchId: "outside-series" }) },
     ];
 
-    const tabs = buildTabs(timeline);
+    const tabs = presenter.buildTabs(timeline);
 
     expect(tabs).toHaveLength(2);
     expect(tabs.every((tab) => tab.type === "match")).toBe(true);
@@ -122,7 +119,7 @@ describe("individual-tracker-overlay-presenter", () => {
       { type: "match", match: aMatchWith({ matchId: "solo", gameVariantCategory: 8 }) },
     ];
 
-    const tabs = buildTabs(timeline);
+    const tabs = presenter.buildTabs(timeline);
 
     expect(tabs).toHaveLength(2);
     const [seriesTab, matchTab] = tabs;
@@ -148,7 +145,7 @@ describe("individual-tracker-overlay-presenter", () => {
       { type: "match", match: aMatchWith({ matchId: "solo" }) },
     ];
 
-    const tabs = buildTabs(timeline);
+    const tabs = presenter.buildTabs(timeline);
     const seriesTabs = tabs.filter((tab) => tab.type === "series");
 
     expect(seriesTabs).toHaveLength(2);
@@ -166,7 +163,7 @@ describe("individual-tracker-overlay-presenter", () => {
       matches: [],
     });
 
-    const tabs = buildTabs([], activeSeries);
+    const tabs = presenter.buildTabs([], activeSeries);
 
     expect(tabs).toHaveLength(1);
     const [seriesTab] = tabs;
@@ -179,7 +176,7 @@ describe("individual-tracker-overlay-presenter", () => {
   });
 
   it("builds pre-series ticker group only when ticker is enabled and active series has no matches", () => {
-    const groups = buildPreSeriesTickerGroup({
+    const groups = presenter.buildPreSeriesTickerGroup({
       showTicker: true,
       activeSeries: aSeriesWith({ matches: [], isActive: true }),
       playerName: "TrackedPlayer",
@@ -194,7 +191,7 @@ describe("individual-tracker-overlay-presenter", () => {
   });
 
   it("builds top-section team details with xbox-only names when discord names are hidden", () => {
-    const model = buildOverlayViewModel({
+    const model = presenter.present({
       renderModel: aRenderModelWith({
         timeline: [
           {
@@ -224,7 +221,7 @@ describe("individual-tracker-overlay-presenter", () => {
   });
 
   it("omits player rows entirely when both discord and xbox names are hidden", () => {
-    const model = buildOverlayViewModel({
+    const model = presenter.present({
       renderModel: aRenderModelWith({
         timeline: [
           {

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -1,7 +1,40 @@
 import { describe, expect, it } from "vitest";
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { gameModeIconSrc } from "../../game-mode-icon";
-import type { ViewerMatchTab, ViewerSeriesTab, ViewerTimelineItem } from "../../viewer/types";
-import { buildPreSeriesTickerGroup, buildTabs, getActiveSeries } from "../individual-tracker-overlay-presenter";
+import type {
+  IndividualTrackerViewerRenderModel,
+  ViewerMatchTab,
+  ViewerSeriesTab,
+  ViewerTimelineItem,
+} from "../../viewer/types";
+import {
+  buildOverlayViewModel,
+  buildPreSeriesTickerGroup,
+  buildTabs,
+  getActiveSeries,
+} from "../individual-tracker-overlay-presenter";
+
+function aRenderModelWith(
+  overrides: Partial<IndividualTrackerViewerRenderModel> = {},
+): IndividualTrackerViewerRenderModel {
+  return {
+    trackerId: "tracker-1",
+    gamertag: "TrackedPlayer",
+    status: "active",
+    isLive: true,
+    hasActiveSeries: false,
+    activeSeriesContext: undefined,
+    lastUpdateTime: "2026-01-01T00:00:00.000Z",
+    timeline: [],
+    accumulated: { total: 0, wins: 0, losses: 0, ties: 0 },
+    statsHighlights: undefined,
+    teamColors: [
+      { id: "eagle", name: "Eagle", hex: "#0066CC" },
+      { id: "cobra", name: "Cobra", hex: "#CC0000" },
+    ],
+    ...overrides,
+  };
+}
 
 function aMatchWith(overrides: Partial<ViewerMatchTab> = {}): ViewerMatchTab {
   return {
@@ -158,5 +191,65 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(groups[0].label).toBe("Player Info");
     expect(groups[0].rows[0].showTeamIcon).toBe(false);
     expect(groups[0].rows[0].gamertag).toBe("TrackedPlayer");
+  });
+
+  it("builds top-section team details with xbox-only names when discord names are hidden", () => {
+    const model = buildOverlayViewModel({
+      renderModel: aRenderModelWith({
+        timeline: [
+          {
+            type: "series",
+            series: aSeriesWith({
+              isActive: true,
+              teams: [
+                { id: 0, name: "Alpha", players: [{ discordName: "DiscordAlpha", gamertag: "XboxAlpha" }] },
+                { id: 1, name: "Beta", players: [{ discordName: "DiscordBeta", gamertag: "XboxBeta" }] },
+              ],
+            }),
+          },
+        ],
+      }),
+      streamerSettings: {
+        visibleSections: {
+          showDiscordNames: false,
+          showXboxNames: true,
+        },
+      } satisfies StreamerViewSettings,
+      matchStatsState: null,
+      selectedMatchId: null,
+    });
+
+    expect(model.topSection?.teamLeft?.players).toEqual(["XboxAlpha"]);
+    expect(model.topSection?.teamRight?.players).toEqual(["XboxBeta"]);
+  });
+
+  it("omits player rows entirely when both discord and xbox names are hidden", () => {
+    const model = buildOverlayViewModel({
+      renderModel: aRenderModelWith({
+        timeline: [
+          {
+            type: "series",
+            series: aSeriesWith({
+              isActive: true,
+              teams: [
+                { id: 0, name: "Alpha", players: [{ discordName: "DiscordAlpha", gamertag: "XboxAlpha" }] },
+                { id: 1, name: "Beta", players: [{ discordName: "DiscordBeta", gamertag: "XboxBeta" }] },
+              ],
+            }),
+          },
+        ],
+      }),
+      streamerSettings: {
+        visibleSections: {
+          showDiscordNames: false,
+          showXboxNames: false,
+        },
+      } satisfies StreamerViewSettings,
+      matchStatsState: null,
+      selectedMatchId: null,
+    });
+
+    expect(model.topSection?.teamLeft?.players).toEqual([]);
+    expect(model.topSection?.teamRight?.players).toEqual([]);
   });
 });

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -12,6 +12,7 @@ vi.mock("../../../icons/team-icon", () => ({
 vi.mock("../../../icons/medal-icon", () => ({
   MedalIcon: (): React.ReactNode => null,
 }));
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import {
   aFakeTrackerMatchSummaryWith,
   aFakeTrackerSeriesGroupWith,
@@ -36,6 +37,7 @@ describe("IndividualTrackerOverlay", () => {
     const { container } = render(
       <IndividualTrackerOverlay
         renderModel={aRenderModel({ matches: [], series: [] })}
+        streamerSettings={undefined}
         matchStatsState={null}
         matchStatsPanelState={null}
         selectedMatchId={null}
@@ -51,6 +53,7 @@ describe("IndividualTrackerOverlay", () => {
     const { container } = render(
       <IndividualTrackerOverlay
         renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
+        streamerSettings={undefined}
         matchStatsState={null}
         matchStatsPanelState={null}
         selectedMatchId={null}
@@ -66,6 +69,7 @@ describe("IndividualTrackerOverlay", () => {
     render(
       <IndividualTrackerOverlay
         renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
+        streamerSettings={undefined}
         matchStatsState={{ status: "loading" }}
         matchStatsPanelState={{ status: "loading" }}
         selectedMatchId="m-1"
@@ -81,6 +85,7 @@ describe("IndividualTrackerOverlay", () => {
     render(
       <IndividualTrackerOverlay
         renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
+        streamerSettings={undefined}
         matchStatsState={{
           status: "loaded",
           stats: aFakeMatchStatsWith(),
@@ -107,6 +112,7 @@ describe("IndividualTrackerOverlay", () => {
     render(
       <IndividualTrackerOverlay
         renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
+        streamerSettings={undefined}
         matchStatsState={{ status: "error", message: "Network failure" }}
         matchStatsPanelState={{ status: "error", message: "Network failure" }}
         selectedMatchId="m-1"
@@ -125,6 +131,7 @@ describe("IndividualTrackerOverlay", () => {
     render(
       <IndividualTrackerOverlay
         renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
+        streamerSettings={undefined}
         matchStatsState={{
           status: "loaded",
           stats: aFakeMatchStatsWith(),
@@ -184,6 +191,7 @@ describe("IndividualTrackerOverlay", () => {
             ],
           },
         })}
+        streamerSettings={undefined}
         matchStatsState={null}
         matchStatsPanelState={null}
         selectedMatchId={null}
@@ -236,6 +244,7 @@ describe("IndividualTrackerOverlay", () => {
             ],
           },
         })}
+        streamerSettings={undefined}
         matchStatsState={null}
         matchStatsPanelState={null}
         selectedMatchId={null}
@@ -252,5 +261,181 @@ describe("IndividualTrackerOverlay", () => {
     expect(rightTeamContainer?.textContent).toContain("Beta");
     expect(rightTeamContainer?.textContent).toContain("Beta Player");
     expect(screen.queryByText("Ignored Player")).not.toBeInTheDocument();
+  });
+
+  it("shows a 0:0 series tab and no waiting banner when in-series has no matches yet and ticker is disabled", () => {
+    const renderModel = aRenderModel({
+      hasActiveSeries: true,
+      activeSeriesContext: {
+        title: "Alpha vs Beta",
+        subtitle: "Bo3",
+        teams: [],
+      },
+      matches: [],
+      series: [],
+    });
+    const streamerSettings: StreamerViewSettings = {
+      visibleSections: {
+        showTicker: false,
+      },
+    };
+
+    render(
+      <IndividualTrackerOverlay
+        renderModel={renderModel}
+        streamerSettings={streamerSettings}
+        matchStatsState={null}
+        matchStatsPanelState={null}
+        selectedMatchId={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /series score/i })).toBeInTheDocument();
+    expect(screen.queryByText("Waiting for first match to complete...")).not.toBeInTheDocument();
+  });
+
+  it("shows player pre-series ticker with no team icon when in-series has no matches and ticker is enabled", () => {
+    const renderModel = aRenderModel({
+      gamertag: "TrackedPlayer",
+      hasActiveSeries: true,
+      activeSeriesContext: {
+        title: "Alpha vs Beta",
+        subtitle: "Bo3",
+        teams: [],
+      },
+      matches: [],
+      series: [],
+    });
+    const streamerSettings: StreamerViewSettings = {
+      visibleSections: {
+        showTicker: true,
+      },
+    };
+
+    render(
+      <IndividualTrackerOverlay
+        renderModel={renderModel}
+        streamerSettings={streamerSettings}
+        matchStatsState={null}
+        matchStatsPanelState={null}
+        selectedMatchId={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText("Player Info")).toBeInTheDocument();
+    expect(screen.getByText("TrackedPlayer")).toBeInTheDocument();
+    expect(screen.queryByText("Waiting for first match to complete...")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("team-icon-0")).not.toBeInTheDocument();
+  });
+
+  it("respects visibility settings for tabs and top section content", () => {
+    const renderModel = aRenderModel({
+      hasActiveSeries: true,
+      activeSeriesContext: {
+        title: "Custom Series Title",
+        subtitle: "Custom Series Subtitle",
+        teams: [
+          {
+            id: 0,
+            name: "Alpha",
+            players: [{ discordId: null, discordName: "AlphaDiscord", gamertag: "AlphaTag", xboxId: null }],
+          },
+          {
+            id: 1,
+            name: "Beta",
+            players: [{ discordId: null, discordName: "BetaDiscord", gamertag: "BetaTag", xboxId: null }],
+          },
+        ],
+      },
+      matches: [],
+      series: [],
+    });
+
+    const streamerSettings: StreamerViewSettings = {
+      visibleSections: {
+        showTabs: false,
+        showTitle: false,
+        showSubtitle: false,
+        showTeamDetails: false,
+      },
+    };
+
+    render(
+      <IndividualTrackerOverlay
+        renderModel={renderModel}
+        streamerSettings={streamerSettings}
+        matchStatsState={null}
+        matchStatsPanelState={null}
+        selectedMatchId={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /series score/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("Custom Series Title")).not.toBeInTheDocument();
+    expect(screen.queryByText("Custom Series Subtitle")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("team-icon-0")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("team-icon-1")).not.toBeInTheDocument();
+  });
+
+  it("uses xbox names in team details when discord names are hidden", () => {
+    const renderModel = aRenderModel({
+      matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" }), aFakeTrackerMatchSummaryWith({ matchId: "m-2" })],
+      series: [
+        aFakeTrackerSeriesGroupWith({
+          id: "series-1",
+          title: "Alpha vs Beta",
+          subtitle: "Bo3",
+          matchIds: ["m-1", "m-2"],
+          score: "1:0",
+        }),
+      ],
+      hasActiveSeries: true,
+      activeSeriesContext: {
+        title: "Alpha vs Beta",
+        subtitle: "Bo3",
+        teams: [
+          {
+            id: 0,
+            name: "Alpha",
+            players: [{ discordId: null, discordName: "DiscordAlpha", gamertag: "XboxAlpha", xboxId: null }],
+          },
+          {
+            id: 1,
+            name: "Beta",
+            players: [{ discordId: null, discordName: "DiscordBeta", gamertag: "XboxBeta", xboxId: null }],
+          },
+        ],
+      },
+    });
+
+    const streamerSettings: StreamerViewSettings = {
+      visibleSections: {
+        showDiscordNames: false,
+        showXboxNames: true,
+      },
+    };
+
+    render(
+      <IndividualTrackerOverlay
+        renderModel={renderModel}
+        streamerSettings={streamerSettings}
+        matchStatsState={null}
+        matchStatsPanelState={null}
+        selectedMatchId={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText("XboxAlpha")).toBeInTheDocument();
+    expect(screen.getByText("XboxBeta")).toBeInTheDocument();
+    expect(screen.queryByText("DiscordAlpha")).not.toBeInTheDocument();
+    expect(screen.queryByText("DiscordBeta")).not.toBeInTheDocument();
   });
 });

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -438,4 +438,62 @@ describe("IndividualTrackerOverlay", () => {
     expect(screen.queryByText("DiscordAlpha")).not.toBeInTheDocument();
     expect(screen.queryByText("DiscordBeta")).not.toBeInTheDocument();
   });
+
+  it("shows only team names when both discord and xbox names are hidden", () => {
+    const renderModel = aRenderModel({
+      matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" }), aFakeTrackerMatchSummaryWith({ matchId: "m-2" })],
+      series: [
+        aFakeTrackerSeriesGroupWith({
+          id: "series-1",
+          title: "Alpha vs Beta",
+          subtitle: "Bo3",
+          matchIds: ["m-1", "m-2"],
+          score: "1:0",
+        }),
+      ],
+      hasActiveSeries: true,
+      activeSeriesContext: {
+        title: "Alpha vs Beta",
+        subtitle: "Bo3",
+        teams: [
+          {
+            id: 0,
+            name: "Alpha",
+            players: [{ discordId: null, discordName: "DiscordAlpha", gamertag: "XboxAlpha", xboxId: null }],
+          },
+          {
+            id: 1,
+            name: "Beta",
+            players: [{ discordId: null, discordName: "DiscordBeta", gamertag: "XboxBeta", xboxId: null }],
+          },
+        ],
+      },
+    });
+
+    const streamerSettings: StreamerViewSettings = {
+      visibleSections: {
+        showDiscordNames: false,
+        showXboxNames: false,
+      },
+    };
+
+    render(
+      <IndividualTrackerOverlay
+        renderModel={renderModel}
+        streamerSettings={streamerSettings}
+        matchStatsState={null}
+        matchStatsPanelState={null}
+        selectedMatchId={null}
+        onSelectMatch={() => undefined}
+        onDeselect={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+    expect(screen.queryByText("DiscordAlpha")).not.toBeInTheDocument();
+    expect(screen.queryByText("XboxAlpha")).not.toBeInTheDocument();
+    expect(screen.queryByText("DiscordBeta")).not.toBeInTheDocument();
+    expect(screen.queryByText("XboxBeta")).not.toBeInTheDocument();
+  });
 });

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../../../services/individual-tracker/fakes/view.fake";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 import { buildViewerRenderModel } from "../../viewer/viewer-render-model";
+import { buildOverlayViewModel, isPanelOpen as computeIsPanelOpen } from "../individual-tracker-overlay-presenter";
 import { IndividualTrackerOverlay } from "../individual-tracker-overlay";
 
 function aRenderModel(
@@ -28,23 +29,43 @@ function aRenderModel(
   return buildViewerRenderModel({ view: aFakeTrackerViewStateWith(overrides) });
 }
 
+function aPropsWith(options?: {
+  renderModel?: ReturnType<typeof buildViewerRenderModel>;
+  streamerSettings?: StreamerViewSettings;
+  matchStatsState?: Parameters<typeof buildOverlayViewModel>[0]["matchStatsState"];
+  matchStatsPanelState?: React.ComponentProps<typeof IndividualTrackerOverlay>["matchStatsPanelState"];
+  selectedMatchId?: string | null;
+  onSelectMatch?: (matchId: string) => void;
+  onDeselect?: () => void;
+}): React.ComponentProps<typeof IndividualTrackerOverlay> {
+  const renderModel = options?.renderModel ?? aRenderModel({ matches: [], series: [] });
+  const streamerSettings = options?.streamerSettings;
+  const matchStatsState = options?.matchStatsState ?? null;
+  const selectedMatchId = options?.selectedMatchId ?? null;
+
+  return {
+    viewModel: buildOverlayViewModel({
+      renderModel,
+      streamerSettings,
+      matchStatsState,
+      selectedMatchId,
+    }),
+    isPanelOpen: computeIsPanelOpen(selectedMatchId, matchStatsState),
+    matchesLength: renderModel.accumulated.total,
+    matchStatsPanelState: options?.matchStatsPanelState ?? null,
+    selectedMatchId,
+    onSelectMatch: options?.onSelectMatch ?? ((): void => undefined),
+    onDeselect: options?.onDeselect ?? ((): void => undefined),
+  };
+}
+
 describe("IndividualTrackerOverlay", () => {
   afterEach(() => {
     cleanup();
   });
 
   it("renders without crashing when the timeline is empty", () => {
-    const { container } = render(
-      <IndividualTrackerOverlay
-        renderModel={aRenderModel({ matches: [], series: [] })}
-        streamerSettings={undefined}
-        matchStatsState={null}
-        matchStatsPanelState={null}
-        selectedMatchId={null}
-        onSelectMatch={() => undefined}
-        onDeselect={() => undefined}
-      />,
-    );
+    const { container } = render(<IndividualTrackerOverlay {...aPropsWith()} />);
 
     expect(container.firstChild).toBeInTheDocument();
   });
@@ -52,13 +73,7 @@ describe("IndividualTrackerOverlay", () => {
   it("renders without crashing when the timeline has items", () => {
     const { container } = render(
       <IndividualTrackerOverlay
-        renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
-        streamerSettings={undefined}
-        matchStatsState={null}
-        matchStatsPanelState={null}
-        selectedMatchId={null}
-        onSelectMatch={() => undefined}
-        onDeselect={() => undefined}
+        {...aPropsWith({ renderModel: aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] }) })}
       />,
     );
 
@@ -68,13 +83,12 @@ describe("IndividualTrackerOverlay", () => {
   it("keeps the stats panel closed when a match is selected but stats are still loading", () => {
     render(
       <IndividualTrackerOverlay
-        renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
-        streamerSettings={undefined}
-        matchStatsState={{ status: "loading" }}
-        matchStatsPanelState={{ status: "loading" }}
-        selectedMatchId="m-1"
-        onSelectMatch={() => undefined}
-        onDeselect={() => undefined}
+        {...aPropsWith({
+          renderModel: aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] }),
+          matchStatsState: { status: "loading" },
+          matchStatsPanelState: { status: "loading" },
+          selectedMatchId: "m-1",
+        })}
       />,
     );
 
@@ -84,24 +98,22 @@ describe("IndividualTrackerOverlay", () => {
   it("opens the stats panel when stats are loaded for a selected match", () => {
     render(
       <IndividualTrackerOverlay
-        renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
-        streamerSettings={undefined}
-        matchStatsState={{
-          status: "loaded",
-          stats: aFakeMatchStatsWith(),
-          playerMap: new Map([
-            ["1111111111", "Alpha"],
-            ["2222222222", "Bravo"],
-            ["3333333333", "Charlie"],
-            ["4444444444", "Delta"],
-          ]),
-          medalMetadata: {},
-          analytics: null,
-        }}
-        matchStatsPanelState={null}
-        selectedMatchId="m-1"
-        onSelectMatch={() => undefined}
-        onDeselect={() => undefined}
+        {...aPropsWith({
+          renderModel: aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] }),
+          matchStatsState: {
+            status: "loaded",
+            stats: aFakeMatchStatsWith(),
+            playerMap: new Map([
+              ["1111111111", "Alpha"],
+              ["2222222222", "Bravo"],
+              ["3333333333", "Charlie"],
+              ["4444444444", "Delta"],
+            ]),
+            medalMetadata: {},
+            analytics: null,
+          },
+          selectedMatchId: "m-1",
+        })}
       />,
     );
 
@@ -111,13 +123,12 @@ describe("IndividualTrackerOverlay", () => {
   it("opens the stats panel when stats fail to load so the error is visible", () => {
     render(
       <IndividualTrackerOverlay
-        renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
-        streamerSettings={undefined}
-        matchStatsState={{ status: "error", message: "Network failure" }}
-        matchStatsPanelState={{ status: "error", message: "Network failure" }}
-        selectedMatchId="m-1"
-        onSelectMatch={() => undefined}
-        onDeselect={() => undefined}
+        {...aPropsWith({
+          renderModel: aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] }),
+          matchStatsState: { status: "error", message: "Network failure" },
+          matchStatsPanelState: { status: "error", message: "Network failure" },
+          selectedMatchId: "m-1",
+        })}
       />,
     );
 
@@ -130,24 +141,23 @@ describe("IndividualTrackerOverlay", () => {
 
     render(
       <IndividualTrackerOverlay
-        renderModel={aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] })}
-        streamerSettings={undefined}
-        matchStatsState={{
-          status: "loaded",
-          stats: aFakeMatchStatsWith(),
-          playerMap: new Map([
-            ["1111111111", "Alpha"],
-            ["2222222222", "Bravo"],
-            ["3333333333", "Charlie"],
-            ["4444444444", "Delta"],
-          ]),
-          medalMetadata: {},
-          analytics: null,
-        }}
-        matchStatsPanelState={null}
-        selectedMatchId="m-1"
-        onSelectMatch={() => undefined}
-        onDeselect={onDeselect}
+        {...aPropsWith({
+          renderModel: aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" })] }),
+          matchStatsState: {
+            status: "loaded",
+            stats: aFakeMatchStatsWith(),
+            playerMap: new Map([
+              ["1111111111", "Alpha"],
+              ["2222222222", "Bravo"],
+              ["3333333333", "Charlie"],
+              ["4444444444", "Delta"],
+            ]),
+            medalMetadata: {},
+            analytics: null,
+          },
+          selectedMatchId: "m-1",
+          onDeselect,
+        })}
       />,
     );
 
@@ -159,44 +169,43 @@ describe("IndividualTrackerOverlay", () => {
   it("renders active series team details using display-name fallbacks", () => {
     render(
       <IndividualTrackerOverlay
-        renderModel={aRenderModel({
-          matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" }), aFakeTrackerMatchSummaryWith({ matchId: "m-2" })],
-          series: [
-            aFakeTrackerSeriesGroupWith({
-              id: "series-1",
+        {...aPropsWith({
+          renderModel: aRenderModel({
+            matches: [
+              aFakeTrackerMatchSummaryWith({ matchId: "m-1" }),
+              aFakeTrackerMatchSummaryWith({ matchId: "m-2" }),
+            ],
+            series: [
+              aFakeTrackerSeriesGroupWith({
+                id: "series-1",
+                title: "Alpha vs Beta",
+                subtitle: "Bo3",
+                matchIds: ["m-1", "m-2"],
+                score: "1:0",
+              }),
+            ],
+            hasActiveSeries: true,
+            activeSeriesContext: {
               title: "Alpha vs Beta",
               subtitle: "Bo3",
-              matchIds: ["m-1", "m-2"],
-              score: "1:0",
-            }),
-          ],
-          hasActiveSeries: true,
-          activeSeriesContext: {
-            title: "Alpha vs Beta",
-            subtitle: "Bo3",
-            teams: [
-              {
-                id: 0,
-                name: "Alpha",
-                players: [
-                  { discordId: null, discordName: "Discord Name", gamertag: "Gamertag Name", xboxId: null },
-                  { discordId: null, discordName: null, gamertag: "Xbox Only", xboxId: null },
-                ],
-              },
-              {
-                id: 1,
-                name: "Beta",
-                players: [{ discordId: null, discordName: null, gamertag: null, xboxId: null }],
-              },
-            ],
-          },
+              teams: [
+                {
+                  id: 0,
+                  name: "Alpha",
+                  players: [
+                    { discordId: null, discordName: "Discord Name", gamertag: "Gamertag Name", xboxId: null },
+                    { discordId: null, discordName: null, gamertag: "Xbox Only", xboxId: null },
+                  ],
+                },
+                {
+                  id: 1,
+                  name: "Beta",
+                  players: [{ discordId: null, discordName: null, gamertag: null, xboxId: null }],
+                },
+              ],
+            },
+          }),
         })}
-        streamerSettings={undefined}
-        matchStatsState={null}
-        matchStatsPanelState={null}
-        selectedMatchId={null}
-        onSelectMatch={() => undefined}
-        onDeselect={() => undefined}
       />,
     );
 
@@ -210,46 +219,45 @@ describe("IndividualTrackerOverlay", () => {
   it("maps team details by team id regardless of active-series team order", () => {
     render(
       <IndividualTrackerOverlay
-        renderModel={aRenderModel({
-          matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" }), aFakeTrackerMatchSummaryWith({ matchId: "m-2" })],
-          series: [
-            aFakeTrackerSeriesGroupWith({
-              id: "series-1",
+        {...aPropsWith({
+          renderModel: aRenderModel({
+            matches: [
+              aFakeTrackerMatchSummaryWith({ matchId: "m-1" }),
+              aFakeTrackerMatchSummaryWith({ matchId: "m-2" }),
+            ],
+            series: [
+              aFakeTrackerSeriesGroupWith({
+                id: "series-1",
+                title: "Alpha vs Beta",
+                subtitle: "Bo3",
+                matchIds: ["m-1", "m-2"],
+                score: "1:0",
+              }),
+            ],
+            hasActiveSeries: true,
+            activeSeriesContext: {
               title: "Alpha vs Beta",
               subtitle: "Bo3",
-              matchIds: ["m-1", "m-2"],
-              score: "1:0",
-            }),
-          ],
-          hasActiveSeries: true,
-          activeSeriesContext: {
-            title: "Alpha vs Beta",
-            subtitle: "Bo3",
-            teams: [
-              {
-                id: 1,
-                name: "Beta",
-                players: [{ discordId: null, discordName: null, gamertag: "Beta Player", xboxId: null }],
-              },
-              {
-                id: 2,
-                name: "Gamma",
-                players: [{ discordId: null, discordName: null, gamertag: "Ignored Player", xboxId: null }],
-              },
-              {
-                id: 0,
-                name: "Alpha",
-                players: [{ discordId: null, discordName: null, gamertag: "Alpha Player", xboxId: null }],
-              },
-            ],
-          },
+              teams: [
+                {
+                  id: 1,
+                  name: "Beta",
+                  players: [{ discordId: null, discordName: null, gamertag: "Beta Player", xboxId: null }],
+                },
+                {
+                  id: 2,
+                  name: "Gamma",
+                  players: [{ discordId: null, discordName: null, gamertag: "Ignored Player", xboxId: null }],
+                },
+                {
+                  id: 0,
+                  name: "Alpha",
+                  players: [{ discordId: null, discordName: null, gamertag: "Alpha Player", xboxId: null }],
+                },
+              ],
+            },
+          }),
         })}
-        streamerSettings={undefined}
-        matchStatsState={null}
-        matchStatsPanelState={null}
-        selectedMatchId={null}
-        onSelectMatch={() => undefined}
-        onDeselect={() => undefined}
       />,
     );
 
@@ -280,17 +288,7 @@ describe("IndividualTrackerOverlay", () => {
       },
     };
 
-    render(
-      <IndividualTrackerOverlay
-        renderModel={renderModel}
-        streamerSettings={streamerSettings}
-        matchStatsState={null}
-        matchStatsPanelState={null}
-        selectedMatchId={null}
-        onSelectMatch={() => undefined}
-        onDeselect={() => undefined}
-      />,
-    );
+    render(<IndividualTrackerOverlay {...aPropsWith({ renderModel, streamerSettings })} />);
 
     expect(screen.getByRole("button", { name: /series score/i })).toBeInTheDocument();
     expect(screen.queryByText("Waiting for first match to complete...")).not.toBeInTheDocument();
@@ -314,17 +312,7 @@ describe("IndividualTrackerOverlay", () => {
       },
     };
 
-    render(
-      <IndividualTrackerOverlay
-        renderModel={renderModel}
-        streamerSettings={streamerSettings}
-        matchStatsState={null}
-        matchStatsPanelState={null}
-        selectedMatchId={null}
-        onSelectMatch={() => undefined}
-        onDeselect={() => undefined}
-      />,
-    );
+    render(<IndividualTrackerOverlay {...aPropsWith({ renderModel, streamerSettings })} />);
 
     expect(screen.getByText("Player Info")).toBeInTheDocument();
     expect(screen.getByText("TrackedPlayer")).toBeInTheDocument();
@@ -364,17 +352,7 @@ describe("IndividualTrackerOverlay", () => {
       },
     };
 
-    render(
-      <IndividualTrackerOverlay
-        renderModel={renderModel}
-        streamerSettings={streamerSettings}
-        matchStatsState={null}
-        matchStatsPanelState={null}
-        selectedMatchId={null}
-        onSelectMatch={() => undefined}
-        onDeselect={() => undefined}
-      />,
-    );
+    render(<IndividualTrackerOverlay {...aPropsWith({ renderModel, streamerSettings })} />);
 
     expect(screen.queryByRole("button", { name: /series score/i })).not.toBeInTheDocument();
     expect(screen.queryByText("Custom Series Title")).not.toBeInTheDocument();
@@ -421,17 +399,7 @@ describe("IndividualTrackerOverlay", () => {
       },
     };
 
-    render(
-      <IndividualTrackerOverlay
-        renderModel={renderModel}
-        streamerSettings={streamerSettings}
-        matchStatsState={null}
-        matchStatsPanelState={null}
-        selectedMatchId={null}
-        onSelectMatch={() => undefined}
-        onDeselect={() => undefined}
-      />,
-    );
+    render(<IndividualTrackerOverlay {...aPropsWith({ renderModel, streamerSettings })} />);
 
     expect(screen.getByText("XboxAlpha")).toBeInTheDocument();
     expect(screen.getByText("XboxBeta")).toBeInTheDocument();
@@ -477,17 +445,7 @@ describe("IndividualTrackerOverlay", () => {
       },
     };
 
-    render(
-      <IndividualTrackerOverlay
-        renderModel={renderModel}
-        streamerSettings={streamerSettings}
-        matchStatsState={null}
-        matchStatsPanelState={null}
-        selectedMatchId={null}
-        onSelectMatch={() => undefined}
-        onDeselect={() => undefined}
-      />,
-    );
+    render(<IndividualTrackerOverlay {...aPropsWith({ renderModel, streamerSettings })} />);
 
     expect(screen.getByText("Alpha")).toBeInTheDocument();
     expect(screen.getByText("Beta")).toBeInTheDocument();

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -20,7 +20,7 @@ import {
 } from "../../../../services/individual-tracker/fakes/view.fake";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 import { buildViewerRenderModel } from "../../viewer/viewer-render-model";
-import { buildOverlayViewModel, isPanelOpen as computeIsPanelOpen } from "../individual-tracker-overlay-presenter";
+import { IndividualTrackerOverlayPresenter, type MatchStatsState } from "../individual-tracker-overlay-presenter";
 import { IndividualTrackerOverlay } from "../individual-tracker-overlay";
 
 function aRenderModel(
@@ -32,25 +32,26 @@ function aRenderModel(
 function aPropsWith(options?: {
   renderModel?: ReturnType<typeof buildViewerRenderModel>;
   streamerSettings?: StreamerViewSettings;
-  matchStatsState?: Parameters<typeof buildOverlayViewModel>[0]["matchStatsState"];
+  matchStatsState?: MatchStatsState;
   matchStatsPanelState?: React.ComponentProps<typeof IndividualTrackerOverlay>["matchStatsPanelState"];
   selectedMatchId?: string | null;
   onSelectMatch?: (matchId: string) => void;
   onDeselect?: () => void;
 }): React.ComponentProps<typeof IndividualTrackerOverlay> {
+  const presenter = new IndividualTrackerOverlayPresenter();
   const renderModel = options?.renderModel ?? aRenderModel({ matches: [], series: [] });
   const streamerSettings = options?.streamerSettings;
   const matchStatsState = options?.matchStatsState ?? null;
   const selectedMatchId = options?.selectedMatchId ?? null;
 
   return {
-    viewModel: buildOverlayViewModel({
+    viewModel: presenter.present({
       renderModel,
       streamerSettings,
       matchStatsState,
       selectedMatchId,
     }),
-    isPanelOpen: computeIsPanelOpen(selectedMatchId, matchStatsState),
+    isPanelOpen: presenter.isPanelOpen(selectedMatchId, matchStatsState),
     matchesLength: renderModel.accumulated.total,
     matchStatsPanelState: options?.matchStatsPanelState ?? null,
     selectedMatchId,

--- a/pages/src/components/individual-tracker/overlay/types.ts
+++ b/pages/src/components/individual-tracker/overlay/types.ts
@@ -1,0 +1,59 @@
+import type React from "react";
+import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import type { StatsHighlightItem } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import type { TeamColor } from "../../team-colors/team-colors";
+import type { TickerMatchGroup } from "../../information-ticker/information-ticker";
+import type { OverlayTab } from "../../streamer-overlay/tabs-bar";
+
+export interface OverlayDisplaySettings {
+  readonly showTicker: boolean;
+  readonly showTabs: boolean;
+  readonly showTitle: boolean;
+  readonly showSubtitle: boolean;
+  readonly showScore: boolean;
+  readonly showTeamDetails: boolean;
+  readonly showDiscordNames: boolean;
+  readonly showXboxNames: boolean;
+}
+
+export interface OverlayTeamDetailsModel {
+  readonly name: string;
+  readonly players: readonly string[];
+}
+
+export interface OverlayTopSectionModel {
+  readonly title: string | null;
+  readonly subtitle: string | null;
+  readonly showScore: boolean;
+  readonly seriesScore: string;
+  readonly showTeamDetails: boolean;
+  readonly teamLeft: OverlayTeamDetailsModel | null;
+  readonly teamRight: OverlayTeamDetailsModel | null;
+}
+
+export interface IndividualTrackerOverlayViewModel {
+  readonly pinTopSection: boolean;
+  readonly topSection: OverlayTopSectionModel | null;
+  readonly statsHighlights: readonly StatsHighlightItem[];
+  readonly teamColors: TeamColor[];
+  readonly tabs: readonly OverlayTab[];
+  readonly tickerMatchGroups: readonly TickerMatchGroup[];
+  readonly showTabs: boolean;
+  readonly showTicker: boolean;
+  readonly showPreSeriesInfo: boolean;
+  readonly fontSizeStyles: React.CSSProperties;
+}
+
+export function getOverlayDisplaySettings(streamerSettings: StreamerViewSettings | undefined): OverlayDisplaySettings {
+  const visibleSections = streamerSettings?.visibleSections;
+  return {
+    showTicker: visibleSections?.showTicker ?? true,
+    showTabs: visibleSections?.showTabs ?? true,
+    showTitle: visibleSections?.showTitle ?? true,
+    showSubtitle: visibleSections?.showSubtitle ?? true,
+    showScore: visibleSections?.showScore ?? true,
+    showTeamDetails: visibleSections?.showTeamDetails ?? true,
+    showDiscordNames: visibleSections?.showDiscordNames ?? true,
+    showXboxNames: visibleSections?.showXboxNames ?? true,
+  };
+}

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -48,6 +48,12 @@ export interface ViewerSeriesTeam {
   readonly players: readonly ViewerSeriesTeamPlayer[];
 }
 
+export interface ViewerActiveSeriesContext {
+  readonly title: string;
+  readonly subtitle: string | null;
+  readonly teams: readonly ViewerSeriesTeam[];
+}
+
 export type ViewerTimelineItem =
   | { readonly type: "match"; readonly match: ViewerMatchTab }
   | { readonly type: "series"; readonly series: ViewerSeriesTab };
@@ -64,6 +70,8 @@ export interface IndividualTrackerViewerRenderModel {
   readonly gamertag: string;
   readonly status: TrackerStatus;
   readonly isLive: boolean;
+  readonly hasActiveSeries: boolean;
+  readonly activeSeriesContext: ViewerActiveSeriesContext | undefined;
   readonly lastUpdateTime: string;
   readonly timeline: readonly ViewerTimelineItem[];
   readonly accumulated: ViewerAccumulatedStats;

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -10,6 +10,7 @@ import { differenceInSeconds, isValid, parseISO } from "date-fns";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type {
+  ViewerActiveSeriesContext,
   IndividualTrackerViewerRenderModel,
   ViewerAccumulatedStats,
   ViewerMatchTab,
@@ -63,6 +64,25 @@ function getSeriesTeams(
       gamertag: player.gamertag,
     })),
   }));
+}
+
+function toViewerActiveSeriesContext(view: TrackerViewState): ViewerActiveSeriesContext | undefined {
+  if (view.activeSeriesContext == null) {
+    return undefined;
+  }
+
+  return {
+    title: view.activeSeriesContext.title,
+    subtitle: view.activeSeriesContext.subtitle,
+    teams: view.activeSeriesContext.teams.map((team) => ({
+      id: team.id,
+      name: team.name,
+      players: team.players.map((player) => ({
+        discordName: player.discordName,
+        gamertag: player.gamertag,
+      })),
+    })),
+  };
 }
 
 function toReadableDurationOrUnknown(startTime: string, endTime: string): string {
@@ -266,6 +286,8 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
     gamertag: view.gamertag,
     status: view.status,
     isLive: view.isLive,
+    hasActiveSeries: view.hasActiveSeries,
+    activeSeriesContext: toViewerActiveSeriesContext(view),
     lastUpdateTime: view.lastUpdateTime,
     timeline: [...timelineWithFallback],
     accumulated,

--- a/pages/src/components/information-ticker/information-ticker.tsx
+++ b/pages/src/components/information-ticker/information-ticker.tsx
@@ -177,6 +177,7 @@ function arePropsEqual(prevProps: InformationTickerProps, nextProps: Information
     if (
       prevRow.type !== nextRow.type ||
       prevRow.teamId !== nextRow.teamId ||
+      prevRow.showTeamIcon !== nextRow.showTeamIcon ||
       prevRow.name !== nextRow.name ||
       prevRow.stats.length !== nextRow.stats.length ||
       prevRow.medals.length !== nextRow.medals.length

--- a/pages/src/components/information-ticker/information-ticker.tsx
+++ b/pages/src/components/information-ticker/information-ticker.tsx
@@ -11,6 +11,7 @@ import styles from "./information-ticker.module.css";
 interface TickerStatRow {
   readonly type: "team" | "player";
   readonly teamId: number;
+  readonly showTeamIcon?: boolean;
   readonly name: string;
   readonly discordName?: string | null;
   readonly gamertag?: string | null;
@@ -81,7 +82,7 @@ const InformationTickerComponent = function InformationTicker({
 
           {/* Team Icon + Name */}
           <div className={styles.tickerName}>
-            <TeamIcon teamId={currentRow.teamId} size="small" />
+            {currentRow.showTeamIcon !== false && <TeamIcon teamId={currentRow.teamId} size="small" />}
             {currentRow.type === "player" && (currentRow.discordName != null || currentRow.gamertag != null) ? (
               <PlayerName
                 discordName={currentRow.discordName ?? null}

--- a/pages/src/components/information-ticker/tests/information-ticker.test.tsx
+++ b/pages/src/components/information-ticker/tests/information-ticker.test.tsx
@@ -167,6 +167,26 @@ describe("InformationTicker", () => {
     expect(screen.getByText("Unknown Player")).toBeInTheDocument();
   });
 
+  it("hides the team icon when showTeamIcon is false", () => {
+    const matchGroup = aFakeTickerMatchGroupWith({
+      rows: [
+        aFakeTickerStatRowWith({
+          type: "player",
+          teamId: 0,
+          name: "Tracked Player",
+          showTeamIcon: false,
+          discordName: null,
+          gamertag: "Tracked Player",
+        }),
+      ],
+    });
+
+    render(<InformationTicker currentMatchGroup={matchGroup} teamColors={teamColors} onScrollComplete={vi.fn()} />);
+
+    expect(screen.queryByTestId("team-icon-0")).not.toBeInTheDocument();
+    expect(screen.getByTestId("player-name")).toBeInTheDocument();
+  });
+
   it("displays multiple stats for a row", () => {
     const matchGroup = aFakeTickerMatchGroupWith({
       rows: [


### PR DESCRIPTION
## Context
The stream overlay work has been landing in focused slices to align individual-tracker overlay behavior with live-tracker overlay behavior while still using API-provided streamer settings. After PR6 merged team details into the top bar, the remaining parity gap was the in-series, no-match-yet state and broader settings-driven UI wiring in the overlay path.

## This PR
This PR delivers PR7 by mirroring live-tracker in-series UI behavior and wiring overlay UI decisions to API-provided streamer settings.

- Add in-series no-match synthetic state so the overlay shows a series tab at 0:0 immediately.
- Remove the waiting banner in that state; when ticker is disabled, only bottom tabs render.
- When ticker is enabled in-series before first match, render pre-series player info with tracked-player color and no team icon when team side is unknown.
- Expand overlay settings wiring to mirror live-tracker UI behavior:
  - ticker visibility
  - tabs visibility
  - title/subtitle/score visibility
  - team-details visibility
  - discord/xbox name visibility for team details
  - font-size CSS variables
- Carry active-series context through the viewer render model to support no-match in-series rendering.
- Extend ticker row support with optional team-icon hiding and add focused regression tests for presenter, overlay UI, and ticker behavior.
- Refactor overlay SPC responsibilities further:
  - move overlay view-model mapping out of the component and into the create/factory layer
  - keep the component focused on rendering and interaction callbacks
  - add presenter/shared-type coverage for the moved mapping logic
- Side note: harden `api/services/halo/tests/resilient-fetch.test.ts` so the debounced KV-write assertions are deterministic in CI and do not depend on a single timer edge.

## Subsequent Work
- refine settings for out of series UI
