### PR TITLE
fix: clear player matches cache on each live-tracker alarm cycle

### DIFF
--- a/api/durable-objects/live-tracker/live-tracker-do.ts
+++ b/api/durable-objects/live-tracker/live-tracker-do.ts
@@ -1053,6 +1053,11 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       const startDateTime = new Date(trackerState.searchStartTime);
       const endDateTime = new Date();
 
+      // Clear the in-memory player matches cache so each fetch cycle starts from
+      // page 0 of match history, ensuring newly completed matches are not missed
+      // due to a stale cache on a warm DO instance.
+      this.haloService.clearPlayerMatchesCache();
+
       const matches = await this.haloService.getSeriesFromDiscordQueue(
         {
           teams,

--- a/api/durable-objects/live-tracker/live-tracker-do.ts
+++ b/api/durable-objects/live-tracker/live-tracker-do.ts
@@ -1053,10 +1053,11 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       const startDateTime = new Date(trackerState.searchStartTime);
       const endDateTime = new Date();
 
-      // Clear the in-memory player matches cache so each fetch cycle starts from
-      // page 0 of match history, ensuring newly completed matches are not missed
-      // due to a stale cache on a warm DO instance.
+      // Clear the in-memory caches so each fetch cycle is deterministic on a warm DO instance.
+      // playerMatchesCache: ensures we refetch from page 0 of match history
+      // userCache: ensures we re-check users even if previously cached as GamesRetrievable.NO
       this.haloService.clearPlayerMatchesCache();
+      this.haloService.clearUserCache();
 
       const matches = await this.haloService.getSeriesFromDiscordQueue(
         {

--- a/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
+++ b/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
@@ -3091,6 +3091,42 @@ describe("LiveTrackerDO", () => {
     });
   });
 
+  describe("player matches cache lifecycle", () => {
+    it("clears the player matches cache before each series fetch so a warm DO instance does not miss newly completed matches", async () => {
+      const trackerState = aFakeStateWith({
+        status: "active",
+        isPaused: false,
+      });
+      storageGetSpy.mockResolvedValue(trackerState);
+
+      const clearPlayerMatchesCacheSpy = vi.spyOn(services.haloService, "clearPlayerMatchesCache");
+      vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
+      vi.spyOn(services.haloService, "getSeriesScore").mockReturnValue("0:0");
+      vi.spyOn(services.discordService, "editMessage").mockResolvedValue(apiMessage);
+
+      await liveTrackerDO.alarm();
+
+      expect(clearPlayerMatchesCacheSpy).toHaveBeenCalledOnce();
+    });
+
+    it("clears the player matches cache on every alarm cycle", async () => {
+      const baseState = aFakeStateWith({ status: "active", isPaused: false });
+      // Return a fresh copy on each getState() so the second alarm is not
+      // blocked by the stale-lock guard (refreshInProgress mutated on the same ref).
+      storageGetSpy.mockImplementation(async () => Promise.resolve({ ...baseState }));
+
+      const clearPlayerMatchesCacheSpy = vi.spyOn(services.haloService, "clearPlayerMatchesCache");
+      vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
+      vi.spyOn(services.haloService, "getSeriesScore").mockReturnValue("0:0");
+      vi.spyOn(services.discordService, "editMessage").mockResolvedValue(apiMessage);
+
+      await liveTrackerDO.alarm();
+      await liveTrackerDO.alarm();
+
+      expect(clearPlayerMatchesCacheSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe("KV Storage Integration", () => {
     it("saves newly discovered matches to KV storage during alarm", async () => {
       const eightPlayerSetup = createEightPlayerSetup();

--- a/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
+++ b/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
@@ -3092,7 +3092,7 @@ describe("LiveTrackerDO", () => {
   });
 
   describe("player matches cache lifecycle", () => {
-    it("clears the player matches cache before each series fetch so a warm DO instance does not miss newly completed matches", async () => {
+    it("clears both in-memory caches before each series fetch so a warm DO instance does not miss newly completed matches", async () => {
       const trackerState = aFakeStateWith({
         status: "active",
         isPaused: false,
@@ -3100,6 +3100,7 @@ describe("LiveTrackerDO", () => {
       storageGetSpy.mockResolvedValue(trackerState);
 
       const clearPlayerMatchesCacheSpy = vi.spyOn(services.haloService, "clearPlayerMatchesCache");
+      const clearUserCacheSpy = vi.spyOn(services.haloService, "clearUserCache");
       vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
       vi.spyOn(services.haloService, "getSeriesScore").mockReturnValue("0:0");
       vi.spyOn(services.discordService, "editMessage").mockResolvedValue(apiMessage);
@@ -3107,15 +3108,17 @@ describe("LiveTrackerDO", () => {
       await liveTrackerDO.alarm();
 
       expect(clearPlayerMatchesCacheSpy).toHaveBeenCalledOnce();
+      expect(clearUserCacheSpy).toHaveBeenCalledOnce();
     });
 
-    it("clears the player matches cache on every alarm cycle", async () => {
+    it("clears both caches on every alarm cycle for deterministic warm DO state", async () => {
       const baseState = aFakeStateWith({ status: "active", isPaused: false });
       // Return a fresh copy on each getState() so the second alarm is not
       // blocked by the stale-lock guard (refreshInProgress mutated on the same ref).
       storageGetSpy.mockImplementation(async () => Promise.resolve({ ...baseState }));
 
       const clearPlayerMatchesCacheSpy = vi.spyOn(services.haloService, "clearPlayerMatchesCache");
+      const clearUserCacheSpy = vi.spyOn(services.haloService, "clearUserCache");
       vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
       vi.spyOn(services.haloService, "getSeriesScore").mockReturnValue("0:0");
       vi.spyOn(services.discordService, "editMessage").mockResolvedValue(apiMessage);
@@ -3124,6 +3127,7 @@ describe("LiveTrackerDO", () => {
       await liveTrackerDO.alarm();
 
       expect(clearPlayerMatchesCacheSpy).toHaveBeenCalledTimes(2);
+      expect(clearUserCacheSpy).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/api/services/halo/halo.ts
+++ b/api/services/halo/halo.ts
@@ -1011,6 +1011,10 @@ export class HaloService {
     this.userCache.clear();
   }
 
+  clearPlayerMatchesCache(): void {
+    this.playerMatchesCache.clear();
+  }
+
   private async populateUserCache(users: MatchPlayer[], startDate: Date, endDate: Date): Promise<void> {
     const processResult = async (
       processedUsers: MatchPlayer[],
@@ -1235,21 +1239,19 @@ export class HaloService {
   ): Promise<PlayerMatchHistory[]> {
     const history = this.playerMatchesCache.get(xboxUserId) ?? [];
 
-    if (!this.playerMatchesCache.has(xboxUserId) || history.length > 0) {
-      while (
-        history.length == 0 ||
-        isAfter(new Date(Preconditions.checkExists(history[history.length - 1]).MatchInfo.StartTime), startDate)
-      ) {
-        const matches = await this.getPlayerMatches(xboxUserId, MatchType.Custom, 25, history.length);
-        history.push(...matches);
+    while (
+      history.length === 0 ||
+      isAfter(new Date(Preconditions.checkExists(history[history.length - 1]).MatchInfo.StartTime), startDate)
+    ) {
+      const matches = await this.getPlayerMatches(xboxUserId, MatchType.Custom, 25, history.length);
+      history.push(...matches);
 
-        if (matches.length === 0) {
-          break;
-        }
+      if (matches.length === 0) {
+        break;
       }
-
-      this.playerMatchesCache.set(xboxUserId, history);
     }
+
+    this.playerMatchesCache.set(xboxUserId, history);
 
     const playerMatches = Preconditions.checkExists(this.playerMatchesCache.get(xboxUserId));
     const matchesCloseToDate = playerMatches.filter((match) => {

--- a/api/services/halo/tests/halo.test.ts
+++ b/api/services/halo/tests/halo.test.ts
@@ -1756,6 +1756,33 @@ describe("Halo service", () => {
     });
   });
 
+  describe("clearPlayerMatchesCache()", () => {
+    it("allows getSeriesFromDiscordQueue to re-fetch page 0 after a call that found no matches", async () => {
+      // First call: no custom games exist yet (e.g. series not started).
+      infiniteClient.getPlayerMatches.mockResolvedValue([]);
+      await expect(haloService.getSeriesFromDiscordQueue(getNeatQueueSeriesData())).rejects.toThrow();
+      const firstCallCount = infiniteClient.getPlayerMatches.mock.calls.length;
+      expect(firstCallCount).toBeGreaterThan(0);
+
+      // After clearing both caches: page 0 is fetched fresh and matches are found.
+      // clearUserCache is needed so users are not stuck with GamesRetrievable.NO
+      // from the first call; clearPlayerMatchesCache resets the match fetch history.
+      haloService.clearUserCache();
+      haloService.clearPlayerMatchesCache();
+      infiniteClient.getPlayerMatches.mockClear();
+      // Restore the default fake implementation that returns real match data.
+      infiniteClient.getPlayerMatches.mockImplementation(async (xboxUserId, _matchType, _count, start) => {
+        if (xboxUserId === "0000000000001" && (start === 0 || start == null)) {
+          return Promise.resolve(getPlayerMatches());
+        }
+        return Promise.resolve([]);
+      });
+
+      await expect(haloService.getSeriesFromDiscordQueue(getNeatQueueSeriesData())).resolves.toBeDefined();
+      expect(infiniteClient.getPlayerMatches.mock.calls.length).toBeGreaterThan(0);
+    });
+  });
+
   describe("getMatchDetails()", () => {
     it("returns the match details", async () => {
       const matchDetails = await haloService.getMatchDetails(["d81554d7-ddfe-44da-a6cb-000000000ctf"]);


### PR DESCRIPTION
## Context
The live tracker uses `HaloService.getSeriesFromDiscordQueue` on every alarm cycle. Internally this goes through `getPlayerMatchesByRange`, which maintains an in-memory `playerMatchesCache` on the `HaloService` instance. While DOs are typically evicted between 3-minute alarm cycles, if an instance stays warm the cache is never reset. More critically, the cache guard had a logic bug: when a player's entry was stored as an empty array (zero custom-game history), subsequent calls would skip the fetch entirely and permanently return no matches for that player — even after a game was completed.

## This PR

Two targeted changes:

**1. Fix the empty-cache guard in `getPlayerMatchesByRange`** (`api/services/halo/halo.ts`)  
Remove the outer `if (!has() || length > 0)` guard. The `while` loop already encodes the correct pagination semantics: enter when the cache is empty (`length === 0`) or when the oldest fetched match is still within the search window. The removed guard was causing the "cache hit with empty array → skip entirely" path which could permanently suppress fresh fetches.

**2. Clear `playerMatchesCache` before each `getSeriesFromDiscordQueue` call** (`api/durable-objects/live-tracker/live-tracker-do.ts`)  
Adds `clearPlayerMatchesCache()` to `HaloService` and calls it at the top of `fetchAndMergeSeriesData`. This makes each alarm cycle deterministically start from page 0 of match history, ensuring newly completed games are always discovered regardless of DO warmth.

Tests added:
- `HaloService.clearPlayerMatchesCache()`: verifies re-fetch succeeds after a call that previously found no matches
- Live-tracker DO: verifies the cache is cleared once per alarm and on every consecutive alarm cycle

Validation: `npm run done` (format + typecheck + eslint + vitest related) — all pass.

## Subsequent Work
- Optional: search from latest known match end time as `startDateTime` to reduce Waypoint API pages fetched per alarm once matches accumulate.
