### PR TITLE
fix(overlay): complete ticker, preview, colors, and top stats highlights behavior

### DIFF
--- a/api/routes/individual-tracker/follow.ts
+++ b/api/routes/individual-tracker/follow.ts
@@ -6,6 +6,10 @@ import {
   trackerDirectoryContract,
   trackerDirectoryMessageContract,
 } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import {
+  DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS,
+  INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT,
+} from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { IndividualTrackersRow } from "../../services/database/types/individual_trackers";
 import type { Services } from "../../services/install";
 import type { RoutesRegisterHandler } from "../base/types";
@@ -25,7 +29,9 @@ async function buildDirectory(env: Env, userId: string, services: Services): Pro
   ]);
 
   const nonStopped = allTrackers.filter(isNonStopped);
-  const statsHighlightSlots = streamerSettings.visibleSections?.statsHighlightSlots;
+  const statsHighlightSlots =
+    streamerSettings.visibleSections?.statsHighlightSlots ??
+    DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS.slice(0, INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT);
 
   const entries = await Promise.all(
     nonStopped.map(async (row): Promise<TrackerDirectoryEntry> => {

--- a/api/routes/individual-tracker/tests/view.test.ts
+++ b/api/routes/individual-tracker/tests/view.test.ts
@@ -1,6 +1,10 @@
 import type { AutoRouterType } from "itty-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import {
+  DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS,
+  INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT,
+} from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { createApiRouter } from "../../../base/router";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import { aFakeDurableObjectNamespaceWith } from "../../../base/fakes/do.fake";
@@ -135,6 +139,72 @@ describe("/api/individual-tracker view route", () => {
     expect(body.view.status).toBe("stopped");
     expect(body.view.isLive).toBe(false);
     expect(body.view.matches).toEqual([]);
+  });
+
+  it("requests default stats highlight slots when settings omit explicit slots", async () => {
+    const doStub = aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } });
+    const fetchSpy = vi.spyOn(doStub, "fetch");
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+
+    const row = aFakeIndividualTrackersRow({
+      TrackerId: "t-default-slots",
+      UserId: "user-123",
+      Gamertag: "DefaultSlotsTag",
+      Status: "active",
+      IsLive: 1,
+    });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env: localEnv });
+      vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(row);
+      vi.spyOn(services.individualTrackerService, "getSettingsForView").mockResolvedValue({});
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(getRequest("/api/individual-tracker/t-default-slots/view"), localEnv)) as Response;
+
+    expect(res.status).toBe(200);
+    const call = fetchSpy.mock.calls[0]?.[0];
+    const rawUrl = typeof call === "string" ? call : call instanceof URL ? call.toString() : call?.url;
+    const parsedUrl = new URL(rawUrl ?? "http://do/view-state");
+    expect(parsedUrl.searchParams.get("statsHighlightSlots")).toBe(
+      JSON.stringify(
+        DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS.slice(0, INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT),
+      ),
+    );
+  });
+
+  it("does not request stats highlight slots when settings explicitly disable them", async () => {
+    const doStub = aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } });
+    const fetchSpy = vi.spyOn(doStub, "fetch");
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+
+    const row = aFakeIndividualTrackersRow({
+      TrackerId: "t-empty-slots",
+      UserId: "user-123",
+      Gamertag: "EmptySlotsTag",
+      Status: "active",
+      IsLive: 1,
+    });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env: localEnv });
+      vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(row);
+      vi.spyOn(services.individualTrackerService, "getSettingsForView").mockResolvedValue({
+        visibleSections: {
+          statsHighlightSlots: [],
+        },
+      });
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(getRequest("/api/individual-tracker/t-empty-slots/view"), localEnv)) as Response;
+
+    expect(res.status).toBe(200);
+    const call = fetchSpy.mock.calls[0]?.[0];
+    const rawUrl = typeof call === "string" ? call : call instanceof URL ? call.toString() : call?.url;
+    const parsedUrl = new URL(rawUrl ?? "http://do/view-state");
+    expect(parsedUrl.searchParams.get("statsHighlightSlots")).toBeNull();
   });
 
   describe("ws", () => {

--- a/api/routes/individual-tracker/view.ts
+++ b/api/routes/individual-tracker/view.ts
@@ -2,6 +2,10 @@ import { parsePathParams } from "@guilty-spark/shared/base/request-parsing";
 import { errorContract } from "@guilty-spark/shared/contracts/error";
 import { trackerParamsSchema } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import { trackerViewContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import {
+  DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS,
+  INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT,
+} from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { RoutesRegisterHandler } from "../base/types";
 import { fetchTrackerDoViewState, toTrackerView } from "./mapper";
 
@@ -23,7 +27,9 @@ export const trackerViewRoutesRegisterHandler: RoutesRegisterHandler = (router, 
       }
 
       const streamerSettings = await individualTrackerService.getSettingsForView(row.UserId);
-      const statsHighlightSlots = streamerSettings.visibleSections?.statsHighlightSlots;
+      const statsHighlightSlots =
+        streamerSettings.visibleSections?.statsHighlightSlots ??
+        DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS.slice(0, INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT);
       const doState = await fetchTrackerDoViewState(env, row.UserId, trackerId, statsHighlightSlots);
 
       return trackerViewContract.toResponse({ view: toTrackerView(row, doState, streamerSettings) }, { noStore: true });

--- a/pages/src/apps/follow-live/create.tsx
+++ b/pages/src/apps/follow-live/create.tsx
@@ -17,12 +17,10 @@ interface FollowLiveAppProps {
 export function FollowLiveApp({ apiHost, gamertag, variant = "viewer" }: FollowLiveAppProps): ReactElement {
   const [state, setState] = useState(ComponentLoaderStatus.PENDING);
   const [services, setServices] = useState<Services | null>(null);
-  const [overlayPreview, setOverlayPreview] = useState<{ showPreview: boolean; previewMode: "player" | "observer" }>(
-    {
-      showPreview: false,
-      previewMode: "observer",
-    },
-  );
+  const [overlayPreview, setOverlayPreview] = useState<{ showPreview: boolean; previewMode: "player" | "observer" }>({
+    showPreview: false,
+    previewMode: "observer",
+  });
 
   useEffect(() => {
     if (variant !== "overlay") {

--- a/pages/src/apps/follow-live/create.tsx
+++ b/pages/src/apps/follow-live/create.tsx
@@ -17,6 +17,25 @@ interface FollowLiveAppProps {
 export function FollowLiveApp({ apiHost, gamertag, variant = "viewer" }: FollowLiveAppProps): ReactElement {
   const [state, setState] = useState(ComponentLoaderStatus.PENDING);
   const [services, setServices] = useState<Services | null>(null);
+  const [overlayPreview, setOverlayPreview] = useState<{ showPreview: boolean; previewMode: "player" | "observer" }>(
+    {
+      showPreview: false,
+      previewMode: "observer",
+    },
+  );
+
+  useEffect(() => {
+    if (variant !== "overlay") {
+      return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const showPreview = params.get("preview") === "1";
+    const previewModeParam = params.get("previewMode");
+    const previewMode = previewModeParam === "player" ? "player" : "observer";
+
+    setOverlayPreview({ showPreview, previewMode });
+  }, [variant]);
 
   useEffect(() => {
     if (gamertag === "") {
@@ -72,6 +91,8 @@ export function FollowLiveApp({ apiHost, gamertag, variant = "viewer" }: FollowL
               matchAnalyticsService={services.matchAnalyticsService}
               seriesMatchesService={services.seriesMatchesService}
               haloClient={services.haloClient}
+              showPreview={overlayPreview.showPreview}
+              previewMode={overlayPreview.previewMode}
             />
           ) : (
             <FollowLiveViewer

--- a/pages/src/components/follow/follow-live-overlay-viewer.tsx
+++ b/pages/src/components/follow/follow-live-overlay-viewer.tsx
@@ -41,6 +41,8 @@ export interface FollowLiveOverlayViewerProps {
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
   readonly haloClient: HaloInfiniteClient;
+  readonly showPreview?: boolean;
+  readonly previewMode?: "player" | "observer";
 }
 
 export function FollowLiveOverlayViewer({
@@ -50,6 +52,8 @@ export function FollowLiveOverlayViewer({
   matchAnalyticsService,
   seriesMatchesService,
   haloClient,
+  showPreview = false,
+  previewMode = "observer",
 }: FollowLiveOverlayViewerProps): React.ReactElement {
   const { directory, directoryStatus, onRetry } = useFollowLiveDirectory({
     followLiveService,
@@ -70,6 +74,8 @@ export function FollowLiveOverlayViewer({
         seriesMatchesService={seriesMatchesService}
         haloClient={haloClient}
         trackerId={liveTracker.trackerId}
+        showPreview={showPreview}
+        previewMode={previewMode}
       />
     );
   }

--- a/pages/src/components/follow/tests/follow-live-overlay-viewer.test.tsx
+++ b/pages/src/components/follow/tests/follow-live-overlay-viewer.test.tsx
@@ -21,7 +21,9 @@ vi.mock("../../individual-tracker/overlay/create", () => ({
     trackerId: string;
     showPreview?: boolean;
     previewMode?: "player" | "observer";
-  }): React.ReactElement => <div data-testid="mock-overlay-page">{`${trackerId}:${String(showPreview)}:${previewMode ?? "observer"}`}</div>,
+  }): React.ReactElement => (
+    <div data-testid="mock-overlay-page">{`${trackerId}:${String(showPreview)}:${previewMode ?? "observer"}`}</div>
+  ),
 }));
 
 function aViewerPropsWith(directory: TrackerDirectory): FollowLiveOverlayViewerProps {

--- a/pages/src/components/follow/tests/follow-live-overlay-viewer.test.tsx
+++ b/pages/src/components/follow/tests/follow-live-overlay-viewer.test.tsx
@@ -13,9 +13,15 @@ import { aFakeSeriesMatchesServiceWith } from "../../../services/stats/fakes/ser
 import { FollowLiveOverlayViewer, type FollowLiveOverlayViewerProps } from "../follow-live-overlay-viewer";
 
 vi.mock("../../individual-tracker/overlay/create", () => ({
-  IndividualTrackerOverlayPage: ({ trackerId }: { trackerId: string }): React.ReactElement => (
-    <div data-testid="mock-overlay-page">{trackerId}</div>
-  ),
+  IndividualTrackerOverlayPage: ({
+    trackerId,
+    showPreview,
+    previewMode,
+  }: {
+    trackerId: string;
+    showPreview?: boolean;
+    previewMode?: "player" | "observer";
+  }): React.ReactElement => <div data-testid="mock-overlay-page">{`${trackerId}:${String(showPreview)}:${previewMode ?? "observer"}`}</div>,
 }));
 
 function aViewerPropsWith(directory: TrackerDirectory): FollowLiveOverlayViewerProps {
@@ -26,6 +32,8 @@ function aViewerPropsWith(directory: TrackerDirectory): FollowLiveOverlayViewerP
     matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     seriesMatchesService: aFakeSeriesMatchesServiceWith(),
     haloClient: aFakeHaloClientWith(),
+    showPreview: false,
+    previewMode: "observer",
   };
 }
 
@@ -47,7 +55,20 @@ describe("FollowLiveOverlayViewer", () => {
     render(<FollowLiveOverlayViewer {...aViewerPropsWith(directory)} />);
 
     await waitFor(() => {
-      expect(screen.getByTestId("mock-overlay-page")).toHaveTextContent("tracker-2");
+      expect(screen.getByTestId("mock-overlay-page")).toHaveTextContent("tracker-2:false:observer");
+    });
+  });
+
+  it("forwards preview flags to the overlay page", async () => {
+    const directory = aDirectoryWith({
+      trackers: [aTrackerWith({ trackerId: "tracker-3", gamertag: "Spartan Three", isLive: true, status: "active" })],
+      liveTrackerId: "tracker-3",
+    });
+
+    render(<FollowLiveOverlayViewer {...aViewerPropsWith(directory)} showPreview previewMode="player" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-overlay-page")).toHaveTextContent("tracker-3:true:player");
     });
   });
 

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -18,6 +18,8 @@ interface IndividualTrackerOverlayPageProps {
   readonly seriesMatchesService: SeriesMatchesService;
   readonly haloClient: HaloInfiniteClient;
   readonly trackerId: string;
+  readonly showPreview?: boolean;
+  readonly previewMode?: "player" | "observer";
 }
 
 export function IndividualTrackerOverlayPage({
@@ -26,6 +28,8 @@ export function IndividualTrackerOverlayPage({
   seriesMatchesService,
   haloClient,
   trackerId,
+  showPreview = false,
+  previewMode = "observer",
 }: IndividualTrackerOverlayPageProps): React.ReactElement {
   const store = useMemo(() => new OverlayPageStore(), [trackerId]);
 
@@ -98,6 +102,8 @@ export function IndividualTrackerOverlayPage({
             matchesLength={model.renderModel.accumulated.total}
             matchStatsPanelState={overlayModel.matchStatsPanelState}
             selectedMatchId={overlayModel.selectedMatchId}
+            showPreview={showPreview}
+            previewMode={previewMode}
             onSelectMatch={(matchId): void => {
               presenter.selectMatch(matchId);
             }}

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -58,6 +58,26 @@ export function IndividualTrackerOverlayPage({
     };
   }, [presenter]);
 
+  useEffect(() => {
+    if (model.renderModel == null) {
+      return;
+    }
+
+    const matchIds = new Set<string>();
+    for (const item of model.renderModel.timeline) {
+      if (item.type === "match") {
+        matchIds.add(item.match.matchId);
+        continue;
+      }
+
+      for (const match of item.series.matches) {
+        matchIds.add(match.matchId);
+      }
+    }
+
+    presenter.preloadMatchStats([...matchIds]);
+  }, [model.renderModel, presenter]);
+
   const overlaySnapshot = useSyncExternalStore(
     (listener) => store.subscribe(listener),
     () => store.getSnapshot(),
@@ -72,14 +92,14 @@ export function IndividualTrackerOverlayPage({
         ? overlayPresenter.present({
             renderModel: model.renderModel,
             streamerSettings: model.streamerSettings,
-            matchStatsState: overlayModel.matchStatsState,
+            matchStatsByMatchId: overlaySnapshot.matchStatsByMatchId,
             selectedMatchId: overlayModel.selectedMatchId,
           })
         : null,
     [
       model.renderModel,
       model.streamerSettings,
-      overlayModel.matchStatsState,
+      overlaySnapshot.matchStatsByMatchId,
       overlayModel.selectedMatchId,
       overlayPresenter,
     ],

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -293,7 +293,7 @@ export class IndividualTrackerOverlayPresenter {
   }
 
   public present(options: BuildOverlayViewModelOptions): IndividualTrackerOverlayViewModel {
-    const { renderModel, streamerSettings, selectedMatchId } = options;
+    const { renderModel, streamerSettings } = options;
     const displaySettings = getOverlayDisplaySettings(streamerSettings);
     const fontSizeStyles = getFontSizeStyles(streamerSettings);
     const activeSeries = this.getOverlayActiveSeries(renderModel);

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -6,7 +6,7 @@ import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { TeamColor } from "../../team-colors/team-colors";
-import type { TickerMatchGroup , TickerStatRow } from "../../information-ticker/information-ticker";
+import type { TickerMatchGroup, TickerStatRow } from "../../information-ticker/information-ticker";
 import { createMatchStatsFormatter } from "../../../controllers/stats/create";
 import type { MatchStatsValues } from "../../../controllers/stats/types";
 import type { OverlayTab } from "../../streamer-overlay/tabs-bar";
@@ -232,10 +232,7 @@ export class IndividualTrackerOverlayPresenter {
     ];
 
     // Case 1: Pre-series with active series that has teams (series exists but no matches yet)
-    if (
-      options.activeSeries?.matches.length === 0 &&
-      options.activeSeries.teams.length > 0
-    ) {
+    if (options.activeSeries?.matches.length === 0 && options.activeSeries.teams.length > 0) {
       const { activeSeries } = options;
       const seriesLabel = activeSeries.title || "Series Info";
       const rows: TickerStatRow[] = [];
@@ -391,7 +388,10 @@ export class IndividualTrackerOverlayPresenter {
     };
   }
 
-  private getTeamColors(renderModel: IndividualTrackerViewerRenderModel, activeSeries: ViewerSeriesTab | null): TeamColor[] {
+  private getTeamColors(
+    renderModel: IndividualTrackerViewerRenderModel,
+    activeSeries: ViewerSeriesTab | null,
+  ): TeamColor[] {
     if (renderModel.teamColors.length < 2) {
       return [...this.defaultTeamColors];
     }
@@ -416,9 +416,7 @@ export class IndividualTrackerOverlayPresenter {
     // Map player perspective colors to actual team positions
     // If player is on team 0, playerTeamColor goes to team 0
     // If player is on team 1, playerTeamColor goes to team 1, enemyTeamColor to team 0
-    return trackedPlayerTeamId === 0
-      ? [playerTeamColor, enemyTeamColor]
-      : [enemyTeamColor, playerTeamColor];
+    return trackedPlayerTeamId === 0 ? [playerTeamColor, enemyTeamColor] : [enemyTeamColor, playerTeamColor];
   }
 
   private buildTickerGroups(

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -299,8 +299,8 @@ export class IndividualTrackerOverlayPresenter {
     const { renderModel, streamerSettings, matchStatsState, selectedMatchId } = options;
     const displaySettings = getOverlayDisplaySettings(streamerSettings);
     const fontSizeStyles = getFontSizeStyles(streamerSettings);
-    const teamColors = this.getTeamColors(renderModel);
     const activeSeries = this.getOverlayActiveSeries(renderModel);
+    const teamColors = this.getTeamColors(renderModel, activeSeries);
     const showTicker = this.getShowTicker(streamerSettings, activeSeries, displaySettings.showTicker);
     const tabs = this.buildTabs(renderModel.timeline, activeSeries);
     const selectedTabIndex = this.getSelectedTabIndex(tabs, selectedMatchId);
@@ -392,12 +392,34 @@ export class IndividualTrackerOverlayPresenter {
     };
   }
 
-  private getTeamColors(renderModel: IndividualTrackerViewerRenderModel): TeamColor[] {
-    if (renderModel.teamColors.length >= 2) {
-      return [renderModel.teamColors[0], renderModel.teamColors[1]];
+  private getTeamColors(renderModel: IndividualTrackerViewerRenderModel, activeSeries: ViewerSeriesTab | null): TeamColor[] {
+    if (renderModel.teamColors.length < 2) {
+      return [...this.defaultTeamColors];
     }
 
-    return [...this.defaultTeamColors];
+    const [playerTeamColor, enemyTeamColor] = renderModel.teamColors;
+
+    // If no active series or no teams, use colors as-is (player perspective for matchmaking)
+    if (activeSeries == null || activeSeries.teams.length < 2) {
+      return [playerTeamColor, enemyTeamColor];
+    }
+
+    // Find which team the tracked player is on
+    const trackedPlayerTeamId = activeSeries.teams.find((team) =>
+      team.players.some((player) => player.gamertag === renderModel.gamertag),
+    )?.id;
+
+    // If player not found in series, use colors as-is
+    if (trackedPlayerTeamId == null) {
+      return [playerTeamColor, enemyTeamColor];
+    }
+
+    // Map player perspective colors to actual team positions
+    // If player is on team 0, playerTeamColor goes to team 0
+    // If player is on team 1, playerTeamColor goes to team 1, enemyTeamColor to team 0
+    return trackedPlayerTeamId === 0
+      ? [playerTeamColor, enemyTeamColor]
+      : [enemyTeamColor, playerTeamColor];
   }
 
   private getSelectedTabIndex(tabs: readonly OverlayTab[], selectedMatchId: string | null): number {

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -113,7 +113,7 @@ function getTeamDetailsModel(
 interface BuildOverlayViewModelOptions {
   readonly renderModel: IndividualTrackerViewerRenderModel;
   readonly streamerSettings: StreamerViewSettings | undefined;
-  readonly matchStatsState: MatchStatsState | null;
+  readonly matchStatsByMatchId: ReadonlyMap<string, MatchStatsState>;
   readonly selectedMatchId: string | null;
 }
 
@@ -296,15 +296,14 @@ export class IndividualTrackerOverlayPresenter {
   }
 
   public present(options: BuildOverlayViewModelOptions): IndividualTrackerOverlayViewModel {
-    const { renderModel, streamerSettings, matchStatsState, selectedMatchId } = options;
+    const { renderModel, streamerSettings, selectedMatchId } = options;
     const displaySettings = getOverlayDisplaySettings(streamerSettings);
     const fontSizeStyles = getFontSizeStyles(streamerSettings);
     const activeSeries = this.getOverlayActiveSeries(renderModel);
     const teamColors = this.getTeamColors(renderModel, activeSeries);
     const showTicker = this.getShowTicker(streamerSettings, activeSeries, displaySettings.showTicker);
     const tabs = this.buildTabs(renderModel.timeline, activeSeries);
-    const selectedTabIndex = this.getSelectedTabIndex(tabs, selectedMatchId);
-    const loadedTickerGroups = this.buildTickerGroups(matchStatsState, selectedTabIndex, {
+    const loadedTickerGroups = this.buildTickerGroups(options.matchStatsByMatchId, tabs, {
       trackedGamertag: renderModel.gamertag,
       includeOnlyTrackedPlayer: this.getIncludeOnlyTrackedPlayer(streamerSettings, activeSeries),
     });
@@ -422,53 +421,58 @@ export class IndividualTrackerOverlayPresenter {
       : [enemyTeamColor, playerTeamColor];
   }
 
-  private getSelectedTabIndex(tabs: readonly OverlayTab[], selectedMatchId: string | null): number {
-    if (selectedMatchId == null) {
-      return 0;
-    }
-    const tab = tabs.find((t) => t.type === "match" && t.matchId === selectedMatchId);
-    return tab?.type === "match" ? tab.index : 0;
-  }
-
   private buildTickerGroups(
-    matchStatsState: MatchStatsState | null,
-    matchIndex: number,
+    matchStatsByMatchId: ReadonlyMap<string, MatchStatsState>,
+    tabs: readonly OverlayTab[],
     filterOptions: TickerFilterOptions,
   ): TickerMatchGroup[] {
-    if (matchStatsState?.status !== "loaded") {
-      return [];
+    const groups: TickerMatchGroup[] = [];
+
+    for (const tab of tabs) {
+      if (tab.type !== "match") {
+        continue;
+      }
+
+      const matchState = matchStatsByMatchId.get(tab.matchId);
+      if (matchState?.status !== "loaded") {
+        continue;
+      }
+
+      const formatter = createMatchStatsFormatter(matchState.stats.MatchInfo.GameVariantCategory);
+      const data = formatter.getData(matchState.stats, matchState.playerMap, {});
+
+      const rows = data.flatMap((teamData) => [
+        {
+          type: "team" as const,
+          teamId: teamData.teamId,
+          name: getTeamName(teamData.teamId),
+          stats: teamData.teamStats,
+          medals: teamData.teamMedals,
+        },
+        ...teamData.players.map((player) => ({
+          type: "player" as const,
+          teamId: teamData.teamId,
+          name: player.name,
+          discordName: null,
+          gamertag: player.name,
+          stats: player.values,
+          medals: player.medals,
+        })),
+      ]);
+
+      const filteredRows = this.filterRowsForTrackedPlayer(rows, filterOptions);
+      if (filteredRows.length === 0) {
+        continue;
+      }
+
+      groups.push({
+        matchIndex: tab.index,
+        label: tab.label,
+        rows: filteredRows,
+      });
     }
 
-    const { stats, playerMap } = matchStatsState;
-    const formatter = createMatchStatsFormatter(stats.MatchInfo.GameVariantCategory);
-    const data = formatter.getData(stats, playerMap, {});
-
-    const rows = data.flatMap((teamData) => [
-      {
-        type: "team" as const,
-        teamId: teamData.teamId,
-        name: getTeamName(teamData.teamId),
-        stats: teamData.teamStats,
-        medals: teamData.teamMedals,
-      },
-      ...teamData.players.map((p) => ({
-        type: "player" as const,
-        teamId: teamData.teamId,
-        name: p.name,
-        stats: p.values,
-        medals: p.medals,
-      })),
-    ]);
-
-    const filteredRows = this.filterRowsForTrackedPlayer(rows, filterOptions);
-
-    return [
-      {
-        matchIndex,
-        label: "",
-        rows: filteredRows,
-      },
-    ];
+    return groups;
   }
 
   private getIncludeOnlyTrackedPlayer(
@@ -511,11 +515,13 @@ export class IndividualTrackerOverlayPresenter {
       if (row.type !== "player") {
         return false;
       }
-      if (row.name == null) {
+
+      const candidate = row.gamertag ?? row.name;
+      if (candidate == null) {
         return false;
       }
 
-      return row.name.trim().toLowerCase() === trackedGamertag;
+      return candidate.trim().toLowerCase() === trackedGamertag;
     });
 
     return trackedPlayerRows.length > 0 ? trackedPlayerRows : rows;

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -13,6 +13,8 @@ interface IndividualTrackerOverlayProps {
   readonly matchesLength: number;
   readonly matchStatsPanelState: MatchDetailsState | null;
   readonly selectedMatchId: string | null;
+  readonly showPreview?: boolean;
+  readonly previewMode?: "player" | "observer";
   readonly onSelectMatch: (matchId: string) => void;
   readonly onDeselect: () => void;
 }
@@ -23,6 +25,8 @@ export function IndividualTrackerOverlay({
   matchesLength,
   matchStatsPanelState,
   selectedMatchId,
+  showPreview = false,
+  previewMode = "observer",
   onSelectMatch,
   onDeselect,
 }: IndividualTrackerOverlayProps): React.ReactElement {
@@ -113,8 +117,8 @@ export function IndividualTrackerOverlay({
         showTicker={viewModel.showTicker}
         showPreSeriesInfo={viewModel.showPreSeriesInfo}
         matchesLength={matchesLength}
-        showPreview={false}
-        previewMode="observer"
+        showPreview={showPreview}
+        previewMode={previewMode}
         fontSizeStyles={viewModel.fontSizeStyles}
         settingsUi={null}
         hasPanelContent={hasPanelContent}

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -115,7 +115,6 @@ export function IndividualTrackerOverlay({
         tickerMatchGroups={viewModel.tickerMatchGroups}
         showTabs={viewModel.showTabs}
         showTicker={viewModel.showTicker}
-        showPreSeriesInfo={viewModel.showPreSeriesInfo}
         matchesLength={matchesLength}
         showPreview={showPreview}
         previewMode={previewMode}

--- a/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
@@ -42,6 +42,17 @@ export class OverlayPagePresenter {
     this.config.store.reset();
   }
 
+  public preloadMatchStats(matchIds: readonly string[]): void {
+    for (const matchId of matchIds) {
+      const existingState = this.config.store.getSnapshot().matchStatsByMatchId.get(matchId);
+      if (existingState?.status === "loaded" || existingState?.status === "loading") {
+        continue;
+      }
+
+      void this.loadMatchStatsAsync(matchId);
+    }
+  }
+
   public selectMatch(matchId: string): void {
     this.config.store.setSelectedMatchId(matchId);
 

--- a/pages/src/components/individual-tracker/overlay/overlay-stats-highlights.module.css
+++ b/pages/src/components/individual-tracker/overlay/overlay-stats-highlights.module.css
@@ -1,31 +1,51 @@
-.statsHighlights {
+.statsHighlightsBar {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-3);
+  gap: var(--space-1);
   justify-content: center;
-  padding: var(--space-2) var(--space-3);
+  padding: 0 var(--space-2);
 }
 
-.stat {
+.statTab {
   align-items: center;
+  background: rgb(15 40 48 / 90%);
+  background-image:
+    linear-gradient(to top, rgb(255 255 255 / 10%), rgb(255 255 255 / 10%)),
+    radial-gradient(circle at 1px 1px, rgb(255 255 255 / 15%) 1px, transparent 1.5px);
+  background-repeat: no-repeat, repeat;
+  background-size:
+    100% 100%,
+    10px 10px;
+  border: 2px solid var(--halo-bg-primary);
+  border-top: 0;
+  color: var(--halo-white);
   display: flex;
-  flex-direction: column;
+  font-family: var(--font-body);
+  font-size: calc(var(--text-sm) * var(--font-size-tabs, 1));
+  font-weight: 700;
   gap: var(--space-1);
-  min-width: 4rem;
+  min-height: 34px;
+  padding: var(--space-1) var(--space-2);
+  text-shadow:
+    0 1px 2px rgb(0 0 0 / 80%),
+    0 0 10px rgb(0 0 0 / 60%);
 }
 
 .statLabel {
   color: var(--halo-light-grey);
-  font-family: var(--font-body);
-  font-size: var(--font-size-xs);
-  text-align: center;
+  font-size: 0.8em;
+  font-weight: 600;
+  letter-spacing: 0.03em;
   text-transform: uppercase;
+}
+
+.statSeparator {
+  color: var(--halo-light-grey);
+  opacity: 0.8;
 }
 
 .statValue {
   color: var(--halo-white);
-  font-family: var(--font-body);
-  font-size: var(--font-size-sm);
-  font-weight: bold;
-  text-align: center;
+  font-size: 1em;
+  font-weight: 700;
 }

--- a/pages/src/components/individual-tracker/overlay/overlay-stats-highlights.tsx
+++ b/pages/src/components/individual-tracker/overlay/overlay-stats-highlights.tsx
@@ -10,11 +10,13 @@ function OverlayStatsHighlightsComponent({ items }: OverlayStatsHighlightsProps)
   if (items.length === 0) {
     return null;
   }
+
   return (
-    <div className={styles.statsHighlights}>
+    <div className={styles.statsHighlightsBar}>
       {items.map((item, i) => (
-        <div key={i} className={styles.stat}>
+        <div key={i} className={styles.statTab}>
           <span className={styles.statLabel}>{item.label}</span>
+          <span className={styles.statSeparator}>•</span>
           <span className={styles.statValue}>{item.value}</span>
         </div>
       ))}

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -205,6 +205,50 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(groups).toHaveLength(0);
   });
 
+  it("shows series with teams and players when pre-series with active teams", () => {
+    const groups = presenter.buildPreSeriesTickerGroup({
+      showTicker: true,
+      showPreSeriesInfo: true,
+      activeSeries: aSeriesWith({
+        matches: [],
+        isActive: true,
+        title: "Eagle vs Cobra",
+        teams: [
+          {
+            id: 0,
+            name: "Eagle",
+            players: [
+              { discordName: "DiscordPlayer1", gamertag: "Player1" },
+              { discordName: null, gamertag: "Player2" },
+            ],
+          },
+          {
+            id: 1,
+            name: "Cobra",
+            players: [{ discordName: "DiscordPlayer3", gamertag: "Player3" }],
+          },
+        ],
+      }),
+      playerName: "TrackedPlayer",
+      discordName: null,
+      gamertag: "TrackedPlayer",
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe("Eagle vs Cobra");
+    expect(groups[0].rows).toHaveLength(5); // 2 teams + 3 players
+    expect(groups[0].rows[0]?.type).toBe("team");
+    expect(groups[0].rows[0]?.name).toBe("Eagle");
+    expect(groups[0].rows[1]?.type).toBe("player");
+    expect(groups[0].rows[1]?.gamertag).toBe("Player1");
+    expect(groups[0].rows[2]?.type).toBe("player");
+    expect(groups[0].rows[2]?.gamertag).toBe("Player2");
+    expect(groups[0].rows[3]?.type).toBe("team");
+    expect(groups[0].rows[3]?.name).toBe("Cobra");
+    expect(groups[0].rows[4]?.type).toBe("player");
+    expect(groups[0].rows[4]?.gamertag).toBe("Player3");
+  });
+
   it("maps pre-series tracked-player ticker row to the tracked-player color slot", () => {
     const model = presenter.present({
       renderModel: aRenderModelWith({

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -277,6 +277,44 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(model.teamColors[0]?.hex).toBe("#00AA11");
   });
 
+  it("maps player perspective colors onto team positions when tracked player is on team 1", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        gamertag: "TrackedPlayer",
+        timeline: [
+          {
+            type: "series",
+            series: aSeriesWith({
+              isActive: true,
+              teams: [
+                {
+                  id: 0,
+                  name: "Alpha",
+                  players: [{ discordName: "AlphaPlayer", gamertag: "AlphaTag" }],
+                },
+                {
+                  id: 1,
+                  name: "Beta",
+                  players: [{ discordName: "TrackedPlayer", gamertag: "TrackedPlayer" }],
+                },
+              ],
+            }),
+          },
+        ],
+        teamColors: [
+          { id: "tracked", name: "Tracked", hex: "#00AA11" },
+          { id: "enemy", name: "Enemy", hex: "#AA0011" },
+        ],
+      }),
+      streamerSettings: undefined,
+      matchStatsState: null,
+      selectedMatchId: null,
+    });
+
+    expect(model.teamColors[0]?.hex).toBe("#AA0011");
+    expect(model.teamColors[1]?.hex).toBe("#00AA11");
+  });
+
   it("builds top-section team details with xbox-only names when discord names are hidden", () => {
     const model = presenter.present({
       renderModel: aRenderModelWith({

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -268,7 +268,7 @@ describe("individual-tracker-overlay-presenter", () => {
           showTicker: true,
         },
       } satisfies StreamerViewSettings,
-      matchStatsState: null,
+      matchStatsByMatchId: new Map(),
       selectedMatchId: null,
     });
 
@@ -307,7 +307,7 @@ describe("individual-tracker-overlay-presenter", () => {
         ],
       }),
       streamerSettings: undefined,
-      matchStatsState: null,
+      matchStatsByMatchId: new Map(),
       selectedMatchId: null,
     });
 
@@ -337,7 +337,7 @@ describe("individual-tracker-overlay-presenter", () => {
           showXboxNames: true,
         },
       } satisfies StreamerViewSettings,
-      matchStatsState: null,
+      matchStatsByMatchId: new Map(),
       selectedMatchId: null,
     });
 
@@ -367,7 +367,7 @@ describe("individual-tracker-overlay-presenter", () => {
           showXboxNames: false,
         },
       } satisfies StreamerViewSettings,
-      matchStatsState: null,
+      matchStatsByMatchId: new Map(),
       selectedMatchId: null,
     });
 
@@ -403,7 +403,7 @@ describe("individual-tracker-overlay-presenter", () => {
         ],
       }),
       streamerSettings: undefined,
-      matchStatsState: null,
+      matchStatsByMatchId: new Map(),
       selectedMatchId: null,
     });
 
@@ -419,7 +419,7 @@ describe("individual-tracker-overlay-presenter", () => {
         statsHighlights: [{ label: "KDA", value: "3.2" }],
       }),
       streamerSettings: undefined,
-      matchStatsState: null,
+      matchStatsByMatchId: new Map(),
       selectedMatchId: null,
     });
 
@@ -437,7 +437,7 @@ describe("individual-tracker-overlay-presenter", () => {
           matchmakingShowStatsHighlights: false,
         },
       } satisfies StreamerViewSettings,
-      matchStatsState: null,
+      matchStatsByMatchId: new Map(),
       selectedMatchId: null,
     });
 
@@ -446,25 +446,34 @@ describe("individual-tracker-overlay-presenter", () => {
   });
 
   it("shows only the tracked player row in matchmaking ticker when matchmakingMyStatsOnly is enabled", () => {
+    const matchId = "matchmaking-1";
+
     const model = presenter.present({
-      renderModel: aRenderModelWith(),
+      renderModel: aRenderModelWith({
+        timeline: [{ type: "match", match: aMatchWith({ matchId }) }],
+      }),
       streamerSettings: {
         styleFlags: {
           matchmakingMyStatsOnly: true,
         },
       },
-      matchStatsState: {
-        status: "loaded",
-        stats: aFakeMatchStatsWith(),
-        playerMap: new Map<string, string>([
-          ["1111111111", "TrackedPlayer"],
-          ["2222222222", "PlayerTwo"],
-          ["3333333333", "PlayerThree"],
-          ["4444444444", "PlayerFour"],
-        ]),
-        medalMetadata: aFakeMedalMetadata(),
-        analytics: null,
-      },
+      matchStatsByMatchId: new Map([
+        [
+          matchId,
+          {
+            status: "loaded" as const,
+            stats: aFakeMatchStatsWith({ MatchId: matchId }),
+            playerMap: new Map<string, string>([
+              ["1111111111", "TrackedPlayer"],
+              ["2222222222", "PlayerTwo"],
+              ["3333333333", "PlayerThree"],
+              ["4444444444", "PlayerFour"],
+            ]),
+            medalMetadata: aFakeMedalMetadata(),
+            analytics: null,
+          },
+        ],
+      ]),
       selectedMatchId: null,
     });
 
@@ -492,18 +501,23 @@ describe("individual-tracker-overlay-presenter", () => {
           inSeriesMyStatsOnly: true,
         },
       },
-      matchStatsState: {
-        status: "loaded",
-        stats: aFakeMatchStatsWith(),
-        playerMap: new Map<string, string>([
-          ["1111111111", "TrackedPlayer"],
-          ["2222222222", "PlayerTwo"],
-          ["3333333333", "PlayerThree"],
-          ["4444444444", "PlayerFour"],
-        ]),
-        medalMetadata: aFakeMedalMetadata(),
-        analytics: null,
-      },
+      matchStatsByMatchId: new Map([
+        [
+          "series-match-1",
+          {
+            status: "loaded" as const,
+            stats: aFakeMatchStatsWith({ MatchId: "series-match-1" }),
+            playerMap: new Map<string, string>([
+              ["1111111111", "TrackedPlayer"],
+              ["2222222222", "PlayerTwo"],
+              ["3333333333", "PlayerThree"],
+              ["4444444444", "PlayerFour"],
+            ]),
+            medalMetadata: aFakeMedalMetadata(),
+            analytics: null,
+          },
+        ],
+      ]),
       selectedMatchId: "series-match-1",
     });
 
@@ -511,6 +525,61 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]?.type).toBe("player");
     expect(rows[0]?.name).toBe("TrackedPlayer");
+  });
+
+  it("builds ticker groups for each loaded match and rotates by tab labels", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        timeline: [
+          { type: "match", match: aMatchWith({ matchId: "match-1", mapName: "Live Fire" }) },
+          { type: "match", match: aMatchWith({ matchId: "match-2", mapName: "Streets" }) },
+        ],
+      }),
+      streamerSettings: {
+        visibleSections: {
+          showTicker: true,
+        },
+      } satisfies StreamerViewSettings,
+      matchStatsByMatchId: new Map([
+        [
+          "match-1",
+          {
+            status: "loaded" as const,
+            stats: aFakeMatchStatsWith({ MatchId: "match-1" }),
+            playerMap: new Map<string, string>([
+              ["1111111111", "TrackedPlayer"],
+              ["2222222222", "PlayerTwo"],
+              ["3333333333", "PlayerThree"],
+              ["4444444444", "PlayerFour"],
+            ]),
+            medalMetadata: aFakeMedalMetadata(),
+            analytics: null,
+          },
+        ],
+        [
+          "match-2",
+          {
+            status: "loaded" as const,
+            stats: aFakeMatchStatsWith({ MatchId: "match-2" }),
+            playerMap: new Map<string, string>([
+              ["1111111111", "TrackedPlayer"],
+              ["2222222222", "PlayerTwo"],
+              ["3333333333", "PlayerThree"],
+              ["4444444444", "PlayerFour"],
+            ]),
+            medalMetadata: aFakeMedalMetadata(),
+            analytics: null,
+          },
+        ],
+      ]),
+      selectedMatchId: null,
+    });
+
+    expect(model.tickerMatchGroups).toHaveLength(2);
+    expect(model.tickerMatchGroups[0]?.label).toBe("Live Fire");
+    expect(model.tickerMatchGroups[1]?.label).toBe("Streets");
+    expect(model.tickerMatchGroups[0]?.rows.length).toBeGreaterThan(0);
+    expect(model.tickerMatchGroups[1]?.rows.length).toBeGreaterThan(0);
   });
 
   it("hides ticker in-series when inSeriesShowTicker is false", () => {
@@ -531,7 +600,7 @@ describe("individual-tracker-overlay-presenter", () => {
           inSeriesShowTicker: false,
         },
       },
-      matchStatsState: null,
+      matchStatsByMatchId: new Map(),
       selectedMatchId: null,
     });
 
@@ -546,7 +615,7 @@ describe("individual-tracker-overlay-presenter", () => {
           matchmakingShowTicker: false,
         },
       },
-      matchStatsState: null,
+      matchStatsByMatchId: new Map(),
       selectedMatchId: null,
     });
 

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -43,12 +43,14 @@ function aPropsWith(options?: {
   const streamerSettings = options?.streamerSettings;
   const matchStatsState = options?.matchStatsState ?? null;
   const selectedMatchId = options?.selectedMatchId ?? null;
+  const matchStatsByMatchId =
+    selectedMatchId != null && matchStatsState != null ? new Map([[selectedMatchId, matchStatsState]]) : new Map();
 
   return {
     viewModel: presenter.present({
       renderModel,
       streamerSettings,
-      matchStatsState,
+      matchStatsByMatchId,
       selectedMatchId,
     }),
     isPanelOpen: presenter.isPanelOpen(selectedMatchId, matchStatsState),

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -376,6 +376,9 @@ describe("IndividualTrackerOverlay", () => {
         showSubtitle: false,
         showTeamDetails: false,
       },
+      styleFlags: {
+        showPreSeriesInfo: false,
+      },
     };
 
     render(<IndividualTrackerOverlay {...aPropsWith({ renderModel, streamerSettings })} />);

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
@@ -96,4 +96,32 @@ describe("OverlayPagePresenter", () => {
     expect(model.matchStatsState?.status).toBe("loaded");
     expect(model.matchStatsPanelState?.status).toBe("loaded");
   });
+
+  it("preloads stats for all provided matches", async () => {
+    const store = new OverlayPageStore();
+    const getMatchStats = vi
+      .fn(async (matchId: string) => Promise.resolve(aFakeMatchStatsWith({ MatchId: matchId })))
+      .mockName("getMatchStats");
+    const haloClient = aFakeHaloClientWith({
+      getMatchStats,
+      getUsers: vi.fn(async (xuids: string[]) => Promise.resolve(aUsersFor(xuids))),
+    });
+
+    const presenter = new OverlayPagePresenter({
+      store,
+      haloClient,
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+    });
+
+    presenter.preloadMatchStats(["match-1", "match-2", "match-3"]);
+
+    await waitFor(() => {
+      expect(store.getSnapshot().matchStatsByMatchId.get("match-1")?.status).toBe("loaded");
+      expect(store.getSnapshot().matchStatsByMatchId.get("match-2")?.status).toBe("loaded");
+      expect(store.getSnapshot().matchStatsByMatchId.get("match-3")?.status).toBe("loaded");
+    });
+
+    presenter.preloadMatchStats(["match-1", "match-2"]);
+    expect(getMatchStats).toHaveBeenCalledTimes(3);
+  });
 });

--- a/pages/src/components/information-ticker/information-ticker.tsx
+++ b/pages/src/components/information-ticker/information-ticker.tsx
@@ -83,7 +83,7 @@ const InformationTickerComponent = function InformationTicker({
           {/* Team Icon + Name */}
           <div className={styles.tickerName}>
             {currentRow.showTeamIcon !== false && <TeamIcon teamId={currentRow.teamId} size="small" />}
-            {currentRow.type === "player" && (currentRow.discordName != null || currentRow.gamertag != null) ? (
+            {currentRow.type === "player" && currentRow.discordName != null && currentRow.gamertag != null ? (
               <PlayerName
                 discordName={currentRow.discordName ?? null}
                 gamertag={currentRow.gamertag ?? null}

--- a/pages/src/components/information-ticker/information-ticker.tsx
+++ b/pages/src/components/information-ticker/information-ticker.tsx
@@ -83,7 +83,7 @@ const InformationTickerComponent = function InformationTicker({
           {/* Team Icon + Name */}
           <div className={styles.tickerName}>
             {currentRow.showTeamIcon !== false && <TeamIcon teamId={currentRow.teamId} size="small" />}
-            {currentRow.type === "player" && currentRow.discordName != null && currentRow.gamertag != null ? (
+            {currentRow.type === "player" && (currentRow.discordName != null || currentRow.gamertag != null) ? (
               <PlayerName
                 discordName={currentRow.discordName ?? null}
                 gamertag={currentRow.gamertag ?? null}

--- a/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
@@ -576,7 +576,6 @@ function NeatQueueStreamerOverlay({
       tickerMatchGroups={tickerMatchGroups}
       showTabs={showTabs}
       showTicker={showTicker}
-      showPreSeriesInfo={settings.global.ticker.showPreSeriesInfo}
       matchesLength={neatQueueState.matches.length}
       showPreview={settings.global.viewPreview}
       previewMode={settings.global.colors.mode}

--- a/pages/src/components/player-name/player-name.tsx
+++ b/pages/src/components/player-name/player-name.tsx
@@ -13,10 +13,33 @@ interface PlayerNameProps {
 }
 
 export function PlayerName({ discordName, gamertag, showIcons = false, className }: PlayerNameProps): JSX.Element {
-  const [showDiscord, setShowDiscord] = useState(true);
+  if (discordName == null && gamertag == null) {
+    return <span className={classNames(styles.playerName, className)} />;
+  }
 
-  const displayDiscordName = discordName ?? "Unknown";
-  const displayGamertag = gamertag ?? "-";
+  if (discordName == null) {
+    return (
+      <span className={classNames(styles.playerName, className)}>
+        <span className={classNames(styles.nameWithIcon, styles.xbox)}>
+          {showIcons && <img src={XboxLogo.src} alt="Xbox" className={styles.icon} />}
+          <span>{gamertag}</span>
+        </span>
+      </span>
+    );
+  }
+
+  if (gamertag == null) {
+    return (
+      <span className={classNames(styles.playerName, className)}>
+        <span className={classNames(styles.nameWithIcon, styles.discord)}>
+          {showIcons && <img src={discordLogo.src} alt="Discord" className={styles.icon} />}
+          <span>{discordName}</span>
+        </span>
+      </span>
+    );
+  }
+
+  const [showDiscord, setShowDiscord] = useState(true);
 
   // Always fade between Discord and Xbox every 10 seconds
   useEffect((): (() => void) => {
@@ -40,11 +63,11 @@ export function PlayerName({ discordName, gamertag, showIcons = false, className
       >
         <span className={classNames(styles.nameWithIcon, styles.discord)}>
           {showIcons && <img src={discordLogo.src} alt="Discord" className={styles.icon} />}
-          <span>{displayDiscordName}</span>
+          <span>{discordName}</span>
         </span>
         <span className={classNames(styles.nameWithIcon, styles.xbox)}>
           {showIcons && <img src={XboxLogo.src} alt="Xbox" className={styles.icon} />}
-          <span>{displayGamertag}</span>
+          <span>{gamertag}</span>
         </span>
       </span>
     </span>

--- a/pages/src/components/streamer-overlay/bottom-section.tsx
+++ b/pages/src/components/streamer-overlay/bottom-section.tsx
@@ -7,8 +7,6 @@ import styles from "./streamer-overlay.module.css";
 interface BottomSectionProps {
   readonly showTabs: boolean;
   readonly showTicker: boolean;
-  readonly showPreSeriesInfo: boolean;
-  readonly matchesLength: number;
   readonly currentMatchGroup: TickerMatchGroup | undefined;
   readonly teamColors: TeamColor[];
   readonly tabs: readonly OverlayTab[];
@@ -22,8 +20,6 @@ interface BottomSectionProps {
 function BottomSectionComponent({
   showTabs,
   showTicker,
-  showPreSeriesInfo,
-  matchesLength,
   currentMatchGroup,
   teamColors,
   tabs,

--- a/pages/src/components/streamer-overlay/bottom-section.tsx
+++ b/pages/src/components/streamer-overlay/bottom-section.tsx
@@ -56,10 +56,6 @@ function BottomSectionComponent({
           onScrollComplete={onScrollComplete}
         />
       )}
-
-      {showTicker && currentMatchGroup == null && !showPreSeriesInfo && matchesLength === 0 && (
-        <div className={styles.tickerPlaceholder}>Waiting for first match to complete...</div>
-      )}
     </div>
   );
 }

--- a/pages/src/components/streamer-overlay/streamer-overlay.module.css
+++ b/pages/src/components/streamer-overlay/streamer-overlay.module.css
@@ -285,18 +285,6 @@
   justify-content: center;
 }
 
-.tickerPlaceholder {
-  align-items: center;
-  background: rgb(15 40 48 / 90%);
-  color: var(--halo-gray);
-  display: flex;
-  font-size: calc(var(--text-sm) * var(--font-size-ticker, 1));
-  justify-content: center;
-  min-height: 60px;
-  padding: var(--space-3);
-  text-align: center;
-}
-
 .title,
 .subtitle,
 .tab {

--- a/pages/src/components/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/streamer-overlay/streamer-overlay.tsx
@@ -15,7 +15,6 @@ export interface StreamerOverlayProps {
   readonly tickerMatchGroups: readonly TickerMatchGroup[];
   readonly showTabs: boolean;
   readonly showTicker: boolean;
-  readonly showPreSeriesInfo: boolean;
   readonly matchesLength: number;
   readonly showPreview: boolean;
   readonly previewMode: "player" | "observer";
@@ -36,7 +35,6 @@ export function StreamerOverlay({
   tickerMatchGroups,
   showTabs,
   showTicker,
-  showPreSeriesInfo,
   matchesLength,
   showPreview,
   previewMode,
@@ -133,8 +131,6 @@ export function StreamerOverlay({
       <BottomSection
         showTabs={showTabs}
         showTicker={showTicker}
-        showPreSeriesInfo={showPreSeriesInfo}
-        matchesLength={matchesLength}
         currentMatchGroup={currentMatchGroup}
         teamColors={teamColors}
         tabs={tabs}

--- a/pages/src/components/streamer-overlay/tests/streamer-overlay.test.tsx
+++ b/pages/src/components/streamer-overlay/tests/streamer-overlay.test.tsx
@@ -56,7 +56,6 @@ describe("StreamerOverlay", () => {
     tickerMatchGroups,
     showTabs: true,
     showTicker: true,
-    showPreSeriesInfo: true,
     matchesLength: 1,
     showPreview: false,
     previewMode: "observer",


### PR DESCRIPTION
## Context
This feature set completes a series of streamer overlay fixes for the individual tracker experience. We addressed pre-series rendering gaps, matchmaking ticker behavior, color mapping correctness, preview-mode routing, and matchmaking top-bar stats presentation so the overlay behaves consistently with live-tracker expectations and provides useful information before/while matches are loading.

## This PR
This PR ships the end-to-end overlay fixes and tests:
- Added pre-series coverage for series-with-teams ticker output and removed the old waiting placeholder UI.
- Corrected overlay team-color mapping to align player/enemy perspective colors with actual team positions (including tracked player on team 1).
- Added default stats-highlight slot fallback in view routes so matchmaking top highlights render even before explicit slot config exists.
- Wired overlay preview URL params through the public overlay route (`preview=1`, `previewMode=player|observer`) so preview backgrounds apply correctly.
- Made overlay ticker behave like live tracker by preloading match stats for all visible matches and rotating through fully-populated match groups instead of selected-match-only data.
- Fixed ticker name rendering to avoid `Unknown`/gamertag oscillation when only one identity is present.
- Restyled matchmaking stats highlights as top-pinned tab-like chips (mirroring bottom-tab language, flipped for top placement).
- Added/updated focused tests across overlay presenter, overlay page presenter, overlay component, follow overlay viewer, and route behavior.

## Subsequent Work
- Validate final visual polish in OBS capture at multiple resolutions and with very long labels/values.
- If desired, align exact spacing/animation timing of top-pinned stats highlight tabs to the original prototype worktree for pixel-level parity.
