### PR TITLE
fix: end active series when matchmaking match is discovered

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -343,6 +343,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     const strategy = markerFound ? "marker" : trackerState.lastSeenMatchId != null ? "fallback" : "initial";
     const matchesToProcess = this.getMatchesToProcessBeforeMarker(allMatches, markerFound, markerFoundAtIndex);
     const knownIds = new Set(trackerState.matchIds);
+    const existingActiveSeriesMatchIds = new Set(trackerState.activeSeries?.matchIds ?? []);
 
     let skippedAlreadyKnown = 0;
     let skippedBeforeStart = 0;
@@ -358,6 +359,19 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       if (new Date(match.MatchInfo.StartTime) < searchStart) {
         skippedBeforeStart++;
         continue;
+      }
+
+      const isMatchmakingMatch = match.MatchInfo.Playlist != null;
+      if (trackerState.activeSeries != null && isMatchmakingMatch) {
+        this.retireActiveSeries(trackerState);
+        this.logService.info(
+          "IndividualTracker: series ended after matchmaking match was discovered",
+          new Map([
+            ["trackerId", trackerState.trackerId],
+            ["gamertag", trackerState.gamertag],
+            ["matchId", matchId],
+          ]),
+        );
       }
 
       const outcome = getMatchOutcomeLabel(match.Outcome);
@@ -381,7 +395,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         gameVariantCategory: match.MatchInfo.GameVariantCategory,
         outcome,
         score: "",
-        isMatchmaking: match.MatchInfo.Playlist != null,
+        isMatchmaking: isMatchmakingMatch,
         teamRosterSignature: null,
         teamOutcomes: null,
       };
@@ -392,6 +406,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       const durationSeconds = getDurationInSeconds(match.MatchInfo.Duration);
       if (durationSeconds >= 120) {
         trackerState.selectedMatchIds.push(matchId);
+      }
+      if (trackerState.activeSeries != null && !isMatchmakingMatch && !existingActiveSeriesMatchIds.has(matchId)) {
+        trackerState.activeSeries.matchIds.push(matchId);
+        existingActiveSeriesMatchIds.add(matchId);
       }
       newlyDiscovered.add(matchId);
       discoveredNewMatch = true;
@@ -426,15 +444,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     );
 
     this.updateLastSeenMatchIdMarker(trackerState, allMatches);
