### PR TITLE
test(overlay): add pre-series tracked-player color coverage

### DIFF
--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -190,6 +190,34 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(groups[0].rows[0].gamertag).toBe("TrackedPlayer");
   });
 
+  it("maps pre-series tracked-player ticker row to the tracked-player color slot", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        hasActiveSeries: true,
+        activeSeriesContext: {
+          title: "Alpha vs Beta",
+          subtitle: "Bo3",
+          teams: [],
+        },
+        teamColors: [
+          { id: "tracked", name: "Tracked", hex: "#00AA11" },
+          { id: "enemy", name: "Enemy", hex: "#AA0011" },
+        ],
+      }),
+      streamerSettings: {
+        visibleSections: {
+          showTicker: true,
+        },
+      } satisfies StreamerViewSettings,
+      matchStatsState: null,
+      selectedMatchId: null,
+    });
+
+    expect(model.tickerMatchGroups).toHaveLength(1);
+    expect(model.tickerMatchGroups[0]?.rows[0]?.teamId).toBe(0);
+    expect(model.teamColors[0]?.hex).toBe("#00AA11");
+  });
+
   it("builds top-section team details with xbox-only names when discord names are hidden", () => {
     const model = presenter.present({
       renderModel: aRenderModelWith({

--- a/pages/src/components/information-ticker/tests/information-ticker.test.tsx
+++ b/pages/src/components/information-ticker/tests/information-ticker.test.tsx
@@ -187,6 +187,27 @@ describe("InformationTicker", () => {
     expect(screen.getByTestId("player-name")).toBeInTheDocument();
   });
 
+  it("applies the row color CSS variable from the row team id", () => {
+    const matchGroup = aFakeTickerMatchGroupWith({
+      rows: [
+        aFakeTickerStatRowWith({
+          type: "player",
+          teamId: 1,
+          name: "Tracked Player",
+          showTeamIcon: false,
+          discordName: null,
+          gamertag: "Tracked Player",
+        }),
+      ],
+    });
+
+    const { container } = render(
+      <InformationTicker currentMatchGroup={matchGroup} teamColors={teamColors} onScrollComplete={vi.fn()} />,
+    );
+
+    expect(container.firstChild).toHaveStyle("--row-color: #CC0000");
+  });
+
   it("displays multiple stats for a row", () => {
     const matchGroup = aFakeTickerMatchGroupWith({
       rows: [


### PR DESCRIPTION
## Context
Post-merge overlay parity review identified a gap in explicit regression coverage around the in-series pre-match ticker path. Behavior already mapped tracked-player rows through team IDs and team color slots, but tests did not assert that color mapping directly.

## This PR
This PR adds focused regression coverage for tracked-player pre-series color mapping.
- Add overlay presenter test asserting pre-series tracked-player rows are emitted with `teamId: 0` and that the tracked-player color slot is preserved in the view model.
- Add information ticker test asserting row `teamId` resolves to the expected `--row-color` CSS variable.
- Keep runtime behavior unchanged (test-only PR).

## Subsequent Work
- PR 10: Final live-tracker vs individual-tracker overlay settings parity pass (labels/defaults/behavior wording).
