### PR TITLE
feat: add context-aware my-stats-only ticker filters

### DIFF
--- a/pages/src/components/follow/tests/follow-live-viewer.test.tsx
+++ b/pages/src/components/follow/tests/follow-live-viewer.test.tsx
@@ -33,7 +33,7 @@ vi.mock("../../individual-tracker/viewer/create", () => ({
       <div data-testid="mock-viewer" data-instance-id={instanceId.toString()}>
         {trackerId}
         <span data-testid="mock-streamer-settings">
-          {streamerSettings?.styleFlags?.showMatchmakingStatsOnly === true ? "true" : "false"}
+          {streamerSettings?.styleFlags?.matchmakingMyStatsOnly === true ? "true" : "false"}
         </span>
         <span data-testid="mock-connection-status-override">{connectionStatusOverride ?? "none"}</span>
       </div>
@@ -109,7 +109,7 @@ describe("FollowLiveViewer", () => {
     const directoryWithSettings: TrackerDirectory = aDirectoryWith({
       streamerSettings: {
         styleFlags: {
-          showMatchmakingStatsOnly: true,
+          matchmakingMyStatsOnly: true,
         },
       },
     });

--- a/pages/src/components/individual-tracker-manager/create.tsx
+++ b/pages/src/components/individual-tracker-manager/create.tsx
@@ -122,6 +122,8 @@ export function IndividualTrackerManagerPage({
           observerEnemyColor={settingsSnapshot.observerEnemyColor}
           displaySettings={settingsSnapshot.displaySettings}
           tickerSettings={settingsSnapshot.tickerSettings}
+          inSeriesMyStatsOnly={settingsSnapshot.inSeriesMyStatsOnly}
+          matchmakingMyStatsOnly={settingsSnapshot.matchmakingMyStatsOnly}
           fontSizeSettings={settingsSnapshot.fontSizeSettings}
           saveStatus={settingsSnapshot.saveStatus}
           saveErrorMessage={settingsSnapshot.saveErrorMessage}
@@ -139,6 +141,12 @@ export function IndividualTrackerManagerPage({
           }}
           onTickerSettingsChange={(updates): void => {
             settingsPresenter.setTickerSettings(updates);
+          }}
+          onInSeriesMyStatsOnlyChange={(enabled): void => {
+            settingsPresenter.setInSeriesMyStatsOnly(enabled);
+          }}
+          onMatchmakingMyStatsOnlyChange={(enabled): void => {
+            settingsPresenter.setMatchmakingMyStatsOnly(enabled);
           }}
           onFontSizesChange={(updates): void => {
             settingsPresenter.setFontSizes(updates);

--- a/pages/src/components/individual-tracker-manager/streamer-settings/create.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/create.tsx
@@ -45,6 +45,8 @@ export function StreamerSettingsSection({
       observerEnemyColor={snapshot.observerEnemyColor}
       displaySettings={snapshot.displaySettings}
       tickerSettings={snapshot.tickerSettings}
+      inSeriesMyStatsOnly={snapshot.inSeriesMyStatsOnly}
+      matchmakingMyStatsOnly={snapshot.matchmakingMyStatsOnly}
       fontSizeSettings={snapshot.fontSizeSettings}
       saveStatus={snapshot.saveStatus}
       saveErrorMessage={snapshot.saveErrorMessage}
@@ -62,6 +64,12 @@ export function StreamerSettingsSection({
       }}
       onTickerSettingsChange={(updates): void => {
         presenter.setTickerSettings(updates);
+      }}
+      onInSeriesMyStatsOnlyChange={(enabled): void => {
+        presenter.setInSeriesMyStatsOnly(enabled);
+      }}
+      onMatchmakingMyStatsOnlyChange={(enabled): void => {
+        presenter.setMatchmakingMyStatsOnly(enabled);
       }}
       onFontSizesChange={(updates): void => {
         presenter.setFontSizes(updates);

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-presenter.ts
@@ -67,6 +67,8 @@ function settingsToSnapshot(
       showObjectiveStats: styleFlags.showObjectiveStats ?? snapshot.tickerSettings.showObjectiveStats,
       medalRarityFilter: styleFlags.medalRarityFilter ?? snapshot.tickerSettings.medalRarityFilter,
     },
+    inSeriesMyStatsOnly: styleFlags.inSeriesMyStatsOnly ?? snapshot.inSeriesMyStatsOnly,
+    matchmakingMyStatsOnly: styleFlags.matchmakingMyStatsOnly ?? snapshot.matchmakingMyStatsOnly,
     fontSizeSettings: {
       queueInfo: fontSizes.queueInfo ?? snapshot.fontSizeSettings.queueInfo,
       score: fontSizes.score ?? snapshot.fontSizeSettings.score,
@@ -100,6 +102,8 @@ function snapshotToSettings(snapshot: StreamerSettingsSnapshot): StreamerViewSet
       selectedSlayerStats: [...snapshot.tickerSettings.selectedSlayerStats],
       showObjectiveStats: snapshot.tickerSettings.showObjectiveStats,
       medalRarityFilter: [...snapshot.tickerSettings.medalRarityFilter],
+      inSeriesMyStatsOnly: snapshot.inSeriesMyStatsOnly,
+      matchmakingMyStatsOnly: snapshot.matchmakingMyStatsOnly,
     },
     visibleSections: {
       showTeamDetails: snapshot.displaySettings.showTeamDetails,
@@ -195,6 +199,24 @@ export class StreamerSettingsPresenter {
     }
     const current = this.config.store.getSnapshot().tickerSettings;
     this.config.store.setTickerSettings({ ...current, ...updates });
+    this.scheduleSave();
+  }
+
+  public setInSeriesMyStatsOnly(enabled: boolean): void {
+    if (this.isDisposed) {
+      return;
+    }
+
+    this.config.store.batchUpdate({ inSeriesMyStatsOnly: enabled });
+    this.scheduleSave();
+  }
+
+  public setMatchmakingMyStatsOnly(enabled: boolean): void {
+    if (this.isDisposed) {
+      return;
+    }
+
+    this.config.store.batchUpdate({ matchmakingMyStatsOnly: enabled });
     this.scheduleSave();
   }
 

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-store.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-store.ts
@@ -15,6 +15,8 @@ export interface StreamerSettingsSnapshot {
   readonly observerEnemyColor: string;
   readonly displaySettings: DisplaySettings;
   readonly tickerSettings: TickerSettings;
+  readonly inSeriesMyStatsOnly: boolean;
+  readonly matchmakingMyStatsOnly: boolean;
   readonly fontSizeSettings: FontSizeSettings;
   readonly statsHighlightSlots: readonly IndividualStatsHighlightOption[];
   readonly saveStatus: SaveStatus;
@@ -62,6 +64,8 @@ export class StreamerSettingsStore {
       observerEnemyColor: "cerulean",
       displaySettings: DEFAULT_DISPLAY_SETTINGS,
       tickerSettings: DEFAULT_TICKER_SETTINGS,
+      inSeriesMyStatsOnly: false,
+      matchmakingMyStatsOnly: false,
       fontSizeSettings: DEFAULT_FONT_SIZE_SETTINGS,
       statsHighlightSlots: [],
       saveStatus: "idle",

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import type { StreamerViewColorMode } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { Alert } from "../../alert/alert";
 import { Button } from "../../button/button";
+import { Checkbox } from "../../checkbox/checkbox";
 import { TeamColorPicker } from "../../team-colors/team-color-picker";
 import { DisplaySettingsSection } from "../../live-tracker/settings/display-settings-section";
 import { TickerSettingsSection } from "../../live-tracker/settings/ticker-settings-section";
@@ -55,6 +56,8 @@ export interface StreamerSettingsSectionViewProps {
   readonly observerEnemyColor: string;
   readonly displaySettings: DisplaySettings;
   readonly tickerSettings: TickerSettings;
+  readonly inSeriesMyStatsOnly: boolean;
+  readonly matchmakingMyStatsOnly: boolean;
   readonly fontSizeSettings: FontSizeSettings;
   readonly saveStatus: SaveStatus;
   readonly saveErrorMessage: string | null;
@@ -63,6 +66,8 @@ export interface StreamerSettingsSectionViewProps {
   readonly onObserverColorsChange: (teamColor: string, enemyColor: string) => void;
   readonly onDisplaySettingsChange: (updates: Partial<DisplaySettings>) => void;
   readonly onTickerSettingsChange: (updates: Partial<TickerSettings>) => void;
+  readonly onInSeriesMyStatsOnlyChange: (enabled: boolean) => void;
+  readonly onMatchmakingMyStatsOnlyChange: (enabled: boolean) => void;
   readonly onFontSizesChange: (updates: Partial<FontSizeSettings>) => void;
 }
 
@@ -75,6 +80,8 @@ export function StreamerSettingsSectionView({
   observerEnemyColor,
   displaySettings,
   tickerSettings,
+  inSeriesMyStatsOnly,
+  matchmakingMyStatsOnly,
   fontSizeSettings,
   saveStatus,
   saveErrorMessage,
@@ -83,6 +90,8 @@ export function StreamerSettingsSectionView({
   onObserverColorsChange,
   onDisplaySettingsChange,
   onTickerSettingsChange,
+  onInSeriesMyStatsOnlyChange,
+  onMatchmakingMyStatsOnlyChange,
   onFontSizesChange,
 }: StreamerSettingsSectionViewProps): React.ReactElement {
   const [copyTarget, setCopyTarget] = useState<CopyTarget>("idle");
@@ -316,6 +325,22 @@ export function StreamerSettingsSectionView({
           In the overlay at the bottom, the Information Ticker provides detailed insights at a glance.
         </p>
         <TickerSettingsSection settings={tickerSettings} onChange={onTickerSettingsChange} />
+        <Checkbox
+          checked={inSeriesMyStatsOnly}
+          onChange={(checked): void => {
+            onInSeriesMyStatsOnlyChange(checked);
+          }}
+          label="In-Series: Show Only My Stats"
+          description="When enabled, the ticker only rotates your player row during an active series."
+        />
+        <Checkbox
+          checked={matchmakingMyStatsOnly}
+          onChange={(checked): void => {
+            onMatchmakingMyStatsOnlyChange(checked);
+          }}
+          label="Matchmaking: Show Only My Stats"
+          description="When enabled, the ticker only rotates your player row during matchmaking matches."
+        />
       </div>
 
       <div className={styles.card}>

--- a/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings-presenter.test.ts
@@ -80,7 +80,11 @@ describe("StreamerSettingsPresenter", () => {
       presenter.loadSettings(
         {
           visibleSections: { showTicker: false, showTabs: false },
-          styleFlags: { showPreSeriesInfo: false },
+          styleFlags: {
+            showPreSeriesInfo: false,
+            inSeriesMyStatsOnly: true,
+            matchmakingMyStatsOnly: true,
+          },
         },
         null,
       );
@@ -88,6 +92,8 @@ describe("StreamerSettingsPresenter", () => {
       expect(store.getSnapshot().tickerSettings.showTicker).toBe(false);
       expect(store.getSnapshot().tickerSettings.showTabs).toBe(false);
       expect(store.getSnapshot().tickerSettings.showPreSeriesInfo).toBe(false);
+      expect(store.getSnapshot().inSeriesMyStatsOnly).toBe(true);
+      expect(store.getSnapshot().matchmakingMyStatsOnly).toBe(true);
     });
 
     it("sets the gamertag on the store", () => {
@@ -254,6 +260,44 @@ describe("StreamerSettingsPresenter", () => {
 
       expect(store.getSnapshot().tickerSettings.showTicker).toBe(false);
       expect(store.getSnapshot().tickerSettings.showTabs).toBe(true);
+    });
+  });
+
+  describe("setInSeriesMyStatsOnly", () => {
+    it("updates inSeriesMyStatsOnly in the store and schedules a save", async () => {
+      const { store, presenter, settingsService } = aHarness();
+      const updateSpy: MockInstance<typeof settingsService.updateSettings> = vi.spyOn(
+        settingsService,
+        "updateSettings",
+      );
+
+      presenter.setInSeriesMyStatsOnly(true);
+
+      expect(store.getSnapshot().inSeriesMyStatsOnly).toBe(true);
+
+      await vi.runAllTimersAsync();
+
+      const [[saved]] = updateSpy.mock.calls;
+      expect(saved.styleFlags?.inSeriesMyStatsOnly).toBe(true);
+    });
+  });
+
+  describe("setMatchmakingMyStatsOnly", () => {
+    it("updates matchmakingMyStatsOnly in the store and schedules a save", async () => {
+      const { store, presenter, settingsService } = aHarness();
+      const updateSpy: MockInstance<typeof settingsService.updateSettings> = vi.spyOn(
+        settingsService,
+        "updateSettings",
+      );
+
+      presenter.setMatchmakingMyStatsOnly(true);
+
+      expect(store.getSnapshot().matchmakingMyStatsOnly).toBe(true);
+
+      await vi.runAllTimersAsync();
+
+      const [[saved]] = updateSpy.mock.calls;
+      expect(saved.styleFlags?.matchmakingMyStatsOnly).toBe(true);
     });
   });
 

--- a/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
@@ -65,6 +65,8 @@ function aFakeProps(overrides?: Partial<StreamerSettingsSectionViewProps>): Stre
     observerEnemyColor: "cerulean",
     displaySettings: DEFAULT_DISPLAY_SETTINGS,
     tickerSettings: DEFAULT_TICKER_SETTINGS,
+    inSeriesMyStatsOnly: false,
+    matchmakingMyStatsOnly: false,
     fontSizeSettings: DEFAULT_FONT_SIZE_SETTINGS,
     saveStatus: "idle",
     saveErrorMessage: null,
@@ -73,6 +75,8 @@ function aFakeProps(overrides?: Partial<StreamerSettingsSectionViewProps>): Stre
     onObserverColorsChange: (): void => undefined,
     onDisplaySettingsChange: (): void => undefined,
     onTickerSettingsChange: (): void => undefined,
+    onInSeriesMyStatsOnlyChange: (): void => undefined,
+    onMatchmakingMyStatsOnlyChange: (): void => undefined,
     onFontSizesChange: (): void => undefined,
     ...overrides,
   };
@@ -245,6 +249,28 @@ describe("StreamerSettingsSectionView", () => {
       expect(screen.getByTestId("color-picker-Player enemy color")).toBeInTheDocument();
       expect(screen.getByTestId("color-picker-Eagle")).toBeInTheDocument();
       expect(screen.getByTestId("color-picker-Cobra")).toBeInTheDocument();
+    });
+
+    it("calls onInSeriesMyStatsOnlyChange when the in-series toggle is clicked", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn<(enabled: boolean) => void>();
+
+      render(<StreamerSettingsSectionView {...aFakeProps({ onInSeriesMyStatsOnlyChange: onChange })} />);
+
+      await user.click(screen.getByText("In-Series: Show Only My Stats"));
+
+      expect(onChange).toHaveBeenCalledWith(true);
+    });
+
+    it("calls onMatchmakingMyStatsOnlyChange when the matchmaking toggle is clicked", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn<(enabled: boolean) => void>();
+
+      render(<StreamerSettingsSectionView {...aFakeProps({ onMatchmakingMyStatsOnlyChange: onChange })} />);
+
+      await user.click(screen.getByText("Matchmaking: Show Only My Stats"));
+
+      expect(onChange).toHaveBeenCalledWith(true);
     });
   });
 });

--- a/pages/src/components/individual-tracker-manager/tests/individual-tracker-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/tests/individual-tracker-presenter.test.ts
@@ -41,7 +41,7 @@ function aHarness(session: SessionResponse = AUTHENTICATED_SESSION): Harness {
   const liveTrackersController = aFakeLiveTrackersController();
   const authService = aFakeAuthServiceWith({ session });
   const settingsService = aFakeIndividualTrackerSettingsServiceWith({
-    styleFlags: { showMatchmakingStatsOnly: true },
+    styleFlags: { matchmakingMyStatsOnly: true },
   });
   const presenter = new IndividualTrackerPresenter({
     authService,
@@ -91,7 +91,7 @@ describe("IndividualTrackerPresenter", () => {
       presenter.start();
       await flushPromises();
       expect(presenter.getSnapshot().streamerSettings).toMatchObject({
-        styleFlags: { showMatchmakingStatsOnly: true },
+        styleFlags: { matchmakingMyStatsOnly: true },
       });
     });
   });

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -1,4 +1,3 @@
-import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
 import { getTeamName } from "@guilty-spark/shared/halo/team";
 import type { MatchStats } from "halo-infinite-api";
 import type { CSSProperties } from "react";
@@ -20,6 +19,11 @@ import type {
   OverlayTopSectionModel,
 } from "./types";
 import { getOverlayDisplaySettings } from "./types";
+
+interface TickerFilterOptions {
+  readonly trackedGamertag: string;
+  readonly includeOnlyTrackedPlayer: boolean;
+}
 
 export type MatchStatsState =
   | { readonly status: "loading" }
@@ -245,7 +249,10 @@ export class IndividualTrackerOverlayPresenter {
     const activeSeries = this.getOverlayActiveSeries(renderModel);
     const tabs = this.buildTabs(renderModel.timeline, activeSeries);
     const selectedTabIndex = this.getSelectedTabIndex(tabs, selectedMatchId);
-    const loadedTickerGroups = this.buildTickerGroups(matchStatsState, selectedTabIndex);
+    const loadedTickerGroups = this.buildTickerGroups(matchStatsState, selectedTabIndex, {
+      trackedGamertag: renderModel.gamertag,
+      includeOnlyTrackedPlayer: this.getIncludeOnlyTrackedPlayer(streamerSettings, activeSeries),
+    });
     const tickerMatchGroups =
       loadedTickerGroups.length > 0
         ? loadedTickerGroups
@@ -329,38 +336,80 @@ export class IndividualTrackerOverlayPresenter {
     return tab?.type === "match" ? tab.index : 0;
   }
 
-  private buildTickerGroups(matchStatsState: MatchStatsState | null, matchIndex: number): TickerMatchGroup[] {
+  private buildTickerGroups(
+    matchStatsState: MatchStatsState | null,
+    matchIndex: number,
+    filterOptions: TickerFilterOptions,
+  ): TickerMatchGroup[] {
     if (matchStatsState?.status !== "loaded") {
       return [];
     }
 
-    const { stats } = matchStatsState;
+    const { stats, playerMap } = matchStatsState;
     const formatter = createMatchStatsFormatter(stats.MatchInfo.GameVariantCategory);
-    const playerMap = new Map(stats.Players.map((p) => [getPlayerXuid(p), getPlayerXuid(p)]));
     const data = formatter.getData(stats, playerMap, {});
+
+    const rows = data.flatMap((teamData) => [
+      {
+        type: "team" as const,
+        teamId: teamData.teamId,
+        name: getTeamName(teamData.teamId),
+        stats: teamData.teamStats,
+        medals: teamData.teamMedals,
+      },
+      ...teamData.players.map((p) => ({
+        type: "player" as const,
+        teamId: teamData.teamId,
+        name: p.name,
+        stats: p.values,
+        medals: p.medals,
+      })),
+    ]);
+
+    const filteredRows = this.filterRowsForTrackedPlayer(rows, filterOptions);
 
     return [
       {
         matchIndex,
         label: "",
-        rows: data.flatMap((teamData) => [
-          {
-            type: "team" as const,
-            teamId: teamData.teamId,
-            name: getTeamName(teamData.teamId),
-            stats: teamData.teamStats,
-            medals: teamData.teamMedals,
-          },
-          ...teamData.players.map((p) => ({
-            type: "player" as const,
-            teamId: teamData.teamId,
-            name: p.name,
-            stats: p.values,
-            medals: p.medals,
-          })),
-        ]),
+        rows: filteredRows,
       },
     ];
+  }
+
+  private getIncludeOnlyTrackedPlayer(
+    streamerSettings: StreamerViewSettings | undefined,
+    activeSeries: ViewerSeriesTab | null,
+  ): boolean {
+    if (activeSeries != null) {
+      return streamerSettings?.styleFlags?.inSeriesMyStatsOnly === true;
+    }
+
+    return streamerSettings?.styleFlags?.matchmakingMyStatsOnly === true;
+  }
+
+  private filterRowsForTrackedPlayer(
+    rows: TickerMatchGroup["rows"],
+    filterOptions: TickerFilterOptions,
+  ): TickerMatchGroup["rows"] {
+    if (!filterOptions.includeOnlyTrackedPlayer) {
+      return rows;
+    }
+
+    const trackedGamertag = filterOptions.trackedGamertag.trim().toLowerCase();
+    if (trackedGamertag === "") {
+      return rows;
+    }
+
+    const trackedPlayerRows = rows.filter((row) => {
+      if (row.type !== "player") {
+        return false;
+      }
+
+      return row.name.trim().toLowerCase() === trackedGamertag;
+    });
+
+    return trackedPlayerRows.length > 0 ? trackedPlayerRows : rows;
   }
 
   private getShowTabs(renderModel: IndividualTrackerViewerRenderModel): boolean {

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import { aFakeMatchStatsWith, aFakeMedalMetadata } from "../../../../controllers/stats/fakes/data";
 import { gameModeIconSrc } from "../../game-mode-icon";
 import type {
   IndividualTrackerViewerRenderModel,
@@ -314,5 +315,73 @@ describe("individual-tracker-overlay-presenter", () => {
       { key: "Same:Tag", label: "Same" },
       { key: "Same:Tag:1", label: "Same" },
     ]);
+  });
+
+  it("shows only the tracked player row in matchmaking ticker when matchmakingMyStatsOnly is enabled", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith(),
+      streamerSettings: {
+        styleFlags: {
+          matchmakingMyStatsOnly: true,
+        },
+      },
+      matchStatsState: {
+        status: "loaded",
+        stats: aFakeMatchStatsWith(),
+        playerMap: new Map<string, string>([
+          ["1111111111", "TrackedPlayer"],
+          ["2222222222", "PlayerTwo"],
+          ["3333333333", "PlayerThree"],
+          ["4444444444", "PlayerFour"],
+        ]),
+        medalMetadata: aFakeMedalMetadata(),
+        analytics: null,
+      },
+      selectedMatchId: null,
+    });
+
+    const rows = model.tickerMatchGroups[0]?.rows ?? [];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.type).toBe("player");
+    expect(rows[0]?.name).toBe("TrackedPlayer");
+  });
+
+  it("shows only the tracked player row in-series ticker when inSeriesMyStatsOnly is enabled", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        timeline: [
+          {
+            type: "series",
+            series: aSeriesWith({
+              isActive: true,
+              matches: [aMatchWith({ matchId: "series-match-1" })],
+            }),
+          },
+        ],
+      }),
+      streamerSettings: {
+        styleFlags: {
+          inSeriesMyStatsOnly: true,
+        },
+      },
+      matchStatsState: {
+        status: "loaded",
+        stats: aFakeMatchStatsWith(),
+        playerMap: new Map<string, string>([
+          ["1111111111", "TrackedPlayer"],
+          ["2222222222", "PlayerTwo"],
+          ["3333333333", "PlayerThree"],
+          ["4444444444", "PlayerFour"],
+        ]),
+        medalMetadata: aFakeMedalMetadata(),
+        analytics: null,
+      },
+      selectedMatchId: "series-match-1",
+    });
+
+    const rows = model.tickerMatchGroups[0]?.rows ?? [];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.type).toBe("player");
+    expect(rows[0]?.name).toBe("TrackedPlayer");
   });
 });

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -45,7 +45,7 @@ describe("useIndividualTrackerViewer", () => {
 
     const initialSettings: StreamerViewSettings = {
       styleFlags: {
-        showMatchmakingStatsOnly: true,
+        matchmakingMyStatsOnly: true,
       },
     };
 
@@ -71,7 +71,7 @@ describe("useIndividualTrackerViewer", () => {
 
     const nextSettings: StreamerViewSettings = {
       styleFlags: {
-        showMatchmakingStatsOnly: true,
+        matchmakingMyStatsOnly: true,
       },
     };
 

--- a/shared/src/individual-tracker/streamer-view-settings.ts
+++ b/shared/src/individual-tracker/streamer-view-settings.ts
@@ -140,7 +140,8 @@ export const streamerViewStyleFlagsSchema = z.object({
   selectedSlayerStats: z.array(z.string()).optional(),
   showObjectiveStats: z.boolean().optional(),
   medalRarityFilter: z.array(z.number()).optional(),
-  showMatchmakingStatsOnly: z.boolean().optional(),
+  inSeriesMyStatsOnly: z.boolean().optional(),
+  matchmakingMyStatsOnly: z.boolean().optional(),
 });
 export type StreamerViewStyleFlags = z.infer<typeof streamerViewStyleFlagsSchema>;
 


### PR DESCRIPTION
## Context
This continues the individual-tracker overlay settings parity work by wiring streamer controls that let the ticker show only the tracked player's stats in the relevant context. The goal is context-aware behavior: separate controls for In Series and Matchmaking, with client-side filtering applied in the overlay ticker model.

## This PR
- Renames the latent setting key from `showMatchmakingStatsOnly` to `matchmakingMyStatsOnly`.
- Adds a companion setting `inSeriesMyStatsOnly`.
- Wires both settings through the streamer settings store/presenter load-save roundtrip.
- Adds two Information Ticker controls in the streamer settings UI:
  - In-Series: Show Only My Stats
  - Matchmaking: Show Only My Stats
- Applies client-side ticker filtering in the overlay presenter:
  - In series uses `inSeriesMyStatsOnly`
  - Matchmaking uses `matchmakingMyStatsOnly`
  - Falls back to unfiltered rows when tracked player resolution is unavailable
- Updates and adds focused regression tests for rename coverage, persistence, UI toggles, and overlay filtering behavior.
- Validation: `npm run done` is green.

Backward compatibility note:
- Backward compatibility for the old `showMatchmakingStatsOnly` key is intentionally not maintained in this PR because the feature is not live yet.

## Subsequent Work
- Restructure streamer settings UI into context-first sections (Global, In Series, Matchmaking).
- Complete remaining settings parity pass for context/section grouping and wording polish.