-
-    if (trackerState.activeSeries != null && newlyDiscovered.size > 0) {
-      const existingSeriesMatchIds = new Set(trackerState.activeSeries.matchIds);
-      for (const matchId of newlyDiscovered) {
-        if (!existingSeriesMatchIds.has(matchId)) {
-          trackerState.activeSeries.matchIds.push(matchId);
-        }
-      }
-    }
 
     for (const matchId of trackerState.matchIds) {
       if (newlyDiscovered.has(matchId)) {

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -342,14 +342,14 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     const searchStart = new Date(trackerState.searchStartTime);
     const strategy = markerFound ? "marker" : trackerState.lastSeenMatchId != null ? "fallback" : "initial";
     const matchesToProcess = this.getMatchesToProcessBeforeMarker(allMatches, markerFound, markerFoundAtIndex);
+    const matchesToProcessInTimeOrder = [...matchesToProcess].reverse();
     const knownIds = new Set(trackerState.matchIds);
     const existingActiveSeriesMatchIds = new Set(trackerState.activeSeries?.matchIds ?? []);
-    let seriesRetiredByMatchmakingThisPoll = false;
 
     let skippedAlreadyKnown = 0;
     let skippedBeforeStart = 0;
 
-    for (const match of matchesToProcess) {
+    for (const match of matchesToProcessInTimeOrder) {
       const matchId = match.MatchId;
 
       if (knownIds.has(matchId)) {
@@ -365,7 +365,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       const isMatchmakingMatch = match.MatchInfo.Playlist != null;
       if (trackerState.activeSeries != null && isMatchmakingMatch) {
         this.retireActiveSeries(trackerState);
-        seriesRetiredByMatchmakingThisPoll = true;
         this.logService.info(
           "IndividualTracker: series ended after matchmaking match was discovered",
           new Map([
@@ -412,11 +411,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       if (trackerState.activeSeries != null && !isMatchmakingMatch && !existingActiveSeriesMatchIds.has(matchId)) {
         trackerState.activeSeries.matchIds.push(matchId);
         existingActiveSeriesMatchIds.add(matchId);
-      } else if (seriesRetiredByMatchmakingThisPoll && !isMatchmakingMatch) {
-        const lastCompletedSeries = trackerState.completedSeries?.at(-1);
-        if (lastCompletedSeries != null && !lastCompletedSeries.matchIds.includes(matchId)) {
-          lastCompletedSeries.matchIds.push(matchId);
-        }
       }
       newlyDiscovered.add(matchId);
       discoveredNewMatch = true;

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -344,6 +344,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     const matchesToProcess = this.getMatchesToProcessBeforeMarker(allMatches, markerFound, markerFoundAtIndex);
     const knownIds = new Set(trackerState.matchIds);
     const existingActiveSeriesMatchIds = new Set(trackerState.activeSeries?.matchIds ?? []);
+    let seriesRetiredByMatchmakingThisPoll = false;
 
     let skippedAlreadyKnown = 0;
     let skippedBeforeStart = 0;
@@ -364,6 +365,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       const isMatchmakingMatch = match.MatchInfo.Playlist != null;
       if (trackerState.activeSeries != null && isMatchmakingMatch) {
         this.retireActiveSeries(trackerState);
+        seriesRetiredByMatchmakingThisPoll = true;
         this.logService.info(
           "IndividualTracker: series ended after matchmaking match was discovered",
           new Map([
@@ -410,6 +412,11 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       if (trackerState.activeSeries != null && !isMatchmakingMatch && !existingActiveSeriesMatchIds.has(matchId)) {
         trackerState.activeSeries.matchIds.push(matchId);
         existingActiveSeriesMatchIds.add(matchId);
+      } else if (seriesRetiredByMatchmakingThisPoll && !isMatchmakingMatch) {
+        const lastCompletedSeries = trackerState.completedSeries?.at(-1);
+        if (lastCompletedSeries != null && !lastCompletedSeries.matchIds.includes(matchId)) {
+          lastCompletedSeries.matchIds.push(matchId);
+        }
       }
       newlyDiscovered.add(matchId);
       discoveredNewMatch = true;

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -78,7 +78,13 @@ const createMockStartRequest = (
   ...overrides,
 });
 
-const aFakePlayerMatch = (matchId: string, startTime: string, outcome = 2, duration = "PT10M"): PlayerMatchHistory =>
+const aFakePlayerMatch = (
+  matchId: string,
+  startTime: string,
+  outcome = 2,
+  duration = "PT10M",
+  isMatchmaking = false,
+): PlayerMatchHistory =>
   ({
     MatchId: matchId,
     Outcome: outcome,
@@ -89,6 +95,7 @@ const aFakePlayerMatch = (matchId: string, startTime: string, outcome = 2, durat
       GameVariantCategory: 6,
       MapVariant: { AssetId: "map-asset", VersionId: "v1" },
       UgcGameVariant: { AssetId: "mode-asset", VersionId: "v1" },
+      ...(isMatchmaking ? { Playlist: { AssetId: "playlist-asset", VersionId: "v1" } } : {}),
     },
   }) as unknown as PlayerMatchHistory;
 
@@ -1593,6 +1600,47 @@ describe("IndividualTrackerDO", () => {
 
       const persisted = lastPersistedState(storagePutSpy);
       expect(persisted.selectedMatchIds).toEqual(["match-new"]);
+    });
+
+    it("ends an active series before appending a newly discovered matchmaking match", async () => {
+      ownerClient.getPlayerMatches
+        .mockResolvedValueOnce([aFakePlayerMatch("match-matchmaking", "2024-11-26T11:30:00.000Z", 2, "PT5M", true)])
+        .mockResolvedValueOnce([]);
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          searchStartTime: "2024-11-26T11:00:00.000Z",
+          matchIds: ["series-custom-match"],
+          discoveredMatches: {
+            "series-custom-match": aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "series-custom-match",
+              isMatchmaking: false,
+            }),
+          },
+          activeSeries: {
+            title: "Active Series",
+            subtitle: "Customs",
+            guildIconUrl: null,
+            teams: [],
+            matchIds: ["series-custom-match"],
+            startedAt: "2024-11-26T11:00:00.000Z",
+            isActive: true,
+          },
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries).toBeUndefined();
+      expect(persisted.completedSeries).toHaveLength(1);
+      expect(persisted.completedSeries?.[0]).toMatchObject({
+        title: "Active Series",
+        matchIds: ["series-custom-match"],
+        isActive: false,
+      });
+      expect(persisted.matchIds).toEqual(["series-custom-match", "match-matchmaking"]);
+      expect(persisted.discoveredMatches["match-matchmaking"]?.isMatchmaking).toBe(true);
     });
 
     it("stores outcome, score, and the resolved map name for a newly discovered match", async () => {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1643,6 +1643,47 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.discoveredMatches["match-matchmaking"]?.isMatchmaking).toBe(true);
     });
 
+    it("keeps older custom matches in the completed series when a newer matchmaking match appears in the same batch", async () => {
+      ownerClient.getPlayerMatches
+        .mockResolvedValueOnce([
+          aFakePlayerMatch("match-matchmaking", "2024-11-26T11:32:00.000Z", 2, "PT5M", true),
+          aFakePlayerMatch("match-custom-older", "2024-11-26T11:25:00.000Z", 2, "PT5M", false),
+        ])
+        .mockResolvedValueOnce([]);
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          searchStartTime: "2024-11-26T11:00:00.000Z",
+          matchIds: ["series-custom-existing"],
+          discoveredMatches: {
+            "series-custom-existing": aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "series-custom-existing",
+              isMatchmaking: false,
+            }),
+          },
+          activeSeries: {
+            title: "Active Series",
+            subtitle: "Customs",
+            guildIconUrl: null,
+            teams: [],
+            matchIds: ["series-custom-existing"],
+            startedAt: "2024-11-26T11:00:00.000Z",
+            isActive: true,
+          },
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries).toBeUndefined();
+      expect(persisted.completedSeries).toHaveLength(1);
+      expect(persisted.completedSeries?.[0]?.matchIds).toEqual(["series-custom-existing", "match-custom-older"]);
+      expect(persisted.matchIds).toEqual(["series-custom-existing", "match-matchmaking", "match-custom-older"]);
+      expect(persisted.discoveredMatches["match-matchmaking"]?.isMatchmaking).toBe(true);
+      expect(persisted.discoveredMatches["match-custom-older"]?.isMatchmaking).toBe(false);
+    });
+
     it("stores outcome, score, and the resolved map name for a newly discovered match", async () => {
       ownerClient.getPlayerMatches
         .mockResolvedValueOnce([aFakePlayerMatch("match-new", "2024-11-26T11:30:00.000Z", 3)])

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1476,8 +1476,8 @@ describe("IndividualTrackerDO", () => {
       // Should find marker on page 1 and stop polling (no page 2 fetched)
       expect(ownerClient.getPlayerMatches).toHaveBeenCalledTimes(2);
       const persisted = lastPersistedState(storagePutSpy);
-      // Should only process matches before marker (match-new-1, match-new-2)
-      expect(persisted.matchIds).toEqual(["match-new-1", "match-new-2"]);
+      // Should only process matches before marker in time order (oldest to newest)
+      expect(persisted.matchIds).toEqual(["match-new-2", "match-new-1"]);
       expect(persisted.matchIds).not.toContain("match-old-3");
       // Marker becomes new lastSeenMatchId for next poll
       expect(persisted.lastSeenMatchId).toBe("match-new-1");
@@ -1679,9 +1679,50 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.activeSeries).toBeUndefined();
       expect(persisted.completedSeries).toHaveLength(1);
       expect(persisted.completedSeries?.[0]?.matchIds).toEqual(["series-custom-existing", "match-custom-older"]);
-      expect(persisted.matchIds).toEqual(["series-custom-existing", "match-matchmaking", "match-custom-older"]);
+      expect(persisted.matchIds).toEqual(["series-custom-existing", "match-custom-older", "match-matchmaking"]);
       expect(persisted.discoveredMatches["match-matchmaking"]?.isMatchmaking).toBe(true);
       expect(persisted.discoveredMatches["match-custom-older"]?.isMatchmaking).toBe(false);
+    });
+
+    it("does not include newer custom matches in completed series when an older matchmaking match is the boundary", async () => {
+      ownerClient.getPlayerMatches
+        .mockResolvedValueOnce([
+          aFakePlayerMatch("match-custom-newer", "2024-11-26T11:32:00.000Z", 2, "PT5M", false),
+          aFakePlayerMatch("match-matchmaking-older", "2024-11-26T11:25:00.000Z", 2, "PT5M", true),
+        ])
+        .mockResolvedValueOnce([]);
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          searchStartTime: "2024-11-26T11:00:00.000Z",
+          matchIds: ["series-custom-existing"],
+          discoveredMatches: {
+            "series-custom-existing": aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "series-custom-existing",
+              isMatchmaking: false,
+            }),
+          },
+          activeSeries: {
+            title: "Active Series",
+            subtitle: "Customs",
+            guildIconUrl: null,
+            teams: [],
+            matchIds: ["series-custom-existing"],
+            startedAt: "2024-11-26T11:00:00.000Z",
+            isActive: true,
+          },
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries).toBeUndefined();
+      expect(persisted.completedSeries).toHaveLength(1);
+      expect(persisted.completedSeries?.[0]?.matchIds).toEqual(["series-custom-existing"]);
+      expect(persisted.matchIds).toEqual(["series-custom-existing", "match-matchmaking-older", "match-custom-newer"]);
+      expect(persisted.discoveredMatches["match-matchmaking-older"]?.isMatchmaking).toBe(true);
+      expect(persisted.discoveredMatches["match-custom-newer"]?.isMatchmaking).toBe(false);
     });
 
     it("stores outcome, score, and the resolved map name for a newly discovered match", async () => {


### PR DESCRIPTION
## Context
The individual tracker can keep an `activeSeries` while polling for new matches. During that window, it currently appends any newly discovered match IDs to the active series bucket, including matchmaking games. That behavior is incorrect because active series should represent custom-game flow only.

## This PR
- Updates the DO polling path to treat newly discovered matchmaking matches as a series boundary.
- When `activeSeries` exists and a matchmaking match is discovered:
  - retire the active series first
  - then append the discovered match to tracker match history as normal
- Restricts active-series match ID appends to newly discovered custom matches only.
- Adds alarm-path regression coverage proving that a matchmaking discovery:
  - ends the active series
  - preserves the completed-series snapshot
  - still records the matchmaking match in discovered match history.

Validation:
- `npx vitest run api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts`
- `npm run done`

## Subsequent Work
- Optional hardening: add a follow-up test for mixed discovery batches (custom + matchmaking in the same poll page) to lock ordering semantics explicitly.
