### PR TITLE
refactor(overlay): stabilize top-section player row keys

### DIFF
--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -15,6 +15,7 @@ import { gameModeIconSrc } from "../game-mode-icon";
 import type {
   IndividualTrackerOverlayViewModel,
   OverlayDisplaySettings,
+  OverlayTeamPlayerModel,
   OverlayTeamDetailsModel,
   OverlayTopSectionModel,
 } from "./types";
@@ -66,6 +67,12 @@ function getSeriesPlayerDisplayNameForSettings(
   return player.discordName ?? player.gamertag ?? "Unknown";
 }
 
+function getSeriesPlayerStableKey(
+  player: { readonly discordName: string | null; readonly gamertag: string | null },
+): string {
+  return `${player.discordName ?? "none"}:${player.gamertag ?? "none"}`;
+}
+
 function getTeamDetailsModel(
   team: {
     readonly name: string;
@@ -73,10 +80,13 @@ function getTeamDetailsModel(
   },
   settings: Pick<OverlayDisplaySettings, "showDiscordNames" | "showXboxNames">,
 ): OverlayTeamDetailsModel {
-  const players =
+  const players: readonly OverlayTeamPlayerModel[] =
     !settings.showDiscordNames && !settings.showXboxNames
       ? []
-      : team.players.map((player) => getSeriesPlayerDisplayNameForSettings(player, settings));
+      : team.players.map((player) => ({
+          key: getSeriesPlayerStableKey(player),
+          label: getSeriesPlayerDisplayNameForSettings(player, settings),
+        }));
 
   return {
     name: team.name,

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -67,9 +67,10 @@ function getSeriesPlayerDisplayNameForSettings(
   return player.discordName ?? player.gamertag ?? "Unknown";
 }
 
-function getSeriesPlayerStableKey(
-  player: { readonly discordName: string | null; readonly gamertag: string | null },
-): string {
+function getSeriesPlayerStableKey(player: {
+  readonly discordName: string | null;
+  readonly gamertag: string | null;
+}): string {
   return `${player.discordName ?? "none"}:${player.gamertag ?? "none"}`;
 }
 
@@ -83,10 +84,20 @@ function getTeamDetailsModel(
   const players: readonly OverlayTeamPlayerModel[] =
     !settings.showDiscordNames && !settings.showXboxNames
       ? []
-      : team.players.map((player) => ({
-          key: getSeriesPlayerStableKey(player),
-          label: getSeriesPlayerDisplayNameForSettings(player, settings),
-        }));
+      : ((): readonly OverlayTeamPlayerModel[] => {
+          const keyCounts = new Map<string, number>();
+
+          return team.players.map((player) => {
+            const baseKey = getSeriesPlayerStableKey(player);
+            const count = keyCounts.get(baseKey) ?? 0;
+            keyCounts.set(baseKey, count + 1);
+
+            return {
+              key: count === 0 ? baseKey : `${baseKey}:${count.toString()}`,
+              label: getSeriesPlayerDisplayNameForSettings(player, settings),
+            };
+          });
+        })();
 
   return {
     name: team.name,

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -41,8 +41,8 @@ export function IndividualTrackerOverlay({
             viewModel.topSection.teamLeft != null ? (
               <>
                 <div>{viewModel.topSection.teamLeft.name}</div>
-                {viewModel.topSection.teamLeft.players.map((player, index) => (
-                  <div key={`left-${index.toString()}`}>{player}</div>
+                {viewModel.topSection.teamLeft.players.map((player) => (
+                  <div key={`left-${player.key}`}>{player.label}</div>
                 ))}
               </>
             ) : null
@@ -51,8 +51,8 @@ export function IndividualTrackerOverlay({
             viewModel.topSection.teamRight != null ? (
               <>
                 <div>{viewModel.topSection.teamRight.name}</div>
-                {viewModel.topSection.teamRight.players.map((player, index) => (
-                  <div key={`right-${index.toString()}`}>{player}</div>
+                {viewModel.topSection.teamRight.players.map((player) => (
+                  <div key={`right-${player.key}`}>{player.label}</div>
                 ))}
               </>
             ) : null

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -216,8 +216,8 @@ describe("individual-tracker-overlay-presenter", () => {
       selectedMatchId: null,
     });
 
-    expect(model.topSection?.teamLeft?.players).toEqual(["XboxAlpha"]);
-    expect(model.topSection?.teamRight?.players).toEqual(["XboxBeta"]);
+    expect(model.topSection?.teamLeft?.players).toEqual([{ key: "DiscordAlpha:XboxAlpha", label: "XboxAlpha" }]);
+    expect(model.topSection?.teamRight?.players).toEqual([{ key: "DiscordBeta:XboxBeta", label: "XboxBeta" }]);
   });
 
   it("omits player rows entirely when both discord and xbox names are hidden", () => {

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -249,4 +249,42 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(model.topSection?.teamLeft?.players).toEqual([]);
     expect(model.topSection?.teamRight?.players).toEqual([]);
   });
+
+  it("deduplicates top-section player keys when display names repeat", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        timeline: [
+          {
+            type: "series",
+            series: aSeriesWith({
+              isActive: true,
+              teams: [
+                {
+                  id: 0,
+                  name: "Alpha",
+                  players: [
+                    { discordName: "Same", gamertag: "Tag" },
+                    { discordName: "Same", gamertag: "Tag" },
+                  ],
+                },
+                {
+                  id: 1,
+                  name: "Beta",
+                  players: [{ discordName: "Other", gamertag: "OtherTag" }],
+                },
+              ],
+            }),
+          },
+        ],
+      }),
+      streamerSettings: undefined,
+      matchStatsState: null,
+      selectedMatchId: null,
+    });
+
+    expect(model.topSection?.teamLeft?.players).toEqual([
+      { key: "Same:Tag", label: "Same" },
+      { key: "Same:Tag:1", label: "Same" },
+    ]);
+  });
 });

--- a/pages/src/components/individual-tracker/overlay/types.ts
+++ b/pages/src/components/individual-tracker/overlay/types.ts
@@ -18,7 +18,12 @@ export interface OverlayDisplaySettings {
 
 export interface OverlayTeamDetailsModel {
   readonly name: string;
-  readonly players: readonly string[];
+  readonly players: readonly OverlayTeamPlayerModel[];
+}
+
+export interface OverlayTeamPlayerModel {
+  readonly key: string;
+  readonly label: string;
 }
 
 export interface OverlayTopSectionModel {


### PR DESCRIPTION
## Context
Overlay in-series parity landed in focused slices through PR #617. Post-merge review identified a render-stability refinement in team details: player rows in the top section were keyed by index, which can cause unnecessary remounting when list order changes.

## This PR
This PR stabilizes overlay team-detail player row identity.
- Replace index-based player row keys in the overlay top section with presenter-provided stable keys.
- Update overlay team-detail view model shape to carry `{ key, label }` entries instead of raw strings.
- Keep existing display behavior unchanged.
- Add/adjust presenter tests to validate the new keyed model output.

## Subsequent Work
- PR 9: Add explicit regression coverage for pre-series tracked-player colour mapping.
- PR 10: Do a final live-tracker vs individual-tracker overlay settings parity pass (labels/defaults/behavior wording).
