### PR TITLE
fix: include team emojis in initial live-tracker channel score

### DIFF
--- a/api/durable-objects/live-tracker/live-tracker-do.ts
+++ b/api/durable-objects/live-tracker/live-tracker-do.ts
@@ -337,11 +337,7 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
         embedData,
       );
 
-      const initialChannelSeriesScore = this.haloService.getSeriesScore(
-        [],
-        "en-US",
-        trackerState.teams.length === 2,
-      );
+      const initialChannelSeriesScore = this.haloService.getSeriesScore([], "en-US", trackerState.teams.length === 2);
       await this.updateChannelName(trackerState, initialChannelSeriesScore, true);
       await this.discordService.editMessage(
         startRequest.channelId,

--- a/api/durable-objects/live-tracker/live-tracker-do.ts
+++ b/api/durable-objects/live-tracker/live-tracker-do.ts
@@ -337,7 +337,9 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
         embedData,
       );
 
-      await this.updateChannelName(trackerState, trackerState.seriesScore, true);
+      const initialChannelSeriesScore =
+        trackerState.teams.length === 2 ? `🦅 ${trackerState.seriesScore} 🐍` : trackerState.seriesScore;
+      await this.updateChannelName(trackerState, initialChannelSeriesScore, true);
       await this.discordService.editMessage(
         startRequest.channelId,
         loadingMessage.id,

--- a/api/durable-objects/live-tracker/live-tracker-do.ts
+++ b/api/durable-objects/live-tracker/live-tracker-do.ts
@@ -337,8 +337,11 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
         embedData,
       );
 
-      const initialChannelSeriesScore =
-        trackerState.teams.length === 2 ? `🦅 ${trackerState.seriesScore} 🐍` : trackerState.seriesScore;
+      const initialChannelSeriesScore = this.haloService.getSeriesScore(
+        [],
+        "en-US",
+        trackerState.teams.length === 2,
+      );
       await this.updateChannelName(trackerState, initialChannelSeriesScore, true);
       await this.discordService.editMessage(
         startRequest.channelId,

--- a/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
+++ b/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
@@ -563,6 +563,34 @@ describe("LiveTrackerDO", () => {
       const data: { success: boolean } = await response.json();
       expect(data.success).toBe(true);
     });
+
+    it("passes emoji-wrapped initial series score to channel name updates", async () => {
+      const startData = createMockStartData();
+      const request = new Request("http://do/start", {
+        method: "POST",
+        body: JSON.stringify(startData),
+      });
+
+      vi.spyOn(services.discordService, "createMessage").mockResolvedValue(apiMessage);
+      vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue(apiMessage);
+      vi.spyOn(services.discordService, "editMessage").mockResolvedValue(apiMessage);
+      const updateChannelNameSpy = vi
+        .spyOn(
+          liveTrackerDO as unknown as {
+            updateChannelName: (state: LiveTrackerState, seriesScore: string, force: boolean) => Promise<void>;
+          },
+          "updateChannelName",
+        )
+        .mockResolvedValue(undefined);
+
+      vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
+      vi.spyOn(services.haloService, "getSeriesScore").mockReturnValue("0:0");
+
+      const response = await liveTrackerDO.fetch(request);
+
+      expect(response.status).toBe(200);
+      expect(updateChannelNameSpy).toHaveBeenCalledWith(expect.any(Object), "🦅 0:0 🐍", true);
+    });
   });
 
   describe("handlePause()", () => {

--- a/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
+++ b/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
@@ -442,7 +442,9 @@ describe("LiveTrackerDO", () => {
       storageGetSpy.mockResolvedValue(trackerState);
       vi.spyOn(services.discordService, "editMessage").mockResolvedValue(apiMessage);
       vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
-      vi.spyOn(services.haloService, "getSeriesScore").mockReturnValue("0:0");
+      vi.spyOn(services.haloService, "getSeriesScore").mockImplementation((_matches, _locale, includeEmoji) =>
+        includeEmoji === true ? "🦅 0:0 🐍" : "0:0",
+      );
 
       const response = await liveTrackerDO.fetch(new Request("http://do/refresh", { method: "POST" }));
 
@@ -534,7 +536,9 @@ describe("LiveTrackerDO", () => {
       vi.spyOn(services.discordService, "createMessage").mockResolvedValue(apiMessage);
       vi.spyOn(services.discordService, "editMessage").mockResolvedValue(apiMessage);
       vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
-      vi.spyOn(services.haloService, "getSeriesScore").mockReturnValue("0:0");
+      vi.spyOn(services.haloService, "getSeriesScore").mockImplementation((_matches, _locale, includeEmoji) =>
+        includeEmoji === true ? "🦅 0:0 🐍" : "0:0",
+      );
 
       const response = await liveTrackerDO.fetch(request);
 
@@ -584,12 +588,21 @@ describe("LiveTrackerDO", () => {
         .mockResolvedValue(undefined);
 
       vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
-      vi.spyOn(services.haloService, "getSeriesScore").mockReturnValue("0:0");
+      vi.spyOn(services.haloService, "getSeriesScore").mockImplementation((_matches, _locale, includeEmoji) =>
+        includeEmoji === true ? "🦅 0:0 🐍" : "0:0",
+      );
 
       const response = await liveTrackerDO.fetch(request);
 
       expect(response.status).toBe(200);
-      expect(updateChannelNameSpy).toHaveBeenCalledWith(expect.any(Object), "🦅 0:0 🐍", true);
+      const initialChannelNameCall = updateChannelNameSpy.mock.calls[0];
+      expect(initialChannelNameCall).toBeDefined();
+      if (initialChannelNameCall == null) {
+        return;
+      }
+      const [, scoreArg, forceArg] = initialChannelNameCall;
+      expect(scoreArg).toBe("🦅 0:0 🐍");
+      expect(forceArg).toBe(true);
     });
   });
 

--- a/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
+++ b/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
@@ -595,7 +595,7 @@ describe("LiveTrackerDO", () => {
       const response = await liveTrackerDO.fetch(request);
 
       expect(response.status).toBe(200);
-      const initialChannelNameCall = updateChannelNameSpy.mock.calls[0];
+      const [initialChannelNameCall] = updateChannelNameSpy.mock.calls;
       expect(initialChannelNameCall).toBeDefined();
       if (initialChannelNameCall == null) {
         return;


### PR DESCRIPTION
## Context
NeatQueue live-tracker channel names include a series score suffix. During normal score updates (for example, `2:1`) the suffix is formatted with eagle/snake emoji wrappers, but the initial startup score path used a plain `0:0` value. That created inconsistent channel names and was incorrect for the first score render.

## This PR
- Fixes the live-tracker start path to pass an emoji-wrapped score to channel-name updates for standard two-team series.
- Keeps the stored `seriesScore` value unchanged for embed/state usage; only the channel-name presentation input is adjusted.
- Adds regression coverage in `handleStart()` to verify the channel-name updater receives `🦅 0:0 🐍` on startup.

Validation:
- `npx vitest run api/durable-objects/live-tracker/tests/live-tracker-do.test.ts`
- `npm run done`

## Subsequent Work
- Optional follow-up: centralize channel-name score formatting in one helper used by both startup and alarm paths to reduce formatting drift risk.
