### PR TITLE
feat: reorganize streamer settings by overlay context

### DIFF
--- a/pages/src/components/individual-tracker-manager/create.tsx
+++ b/pages/src/components/individual-tracker-manager/create.tsx
@@ -124,6 +124,7 @@ export function IndividualTrackerManagerPage({
           tickerSettings={settingsSnapshot.tickerSettings}
           inSeriesShowTicker={settingsSnapshot.inSeriesShowTicker}
           matchmakingShowTicker={settingsSnapshot.matchmakingShowTicker}
+          matchmakingShowStatsHighlights={settingsSnapshot.matchmakingShowStatsHighlights}
           inSeriesMyStatsOnly={settingsSnapshot.inSeriesMyStatsOnly}
           matchmakingMyStatsOnly={settingsSnapshot.matchmakingMyStatsOnly}
           fontSizeSettings={settingsSnapshot.fontSizeSettings}
@@ -149,6 +150,9 @@ export function IndividualTrackerManagerPage({
           }}
           onMatchmakingShowTickerChange={(enabled): void => {
             settingsPresenter.setMatchmakingShowTicker(enabled);
+          }}
+          onMatchmakingShowStatsHighlightsChange={(enabled): void => {
+            settingsPresenter.setMatchmakingShowStatsHighlights(enabled);
           }}
           onInSeriesMyStatsOnlyChange={(enabled): void => {
             settingsPresenter.setInSeriesMyStatsOnly(enabled);

--- a/pages/src/components/individual-tracker-manager/create.tsx
+++ b/pages/src/components/individual-tracker-manager/create.tsx
@@ -122,6 +122,8 @@ export function IndividualTrackerManagerPage({
           observerEnemyColor={settingsSnapshot.observerEnemyColor}
           displaySettings={settingsSnapshot.displaySettings}
           tickerSettings={settingsSnapshot.tickerSettings}
+          inSeriesShowTicker={settingsSnapshot.inSeriesShowTicker}
+          matchmakingShowTicker={settingsSnapshot.matchmakingShowTicker}
           inSeriesMyStatsOnly={settingsSnapshot.inSeriesMyStatsOnly}
           matchmakingMyStatsOnly={settingsSnapshot.matchmakingMyStatsOnly}
           fontSizeSettings={settingsSnapshot.fontSizeSettings}
@@ -141,6 +143,12 @@ export function IndividualTrackerManagerPage({
           }}
           onTickerSettingsChange={(updates): void => {
             settingsPresenter.setTickerSettings(updates);
+          }}
+          onInSeriesShowTickerChange={(enabled): void => {
+            settingsPresenter.setInSeriesShowTicker(enabled);
+          }}
+          onMatchmakingShowTickerChange={(enabled): void => {
+            settingsPresenter.setMatchmakingShowTicker(enabled);
           }}
           onInSeriesMyStatsOnlyChange={(enabled): void => {
             settingsPresenter.setInSeriesMyStatsOnly(enabled);

--- a/pages/src/components/individual-tracker-manager/streamer-settings/create.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/create.tsx
@@ -45,6 +45,9 @@ export function StreamerSettingsSection({
       observerEnemyColor={snapshot.observerEnemyColor}
       displaySettings={snapshot.displaySettings}
       tickerSettings={snapshot.tickerSettings}
+      inSeriesShowTicker={snapshot.inSeriesShowTicker}
+      matchmakingShowTicker={snapshot.matchmakingShowTicker}
+      matchmakingShowStatsHighlights={snapshot.matchmakingShowStatsHighlights}
       inSeriesMyStatsOnly={snapshot.inSeriesMyStatsOnly}
       matchmakingMyStatsOnly={snapshot.matchmakingMyStatsOnly}
       fontSizeSettings={snapshot.fontSizeSettings}
@@ -64,6 +67,15 @@ export function StreamerSettingsSection({
       }}
       onTickerSettingsChange={(updates): void => {
         presenter.setTickerSettings(updates);
+      }}
+      onInSeriesShowTickerChange={(enabled): void => {
+        presenter.setInSeriesShowTicker(enabled);
+      }}
+      onMatchmakingShowTickerChange={(enabled): void => {
+        presenter.setMatchmakingShowTicker(enabled);
+      }}
+      onMatchmakingShowStatsHighlightsChange={(enabled): void => {
+        presenter.setMatchmakingShowStatsHighlights(enabled);
       }}
       onInSeriesMyStatsOnlyChange={(enabled): void => {
         presenter.setInSeriesMyStatsOnly(enabled);

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-presenter.ts
@@ -67,6 +67,11 @@ function settingsToSnapshot(
       showObjectiveStats: styleFlags.showObjectiveStats ?? snapshot.tickerSettings.showObjectiveStats,
       medalRarityFilter: styleFlags.medalRarityFilter ?? snapshot.tickerSettings.medalRarityFilter,
     },
+    inSeriesShowTicker: styleFlags.inSeriesShowTicker ?? visibleSections.showTicker ?? snapshot.inSeriesShowTicker,
+    matchmakingShowTicker:
+      styleFlags.matchmakingShowTicker ?? visibleSections.showTicker ?? snapshot.matchmakingShowTicker,
+    matchmakingShowStatsHighlights:
+      styleFlags.matchmakingShowStatsHighlights ?? snapshot.matchmakingShowStatsHighlights,
     inSeriesMyStatsOnly: styleFlags.inSeriesMyStatsOnly ?? snapshot.inSeriesMyStatsOnly,
     matchmakingMyStatsOnly: styleFlags.matchmakingMyStatsOnly ?? snapshot.matchmakingMyStatsOnly,
     fontSizeSettings: {
@@ -102,6 +107,9 @@ function snapshotToSettings(snapshot: StreamerSettingsSnapshot): StreamerViewSet
       selectedSlayerStats: [...snapshot.tickerSettings.selectedSlayerStats],
       showObjectiveStats: snapshot.tickerSettings.showObjectiveStats,
       medalRarityFilter: [...snapshot.tickerSettings.medalRarityFilter],
+      inSeriesShowTicker: snapshot.inSeriesShowTicker,
+      matchmakingShowTicker: snapshot.matchmakingShowTicker,
+      matchmakingShowStatsHighlights: snapshot.matchmakingShowStatsHighlights,
       inSeriesMyStatsOnly: snapshot.inSeriesMyStatsOnly,
       matchmakingMyStatsOnly: snapshot.matchmakingMyStatsOnly,
     },
@@ -217,6 +225,33 @@ export class StreamerSettingsPresenter {
     }
 
     this.config.store.batchUpdate({ matchmakingMyStatsOnly: enabled });
+    this.scheduleSave();
+  }
+
+  public setInSeriesShowTicker(enabled: boolean): void {
+    if (this.isDisposed) {
+      return;
+    }
+
+    this.config.store.batchUpdate({ inSeriesShowTicker: enabled });
+    this.scheduleSave();
+  }
+
+  public setMatchmakingShowTicker(enabled: boolean): void {
+    if (this.isDisposed) {
+      return;
+    }
+
+    this.config.store.batchUpdate({ matchmakingShowTicker: enabled });
+    this.scheduleSave();
+  }
+
+  public setMatchmakingShowStatsHighlights(enabled: boolean): void {
+    if (this.isDisposed) {
+      return;
+    }
+
+    this.config.store.batchUpdate({ matchmakingShowStatsHighlights: enabled });
     this.scheduleSave();
   }
 

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-store.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-store.ts
@@ -1,3 +1,7 @@
+import {
+  DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS,
+  INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT,
+} from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type {
   IndividualStatsHighlightOption,
   StreamerViewColorMode,
@@ -27,14 +31,17 @@ export interface StreamerSettingsSnapshot {
 }
 
 const DEFAULT_DISPLAY_SETTINGS: DisplaySettings = {
-  showTeamDetails: false,
-  showDiscordNames: true,
+  showTeamDetails: true,
+  showDiscordNames: false,
   showXboxNames: true,
   showServerIcon: true,
   showTitle: true,
   showSubtitle: true,
   showScore: true,
 };
+
+const DEFAULT_STATS_HIGHLIGHT_SLOTS: readonly IndividualStatsHighlightOption[] =
+  DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS.slice(0, INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT);
 
 const DEFAULT_TICKER_SETTINGS: TickerSettings = {
   showTicker: true,
@@ -73,7 +80,7 @@ export class StreamerSettingsStore {
       inSeriesMyStatsOnly: false,
       matchmakingMyStatsOnly: false,
       fontSizeSettings: DEFAULT_FONT_SIZE_SETTINGS,
-      statsHighlightSlots: [],
+      statsHighlightSlots: DEFAULT_STATS_HIGHLIGHT_SLOTS,
       saveStatus: "idle",
       saveErrorMessage: null,
     };

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-store.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-store.ts
@@ -15,6 +15,9 @@ export interface StreamerSettingsSnapshot {
   readonly observerEnemyColor: string;
   readonly displaySettings: DisplaySettings;
   readonly tickerSettings: TickerSettings;
+  readonly inSeriesShowTicker: boolean;
+  readonly matchmakingShowTicker: boolean;
+  readonly matchmakingShowStatsHighlights: boolean;
   readonly inSeriesMyStatsOnly: boolean;
   readonly matchmakingMyStatsOnly: boolean;
   readonly fontSizeSettings: FontSizeSettings;
@@ -64,6 +67,9 @@ export class StreamerSettingsStore {
       observerEnemyColor: "cerulean",
       displaySettings: DEFAULT_DISPLAY_SETTINGS,
       tickerSettings: DEFAULT_TICKER_SETTINGS,
+      inSeriesShowTicker: true,
+      matchmakingShowTicker: true,
+      matchmakingShowStatsHighlights: true,
       inSeriesMyStatsOnly: false,
       matchmakingMyStatsOnly: false,
       fontSizeSettings: DEFAULT_FONT_SIZE_SETTINGS,

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
@@ -158,6 +158,12 @@
   margin: 0;
 }
 
+.sectionDivider {
+  border: 0;
+  border-top: 1px solid color-mix(in srgb, var(--halo-teal-primary) 22%, transparent);
+  margin: var(--space-1) 0;
+}
+
 .floatingSaveToast {
   bottom: var(--space-4);
   max-width: min(26rem, calc(100vw - (var(--space-4) * 2)));

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
@@ -164,6 +164,18 @@
   margin: var(--space-1) 0;
 }
 
+.srOnly {
+  border: 0;
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 .floatingSaveToast {
   bottom: var(--space-4);
   max-width: min(26rem, calc(100vw - (var(--space-4) * 2)));

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
@@ -116,6 +116,11 @@
   opacity: 0.5;
 }
 
+.modeToggleButton:focus-visible {
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--halo-white) 88%, transparent);
+  outline: none;
+}
+
 .modeToggleButtonActive {
   background: color-mix(in srgb, var(--halo-teal-primary) 22%, transparent);
   color: var(--halo-white);

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
@@ -78,6 +78,56 @@
   gap: var(--space-2);
 }
 
+.modeToggle {
+  align-self: flex-start;
+  background: color-mix(in srgb, var(--halo-bg) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 35%, transparent);
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  max-width: 100%;
+  overflow: hidden;
+  width: fit-content;
+}
+
+.modeToggleButton {
+  background: transparent;
+  border: 0;
+  border-right: 1px solid color-mix(in srgb, var(--halo-teal-primary) 30%, transparent);
+  color: var(--halo-gray);
+  cursor: pointer;
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  min-height: 32px;
+  padding: var(--space-1) var(--space-4);
+  text-transform: uppercase;
+  transition:
+    background var(--transition-base) ease,
+    color var(--transition-base) ease;
+}
+
+.modeToggleButton:last-child {
+  border-right: 0;
+}
+
+.modeToggleButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.modeToggleButtonActive {
+  background: color-mix(in srgb, var(--halo-teal-primary) 22%, transparent);
+  color: var(--halo-white);
+}
+
+@media (--tablet-viewport) {
+  .modeToggleButton {
+    letter-spacing: 0.15em;
+    padding: var(--space-2) var(--space-6);
+  }
+}
+
 .pickerGrid {
   display: grid;
   gap: var(--space-3);
@@ -93,6 +143,19 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+}
+
+.subsection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.subsectionTitle {
+  color: var(--halo-white);
+  font-family: var(--font-heading);
+  font-size: var(--text-base);
+  margin: 0;
 }
 
 .floatingSaveToast {

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -292,6 +292,9 @@ export function StreamerSettingsSectionView({
             Observer Mode
           </button>
         </div>
+
+        <hr className={styles.sectionDivider} />
+
         <div className={styles.subsection}>
           <h4 className={styles.subsectionTitle}>Player Colors</h4>
           <p className={styles.cardDescription}>Used whenever color mode is set to player.</p>
@@ -318,6 +321,9 @@ export function StreamerSettingsSectionView({
             />
           </div>
         </div>
+
+        <hr className={styles.sectionDivider} />
+
         <div className={styles.subsection}>
           <h4 className={styles.subsectionTitle}>Observer Colors</h4>
           <p className={styles.cardDescription}>Global observer colors for fixed-team mode.</p>
@@ -344,6 +350,24 @@ export function StreamerSettingsSectionView({
             />
           </div>
         </div>
+
+        <hr className={styles.sectionDivider} />
+
+        <div className={styles.subsection}>
+          <h4 className={styles.subsectionTitle}>Information Ticker</h4>
+          <p className={styles.cardDescription}>
+            These ticker stat and medal filters apply to both In Series and Matchmaking ticker rows.
+          </p>
+        </div>
+        <TickerSettingsSection
+          settings={tickerSettings}
+          onChange={onTickerSettingsChange}
+          showTickerVisibilityToggle={false}
+          showPreSeriesInfoToggle={false}
+        />
+
+        <hr className={styles.sectionDivider} />
+
         <div className={styles.subsection}>
           <h4 className={styles.subsectionTitle}>Text Sizes</h4>
           <p className={styles.cardDescription}>Adjust the size of text for different sections.</p>
@@ -385,19 +409,6 @@ export function StreamerSettingsSectionView({
             }}
           />
         </div>
-
-        <div className={styles.subsection}>
-          <h4 className={styles.subsectionTitle}>Information Ticker</h4>
-          <p className={styles.cardDescription}>
-            These ticker stat and medal filters apply to both In Series and Matchmaking ticker rows.
-          </p>
-        </div>
-        <TickerSettingsSection
-          settings={tickerSettings}
-          onChange={onTickerSettingsChange}
-          showTickerVisibilityToggle={false}
-          showPreSeriesInfoToggle={false}
-        />
       </div>
 
       <div className={styles.card}>
@@ -412,6 +423,8 @@ export function StreamerSettingsSectionView({
           </p>
         </div>
         <DisplaySettingsSection settings={displaySettings} onChange={onDisplaySettingsChange} />
+
+        <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
           <h4 className={styles.subsectionTitle}>Bottom Section</h4>
@@ -464,6 +477,8 @@ export function StreamerSettingsSectionView({
           label="Show stats highlights"
           description="Controls top-bar stats in the overlay only. The Stats Highlights tab is the master source for which stats are available to viewers."
         />
+
+        <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
           <h4 className={styles.subsectionTitle}>Bottom Section</h4>

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -218,9 +218,9 @@ export function StreamerSettingsSectionView({
                 {copyTarget === "view" ? "Copied!" : "Copy"}
               </Button>
             </div>
-          </div>
 
-          <div className={styles.card}>
+            <hr className={styles.sectionDivider} />
+
             <h3 className={styles.cardTitle}>Overlay URL</h3>
             <p className={styles.cardDescription}>Use this in OBS as a Browser Source.</p>
             <p className={styles.urlText}>{urls?.overlayUrl}</p>

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -445,7 +445,12 @@ export function StreamerSettingsSectionView({
           onChange={(checked): void => {
             onInSeriesShowTickerChange(checked);
           }}
-          label="Show Information Ticker"
+          label={
+            <>
+              <span className={styles.srOnly}>In Series </span>
+              Show Information Ticker
+            </>
+          }
           description="Toggle ticker visibility for in-series overlay state."
         />
         <Checkbox
@@ -453,7 +458,12 @@ export function StreamerSettingsSectionView({
           onChange={(checked): void => {
             onInSeriesMyStatsOnlyChange(checked);
           }}
-          label="Show only my stats"
+          label={
+            <>
+              <span className={styles.srOnly}>In Series </span>
+              Show only my stats
+            </>
+          }
           description="When enabled, the ticker only rotates your player row during an active series."
         />
       </div>
@@ -489,7 +499,12 @@ export function StreamerSettingsSectionView({
           onChange={(checked): void => {
             onMatchmakingShowTickerChange(checked);
           }}
-          label="Show Information Ticker"
+          label={
+            <>
+              <span className={styles.srOnly}>Matchmaking </span>
+              Show Information Ticker
+            </>
+          }
           description="Toggle ticker visibility for matchmaking overlay state."
         />
         <Checkbox
@@ -497,7 +512,12 @@ export function StreamerSettingsSectionView({
           onChange={(checked): void => {
             onMatchmakingMyStatsOnlyChange(checked);
           }}
-          label="Show only my stats"
+          label={
+            <>
+              <span className={styles.srOnly}>Matchmaking </span>
+              Show only my stats
+            </>
+          }
           description="When enabled, the ticker only rotates your player row during matchmaking matches."
         />
       </div>

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import classNames from "classnames";
 import type { StreamerViewColorMode } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { Alert } from "../../alert/alert";
 import { Button } from "../../button/button";
@@ -56,6 +57,9 @@ export interface StreamerSettingsSectionViewProps {
   readonly observerEnemyColor: string;
   readonly displaySettings: DisplaySettings;
   readonly tickerSettings: TickerSettings;
+  readonly inSeriesShowTicker: boolean;
+  readonly matchmakingShowTicker: boolean;
+  readonly matchmakingShowStatsHighlights: boolean;
   readonly inSeriesMyStatsOnly: boolean;
   readonly matchmakingMyStatsOnly: boolean;
   readonly fontSizeSettings: FontSizeSettings;
@@ -66,6 +70,9 @@ export interface StreamerSettingsSectionViewProps {
   readonly onObserverColorsChange: (teamColor: string, enemyColor: string) => void;
   readonly onDisplaySettingsChange: (updates: Partial<DisplaySettings>) => void;
   readonly onTickerSettingsChange: (updates: Partial<TickerSettings>) => void;
+  readonly onInSeriesShowTickerChange: (enabled: boolean) => void;
+  readonly onMatchmakingShowTickerChange: (enabled: boolean) => void;
+  readonly onMatchmakingShowStatsHighlightsChange: (enabled: boolean) => void;
   readonly onInSeriesMyStatsOnlyChange: (enabled: boolean) => void;
   readonly onMatchmakingMyStatsOnlyChange: (enabled: boolean) => void;
   readonly onFontSizesChange: (updates: Partial<FontSizeSettings>) => void;
@@ -80,6 +87,9 @@ export function StreamerSettingsSectionView({
   observerEnemyColor,
   displaySettings,
   tickerSettings,
+  inSeriesShowTicker,
+  matchmakingShowTicker,
+  matchmakingShowStatsHighlights,
   inSeriesMyStatsOnly,
   matchmakingMyStatsOnly,
   fontSizeSettings,
@@ -90,6 +100,9 @@ export function StreamerSettingsSectionView({
   onObserverColorsChange,
   onDisplaySettingsChange,
   onTickerSettingsChange,
+  onInSeriesShowTickerChange,
+  onMatchmakingShowTickerChange,
+  onMatchmakingShowStatsHighlightsChange,
   onInSeriesMyStatsOnlyChange,
   onMatchmakingMyStatsOnlyChange,
   onFontSizesChange,
@@ -187,6 +200,8 @@ export function StreamerSettingsSectionView({
             <p className={styles.urlText}>{urls?.viewUrl}</p>
             <div className={styles.buttonRow}>
               <Button
+                variant="secondary"
+                size="small"
                 onClick={(): void => {
                   handleOpenUrl(urls?.viewUrl ?? "");
                 }}
@@ -194,6 +209,8 @@ export function StreamerSettingsSectionView({
                 Open viewer
               </Button>
               <Button
+                variant="secondary"
+                size="small"
                 onClick={(): void => {
                   handleCopy("view", urls?.viewUrl ?? "");
                 }}
@@ -209,6 +226,8 @@ export function StreamerSettingsSectionView({
             <p className={styles.urlText}>{urls?.overlayUrl}</p>
             <div className={styles.buttonRow}>
               <Button
+                variant="secondary"
+                size="small"
                 onClick={(): void => {
                   handleOpenUrl(urls?.overlayUrl ?? "");
                 }}
@@ -216,6 +235,8 @@ export function StreamerSettingsSectionView({
                 Open overlay
               </Button>
               <Button
+                variant="secondary"
+                size="small"
                 onClick={(): void => {
                   handleOpenUrl(buildOverlayPreviewUrl(urls?.overlayUrl ?? "", defaultColorMode));
                 }}
@@ -223,6 +244,8 @@ export function StreamerSettingsSectionView({
                 Open overlay with preview
               </Button>
               <Button
+                variant="secondary"
+                size="small"
                 onClick={(): void => {
                   handleCopy("overlay", urls?.overlayUrl ?? "");
                 }}
@@ -237,36 +260,42 @@ export function StreamerSettingsSectionView({
       <div className={styles.card}>
         <h3 className={styles.cardTitle}>Global Defaults</h3>
         <p className={styles.cardDescription}>These controls apply to both In Series and Matchmaking overlay states.</p>
-      </div>
-
-      <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Default Color Mode</h3>
-        <p className={styles.cardDescription}>Configure the default color mode for the overlay.</p>
-        <div className={styles.modeRow}>
-          <Button
-            variant={defaultColorMode === "player" ? "primary" : "secondary"}
+        <div className={styles.subsection}>
+          <h4 className={styles.subsectionTitle}>Default Color Mode</h4>
+          <p className={styles.cardDescription}>Configure the default color mode for the overlay.</p>
+        </div>
+        <div className={styles.modeToggle} role="group" aria-label="Default color mode">
+          <button
+            type="button"
+            aria-pressed={defaultColorMode === "player"}
             disabled={isSaving}
+            className={classNames(styles.modeToggleButton, {
+              [styles.modeToggleButtonActive]: defaultColorMode === "player",
+            })}
             onClick={(): void => {
               onDefaultColorModeChange("player");
             }}
           >
             Player Mode
-          </Button>
-          <Button
-            variant={defaultColorMode === "observer" ? "primary" : "secondary"}
+          </button>
+          <button
+            type="button"
+            aria-pressed={defaultColorMode === "observer"}
             disabled={isSaving}
+            className={classNames(styles.modeToggleButton, {
+              [styles.modeToggleButtonActive]: defaultColorMode === "observer",
+            })}
             onClick={(): void => {
               onDefaultColorModeChange("observer");
             }}
           >
             Observer Mode
-          </Button>
+          </button>
         </div>
-      </div>
-
-      <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Player Colors</h3>
-        <p className={styles.cardDescription}>Used whenever color mode is set to player.</p>
+        <div className={styles.subsection}>
+          <h4 className={styles.subsectionTitle}>Player Colors</h4>
+          <p className={styles.cardDescription}>Used whenever color mode is set to player.</p>
+        </div>
         <div className={styles.pickerGrid}>
           <div>
             <label className={styles.preferenceLabel}>Player team color</label>
@@ -289,11 +318,10 @@ export function StreamerSettingsSectionView({
             />
           </div>
         </div>
-      </div>
-
-      <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Observer Colors</h3>
-        <p className={styles.cardDescription}>Global observer colors for fixed-team mode.</p>
+        <div className={styles.subsection}>
+          <h4 className={styles.subsectionTitle}>Observer Colors</h4>
+          <p className={styles.cardDescription}>Global observer colors for fixed-team mode.</p>
+        </div>
         <div className={styles.pickerGrid}>
           <div>
             <label className={styles.preferenceLabel}>Eagle</label>
@@ -316,11 +344,10 @@ export function StreamerSettingsSectionView({
             />
           </div>
         </div>
-      </div>
-
-      <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Text Sizes</h3>
-        <p className={styles.cardDescription}>Adjust the size of text for different sections.</p>
+        <div className={styles.subsection}>
+          <h4 className={styles.subsectionTitle}>Text Sizes</h4>
+          <p className={styles.cardDescription}>Adjust the size of text for different sections.</p>
+        </div>
         <div className={styles.fontSizeContainer}>
           <FontSizeSlider
             label="Queue Info"
@@ -358,6 +385,19 @@ export function StreamerSettingsSectionView({
             }}
           />
         </div>
+
+        <div className={styles.subsection}>
+          <h4 className={styles.subsectionTitle}>Information Ticker</h4>
+          <p className={styles.cardDescription}>
+            These ticker stat and medal filters apply to both In Series and Matchmaking ticker rows.
+          </p>
+        </div>
+        <TickerSettingsSection
+          settings={tickerSettings}
+          onChange={onTickerSettingsChange}
+          showTickerVisibilityToggle={false}
+          showPreSeriesInfoToggle={false}
+        />
       </div>
 
       <div className={styles.card}>
@@ -365,21 +405,20 @@ export function StreamerSettingsSectionView({
         <p className={styles.cardDescription}>
           Controls in this section apply when the overlay is currently in a series.
         </p>
-      </div>
-
-      <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Top Section</h3>
-        <p className={styles.cardDescription}>
-          Control title, teams, and score display for in-series top bar rendering.
-        </p>
+        <div className={styles.subsection}>
+          <h4 className={styles.subsectionTitle}>Top Section</h4>
+          <p className={styles.cardDescription}>
+            Control title, teams, and score display for in-series top bar rendering.
+          </p>
+        </div>
         <DisplaySettingsSection settings={displaySettings} onChange={onDisplaySettingsChange} />
-      </div>
 
-      <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Bottom Section</h3>
-        <p className={styles.cardDescription}>
-          Configure in-series ticker behavior before and during active series match flow.
-        </p>
+        <div className={styles.subsection}>
+          <h4 className={styles.subsectionTitle}>Bottom Section</h4>
+          <p className={styles.cardDescription}>
+            Configure in-series ticker behavior before and during active series match flow.
+          </p>
+        </div>
         <Checkbox
           checked={tickerSettings.showPreSeriesInfo}
           onChange={(checked): void => {
@@ -389,11 +428,19 @@ export function StreamerSettingsSectionView({
           description="Show individual player info before the first match starts"
         />
         <Checkbox
+          checked={inSeriesShowTicker}
+          onChange={(checked): void => {
+            onInSeriesShowTickerChange(checked);
+          }}
+          label="Show Information Ticker"
+          description="Toggle ticker visibility for in-series overlay state."
+        />
+        <Checkbox
           checked={inSeriesMyStatsOnly}
           onChange={(checked): void => {
             onInSeriesMyStatsOnlyChange(checked);
           }}
-          label="In-Series: Show Only My Stats"
+          label="Show only my stats"
           description="When enabled, the ticker only rotates your player row during an active series."
         />
       </div>
@@ -403,32 +450,39 @@ export function StreamerSettingsSectionView({
         <p className={styles.cardDescription}>
           Controls in this section apply when no active series context is present.
         </p>
-      </div>
+        <div className={styles.subsection}>
+          <h4 className={styles.subsectionTitle}>Top Section</h4>
+          <p className={styles.cardDescription}>
+            Matchmaking top-section stats depend on Stats Highlights and this overlay visibility toggle.
+          </p>
+        </div>
+        <Checkbox
+          checked={matchmakingShowStatsHighlights}
+          onChange={(checked): void => {
+            onMatchmakingShowStatsHighlightsChange(checked);
+          }}
+          label="Show stats highlights"
+          description="Controls top-bar stats in the overlay only. The Stats Highlights tab is the master source for which stats are available to viewers."
+        />
 
-      <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Top Section</h3>
-        <p className={styles.cardDescription}>Matchmaking top section uses Stats Highlights configuration.</p>
-        <Alert variant="info">
-          Matchmaking top-section stats are configured in the Stats Highlights tab in this manager.
-        </Alert>
-      </div>
-
-      <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Bottom Section</h3>
-        <p className={styles.cardDescription}>
-          In the overlay at the bottom, the Information Ticker provides detailed insights at a glance.
-        </p>
-        <TickerSettingsSection
-          settings={tickerSettings}
-          onChange={onTickerSettingsChange}
-          showPreSeriesInfoToggle={false}
+        <div className={styles.subsection}>
+          <h4 className={styles.subsectionTitle}>Bottom Section</h4>
+          <p className={styles.cardDescription}>Configure matchmaking-only ticker behavior.</p>
+        </div>
+        <Checkbox
+          checked={matchmakingShowTicker}
+          onChange={(checked): void => {
+            onMatchmakingShowTickerChange(checked);
+          }}
+          label="Show Information Ticker"
+          description="Toggle ticker visibility for matchmaking overlay state."
         />
         <Checkbox
           checked={matchmakingMyStatsOnly}
           onChange={(checked): void => {
             onMatchmakingMyStatsOnlyChange(checked);
           }}
-          label="Matchmaking: Show Only My Stats"
+          label="Show only my stats"
           description="When enabled, the ticker only rotates your player row during matchmaking matches."
         />
       </div>
@@ -444,8 +498,6 @@ export function StreamerSettingsSectionView({
           )}
         </div>
       ) : null}
-
-      <Alert variant="info">Twitch automation and advanced overlay presets remain in the next Phase 4 slice.</Alert>
     </div>
   );
 }

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -235,7 +235,12 @@ export function StreamerSettingsSectionView({
       )}
 
       <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Presentation defaults</h3>
+        <h3 className={styles.cardTitle}>Global Defaults</h3>
+        <p className={styles.cardDescription}>These controls apply to both In Series and Matchmaking overlay states.</p>
+      </div>
+
+      <div className={styles.card}>
+        <h3 className={styles.cardTitle}>Default Color Mode</h3>
         <p className={styles.cardDescription}>Configure the default color mode for the overlay.</p>
         <div className={styles.modeRow}>
           <Button
@@ -260,7 +265,7 @@ export function StreamerSettingsSectionView({
       </div>
 
       <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Player View Colors</h3>
+        <h3 className={styles.cardTitle}>Player Colors</h3>
         <p className={styles.cardDescription}>Used whenever color mode is set to player.</p>
         <div className={styles.pickerGrid}>
           <div>
@@ -287,7 +292,7 @@ export function StreamerSettingsSectionView({
       </div>
 
       <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Observer View Colors</h3>
+        <h3 className={styles.cardTitle}>Observer Colors</h3>
         <p className={styles.cardDescription}>Global observer colors for fixed-team mode.</p>
         <div className={styles.pickerGrid}>
           <div>
@@ -311,36 +316,6 @@ export function StreamerSettingsSectionView({
             />
           </div>
         </div>
-      </div>
-
-      <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Display Options</h3>
-        <p className={styles.cardDescription}>Control what information is shown on the viewer and overlay.</p>
-        <DisplaySettingsSection settings={displaySettings} onChange={onDisplaySettingsChange} />
-      </div>
-
-      <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Information Ticker</h3>
-        <p className={styles.cardDescription}>
-          In the overlay at the bottom, the Information Ticker provides detailed insights at a glance.
-        </p>
-        <TickerSettingsSection settings={tickerSettings} onChange={onTickerSettingsChange} />
-        <Checkbox
-          checked={inSeriesMyStatsOnly}
-          onChange={(checked): void => {
-            onInSeriesMyStatsOnlyChange(checked);
-          }}
-          label="In-Series: Show Only My Stats"
-          description="When enabled, the ticker only rotates your player row during an active series."
-        />
-        <Checkbox
-          checked={matchmakingMyStatsOnly}
-          onChange={(checked): void => {
-            onMatchmakingMyStatsOnlyChange(checked);
-          }}
-          label="Matchmaking: Show Only My Stats"
-          description="When enabled, the ticker only rotates your player row during matchmaking matches."
-        />
       </div>
 
       <div className={styles.card}>
@@ -383,6 +358,79 @@ export function StreamerSettingsSectionView({
             }}
           />
         </div>
+      </div>
+
+      <div className={styles.card}>
+        <h3 className={styles.cardTitle}>In Series UI</h3>
+        <p className={styles.cardDescription}>
+          Controls in this section apply when the overlay is currently in a series.
+        </p>
+      </div>
+
+      <div className={styles.card}>
+        <h3 className={styles.cardTitle}>Top Section</h3>
+        <p className={styles.cardDescription}>
+          Control title, teams, and score display for in-series top bar rendering.
+        </p>
+        <DisplaySettingsSection settings={displaySettings} onChange={onDisplaySettingsChange} />
+      </div>
+
+      <div className={styles.card}>
+        <h3 className={styles.cardTitle}>Bottom Section</h3>
+        <p className={styles.cardDescription}>
+          Configure in-series ticker behavior before and during active series match flow.
+        </p>
+        <Checkbox
+          checked={tickerSettings.showPreSeriesInfo}
+          onChange={(checked): void => {
+            onTickerSettingsChange({ showPreSeriesInfo: checked });
+          }}
+          label="Display Pre-Series Player Info"
+          description="Show individual player info before the first match starts"
+        />
+        <Checkbox
+          checked={inSeriesMyStatsOnly}
+          onChange={(checked): void => {
+            onInSeriesMyStatsOnlyChange(checked);
+          }}
+          label="In-Series: Show Only My Stats"
+          description="When enabled, the ticker only rotates your player row during an active series."
+        />
+      </div>
+
+      <div className={styles.card}>
+        <h3 className={styles.cardTitle}>Matchmaking UI</h3>
+        <p className={styles.cardDescription}>
+          Controls in this section apply when no active series context is present.
+        </p>
+      </div>
+
+      <div className={styles.card}>
+        <h3 className={styles.cardTitle}>Top Section</h3>
+        <p className={styles.cardDescription}>Matchmaking top section uses Stats Highlights configuration.</p>
+        <Alert variant="info">
+          Matchmaking top-section stats are configured in the Stats Highlights tab in this manager.
+        </Alert>
+      </div>
+
+      <div className={styles.card}>
+        <h3 className={styles.cardTitle}>Bottom Section</h3>
+        <p className={styles.cardDescription}>
+          In the overlay at the bottom, the Information Ticker provides detailed insights at a glance.
+        </p>
+        <TickerSettingsSection
+          settings={tickerSettings}
+          onChange={onTickerSettingsChange}
+          showPreSeriesInfoToggle={false}
+        />
+        <Checkbox
+          checked={matchmakingMyStatsOnly}
+          onChange={(checked): void => {
+            onMatchmakingMyStatsOnlyChange(checked);
+          }}
+          label="Matchmaking: Show Only My Stats"
+          description="When enabled, the ticker only rotates your player row during matchmaking matches."
+        />
       </div>
 
       {showSaveToast ? (

--- a/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings-presenter.test.ts
@@ -82,6 +82,9 @@ describe("StreamerSettingsPresenter", () => {
           visibleSections: { showTicker: false, showTabs: false },
           styleFlags: {
             showPreSeriesInfo: false,
+            inSeriesShowTicker: false,
+            matchmakingShowTicker: true,
+            matchmakingShowStatsHighlights: false,
             inSeriesMyStatsOnly: true,
             matchmakingMyStatsOnly: true,
           },
@@ -92,6 +95,9 @@ describe("StreamerSettingsPresenter", () => {
       expect(store.getSnapshot().tickerSettings.showTicker).toBe(false);
       expect(store.getSnapshot().tickerSettings.showTabs).toBe(false);
       expect(store.getSnapshot().tickerSettings.showPreSeriesInfo).toBe(false);
+      expect(store.getSnapshot().inSeriesShowTicker).toBe(false);
+      expect(store.getSnapshot().matchmakingShowTicker).toBe(true);
+      expect(store.getSnapshot().matchmakingShowStatsHighlights).toBe(false);
       expect(store.getSnapshot().inSeriesMyStatsOnly).toBe(true);
       expect(store.getSnapshot().matchmakingMyStatsOnly).toBe(true);
     });
@@ -298,6 +304,63 @@ describe("StreamerSettingsPresenter", () => {
 
       const [[saved]] = updateSpy.mock.calls;
       expect(saved.styleFlags?.matchmakingMyStatsOnly).toBe(true);
+    });
+  });
+
+  describe("setInSeriesShowTicker", () => {
+    it("updates inSeriesShowTicker in the store and schedules a save", async () => {
+      const { store, presenter, settingsService } = aHarness();
+      const updateSpy: MockInstance<typeof settingsService.updateSettings> = vi.spyOn(
+        settingsService,
+        "updateSettings",
+      );
+
+      presenter.setInSeriesShowTicker(false);
+
+      expect(store.getSnapshot().inSeriesShowTicker).toBe(false);
+
+      await vi.runAllTimersAsync();
+
+      const [[saved]] = updateSpy.mock.calls;
+      expect(saved.styleFlags?.inSeriesShowTicker).toBe(false);
+    });
+  });
+
+  describe("setMatchmakingShowTicker", () => {
+    it("updates matchmakingShowTicker in the store and schedules a save", async () => {
+      const { store, presenter, settingsService } = aHarness();
+      const updateSpy: MockInstance<typeof settingsService.updateSettings> = vi.spyOn(
+        settingsService,
+        "updateSettings",
+      );
+
+      presenter.setMatchmakingShowTicker(false);
+
+      expect(store.getSnapshot().matchmakingShowTicker).toBe(false);
+
+      await vi.runAllTimersAsync();
+
+      const [[saved]] = updateSpy.mock.calls;
+      expect(saved.styleFlags?.matchmakingShowTicker).toBe(false);
+    });
+  });
+
+  describe("setMatchmakingShowStatsHighlights", () => {
+    it("updates matchmakingShowStatsHighlights in the store and schedules a save", async () => {
+      const { store, presenter, settingsService } = aHarness();
+      const updateSpy: MockInstance<typeof settingsService.updateSettings> = vi.spyOn(
+        settingsService,
+        "updateSettings",
+      );
+
+      presenter.setMatchmakingShowStatsHighlights(false);
+
+      expect(store.getSnapshot().matchmakingShowStatsHighlights).toBe(false);
+
+      await vi.runAllTimersAsync();
+
+      const [[saved]] = updateSpy.mock.calls;
+      expect(saved.styleFlags?.matchmakingShowStatsHighlights).toBe(false);
     });
   });
 

--- a/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
@@ -65,6 +65,9 @@ function aFakeProps(overrides?: Partial<StreamerSettingsSectionViewProps>): Stre
     observerEnemyColor: "cerulean",
     displaySettings: DEFAULT_DISPLAY_SETTINGS,
     tickerSettings: DEFAULT_TICKER_SETTINGS,
+    inSeriesShowTicker: true,
+    matchmakingShowTicker: true,
+    matchmakingShowStatsHighlights: true,
     inSeriesMyStatsOnly: false,
     matchmakingMyStatsOnly: false,
     fontSizeSettings: DEFAULT_FONT_SIZE_SETTINGS,
@@ -75,6 +78,9 @@ function aFakeProps(overrides?: Partial<StreamerSettingsSectionViewProps>): Stre
     onObserverColorsChange: (): void => undefined,
     onDisplaySettingsChange: (): void => undefined,
     onTickerSettingsChange: (): void => undefined,
+    onInSeriesShowTickerChange: (): void => undefined,
+    onMatchmakingShowTickerChange: (): void => undefined,
+    onMatchmakingShowStatsHighlightsChange: (): void => undefined,
     onInSeriesMyStatsOnlyChange: (): void => undefined,
     onMatchmakingMyStatsOnlyChange: (): void => undefined,
     onFontSizesChange: (): void => undefined,
@@ -147,6 +153,8 @@ describe("StreamerSettingsSectionView", () => {
 
       const observerBtn = screen.getByRole("button", { name: "Observer Mode" });
       expect(observerBtn).toBeInTheDocument();
+      expect(observerBtn).toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByRole("button", { name: "Player Mode" })).toHaveAttribute("aria-pressed", "false");
     });
 
     it("calls onDefaultColorModeChange when Player Mode is clicked", async () => {
@@ -262,9 +270,23 @@ describe("StreamerSettingsSectionView", () => {
     it("renders matchmaking top-section guidance for stats highlights", () => {
       render(<StreamerSettingsSectionView {...aFakeProps()} />);
 
+      expect(screen.getByText("Show stats highlights")).toBeInTheDocument();
       expect(
-        screen.getByText("Matchmaking top-section stats are configured in the Stats Highlights tab in this manager."),
+        screen.getByText(
+          "Controls top-bar stats in the overlay only. The Stats Highlights tab is the master source for which stats are available to viewers.",
+        ),
       ).toBeInTheDocument();
+    });
+
+    it("calls onMatchmakingShowStatsHighlightsChange when the matchmaking stats highlights toggle is clicked", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn<(enabled: boolean) => void>();
+
+      render(<StreamerSettingsSectionView {...aFakeProps({ onMatchmakingShowStatsHighlightsChange: onChange })} />);
+
+      await user.click(screen.getByText("Show stats highlights"));
+
+      expect(onChange).toHaveBeenCalledWith(false);
     });
 
     it("calls onInSeriesMyStatsOnlyChange when the in-series toggle is clicked", async () => {
@@ -273,7 +295,8 @@ describe("StreamerSettingsSectionView", () => {
 
       render(<StreamerSettingsSectionView {...aFakeProps({ onInSeriesMyStatsOnlyChange: onChange })} />);
 
-      await user.click(screen.getByText("In-Series: Show Only My Stats"));
+      const labels = screen.getAllByText("Show only my stats");
+      await user.click(labels[0]);
 
       expect(onChange).toHaveBeenCalledWith(true);
     });
@@ -284,9 +307,34 @@ describe("StreamerSettingsSectionView", () => {
 
       render(<StreamerSettingsSectionView {...aFakeProps({ onMatchmakingMyStatsOnlyChange: onChange })} />);
 
-      await user.click(screen.getByText("Matchmaking: Show Only My Stats"));
+      const labels = screen.getAllByText("Show only my stats");
+      await user.click(labels[1]);
 
       expect(onChange).toHaveBeenCalledWith(true);
+    });
+
+    it("calls onInSeriesShowTickerChange when the in-series ticker toggle is clicked", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn<(enabled: boolean) => void>();
+
+      render(<StreamerSettingsSectionView {...aFakeProps({ onInSeriesShowTickerChange: onChange })} />);
+
+      const labels = screen.getAllByText("Show Information Ticker");
+      await user.click(labels[0]);
+
+      expect(onChange).toHaveBeenCalledWith(false);
+    });
+
+    it("calls onMatchmakingShowTickerChange when the matchmaking ticker toggle is clicked", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn<(enabled: boolean) => void>();
+
+      render(<StreamerSettingsSectionView {...aFakeProps({ onMatchmakingShowTickerChange: onChange })} />);
+
+      const labels = screen.getAllByText("Show Information Ticker");
+      await user.click(labels[1]);
+
+      expect(onChange).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
@@ -295,8 +295,7 @@ describe("StreamerSettingsSectionView", () => {
 
       render(<StreamerSettingsSectionView {...aFakeProps({ onInSeriesMyStatsOnlyChange: onChange })} />);
 
-      const labels = screen.getAllByText("Show only my stats");
-      await user.click(labels[0]);
+      await user.click(screen.getByRole("checkbox", { name: /in series\s*show only my stats/i }));
 
       expect(onChange).toHaveBeenCalledWith(true);
     });
@@ -307,8 +306,7 @@ describe("StreamerSettingsSectionView", () => {
 
       render(<StreamerSettingsSectionView {...aFakeProps({ onMatchmakingMyStatsOnlyChange: onChange })} />);
 
-      const labels = screen.getAllByText("Show only my stats");
-      await user.click(labels[1]);
+      await user.click(screen.getByRole("checkbox", { name: /matchmaking\s*show only my stats/i }));
 
       expect(onChange).toHaveBeenCalledWith(true);
     });
@@ -319,8 +317,7 @@ describe("StreamerSettingsSectionView", () => {
 
       render(<StreamerSettingsSectionView {...aFakeProps({ onInSeriesShowTickerChange: onChange })} />);
 
-      const labels = screen.getAllByText("Show Information Ticker");
-      await user.click(labels[0]);
+      await user.click(screen.getByRole("checkbox", { name: /in series\s*show information ticker/i }));
 
       expect(onChange).toHaveBeenCalledWith(false);
     });
@@ -331,8 +328,7 @@ describe("StreamerSettingsSectionView", () => {
 
       render(<StreamerSettingsSectionView {...aFakeProps({ onMatchmakingShowTickerChange: onChange })} />);
 
-      const labels = screen.getAllByText("Show Information Ticker");
-      await user.click(labels[1]);
+      await user.click(screen.getByRole("checkbox", { name: /matchmaking\s*show information ticker/i }));
 
       expect(onChange).toHaveBeenCalledWith(false);
     });

--- a/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
@@ -251,6 +251,22 @@ describe("StreamerSettingsSectionView", () => {
       expect(screen.getByTestId("color-picker-Cobra")).toBeInTheDocument();
     });
 
+    it("renders context-first section headings", () => {
+      render(<StreamerSettingsSectionView {...aFakeProps()} />);
+
+      expect(screen.getByRole("heading", { name: "Global Defaults" })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "In Series UI" })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Matchmaking UI" })).toBeInTheDocument();
+    });
+
+    it("renders matchmaking top-section guidance for stats highlights", () => {
+      render(<StreamerSettingsSectionView {...aFakeProps()} />);
+
+      expect(
+        screen.getByText("Matchmaking top-section stats are configured in the Stats Highlights tab in this manager."),
+      ).toBeInTheDocument();
+    });
+
     it("calls onInSeriesMyStatsOnlyChange when the in-series toggle is clicked", async () => {
       const user = userEvent.setup();
       const onChange = vi.fn<(enabled: boolean) => void>();

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -204,12 +204,18 @@ export class IndividualTrackerOverlayPresenter {
 
   public buildPreSeriesTickerGroup(options: {
     readonly showTicker: boolean;
+    readonly showPreSeriesInfo: boolean;
     readonly activeSeries: ViewerSeriesTab | null;
     readonly playerName: string;
     readonly discordName: string | null;
     readonly gamertag: string | null;
   }): TickerMatchGroup[] {
-    if (!options.showTicker || options.activeSeries == null || options.activeSeries.matches.length > 0) {
+    if (
+      !options.showTicker ||
+      !options.showPreSeriesInfo ||
+      options.activeSeries == null ||
+      options.activeSeries.matches.length > 0
+    ) {
       return [];
     }
 
@@ -259,6 +265,7 @@ export class IndividualTrackerOverlayPresenter {
         ? loadedTickerGroups
         : this.buildPreSeriesTickerGroup({
             showTicker,
+            showPreSeriesInfo: streamerSettings?.styleFlags?.showPreSeriesInfo ?? true,
             activeSeries,
             playerName: renderModel.gamertag,
             discordName: null,

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -247,6 +247,7 @@ export class IndividualTrackerOverlayPresenter {
     const fontSizeStyles = getFontSizeStyles(streamerSettings);
     const teamColors = this.getTeamColors(renderModel);
     const activeSeries = this.getOverlayActiveSeries(renderModel);
+    const showTicker = this.getShowTicker(streamerSettings, activeSeries, displaySettings.showTicker);
     const tabs = this.buildTabs(renderModel.timeline, activeSeries);
     const selectedTabIndex = this.getSelectedTabIndex(tabs, selectedMatchId);
     const loadedTickerGroups = this.buildTickerGroups(matchStatsState, selectedTabIndex, {
@@ -257,7 +258,7 @@ export class IndividualTrackerOverlayPresenter {
       loadedTickerGroups.length > 0
         ? loadedTickerGroups
         : this.buildPreSeriesTickerGroup({
-            showTicker: displaySettings.showTicker,
+            showTicker,
             activeSeries,
             playerName: renderModel.gamertag,
             discordName: null,
@@ -267,15 +268,31 @@ export class IndividualTrackerOverlayPresenter {
     return {
       pinTopSection: activeSeries != null,
       topSection: activeSeries != null ? this.getTopSectionModel(activeSeries, displaySettings) : null,
-      statsHighlights: renderModel.statsHighlights ?? [],
+      statsHighlights: this.getMatchmakingStatsHighlights(streamerSettings, activeSeries, renderModel.statsHighlights),
       teamColors,
       tabs,
       tickerMatchGroups,
       showTabs: displaySettings.showTabs && this.getShowTabs(renderModel),
-      showTicker: displaySettings.showTicker,
+      showTicker,
       showPreSeriesInfo: tickerMatchGroups.length > 0 && activeSeries?.matches.length === 0,
       fontSizeStyles,
     };
+  }
+
+  private getMatchmakingStatsHighlights(
+    streamerSettings: StreamerViewSettings | undefined,
+    activeSeries: ViewerSeriesTab | null,
+    statsHighlights: IndividualTrackerViewerRenderModel["statsHighlights"],
+  ): IndividualTrackerOverlayViewModel["statsHighlights"] {
+    if (activeSeries != null) {
+      return [];
+    }
+
+    if (streamerSettings?.styleFlags?.matchmakingShowStatsHighlights === false) {
+      return [];
+    }
+
+    return statsHighlights ?? [];
   }
 
   private getOverlayActiveSeries(renderModel: IndividualTrackerViewerRenderModel): ViewerSeriesTab | null {
@@ -386,6 +403,18 @@ export class IndividualTrackerOverlayPresenter {
     }
 
     return streamerSettings?.styleFlags?.matchmakingMyStatsOnly === true;
+  }
+
+  private getShowTicker(
+    streamerSettings: StreamerViewSettings | undefined,
+    activeSeries: ViewerSeriesTab | null,
+    fallbackShowTicker: boolean,
+  ): boolean {
+    if (activeSeries != null) {
+      return streamerSettings?.styleFlags?.inSeriesShowTicker ?? fallbackShowTicker;
+    }
+
+    return streamerSettings?.styleFlags?.matchmakingShowTicker ?? fallbackShowTicker;
   }
 
   private filterRowsForTrackedPlayer(

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -206,7 +206,7 @@ export class IndividualTrackerOverlayPresenter {
     readonly showTicker: boolean;
     readonly showPreSeriesInfo: boolean;
     readonly activeSeries: ViewerSeriesTab | null;
-    readonly playerName: string;
+    readonly playerName: string | null;
     readonly discordName: string | null;
     readonly gamertag: string | null;
   }): TickerMatchGroup[] {
@@ -267,7 +267,7 @@ export class IndividualTrackerOverlayPresenter {
             showTicker,
             showPreSeriesInfo: streamerSettings?.styleFlags?.showPreSeriesInfo ?? true,
             activeSeries,
-            playerName: renderModel.gamertag,
+            playerName: displaySettings.showXboxNames ? renderModel.gamertag : null,
             discordName: null,
             gamertag: displaySettings.showXboxNames ? renderModel.gamertag : null,
           });
@@ -439,6 +439,9 @@ export class IndividualTrackerOverlayPresenter {
 
     const trackedPlayerRows = rows.filter((row) => {
       if (row.type !== "player") {
+        return false;
+      }
+      if (row.name == null) {
         return false;
       }
 

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -317,6 +317,38 @@ describe("individual-tracker-overlay-presenter", () => {
     ]);
   });
 
+  it("shows matchmaking stats highlights by default when provided by viewer settings", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        statsHighlights: [{ label: "KDA", value: "3.2" }],
+      }),
+      streamerSettings: undefined,
+      matchStatsState: null,
+      selectedMatchId: null,
+    });
+
+    expect(model.topSection).toBeNull();
+    expect(model.statsHighlights).toEqual([{ label: "KDA", value: "3.2" }]);
+  });
+
+  it("hides matchmaking stats highlights when overlay toggle is disabled", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        statsHighlights: [{ label: "KDA", value: "3.2" }],
+      }),
+      streamerSettings: {
+        styleFlags: {
+          matchmakingShowStatsHighlights: false,
+        },
+      } satisfies StreamerViewSettings,
+      matchStatsState: null,
+      selectedMatchId: null,
+    });
+
+    expect(model.topSection).toBeNull();
+    expect(model.statsHighlights).toEqual([]);
+  });
+
   it("shows only the tracked player row in matchmaking ticker when matchmakingMyStatsOnly is enabled", () => {
     const model = presenter.present({
       renderModel: aRenderModelWith(),
@@ -383,5 +415,45 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]?.type).toBe("player");
     expect(rows[0]?.name).toBe("TrackedPlayer");
+  });
+
+  it("hides ticker in-series when inSeriesShowTicker is false", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        timeline: [
+          {
+            type: "series",
+            series: aSeriesWith({
+              isActive: true,
+              matches: [aMatchWith({ matchId: "series-match-1" })],
+            }),
+          },
+        ],
+      }),
+      streamerSettings: {
+        styleFlags: {
+          inSeriesShowTicker: false,
+        },
+      },
+      matchStatsState: null,
+      selectedMatchId: null,
+    });
+
+    expect(model.showTicker).toBe(false);
+  });
+
+  it("hides ticker in matchmaking when matchmakingShowTicker is false", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith(),
+      streamerSettings: {
+        styleFlags: {
+          matchmakingShowTicker: false,
+        },
+      },
+      matchStatsState: null,
+      selectedMatchId: null,
+    });
+
+    expect(model.showTicker).toBe(false);
   });
 });

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -179,6 +179,7 @@ describe("individual-tracker-overlay-presenter", () => {
   it("builds pre-series ticker group only when ticker is enabled and active series has no matches", () => {
     const groups = presenter.buildPreSeriesTickerGroup({
       showTicker: true,
+      showPreSeriesInfo: true,
       activeSeries: aSeriesWith({ matches: [], isActive: true }),
       playerName: "TrackedPlayer",
       discordName: null,
@@ -189,6 +190,19 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(groups[0].label).toBe("Player Info");
     expect(groups[0].rows[0].showTeamIcon).toBe(false);
     expect(groups[0].rows[0].gamertag).toBe("TrackedPlayer");
+  });
+
+  it("hides the pre-series ticker group when pre-series info is disabled", () => {
+    const groups = presenter.buildPreSeriesTickerGroup({
+      showTicker: true,
+      showPreSeriesInfo: false,
+      activeSeries: aSeriesWith({ matches: [], isActive: true }),
+      playerName: "TrackedPlayer",
+      discordName: null,
+      gamertag: "TrackedPlayer",
+    });
+
+    expect(groups).toHaveLength(0);
   });
 
   it("maps pre-series tracked-player ticker row to the tracked-player color slot", () => {

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -312,8 +312,8 @@ describe("individual-tracker-overlay-presenter", () => {
     });
 
     expect(model.topSection?.teamLeft?.players).toEqual([
-      { key: "Same:Tag", label: "Same" },
-      { key: "Same:Tag:1", label: "Same" },
+      { key: "Same:Tag", label: "Tag" },
+      { key: "Same:Tag:1", label: "Tag" },
     ]);
   });
 

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -211,7 +211,7 @@ describe("IndividualTrackerOverlay", () => {
     );
 
     expect(screen.getByText("Alpha")).toBeInTheDocument();
-    expect(screen.getByText("Discord Name")).toBeInTheDocument();
+    expect(screen.getByText("Gamertag Name")).toBeInTheDocument();
     expect(screen.getByText("Xbox Only")).toBeInTheDocument();
     expect(screen.getByText("Beta")).toBeInTheDocument();
     expect(screen.getByText("Unknown")).toBeInTheDocument();

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -321,6 +321,31 @@ describe("IndividualTrackerOverlay", () => {
     expect(screen.queryByTestId("team-icon-0")).not.toBeInTheDocument();
   });
 
+  it("hides the tracked gamertag in pre-series ticker when xbox names are hidden", () => {
+    const renderModel = aRenderModel({
+      gamertag: "TrackedPlayer",
+      hasActiveSeries: true,
+      activeSeriesContext: {
+        title: "Alpha vs Beta",
+        subtitle: "Bo3",
+        teams: [],
+      },
+      matches: [],
+      series: [],
+    });
+    const streamerSettings: StreamerViewSettings = {
+      visibleSections: {
+        showTicker: true,
+        showXboxNames: false,
+      },
+    };
+
+    render(<IndividualTrackerOverlay {...aPropsWith({ renderModel, streamerSettings })} />);
+
+    expect(screen.getByText("Player Info")).toBeInTheDocument();
+    expect(screen.queryByText("TrackedPlayer")).not.toBeInTheDocument();
+  });
+
   it("respects visibility settings for tabs and top section content", () => {
     const renderModel = aRenderModel({
       hasActiveSeries: true,

--- a/pages/src/components/individual-tracker/overlay/types.ts
+++ b/pages/src/components/individual-tracker/overlay/types.ts
@@ -58,7 +58,7 @@ export function getOverlayDisplaySettings(streamerSettings: StreamerViewSettings
     showSubtitle: visibleSections?.showSubtitle ?? true,
     showScore: visibleSections?.showScore ?? true,
     showTeamDetails: visibleSections?.showTeamDetails ?? true,
-    showDiscordNames: visibleSections?.showDiscordNames ?? true,
+    showDiscordNames: visibleSections?.showDiscordNames ?? false,
     showXboxNames: visibleSections?.showXboxNames ?? true,
   };
 }

--- a/pages/src/components/information-ticker/information-ticker.tsx
+++ b/pages/src/components/information-ticker/information-ticker.tsx
@@ -12,7 +12,7 @@ interface TickerStatRow {
   readonly type: "team" | "player";
   readonly teamId: number;
   readonly showTeamIcon?: boolean;
-  readonly name: string;
+  readonly name: string | null;
   readonly discordName?: string | null;
   readonly gamertag?: string | null;
   readonly stats: MatchStatsValues[];
@@ -89,9 +89,9 @@ const InformationTickerComponent = function InformationTicker({
                 gamertag={currentRow.gamertag ?? null}
                 showIcons={false}
               />
-            ) : (
+            ) : currentRow.name != null ? (
               <span>{currentRow.name}</span>
-            )}
+            ) : null}
           </div>
         </div>
 

--- a/pages/src/components/live-tracker/settings/ticker-settings-section.tsx
+++ b/pages/src/components/live-tracker/settings/ticker-settings-section.tsx
@@ -16,9 +16,16 @@ function formatStatName(stat: string): string {
 interface TickerSettingsSectionProps {
   readonly settings: TickerSettings;
   readonly onChange: (updates: Partial<TickerSettings>) => void;
+  readonly showTickerVisibilityToggle?: boolean;
+  readonly showPreSeriesInfoToggle?: boolean;
 }
 
-export function TickerSettingsSection({ settings, onChange }: TickerSettingsSectionProps): React.ReactElement {
+export function TickerSettingsSection({
+  settings,
+  onChange,
+  showTickerVisibilityToggle = true,
+  showPreSeriesInfoToggle = true,
+}: TickerSettingsSectionProps): React.ReactElement {
   const handleStatToggle = (stat: string): void => {
     const isEnabled = settings.selectedSlayerStats.includes(stat);
     const newStats = isEnabled
@@ -45,13 +52,15 @@ export function TickerSettingsSection({ settings, onChange }: TickerSettingsSect
 
   return (
     <div className={styles.container}>
-      <Checkbox
-        checked={settings.showTicker}
-        onChange={(checked): void => {
-          onChange({ showTicker: checked });
-        }}
-        label="Show Information Ticker"
-      />
+      {showTickerVisibilityToggle ? (
+        <Checkbox
+          checked={settings.showTicker}
+          onChange={(checked): void => {
+            onChange({ showTicker: checked });
+          }}
+          label="Show Information Ticker"
+        />
+      ) : null}
 
       {/* Stats Selection */}
       <div className={styles.section}>
@@ -114,16 +123,18 @@ export function TickerSettingsSection({ settings, onChange }: TickerSettingsSect
       </div>
 
       {/* Pre-Series Info Toggle */}
-      <div className={styles.section}>
-        <Checkbox
-          checked={settings.showPreSeriesInfo}
-          onChange={(checked): void => {
-            onChange({ showPreSeriesInfo: checked });
-          }}
-          label="Display Pre-Series Player Info"
-          description="Show individual player info before the first match starts"
-        />
-      </div>
+      {showPreSeriesInfoToggle ? (
+        <div className={styles.section}>
+          <Checkbox
+            checked={settings.showPreSeriesInfo}
+            onChange={(checked): void => {
+              onChange({ showPreSeriesInfo: checked });
+            }}
+            label="Display Pre-Series Player Info"
+            description="Show individual player info before the first match starts"
+          />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/pages/src/components/live-tracker/settings/ticker-settings-section.tsx
+++ b/pages/src/components/live-tracker/settings/ticker-settings-section.tsx
@@ -15,16 +15,16 @@ function formatStatName(stat: string): string {
 
 interface TickerSettingsSectionProps {
   readonly settings: TickerSettings;
-  readonly onChange: (updates: Partial<TickerSettings>) => void;
   readonly showTickerVisibilityToggle?: boolean;
   readonly showPreSeriesInfoToggle?: boolean;
+  readonly onChange: (updates: Partial<TickerSettings>) => void;
 }
 
 export function TickerSettingsSection({
   settings,
-  onChange,
   showTickerVisibilityToggle = true,
   showPreSeriesInfoToggle = true,
+  onChange,
 }: TickerSettingsSectionProps): React.ReactElement {
   const handleStatToggle = (stat: string): void => {
     const isEnabled = settings.selectedSlayerStats.includes(stat);

--- a/shared/src/individual-tracker/streamer-view-settings.ts
+++ b/shared/src/individual-tracker/streamer-view-settings.ts
@@ -140,6 +140,9 @@ export const streamerViewStyleFlagsSchema = z.object({
   selectedSlayerStats: z.array(z.string()).optional(),
   showObjectiveStats: z.boolean().optional(),
   medalRarityFilter: z.array(z.number()).optional(),
+  inSeriesShowTicker: z.boolean().optional(),
+  matchmakingShowTicker: z.boolean().optional(),
+  matchmakingShowStatsHighlights: z.boolean().optional(),
   inSeriesMyStatsOnly: z.boolean().optional(),
   matchmakingMyStatsOnly: z.boolean().optional(),
 });


### PR DESCRIPTION
## Context
PR10 is progressing in slices to align individual-tracker streamer settings with overlay runtime contexts. Slice A shipped my-stats-only ticker filtering controls and behavior. This slice continues by restructuring settings IA around overlay context and clarifying ownership between shared viewer settings and overlay-only display controls.

## This PR
- Reorganizes streamer settings into context-first sections:
  - Global Defaults
  - In Series UI
  - Matchmaking UI
- Adds explicit Matchmaking Top Section overlay toggle:
  - Show stats highlights
- Clarifies dependency semantics:
  - Stats Highlights tab is the master source for viewer-available highlight data
  - Matchmaking Show stats highlights only controls overlay visibility of that section
- Removes redundant matchmaking guidance alert in favor of inline toggle description.
- Adds context-aware runtime behavior wiring in overlay presenter for:
  - Matchmaking stats highlights visibility
  - In-series vs matchmaking ticker visibility
  - In-series vs matchmaking my-stats-only filtering
- Refines streamer defaults for new users:
  - Show team details defaults to true
  - Show Discord names defaults to false
  - Matchmaking show stats highlights defaults to true
  - Stats Highlights defaults to enabled via seeded default slots
- Improves visual consistency by adding section dividers across cards and elevating Information Ticker above Text Sizes in Global Defaults.
- Validation:
  - npm run done passes
  - Focused streamer settings and overlay presenter tests pass

<img width="904" height="4489" alt="localhost_4321_individual-tracker" src="https://github.com/user-attachments/assets/bb3f3fb5-85b1-4f23-9f32-eff61302f9ae" />


## Subsequent Work
- Optional UX follow-up: run a manual overlay smoke pass (viewer + OBS source) to confirm final copy/placement feels right in live usage.
