### PR TITLE
Fix tracker overlay parity and follow live update behavior

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1660,14 +1660,20 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     return state.lastSeenMatchId ?? state.matchIds.at(-1) ?? null;
   }
 
-  private async getPreSeriesPlayerInfo(state: IndividualTrackerInternalState): Promise<PreSeriesPlayerInfo | undefined> {
+  private async getPreSeriesPlayerInfo(
+    state: IndividualTrackerInternalState,
+  ): Promise<PreSeriesPlayerInfo | undefined> {
     const cacheKey = this.getPreSeriesPlayerInfoCacheKey(state);
     if (state.preSeriesPlayerInfoLatestMatchId === cacheKey) {
       return state.preSeriesPlayerInfo;
     }
 
     const preSeriesPlayerInfo = await this.buildPreSeriesPlayerInfo(state);
-    state.preSeriesPlayerInfo = preSeriesPlayerInfo;
+    if (preSeriesPlayerInfo !== undefined) {
+      state.preSeriesPlayerInfo = preSeriesPlayerInfo;
+    } else {
+      delete state.preSeriesPlayerInfo;
+    }
     state.preSeriesPlayerInfoLatestMatchId = cacheKey;
     await this.setState(state);
     return preSeriesPlayerInfo;

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -74,6 +74,7 @@ import type {
   IndividualTrackerSeriesGroup,
   IndividualTrackerSeriesGroupOverride,
   IndividualTrackerViewState,
+  PreSeriesPlayerInfo,
   ActiveSeries,
   SeriesPlayer,
   SeriesTeam,
@@ -137,6 +138,14 @@ function parseStatsHighlightSlots(url: URL): readonly IndividualStatsHighlightOp
   }
 
   return parsedSlots.data;
+}
+
+function normalizeRankTier(rankTier: string | null | undefined): string | null {
+  if (rankTier == null || rankTier === "") {
+    return null;
+  }
+
+  return rankTier;
 }
 
 export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
@@ -1632,6 +1641,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       trackerState != null && statsHighlightSlots.length > 0
         ? await this.buildStatsHighlights(trackerState, statsHighlightSlots)
         : undefined;
+    const preSeriesPlayerInfo = trackerState != null ? await this.buildPreSeriesPlayerInfo(trackerState) : undefined;
 
     if (trackerState == null) {
       return individualTrackerViewStateContract.toResponse({ state: null });
@@ -1641,8 +1651,53 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       state: {
         ...viewState,
         ...(statsHighlights != null ? { statsHighlights: [...statsHighlights] } : {}),
+        ...(preSeriesPlayerInfo != null ? { preSeriesPlayerInfo } : {}),
       },
     });
+  }
+
+  private async buildPreSeriesPlayerInfo(state: IndividualTrackerInternalState): Promise<PreSeriesPlayerInfo | undefined> {
+    try {
+      await this.getUserHaloService(state.userId);
+    } catch (err: unknown) {
+      this.logService.warn(
+        err,
+        new Map([
+          ["context", "IndividualTracker: getUserHaloService failed in buildPreSeriesPlayerInfo"],
+          ["userId", state.userId],
+          ["xuid", state.xuid],
+        ]),
+      );
+      return undefined;
+    }
+
+    const [csrContainer, esraData] = await Promise.all([this.fetchRankedArenaCsr(state.xuid), this.fetchPlayerEsra(state.xuid)]);
+
+    const currentRank = csrContainer?.Current.Value;
+    const allTimePeakRank = csrContainer?.AllTimeMax.Value;
+    const esra = esraData?.esra;
+
+    const info: PreSeriesPlayerInfo = {
+      currentRank: currentRank != null && currentRank > 0 ? currentRank : null,
+      currentRankTier: normalizeRankTier(csrContainer?.Current.Tier),
+      currentRankSubTier: csrContainer?.Current.SubTier ?? null,
+      currentRankMeasurementMatchesRemaining: csrContainer?.Current.MeasurementMatchesRemaining ?? null,
+      currentRankInitialMeasurementMatches: csrContainer?.Current.InitialMeasurementMatches ?? null,
+      allTimePeakRank: allTimePeakRank != null && allTimePeakRank > 0 ? allTimePeakRank : null,
+      esra: esra != null && esra >= 0 ? esra : null,
+      lastRankedGamePlayed: esraData?.lastRankedGamePlayed ?? null,
+    };
+
+    if (
+      info.currentRank == null &&
+      info.allTimePeakRank == null &&
+      info.esra == null &&
+      info.lastRankedGamePlayed == null
+    ) {
+      return undefined;
+    }
+
+    return info;
   }
 
   private async buildStatsHighlights(

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1656,7 +1656,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     });
   }
 
-  private async buildPreSeriesPlayerInfo(state: IndividualTrackerInternalState): Promise<PreSeriesPlayerInfo | undefined> {
+  private async buildPreSeriesPlayerInfo(
+    state: IndividualTrackerInternalState,
+  ): Promise<PreSeriesPlayerInfo | undefined> {
     try {
       await this.getUserHaloService(state.userId);
     } catch (err: unknown) {
@@ -1671,7 +1673,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       return undefined;
     }
 
-    const [csrContainer, esraData] = await Promise.all([this.fetchRankedArenaCsr(state.xuid), this.fetchPlayerEsra(state.xuid)]);
+    const [csrContainer, esraData] = await Promise.all([
+      this.fetchRankedArenaCsr(state.xuid),
+      this.fetchPlayerEsra(state.xuid),
+    ]);
 
     const currentRank = csrContainer?.Current.Value;
     const allTimePeakRank = csrContainer?.AllTimeMax.Value;

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1641,7 +1641,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       trackerState != null && statsHighlightSlots.length > 0
         ? await this.buildStatsHighlights(trackerState, statsHighlightSlots)
         : undefined;
-    const preSeriesPlayerInfo = trackerState != null ? await this.buildPreSeriesPlayerInfo(trackerState) : undefined;
+    const preSeriesPlayerInfo = trackerState != null ? await this.getPreSeriesPlayerInfo(trackerState) : undefined;
 
     if (trackerState == null) {
       return individualTrackerViewStateContract.toResponse({ state: null });
@@ -1654,6 +1654,23 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         ...(preSeriesPlayerInfo != null ? { preSeriesPlayerInfo } : {}),
       },
     });
+  }
+
+  private getPreSeriesPlayerInfoCacheKey(state: IndividualTrackerInternalState): string | null {
+    return state.lastSeenMatchId ?? state.matchIds.at(-1) ?? null;
+  }
+
+  private async getPreSeriesPlayerInfo(state: IndividualTrackerInternalState): Promise<PreSeriesPlayerInfo | undefined> {
+    const cacheKey = this.getPreSeriesPlayerInfoCacheKey(state);
+    if (state.preSeriesPlayerInfoLatestMatchId === cacheKey) {
+      return state.preSeriesPlayerInfo;
+    }
+
+    const preSeriesPlayerInfo = await this.buildPreSeriesPlayerInfo(state);
+    state.preSeriesPlayerInfo = preSeriesPlayerInfo;
+    state.preSeriesPlayerInfoLatestMatchId = cacheKey;
+    await this.setState(state);
+    return preSeriesPlayerInfo;
   }
 
   private async buildPreSeriesPlayerInfo(

--- a/api/durable-objects/individual-tracker/stats-highlights.ts
+++ b/api/durable-objects/individual-tracker/stats-highlights.ts
@@ -257,19 +257,19 @@ function formatStatsHighlightOption(option: IndividualStatsHighlightOption, ctx:
     }
     case "current-rank": {
       const value = csrContainer?.Current.Value;
-      return value != null && value > 0 ? formatStatValue(value) : "–";
+      return value != null && value > 0 ? formatStatValue(value) : "-";
     }
     case "season-peak": {
       const value = csrContainer?.SeasonMax.Value;
-      return value != null && value > 0 ? formatStatValue(value) : "–";
+      return value != null && value > 0 ? formatStatValue(value) : "-";
     }
     case "all-time-peak": {
       const value = csrContainer?.AllTimeMax.Value;
-      return value != null && value > 0 ? formatStatValue(value) : "–";
+      return value != null && value > 0 ? formatStatValue(value) : "-";
     }
     case "esra": {
       const esra = esraData?.esra;
-      return esra != null && esra >= 0 ? formatStatValue(Math.round(esra)) : "–";
+      return esra != null && esra >= 0 ? formatStatValue(Math.round(esra)) : "-";
     }
     case "kills": {
       return totals != null ? formatStatValue(totals.kills) : null;

--- a/api/durable-objects/individual-tracker/tests/stats-highlights.test.ts
+++ b/api/durable-objects/individual-tracker/tests/stats-highlights.test.ts
@@ -540,7 +540,7 @@ describe("statsHighlights", () => {
       });
     });
 
-    it("returns – when getRankedArenaCsrs throws (graceful degradation)", async () => {
+    it("returns - when getRankedArenaCsrs throws (graceful degradation)", async () => {
       vi.spyOn(services.haloService, "getRankedArenaCsrs").mockRejectedValue(new Error("CSR fetch failed"));
 
       const url = new URL("http://do/view-state");
@@ -548,11 +548,11 @@ describe("statsHighlights", () => {
       const response = await individualTrackerDO.fetch(new Request(url.toString(), { method: "GET" }));
       const body: IndividualTrackerViewStateResponse = await response.json();
 
-      expect(body.state?.statsHighlights?.[0]).toEqual({ label: "Current Rank", value: "–" });
-      expect(body.state?.statsHighlights?.[1]).toEqual({ label: "Season Peak", value: "–" });
+      expect(body.state?.statsHighlights?.[0]).toEqual({ label: "Current Rank", value: "-" });
+      expect(body.state?.statsHighlights?.[1]).toEqual({ label: "Season Peak", value: "-" });
     });
 
-    it("returns – when getPlayerEsra throws (graceful degradation)", async () => {
+    it("returns - when getPlayerEsra throws (graceful degradation)", async () => {
       vi.spyOn(services.haloService, "getPlayerEsra").mockRejectedValue(new Error("ESRA fetch failed"));
 
       const url = new URL("http://do/view-state");
@@ -560,10 +560,10 @@ describe("statsHighlights", () => {
       const response = await individualTrackerDO.fetch(new Request(url.toString(), { method: "GET" }));
       const body: IndividualTrackerViewStateResponse = await response.json();
 
-      expect(body.state?.statsHighlights?.[0]).toEqual({ label: "ESRA", value: "–" });
+      expect(body.state?.statsHighlights?.[0]).toEqual({ label: "ESRA", value: "-" });
     });
 
-    it("returns – when no CSR found for xuid (player not ranked)", async () => {
+    it("returns - when no CSR found for xuid (player not ranked)", async () => {
       vi.spyOn(services.haloService, "getRankedArenaCsrs").mockResolvedValue(new Map());
 
       const url = new URL("http://do/view-state");
@@ -571,10 +571,10 @@ describe("statsHighlights", () => {
       const response = await individualTrackerDO.fetch(new Request(url.toString(), { method: "GET" }));
       const body: IndividualTrackerViewStateResponse = await response.json();
 
-      expect(body.state?.statsHighlights?.[0]).toEqual({ label: "Current Rank", value: "–" });
+      expect(body.state?.statsHighlights?.[0]).toEqual({ label: "Current Rank", value: "-" });
     });
 
-    it("returns – for CSR slots when Value is 0 (placement/unranked sentinel)", async () => {
+    it("returns - for CSR slots when Value is 0 (placement/unranked sentinel)", async () => {
       const unrankedCsr = { ...fakeCsr, Value: 0, Tier: "", MeasurementMatchesRemaining: 3 };
       vi.spyOn(services.haloService, "getRankedArenaCsrs").mockResolvedValue(
         new Map([[trackedXuid, { Current: unrankedCsr, SeasonMax: unrankedCsr, AllTimeMax: unrankedCsr }]]),
@@ -587,7 +587,7 @@ describe("statsHighlights", () => {
 
       expect(body.state?.statsHighlights?.[0]).toEqual({
         label: "Current Rank",
-        value: "–",
+        value: "-",
         rankIcon: {
           rankTier: null,
           subTier: 0,
@@ -595,13 +595,31 @@ describe("statsHighlights", () => {
           initialMeasurementMatches: 10,
         },
       });
-      expect(body.state?.statsHighlights?.[1]).toEqual({ label: "Season Peak", value: "–" });
-      expect(body.state?.statsHighlights?.[2]).toEqual({ label: "All Time Peak", value: "–" });
+      expect(body.state?.statsHighlights?.[1]).toEqual({ label: "Season Peak", value: "-" });
+      expect(body.state?.statsHighlights?.[2]).toEqual({ label: "All Time Peak", value: "-" });
     });
 
-    it("still computes non-rank slots while pre-series profile data fetches run", async () => {
+    it("reuses cached pre-series profile data when latest match id is unchanged", async () => {
       const csrSpy = vi.spyOn(services.haloService, "getRankedArenaCsrs");
       const esraSpy = vi.spyOn(services.haloService, "getPlayerEsra");
+
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          xuid: trackedXuid,
+          lastSeenMatchId: "m1",
+          preSeriesPlayerInfoLatestMatchId: "m1",
+          preSeriesPlayerInfo: {
+            currentRank: 1500,
+            currentRankTier: "Onyx",
+            currentRankSubTier: 0,
+            currentRankMeasurementMatchesRemaining: 0,
+            currentRankInitialMeasurementMatches: 10,
+            allTimePeakRank: 1600,
+            esra: 1450,
+            lastRankedGamePlayed: "2024-11-26T10:00:00.000Z",
+          },
+        }),
+      );
 
       const url = new URL("http://do/view-state");
       url.searchParams.set("statsHighlightSlots", JSON.stringify(["kills", "deaths"]));
@@ -610,8 +628,47 @@ describe("statsHighlights", () => {
 
       expect(body.state?.statsHighlights?.[0]?.label).toBe("Kills");
       expect(body.state?.statsHighlights?.[1]?.label).toBe("Deaths");
+      expect(body.state?.preSeriesPlayerInfo?.currentRank).toBe(1500);
+      expect(csrSpy).not.toHaveBeenCalled();
+      expect(esraSpy).not.toHaveBeenCalled();
+    });
+
+    it("refreshes pre-series profile data when latest match id changes", async () => {
+      const csrSpy = vi.spyOn(services.haloService, "getRankedArenaCsrs").mockResolvedValue(
+        new Map([[trackedXuid, fakeCsrContainer]]),
+      );
+      const esraSpy = vi.spyOn(services.haloService, "getPlayerEsra").mockResolvedValue({
+        esra: 1337,
+        lastRankedGamePlayed: "2024-11-26T10:30:00.000Z",
+      });
+
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          xuid: trackedXuid,
+          lastSeenMatchId: "m2",
+          preSeriesPlayerInfoLatestMatchId: "m1",
+          preSeriesPlayerInfo: {
+            currentRank: 1200,
+            currentRankTier: "Gold",
+            currentRankSubTier: 1,
+            currentRankMeasurementMatchesRemaining: null,
+            currentRankInitialMeasurementMatches: null,
+            allTimePeakRank: 1250,
+            esra: 1200,
+            lastRankedGamePlayed: "2024-11-25T10:00:00.000Z",
+          },
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect(body.state?.preSeriesPlayerInfo?.currentRank).toBe(1567);
+      expect(body.state?.preSeriesPlayerInfo?.allTimePeakRank).toBe(1600);
+      expect(body.state?.preSeriesPlayerInfo?.esra).toBe(1337);
       expect(csrSpy).toHaveBeenCalledTimes(1);
       expect(esraSpy).toHaveBeenCalledTimes(1);
+      expect(lastPersistedState(storagePutSpy).preSeriesPlayerInfoLatestMatchId).toBe("m2");
     });
   });
 

--- a/api/durable-objects/individual-tracker/tests/stats-highlights.test.ts
+++ b/api/durable-objects/individual-tracker/tests/stats-highlights.test.ts
@@ -599,16 +599,19 @@ describe("statsHighlights", () => {
       expect(body.state?.statsHighlights?.[2]).toEqual({ label: "All Time Peak", value: "–" });
     });
 
-    it("does not call getRankedArenaCsrs or getPlayerEsra when those slots are not requested", async () => {
+    it("still computes non-rank slots while pre-series profile data fetches run", async () => {
       const csrSpy = vi.spyOn(services.haloService, "getRankedArenaCsrs");
       const esraSpy = vi.spyOn(services.haloService, "getPlayerEsra");
 
       const url = new URL("http://do/view-state");
       url.searchParams.set("statsHighlightSlots", JSON.stringify(["kills", "deaths"]));
-      await individualTrackerDO.fetch(new Request(url.toString(), { method: "GET" }));
+      const response = await individualTrackerDO.fetch(new Request(url.toString(), { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
 
-      expect(csrSpy).not.toHaveBeenCalled();
-      expect(esraSpy).not.toHaveBeenCalled();
+      expect(body.state?.statsHighlights?.[0]?.label).toBe("Kills");
+      expect(body.state?.statsHighlights?.[1]?.label).toBe("Deaths");
+      expect(csrSpy).toHaveBeenCalledTimes(1);
+      expect(esraSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/api/durable-objects/individual-tracker/tests/stats-highlights.test.ts
+++ b/api/durable-objects/individual-tracker/tests/stats-highlights.test.ts
@@ -634,9 +634,9 @@ describe("statsHighlights", () => {
     });
 
     it("refreshes pre-series profile data when latest match id changes", async () => {
-      const csrSpy = vi.spyOn(services.haloService, "getRankedArenaCsrs").mockResolvedValue(
-        new Map([[trackedXuid, fakeCsrContainer]]),
-      );
+      const csrSpy = vi
+        .spyOn(services.haloService, "getRankedArenaCsrs")
+        .mockResolvedValue(new Map([[trackedXuid, fakeCsrContainer]]));
       const esraSpy = vi.spyOn(services.haloService, "getPlayerEsra").mockResolvedValue({
         esra: 1337,
         lastRankedGamePlayed: "2024-11-26T10:30:00.000Z",

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -106,6 +106,17 @@ export interface StatsHighlightItem {
   };
 }
 
+export interface PreSeriesPlayerInfo {
+  currentRank: number | null;
+  currentRankTier: string | null;
+  currentRankSubTier: number | null;
+  currentRankMeasurementMatchesRemaining: number | null;
+  currentRankInitialMeasurementMatches: number | null;
+  allTimePeakRank: number | null;
+  esra: number | null;
+  lastRankedGamePlayed: string | null;
+}
+
 export interface IndividualTrackerInternalState extends IndividualTrackerState {
   searchStartTime: string;
   lastMatchDiscoveredAt: string | undefined;
@@ -223,6 +234,7 @@ export interface IndividualTrackerViewState {
   hasRecentCompletedSeries: boolean;
   activeSeriesContext?: ActiveSeriesContext;
   statsHighlights?: StatsHighlightItem[];
+  preSeriesPlayerInfo?: PreSeriesPlayerInfo;
 }
 
 export interface IndividualTrackerViewStateResponse {

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -128,6 +128,8 @@ export interface IndividualTrackerInternalState extends IndividualTrackerState {
   selectedMatchIds: string[];
   accumulatedPlayerTotals?: AccumulatedPlayerTotals;
   accumulatedMatchIds?: string[];
+  preSeriesPlayerInfo?: PreSeriesPlayerInfo;
+  preSeriesPlayerInfoLatestMatchId?: string | null;
   activeSeries?: ActiveSeries;
   completedSeries?: ActiveSeries[];
   seriesGroupOverrides?: IndividualTrackerSeriesGroupOverride[];

--- a/api/routes/individual-tracker/follow.ts
+++ b/api/routes/individual-tracker/follow.ts
@@ -51,6 +51,59 @@ async function buildDirectory(env: Env, userId: string, services: Services): Pro
   };
 }
 
+async function subscribeToTrackerUpdateSockets(options: {
+  readonly env: Env;
+  readonly userId: string;
+  readonly services: Services;
+  readonly onTrackerUpdate: () => void;
+}): Promise<() => void> {
+  const { env, userId, services, onTrackerUpdate } = options;
+  const rows = await services.databaseService.findIndividualTrackersByUserId(userId);
+  const nonStoppedRows = rows.filter(isNonStopped);
+  const sockets: WebSocket[] = [];
+
+  for (const row of nonStoppedRows) {
+    try {
+      const doId = env.INDIVIDUAL_TRACKER_DO.idFromName(`${row.UserId}:${row.TrackerId}`);
+      const stub = env.INDIVIDUAL_TRACKER_DO.get(doId);
+      const response = await stub.fetch(
+        new Request("http://do/websocket", {
+          headers: {
+            Upgrade: "websocket",
+          },
+        }),
+      );
+
+      const socket = response.webSocket;
+      if (socket == null) {
+        continue;
+      }
+
+      socket.accept();
+      socket.addEventListener("message", onTrackerUpdate);
+      sockets.push(socket);
+    } catch (error) {
+      services.logService.warn(
+        error,
+        new Map([
+          ["context", "Follow WebSocket tracker subscription error"],
+          ["trackerId", row.TrackerId],
+        ]),
+      );
+    }
+  }
+
+  return (): void => {
+    for (const socket of sockets) {
+      try {
+        socket.close(1000, "Follow websocket closing");
+      } catch {
+        // ignore close failures
+      }
+    }
+  };
+}
+
 export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
   router.get("/u/:gamertag/view", async (request, env: Env) => {
     const services = installServices({ env });
@@ -103,27 +156,56 @@ export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router
       let lastPayload = trackerDirectoryMessageContract.serialize({ type: "directory", directory });
       server.send(lastPayload);
 
-      const pollInterval = setInterval(() => {
+      let pushing = false;
+      let queuedPushes = 0;
+
+      const pushDirectoryIfChanged = (): void => {
+        if (pushing) {
+          queuedPushes += 1;
+          return;
+        }
+
+        pushing = true;
         void (async (): Promise<void> => {
           try {
-            const nextDirectory = await buildDirectory(env, identity.UserId, services);
-            const nextPayload = trackerDirectoryMessageContract.serialize({
-              type: "directory",
-              directory: nextDirectory,
-            });
-            if (nextPayload === lastPayload) {
-              return;
+            for (;;) {
+              try {
+                const nextDirectory = await buildDirectory(env, identity.UserId, services);
+                const nextPayload = trackerDirectoryMessageContract.serialize({
+                  type: "directory",
+                  directory: nextDirectory,
+                });
+                if (nextPayload !== lastPayload) {
+                  lastPayload = nextPayload;
+                  server.send(nextPayload);
+                }
+              } catch (pollError) {
+                logService.error(pollError, new Map([["context", "Follow WebSocket poll error"]]));
+              }
+
+              if (queuedPushes === 0) {
+                break;
+              }
+              queuedPushes = 0;
             }
-            lastPayload = nextPayload;
-            server.send(nextPayload);
-          } catch (pollError) {
-            logService.error(pollError, new Map([["context", "Follow WebSocket poll error"]]));
+          } finally {
+            pushing = false;
           }
         })();
-      }, FOLLOW_WS_POLL_INTERVAL_MS);
+      };
+
+      const closeTrackerSubscriptions = await subscribeToTrackerUpdateSockets({
+        env,
+        userId: identity.UserId,
+        services,
+        onTrackerUpdate: pushDirectoryIfChanged,
+      });
+
+      const pollInterval = setInterval(pushDirectoryIfChanged, FOLLOW_WS_POLL_INTERVAL_MS);
 
       const stopPolling = (): void => {
         clearInterval(pollInterval);
+        closeTrackerSubscriptions();
       };
 
       server.addEventListener("close", stopPolling);

--- a/api/routes/individual-tracker/follow.ts
+++ b/api/routes/individual-tracker/follow.ts
@@ -160,15 +160,20 @@ export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router
       server.send(lastPayload);
 
       let pushing = false;
-      let queuedPushes = 0;
+      let pendingPush = false;
       let closeTrackerSubscriptions = (): void => {
         // replaced once the background subscription setup completes
       };
       const subscriptionState = { closed: false };
+      const hasPendingPush = (): boolean => pendingPush;
 
       const pushDirectoryIfChanged = (): void => {
+        if (subscriptionState.closed) {
+          return;
+        }
+
         if (pushing) {
-          queuedPushes += 1;
+          pendingPush = true;
           return;
         }
 
@@ -176,13 +181,15 @@ export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router
         void (async (): Promise<void> => {
           try {
             for (;;) {
+              pendingPush = false;
+
               try {
                 const nextDirectory = await buildDirectory(env, identity.UserId, services);
                 const nextPayload = trackerDirectoryMessageContract.serialize({
                   type: "directory",
                   directory: nextDirectory,
                 });
-                if (nextPayload !== lastPayload) {
+                if (server.readyState === WebSocket.OPEN && nextPayload !== lastPayload) {
                   lastPayload = nextPayload;
                   server.send(nextPayload);
                 }
@@ -190,13 +197,15 @@ export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router
                 logService.error(pollError, new Map([["context", "Follow WebSocket poll error"]]));
               }
 
-              if (queuedPushes === 0) {
+              if (!hasPendingPush()) {
                 break;
               }
-              queuedPushes = 0;
             }
           } finally {
             pushing = false;
+            if (pendingPush && !subscriptionState.closed) {
+              pushDirectoryIfChanged();
+            }
           }
         })();
       };
@@ -210,19 +219,23 @@ export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router
       };
 
       void (async (): Promise<void> => {
-        const closeSubscriptions = await subscribeToTrackerUpdateSockets({
-          env,
-          userId: identity.UserId,
-          services,
-          onTrackerUpdate: pushDirectoryIfChanged,
-        });
+        try {
+          const closeSubscriptions = await subscribeToTrackerUpdateSockets({
+            env,
+            userId: identity.UserId,
+            services,
+            onTrackerUpdate: pushDirectoryIfChanged,
+          });
 
-        if (subscriptionState.closed) {
-          closeSubscriptions();
-          return;
+          if (subscriptionState.closed) {
+            closeSubscriptions();
+            return;
+          }
+
+          closeTrackerSubscriptions = closeSubscriptions;
+        } catch (error) {
+          logService.error(error, new Map([["context", "Follow WebSocket subscription setup error"]]));
         }
-
-        closeTrackerSubscriptions = closeSubscriptions;
       })();
 
       server.addEventListener("close", stopPolling);

--- a/api/routes/individual-tracker/follow.ts
+++ b/api/routes/individual-tracker/follow.ts
@@ -35,7 +35,7 @@ async function buildDirectory(env: Env, userId: string, services: Services): Pro
 
   const entries = await Promise.all(
     nonStopped.map(async (row): Promise<TrackerDirectoryEntry> => {
-      const doState = await fetchTrackerDoViewState(env, row.UserId, row.TrackerId, statsHighlightSlots);
+      const doState = await fetchTrackerDoViewState(env, row.UserId, row.TrackerId, statsHighlightSlots, false);
       return toTrackerView(row, doState);
     }),
   );

--- a/api/routes/individual-tracker/follow.ts
+++ b/api/routes/individual-tracker/follow.ts
@@ -35,7 +35,7 @@ async function buildDirectory(env: Env, userId: string, services: Services): Pro
 
   const entries = await Promise.all(
     nonStopped.map(async (row): Promise<TrackerDirectoryEntry> => {
-      const doState = await fetchTrackerDoViewState(env, row.UserId, row.TrackerId, statsHighlightSlots, false);
+      const doState = await fetchTrackerDoViewState(env, row.UserId, row.TrackerId, statsHighlightSlots);
       return toTrackerView(row, doState);
     }),
   );

--- a/api/routes/individual-tracker/follow.ts
+++ b/api/routes/individual-tracker/follow.ts
@@ -60,38 +60,41 @@ async function subscribeToTrackerUpdateSockets(options: {
   const { env, userId, services, onTrackerUpdate } = options;
   const rows = await services.databaseService.findIndividualTrackersByUserId(userId);
   const nonStoppedRows = rows.filter(isNonStopped);
-  const sockets: WebSocket[] = [];
+  const sockets = (
+    await Promise.all(
+      nonStoppedRows.map(async (row): Promise<WebSocket | null> => {
+        try {
+          const doId = env.INDIVIDUAL_TRACKER_DO.idFromName(`${row.UserId}:${row.TrackerId}`);
+          const stub = env.INDIVIDUAL_TRACKER_DO.get(doId);
+          const response = await stub.fetch(
+            new Request("http://do/websocket", {
+              headers: {
+                Upgrade: "websocket",
+              },
+            }),
+          );
 
-  for (const row of nonStoppedRows) {
-    try {
-      const doId = env.INDIVIDUAL_TRACKER_DO.idFromName(`${row.UserId}:${row.TrackerId}`);
-      const stub = env.INDIVIDUAL_TRACKER_DO.get(doId);
-      const response = await stub.fetch(
-        new Request("http://do/websocket", {
-          headers: {
-            Upgrade: "websocket",
-          },
-        }),
-      );
+          const socket = response.webSocket;
+          if (socket == null) {
+            return null;
+          }
 
-      const socket = response.webSocket;
-      if (socket == null) {
-        continue;
-      }
-
-      socket.accept();
-      socket.addEventListener("message", onTrackerUpdate);
-      sockets.push(socket);
-    } catch (error) {
-      services.logService.warn(
-        error,
-        new Map([
-          ["context", "Follow WebSocket tracker subscription error"],
-          ["trackerId", row.TrackerId],
-        ]),
-      );
-    }
-  }
+          socket.accept();
+          socket.addEventListener("message", onTrackerUpdate);
+          return socket;
+        } catch (error) {
+          services.logService.warn(
+            error,
+            new Map([
+              ["context", "Follow WebSocket tracker subscription error"],
+              ["trackerId", row.TrackerId],
+            ]),
+          );
+          return null;
+        }
+      }),
+    )
+  ).filter((socket): socket is WebSocket => socket != null);
 
   return (): void => {
     for (const socket of sockets) {
@@ -158,6 +161,10 @@ export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       let pushing = false;
       let queuedPushes = 0;
+      let closeTrackerSubscriptions = (): void => {
+        // replaced once the background subscription setup completes
+      };
+      const subscriptionState = { closed: false };
 
       const pushDirectoryIfChanged = (): void => {
         if (pushing) {
@@ -194,19 +201,29 @@ export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router
         })();
       };
 
-      const closeTrackerSubscriptions = await subscribeToTrackerUpdateSockets({
-        env,
-        userId: identity.UserId,
-        services,
-        onTrackerUpdate: pushDirectoryIfChanged,
-      });
-
       const pollInterval = setInterval(pushDirectoryIfChanged, FOLLOW_WS_POLL_INTERVAL_MS);
 
       const stopPolling = (): void => {
         clearInterval(pollInterval);
+        subscriptionState.closed = true;
         closeTrackerSubscriptions();
       };
+
+      void (async (): Promise<void> => {
+        const closeSubscriptions = await subscribeToTrackerUpdateSockets({
+          env,
+          userId: identity.UserId,
+          services,
+          onTrackerUpdate: pushDirectoryIfChanged,
+        });
+
+        if (subscriptionState.closed) {
+          closeSubscriptions();
+          return;
+        }
+
+        closeTrackerSubscriptions = closeSubscriptions;
+      })();
 
       server.addEventListener("close", stopPolling);
       server.addEventListener("error", stopPolling);

--- a/api/routes/individual-tracker/mapper.ts
+++ b/api/routes/individual-tracker/mapper.ts
@@ -133,5 +133,6 @@ export function toTrackerView(
     hasRecentCompletedSeries: doState?.hasRecentCompletedSeries ?? false,
     ...(doState?.activeSeriesContext !== undefined ? { activeSeriesContext: doState.activeSeriesContext } : {}),
     ...(doState?.statsHighlights != null ? { statsHighlights: [...doState.statsHighlights] } : {}),
+    ...(doState?.preSeriesPlayerInfo != null ? { preSeriesPlayerInfo: doState.preSeriesPlayerInfo } : {}),
   };
 }

--- a/api/routes/individual-tracker/tests/follow.test.ts
+++ b/api/routes/individual-tracker/tests/follow.test.ts
@@ -418,18 +418,20 @@ describe("/u/:gamertag follow routes", () => {
       );
 
       const doStub = {
-        fetch: vi.fn((input: RequestInfo | URL) => {
+        fetch: vi.fn(async (input: RequestInfo | URL) => {
           const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
           const parsedUrl = new URL(url);
 
           if (parsedUrl.pathname === "/websocket") {
-            return new Response(null, { status: 101, webSocket: trackerSocket });
+            return Promise.resolve(new Response(null, { status: 101, webSocket: trackerSocket }));
           }
 
-          return new Response(JSON.stringify({ state: aFakeIndividualTrackerViewStateWith({ trackerId: "t1" }) }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
+          return Promise.resolve(
+            new Response(JSON.stringify({ state: aFakeIndividualTrackerViewStateWith({ trackerId: "t1" }) }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+          );
         }),
         connect: (): Socket => {
           throw new Error("Socket connections not supported in fake");
@@ -460,13 +462,7 @@ describe("/u/:gamertag follow routes", () => {
       const sendMock = serverMocks?.["send"];
       expect(sendMock).toHaveBeenCalledTimes(1);
 
-      const trackerSocketMocks = trackerSocket as unknown as Record<string, ReturnType<typeof vi.fn>>;
-      const addEventListenerMock = trackerSocketMocks["addEventListener"];
-      const messageListener = addEventListenerMock?.mock.calls.find((call) => call[0] === "message")?.[1];
-      expect(typeof messageListener).toBe("function");
-      if (typeof messageListener === "function") {
-        messageListener(new Event("message"));
-      }
+      trackerSocket.dispatchEvent(new Event("message"));
 
       await vi.waitFor(() => {
         expect(sendMock).toHaveBeenCalledTimes(2);

--- a/api/routes/individual-tracker/tests/follow.test.ts
+++ b/api/routes/individual-tracker/tests/follow.test.ts
@@ -22,13 +22,30 @@ function wsRequest(path: string): Request {
 }
 
 function makeFakeWebSocket(): WebSocket {
+  const listeners = new Map<string, EventListener[]>();
+
   return {
     accept: vi.fn(),
     send: vi.fn(),
     close: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
+    addEventListener: vi.fn((type: string, listener: EventListener) => {
+      const existing = listeners.get(type) ?? [];
+      listeners.set(type, [...existing, listener]);
+    }),
+    removeEventListener: vi.fn((type: string, listener: EventListener) => {
+      const existing = listeners.get(type) ?? [];
+      listeners.set(
+        type,
+        existing.filter((candidate) => candidate !== listener),
+      );
+    }),
+    dispatchEvent: vi.fn((event: Event) => {
+      const existing = listeners.get(event.type) ?? [];
+      for (const listener of existing) {
+        listener(event);
+      }
+      return true;
+    }),
     readyState: 0,
   } as unknown as WebSocket;
 }
@@ -366,6 +383,96 @@ describe("/u/:gamertag follow routes", () => {
       expect(secondMessage.directory.liveTrackerId).toBe("t2");
     });
 
+    it("pushes an updated directory immediately when a tracker websocket message arrives", async () => {
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "ImmediatePushTag" });
+      const trackerRow = aFakeIndividualTrackersRow({
+        TrackerId: "t1",
+        UserId: "user-1",
+        Status: "active",
+        IsLive: 1,
+      });
+
+      let capturedServer: WebSocket | undefined;
+      const client = makeFakeWebSocket();
+      const server = makeFakeWebSocket();
+      const trackerSocket = makeFakeWebSocket();
+      vi.stubGlobal("WebSocketPair", function () {
+        capturedServer = server;
+        return { 0: client, 1: server };
+      });
+
+      const OriginalResponse = globalThis.Response;
+      vi.stubGlobal(
+        "Response",
+        class FakeResponse extends OriginalResponse {
+          constructor(body: BodyInit | null, init?: ResponseInit & { webSocket?: WebSocket }) {
+            super(body, { ...init, status: init?.status === 101 ? 200 : (init?.status ?? 200) });
+            if (init?.status === 101) {
+              Object.defineProperty(this, "status", { value: 101 });
+            }
+            if (init?.webSocket != null) {
+              Object.defineProperty(this, "webSocket", { value: init.webSocket });
+            }
+          }
+        },
+      );
+
+      const doStub = {
+        fetch: vi.fn((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+          const parsedUrl = new URL(url);
+
+          if (parsedUrl.pathname === "/websocket") {
+            return new Response(null, { status: 101, webSocket: trackerSocket });
+          }
+
+          return new Response(JSON.stringify({ state: aFakeIndividualTrackerViewStateWith({ trackerId: "t1" }) }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }),
+        connect: (): Socket => {
+          throw new Error("Socket connections not supported in fake");
+        },
+        id: {
+          toString: (): string => "fake-do-id",
+          equals: (): boolean => true,
+        },
+        __DURABLE_OBJECT_BRAND: undefined as never,
+      };
+
+      const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env: localEnv });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
+        vi.spyOn(services.databaseService, "findIndividualTrackersByUserId")
+          .mockResolvedValueOnce([trackerRow])
+          .mockResolvedValueOnce([trackerRow])
+          .mockResolvedValueOnce([trackerRow]);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(wsRequest("/u/ImmediatePushTag/ws"), localEnv)) as Response;
+      expect(res.status).toBe(101);
+
+      const serverMocks = capturedServer as unknown as Record<string, ReturnType<typeof vi.fn>> | undefined;
+      const sendMock = serverMocks?.["send"];
+      expect(sendMock).toHaveBeenCalledTimes(1);
+
+      const trackerSocketMocks = trackerSocket as unknown as Record<string, ReturnType<typeof vi.fn>>;
+      const addEventListenerMock = trackerSocketMocks["addEventListener"];
+      const messageListener = addEventListenerMock?.mock.calls.find((call) => call[0] === "message")?.[1];
+      expect(typeof messageListener).toBe("function");
+      if (typeof messageListener === "function") {
+        messageListener(new Event("message"));
+      }
+
+      await vi.waitFor(() => {
+        expect(sendMock).toHaveBeenCalledTimes(2);
+      });
+    });
+
     it("returns 404 when gamertag is not found", async () => {
       const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
         const services = installFakeServicesWith({ env });
@@ -496,6 +603,30 @@ describe("/u/:gamertag follow routes", () => {
       expect(typeof sentArg).toBe("string");
       const msg = trackerDirectoryMessageContract.parse(sentArg as string);
       expect(msg.type).toBe("directory");
+    });
+
+    it("does not request pre-series player info while building follow directories", async () => {
+      const doStub = aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } });
+      const fetchSpy = vi.spyOn(doStub, "fetch");
+      const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "NoPreSeriesTag" });
+      const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1", Status: "active", IsLive: 1 });
+
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env: localEnv });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
+        vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([row]);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/u/NoPreSeriesTag/view"), localEnv)) as Response;
+
+      expect(res.status).toBe(200);
+      const call = fetchSpy.mock.calls[0]?.[0];
+      const rawUrl = typeof call === "string" ? call : call instanceof URL ? call.toString() : call?.url;
+      const parsedUrl = new URL(rawUrl ?? "http://do/view-state");
+      expect(parsedUrl.searchParams.get("includePreSeriesPlayerInfo")).toBeNull();
     });
   });
 });

--- a/api/routes/individual-tracker/tests/follow.test.ts
+++ b/api/routes/individual-tracker/tests/follow.test.ts
@@ -329,8 +329,10 @@ describe("/u/:gamertag follow routes", () => {
       const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
         const services = installFakeServicesWith({ env });
         vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
-        // First call returns t1 live, second call returns t2 live
+        // First call builds initial payload, second call builds tracker subscriptions,
+        // third call (poll) returns t2 as live.
         vi.spyOn(services.databaseService, "findIndividualTrackersByUserId")
+          .mockResolvedValueOnce([trackerOneLive, trackerTwo])
           .mockResolvedValueOnce([trackerOneLive, trackerTwo])
           .mockResolvedValueOnce([trackerTwo, trackerTwoLive]);
         return services;

--- a/api/routes/individual-tracker/tests/follow.test.ts
+++ b/api/routes/individual-tracker/tests/follow.test.ts
@@ -1,4 +1,5 @@
 import type { AutoRouterType } from "itty-router";
+import type { MockInstance } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TrackerDirectoryResponse } from "@guilty-spark/shared/contracts/individual-tracker/follow";
 import { trackerDirectoryMessageContract } from "@guilty-spark/shared/contracts/individual-tracker/follow";
@@ -11,6 +12,7 @@ import {
 } from "../../../durable-objects/individual-tracker/fakes/individual-tracker-do.fake";
 import { aFakeIndividualTrackersRow, aFakeLinkedIdentitiesRow } from "../../../services/database/fakes/database.fake";
 import { installFakeServicesWith } from "../../../services/fakes/services";
+import type { Services } from "../../../services/install";
 import { individualTrackerRoutesRegisterHandler } from "../individual-tracker";
 
 function getRequest(path: string): Request {
@@ -46,7 +48,7 @@ function makeFakeWebSocket(): WebSocket {
       }
       return true;
     }),
-    readyState: 0,
+    readyState: 1,
   } as unknown as WebSocket;
 }
 
@@ -466,6 +468,179 @@ describe("/u/:gamertag follow routes", () => {
 
       await vi.waitFor(() => {
         expect(sendMock).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("schedules another push when tracker updates arrive during a pending push", async () => {
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "QueuedPushTag" });
+      const trackerRowLive = aFakeIndividualTrackersRow({
+        TrackerId: "t1",
+        UserId: "user-1",
+        Status: "active",
+        IsLive: 1,
+      });
+      const trackerRowPaused = aFakeIndividualTrackersRow({
+        TrackerId: "t1",
+        UserId: "user-1",
+        Status: "paused",
+        IsLive: 0,
+      });
+
+      let resolvePendingRows: ((rows: (typeof trackerRowPaused)[]) => void) | undefined;
+      const pendingRowsPromise = new Promise<(typeof trackerRowPaused)[]>((resolve) => {
+        resolvePendingRows = resolve;
+      });
+      let findTrackersSpy: MockInstance<Services["databaseService"]["findIndividualTrackersByUserId"]> | undefined;
+
+      let capturedServer: WebSocket | undefined;
+      const client = makeFakeWebSocket();
+      const server = makeFakeWebSocket();
+      const trackerSocket = makeFakeWebSocket();
+      vi.stubGlobal("WebSocketPair", function () {
+        capturedServer = server;
+        return { 0: client, 1: server };
+      });
+
+      const OriginalResponse = globalThis.Response;
+      vi.stubGlobal(
+        "Response",
+        class FakeResponse extends OriginalResponse {
+          constructor(body: BodyInit | null, init?: ResponseInit & { webSocket?: WebSocket }) {
+            super(body, { ...init, status: init?.status === 101 ? 200 : (init?.status ?? 200) });
+            if (init?.status === 101) {
+              Object.defineProperty(this, "status", { value: 101 });
+            }
+            if (init?.webSocket != null) {
+              Object.defineProperty(this, "webSocket", { value: init.webSocket });
+            }
+          }
+        },
+      );
+
+      const doStub = {
+        fetch: vi.fn(async (input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+          const parsedUrl = new URL(url);
+
+          if (parsedUrl.pathname === "/websocket") {
+            return Promise.resolve(new Response(null, { status: 101, webSocket: trackerSocket }));
+          }
+
+          return Promise.resolve(
+            new Response(JSON.stringify({ state: aFakeIndividualTrackerViewStateWith({ trackerId: "t1" }) }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+          );
+        }),
+        connect: (): Socket => {
+          throw new Error("Socket connections not supported in fake");
+        },
+        id: {
+          toString: (): string => "fake-do-id",
+          equals: (): boolean => true,
+        },
+        __DURABLE_OBJECT_BRAND: undefined as never,
+      };
+
+      const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env: localEnv });
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
+        findTrackersSpy = vi
+          .spyOn(services.databaseService, "findIndividualTrackersByUserId")
+          .mockResolvedValueOnce([trackerRowLive])
+          .mockResolvedValueOnce([trackerRowLive])
+          .mockImplementationOnce(async () => pendingRowsPromise)
+          .mockResolvedValueOnce([trackerRowLive]);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      vi.spyOn(globalThis, "setInterval").mockReturnValue(1 as unknown as NodeJS.Timeout);
+
+      const res = (await router.fetch(wsRequest("/u/QueuedPushTag/ws"), localEnv)) as Response;
+      expect(res.status).toBe(101);
+
+      const serverMocks = capturedServer as unknown as Record<string, ReturnType<typeof vi.fn>> | undefined;
+      const sendMock = serverMocks?.["send"];
+      expect(sendMock).toHaveBeenCalledTimes(1);
+
+      await vi.waitFor(() => {
+        expect(findTrackersSpy?.mock.calls).toHaveLength(2);
+      });
+
+      trackerSocket.dispatchEvent(new Event("message"));
+      trackerSocket.dispatchEvent(new Event("message"));
+      resolvePendingRows?.([trackerRowPaused]);
+
+      await vi.waitFor(() => {
+        expect(sendMock).toHaveBeenCalledTimes(3);
+      });
+
+      const firstMessage = trackerDirectoryMessageContract.parse(sendMock?.mock.calls[0]?.[0] as string);
+      const secondMessage = trackerDirectoryMessageContract.parse(sendMock?.mock.calls[1]?.[0] as string);
+      const thirdMessage = trackerDirectoryMessageContract.parse(sendMock?.mock.calls[2]?.[0] as string);
+      expect(firstMessage.directory.liveTrackerId).toBe("t1");
+      expect(secondMessage.directory.liveTrackerId).toBeNull();
+      expect(thirdMessage.directory.liveTrackerId).toBe("t1");
+    });
+
+    it("logs background subscription setup failures without breaking the handshake", async () => {
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "BrokenSetupTag" });
+      const trackerRow = aFakeIndividualTrackersRow({
+        TrackerId: "t1",
+        UserId: "user-1",
+        Status: "active",
+        IsLive: 1,
+      });
+
+      let capturedServer: WebSocket | undefined;
+      const client = makeFakeWebSocket();
+      const server = makeFakeWebSocket();
+      vi.stubGlobal("WebSocketPair", function () {
+        capturedServer = server;
+        return { 0: client, 1: server };
+      });
+
+      const OriginalResponse = globalThis.Response;
+      vi.stubGlobal(
+        "Response",
+        class FakeResponse extends OriginalResponse {
+          constructor(body: BodyInit | null, init?: ResponseInit & { webSocket?: WebSocket }) {
+            super(body, { ...init, status: init?.status === 101 ? 200 : (init?.status ?? 200) });
+            if (init?.status === 101) {
+              Object.defineProperty(this, "status", { value: 101 });
+            }
+          }
+        },
+      );
+
+      const setupError = new Error("subscription setup failed");
+      let errorSpy: MockInstance<Services["logService"]["error"]> | undefined;
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        errorSpy = vi.spyOn(services.logService, "error");
+        vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
+        vi.spyOn(services.databaseService, "findIndividualTrackersByUserId")
+          .mockResolvedValueOnce([trackerRow])
+          .mockRejectedValueOnce(setupError);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      vi.spyOn(globalThis, "setInterval").mockReturnValue(1 as unknown as NodeJS.Timeout);
+
+      const res = (await router.fetch(wsRequest("/u/BrokenSetupTag/ws"), env)) as Response;
+
+      expect(res.status).toBe(101);
+      const serverMocks = capturedServer as unknown as Record<string, ReturnType<typeof vi.fn>> | undefined;
+      expect(serverMocks?.["send"]).toHaveBeenCalledOnce();
+
+      await vi.waitFor(() => {
+        expect(errorSpy?.mock.calls).toHaveLength(1);
+        expect(errorSpy?.mock.calls[0]?.[0]).toBe(setupError);
+        expect(errorSpy?.mock.calls[0]?.[1]).toEqual(expect.any(Map));
       });
     });
 

--- a/pages/src/components/follow/follow-live-overlay-viewer.tsx
+++ b/pages/src/components/follow/follow-live-overlay-viewer.tsx
@@ -68,7 +68,7 @@ export function FollowLiveOverlayViewer({
   if (liveTracker != null) {
     return (
       <IndividualTrackerOverlayPage
-        key={`${liveTracker.trackerId}:${liveTracker.lastUpdateTime}`}
+        key={liveTracker.trackerId}
         individualTrackerViewService={individualTrackerViewService}
         matchAnalyticsService={matchAnalyticsService}
         seriesMatchesService={seriesMatchesService}

--- a/pages/src/components/follow/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer.tsx
@@ -102,7 +102,7 @@ export function FollowLiveViewer({
       <div className={styles.trackerContent}>
         {selectedTracker != null ? (
           <IndividualTrackerViewerPage
-            key={`${selectedTracker.trackerId}:${selectedTracker.lastUpdateTime}`}
+            key={selectedTracker.trackerId}
             individualTrackerViewService={individualTrackerViewService}
             matchAnalyticsService={matchAnalyticsService}
             seriesMatchesService={seriesMatchesService}

--- a/pages/src/components/follow/tests/follow-live-overlay-viewer.test.tsx
+++ b/pages/src/components/follow/tests/follow-live-overlay-viewer.test.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom/vitest";
 
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
 import { aDirectoryWith, aTrackerWith } from "@guilty-spark/shared/contracts/individual-tracker/fakes/follow.fake";
 import { aFakeHaloClientWith } from "../../../services/fakes/halo-client.fake";
@@ -11,6 +11,8 @@ import { aFakeIndividualTrackerViewServiceWith } from "../../../services/individ
 import { aFakeMatchAnalyticsServiceWith } from "../../../services/stats/fakes/match-analytics.fake";
 import { aFakeSeriesMatchesServiceWith } from "../../../services/stats/fakes/series-matches.fake";
 import { FollowLiveOverlayViewer, type FollowLiveOverlayViewerProps } from "../follow-live-overlay-viewer";
+
+let mockOverlayInstanceCount = 0;
 
 vi.mock("../../individual-tracker/overlay/create", () => ({
   IndividualTrackerOverlayPage: ({
@@ -21,9 +23,18 @@ vi.mock("../../individual-tracker/overlay/create", () => ({
     trackerId: string;
     showPreview?: boolean;
     previewMode?: "player" | "observer";
-  }): React.ReactElement => (
-    <div data-testid="mock-overlay-page">{`${trackerId}:${String(showPreview)}:${previewMode ?? "observer"}`}</div>
-  ),
+  }): React.ReactElement => {
+    const [instanceId] = React.useState(() => {
+      mockOverlayInstanceCount += 1;
+      return mockOverlayInstanceCount;
+    });
+
+    return (
+      <div data-testid="mock-overlay-page" data-instance-id={instanceId.toString()}>
+        {`${trackerId}:${String(showPreview)}:${previewMode ?? "observer"}`}
+      </div>
+    );
+  },
 }));
 
 function aViewerPropsWith(directory: TrackerDirectory): FollowLiveOverlayViewerProps {
@@ -43,6 +54,7 @@ describe("FollowLiveOverlayViewer", () => {
   afterEach(() => {
     cleanup();
     document.title = "";
+    mockOverlayInstanceCount = 0;
   });
 
   it("renders the overlay page for the selected live tracker", async () => {
@@ -100,5 +112,54 @@ describe("FollowLiveOverlayViewer", () => {
     });
 
     expect(screen.queryByTestId("mock-overlay-page")).not.toBeInTheDocument();
+  });
+
+  it("does not remount overlay when only selected tracker last update time changes", async () => {
+    const initialDirectory: TrackerDirectory = aDirectoryWith({
+      trackers: [
+        aTrackerWith({
+          trackerId: "tracker-1",
+          gamertag: "Spartan One",
+          isLive: true,
+          status: "active",
+          lastUpdateTime: "2026-01-01T00:00:00.000Z",
+        }),
+      ],
+      liveTrackerId: "tracker-1",
+    });
+    const followLiveService = aFakeFollowLiveServiceWith({ directory: initialDirectory });
+
+    render(
+      <FollowLiveOverlayViewer
+        gamertag="Spartan One"
+        followLiveService={followLiveService}
+        individualTrackerViewService={aFakeIndividualTrackerViewServiceWith()}
+        matchAnalyticsService={aFakeMatchAnalyticsServiceWith()}
+        seriesMatchesService={aFakeSeriesMatchesServiceWith()}
+        haloClient={aFakeHaloClientWith()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-overlay-page")).toHaveAttribute("data-instance-id", "1");
+    });
+
+    const updatedDirectory: TrackerDirectory = {
+      ...initialDirectory,
+      trackers: [
+        {
+          ...initialDirectory.trackers[0],
+          lastUpdateTime: "2026-01-01T00:01:00.000Z",
+        },
+      ],
+    };
+
+    act(() => {
+      followLiveService.lastConnection?.emitDirectory(updatedDirectory);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-overlay-page")).toHaveAttribute("data-instance-id", "1");
+    });
   });
 });

--- a/pages/src/components/follow/tests/follow-live-viewer.test.tsx
+++ b/pages/src/components/follow/tests/follow-live-viewer.test.tsx
@@ -139,7 +139,7 @@ describe("FollowLiveViewer", () => {
     });
   });
 
-  it("remounts the selected viewer when only the selected tracker last update time changes", async () => {
+  it("does not remount the selected viewer when only the selected tracker last update time changes", async () => {
     const initialDirectory: TrackerDirectory = aDirectoryWith({
       trackers: [
         aTrackerWith({
@@ -184,7 +184,7 @@ describe("FollowLiveViewer", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId("mock-viewer")).toHaveAttribute("data-instance-id", "2");
+      expect(screen.getByTestId("mock-viewer")).toHaveAttribute("data-instance-id", "1");
     });
   });
 

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -235,7 +235,7 @@ export class IndividualTrackerOverlayPresenter {
         value: 0,
         bestInTeam: false,
         bestInMatch: false,
-        display: "–",
+        display: "-",
       },
     ];
 

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -1,6 +1,9 @@
 import { getTeamName } from "@guilty-spark/shared/halo/team";
+import { getRankTierFromCsr } from "@guilty-spark/shared/halo/rank";
 import type { MatchStats } from "halo-infinite-api";
-import type { CSSProperties } from "react";
+import { differenceInHours } from "date-fns";
+import TimeAgo from "javascript-time-ago";
+import { createElement, type CSSProperties } from "react";
 import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
@@ -12,6 +15,7 @@ import type { MatchStatsValues } from "../../../controllers/stats/types";
 import type { OverlayTab } from "../../streamer-overlay/tabs-bar";
 import type { IndividualTrackerViewerRenderModel, ViewerSeriesTab, ViewerTimelineItem } from "../viewer/types";
 import { gameModeIconSrc } from "../game-mode-icon";
+import { RankIcon } from "../../icons/rank-icon";
 import type {
   IndividualTrackerOverlayViewModel,
   OverlayDisplaySettings,
@@ -20,6 +24,9 @@ import type {
   OverlayTopSectionModel,
 } from "./types";
 import { getOverlayDisplaySettings } from "./types";
+import "javascript-time-ago/locale/en";
+
+const timeAgo = new TimeAgo("en");
 
 interface TickerFilterOptions {
   readonly trackedGamertag: string;
@@ -210,6 +217,7 @@ export class IndividualTrackerOverlayPresenter {
     readonly playerName: string | null;
     readonly discordName: string | null;
     readonly gamertag: string | null;
+    readonly preSeriesPlayerInfo: IndividualTrackerViewerRenderModel["preSeriesPlayerInfo"];
   }): TickerMatchGroup[] {
     if (!options.showTicker || !options.showPreSeriesInfo) {
       return [];
@@ -230,6 +238,79 @@ export class IndividualTrackerOverlayPresenter {
         display: "–",
       },
     ];
+
+    const createPreSeriesPlayerStats = (): MatchStatsValues[] => {
+      const info = options.preSeriesPlayerInfo;
+
+      if (info == null) {
+        return createPlaceholderStats();
+      }
+
+      const currentRankDisplay = info.currentRank != null && info.currentRank > 0 ? info.currentRank.toLocaleString() : "Unranked";
+      const peakRankDisplay = info.allTimePeakRank != null ? info.allTimePeakRank.toLocaleString() : "-";
+      const esraDisplay = info.esra != null ? Math.round(info.esra).toLocaleString() : "-";
+      let lastRankedDisplay = "-";
+      if (info.lastRankedGamePlayed != null) {
+        const ago = differenceInHours(new Date(), new Date(info.lastRankedGamePlayed));
+        lastRankedDisplay = ago < 1 ? "Less than an hour ago" : timeAgo.format(new Date(info.lastRankedGamePlayed));
+      }
+
+      return [
+        {
+          name: "Current rank",
+          value: info.currentRank ?? 0,
+          bestInTeam: false,
+          bestInMatch: false,
+          display: currentRankDisplay,
+          icon: createElement(RankIcon, {
+            rankTier: info.currentRankTier,
+            subTier: info.currentRankSubTier,
+            measurementMatchesRemaining: info.currentRankMeasurementMatchesRemaining,
+            initialMeasurementMatches: info.currentRankInitialMeasurementMatches,
+            size: "x-small",
+          }),
+        },
+        {
+          name: "Peak rank",
+          value: info.allTimePeakRank ?? 0,
+          bestInTeam: false,
+          bestInMatch: false,
+          display: peakRankDisplay,
+          icon:
+            info.allTimePeakRank != null
+              ? createElement(RankIcon, {
+                  ...getRankTierFromCsr(info.allTimePeakRank),
+                  measurementMatchesRemaining: null,
+                  initialMeasurementMatches: null,
+                  size: "x-small",
+                })
+              : undefined,
+        },
+        {
+          name: "ESRA",
+          value: info.esra ?? 0,
+          bestInTeam: false,
+          bestInMatch: false,
+          display: esraDisplay,
+          icon:
+            info.esra != null
+              ? createElement(RankIcon, {
+                  ...getRankTierFromCsr(Math.round(info.esra)),
+                  measurementMatchesRemaining: null,
+                  initialMeasurementMatches: null,
+                  size: "x-small",
+                })
+              : undefined,
+        },
+        {
+          name: "Last ranked match played",
+          value: info.lastRankedGamePlayed != null ? new Date(info.lastRankedGamePlayed).getTime() : 0,
+          bestInTeam: false,
+          bestInMatch: false,
+          display: lastRankedDisplay,
+        },
+      ];
+    };
 
     // Case 1: Pre-series with active series that has teams (series exists but no matches yet)
     if (options.activeSeries?.matches.length === 0 && options.activeSeries.teams.length > 0) {
@@ -284,7 +365,7 @@ export class IndividualTrackerOverlayPresenter {
             discordName: options.discordName,
             gamertag: options.gamertag,
             showTeamIcon: false,
-            stats: createPlaceholderStats(),
+            stats: createPreSeriesPlayerStats(),
             medals: [],
           },
         ],
@@ -314,6 +395,7 @@ export class IndividualTrackerOverlayPresenter {
             playerName: displaySettings.showXboxNames ? renderModel.gamertag : null,
             discordName: null,
             gamertag: displaySettings.showXboxNames ? renderModel.gamertag : null,
+            preSeriesPlayerInfo: renderModel.preSeriesPlayerInfo,
           });
 
     return {

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -246,7 +246,8 @@ export class IndividualTrackerOverlayPresenter {
         return createPlaceholderStats();
       }
 
-      const currentRankDisplay = info.currentRank != null && info.currentRank > 0 ? info.currentRank.toLocaleString() : "Unranked";
+      const currentRankDisplay =
+        info.currentRank != null && info.currentRank > 0 ? info.currentRank.toLocaleString() : "Unranked";
       const peakRankDisplay = info.allTimePeakRank != null ? info.allTimePeakRank.toLocaleString() : "-";
       const esraDisplay = info.esra != null ? Math.round(info.esra).toLocaleString() : "-";
       let lastRankedDisplay = "-";

--- a/pages/src/components/individual-tracker/overlay/overlay-stats-highlights.module.css
+++ b/pages/src/components/individual-tracker/overlay/overlay-stats-highlights.module.css
@@ -45,7 +45,10 @@
 }
 
 .statValue {
+  align-items: center;
   color: var(--halo-white);
+  display: inline-flex;
   font-size: 1em;
   font-weight: 700;
+  gap: var(--space-1);
 }

--- a/pages/src/components/individual-tracker/overlay/overlay-stats-highlights.tsx
+++ b/pages/src/components/individual-tracker/overlay/overlay-stats-highlights.tsx
@@ -1,5 +1,6 @@
 import React, { memo } from "react";
 import type { StatsHighlightItem } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import { RankIcon } from "../../icons/rank-icon";
 import styles from "./overlay-stats-highlights.module.css";
 
 interface OverlayStatsHighlightsProps {
@@ -17,7 +18,18 @@ function OverlayStatsHighlightsComponent({ items }: OverlayStatsHighlightsProps)
         <div key={i} className={styles.statTab}>
           <span className={styles.statLabel}>{item.label}</span>
           <span className={styles.statSeparator}>•</span>
-          <span className={styles.statValue}>{item.value}</span>
+          <span className={styles.statValue}>
+            {item.rankIcon != null ? (
+              <RankIcon
+                rankTier={item.rankIcon.rankTier}
+                subTier={item.rankIcon.subTier}
+                measurementMatchesRemaining={item.rankIcon.measurementMatchesRemaining}
+                initialMeasurementMatches={item.rankIcon.initialMeasurementMatches}
+                size="x-small"
+              />
+            ) : null}
+            <span>{item.value}</span>
+          </span>
         </div>
       ))}
     </div>

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -24,6 +24,7 @@ function aRenderModelWith(
     timeline: [],
     accumulated: { total: 0, wins: 0, losses: 0, ties: 0 },
     statsHighlights: undefined,
+    preSeriesPlayerInfo: undefined,
     teamColors: [
       { id: "eagle", name: "Eagle", hex: "#0066CC" },
       { id: "cobra", name: "Cobra", hex: "#CC0000" },
@@ -184,6 +185,7 @@ describe("individual-tracker-overlay-presenter", () => {
       playerName: "TrackedPlayer",
       discordName: null,
       gamertag: "TrackedPlayer",
+      preSeriesPlayerInfo: undefined,
     });
 
     expect(groups).toHaveLength(1);
@@ -200,6 +202,7 @@ describe("individual-tracker-overlay-presenter", () => {
       playerName: "TrackedPlayer",
       discordName: null,
       gamertag: "TrackedPlayer",
+      preSeriesPlayerInfo: undefined,
     });
 
     expect(groups).toHaveLength(0);
@@ -232,6 +235,7 @@ describe("individual-tracker-overlay-presenter", () => {
       playerName: "TrackedPlayer",
       discordName: null,
       gamertag: "TrackedPlayer",
+      preSeriesPlayerInfo: undefined,
     });
 
     expect(groups).toHaveLength(1);
@@ -247,6 +251,36 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(groups[0].rows[3]?.name).toBe("Cobra");
     expect(groups[0].rows[4]?.type).toBe("player");
     expect(groups[0].rows[4]?.gamertag).toBe("Player3");
+  });
+
+  it("uses pre-series player info in matchmaking pre-series ticker when available", () => {
+    const groups = presenter.buildPreSeriesTickerGroup({
+      showTicker: true,
+      showPreSeriesInfo: true,
+      activeSeries: null,
+      playerName: "TrackedPlayer",
+      discordName: null,
+      gamertag: "TrackedPlayer",
+      preSeriesPlayerInfo: {
+        currentRank: 1550,
+        currentRankTier: "Diamond",
+        currentRankSubTier: 2,
+        currentRankMeasurementMatchesRemaining: null,
+        currentRankInitialMeasurementMatches: null,
+        allTimePeakRank: 1625,
+        esra: 1502.4,
+        lastRankedGamePlayed: "2026-01-01T00:00:00.000Z",
+      },
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].rows[0]?.stats[0]?.name).toBe("Current rank");
+    expect(groups[0].rows[0]?.stats[0]?.display).toBe("1,550");
+    expect(groups[0].rows[0]?.stats[1]?.name).toBe("Peak rank");
+    expect(groups[0].rows[0]?.stats[1]?.display).toBe("1,625");
+    expect(groups[0].rows[0]?.stats[2]?.name).toBe("ESRA");
+    expect(groups[0].rows[0]?.stats[2]?.display).toBe("1,502");
+    expect(groups[0].rows[0]?.stats[3]?.name).toBe("Last ranked match played");
   });
 
   it("maps pre-series tracked-player ticker row to the tracked-player color slot", () => {

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-stats-highlights.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-stats-highlights.test.tsx
@@ -1,8 +1,13 @@
 import "@testing-library/jest-dom/vitest";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { OverlayStatsHighlights } from "../overlay-stats-highlights";
+
+vi.mock("../../../icons/rank-icon", () => ({
+  RankIcon: (): React.ReactElement => <img alt="rank-icon" />,
+}));
 
 afterEach(() => {
   cleanup();
@@ -35,5 +40,28 @@ describe("OverlayStatsHighlights", () => {
 
     expect(screen.getByText("Kills")).toBeInTheDocument();
     expect(screen.getByText("N/A")).toBeInTheDocument();
+  });
+
+  it("renders rank icon when slot has rank metadata", () => {
+    render(
+      <OverlayStatsHighlights
+        items={[
+          {
+            label: "Current Rank",
+            value: "1,500",
+            rankIcon: {
+              rankTier: "Onyx",
+              subTier: 0,
+              measurementMatchesRemaining: 0,
+              initialMeasurementMatches: 10,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Current Rank")).toBeInTheDocument();
+    expect(screen.getByText("1,500")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "rank-icon" })).toBeInTheDocument();
   });
 });

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -153,7 +153,7 @@ describe("useIndividualTrackerViewer", () => {
     expect(getMatchStatsSpy).not.toHaveBeenCalled();
   });
 
-  it("treats the public viewer path as connected after the initial view loads", async () => {
+  it("connects websocket in public viewer path after initial view loads", async () => {
     const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
       view: aFakeTrackerViewStateWith({ trackerId: "tracker-1", status: "active" }),
     });
@@ -172,10 +172,18 @@ describe("useIndividualTrackerViewer", () => {
 
     await waitFor(() => {
       expect(result.current.snapshot.status).toBe(ComponentLoaderStatus.LOADED);
-      expect(result.current.snapshot.connectionStatus).toBe("connected");
     });
 
-    expect(connectSpy).not.toHaveBeenCalled();
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    expect(result.current.snapshot.connectionStatus).toBe("connecting");
+
+    act(() => {
+      individualTrackerViewService.lastConnection?.emitStatus("connected");
+    });
+
+    await waitFor(() => {
+      expect(result.current.snapshot.connectionStatus).toBe("connected");
+    });
   });
 
   it("loads long series in a single request when a series entry expands", async () => {

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -153,7 +153,7 @@ describe("useIndividualTrackerViewer", () => {
     expect(getMatchStatsSpy).not.toHaveBeenCalled();
   });
 
-  it("connects websocket in public viewer path after initial view loads", async () => {
+  it("treats the public viewer path as connected after the initial view loads", async () => {
     const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
       view: aFakeTrackerViewStateWith({ trackerId: "tracker-1", status: "active" }),
     });
@@ -172,18 +172,10 @@ describe("useIndividualTrackerViewer", () => {
 
     await waitFor(() => {
       expect(result.current.snapshot.status).toBe(ComponentLoaderStatus.LOADED);
-    });
-
-    expect(connectSpy).toHaveBeenCalledTimes(1);
-    expect(result.current.snapshot.connectionStatus).toBe("connecting");
-
-    act(() => {
-      individualTrackerViewService.lastConnection?.emitStatus("connected");
-    });
-
-    await waitFor(() => {
       expect(result.current.snapshot.connectionStatus).toBe("connected");
     });
+
+    expect(connectSpy).not.toHaveBeenCalled();
   });
 
   it("loads long series in a single request when a series entry expands", async () => {

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -1,4 +1,4 @@
-import type { StatsHighlightItem } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import type { PreSeriesPlayerInfo, StatsHighlightItem } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { TrackerStatus } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import type { NormalizedMatchOutcome } from "@guilty-spark/shared/halo/match-enrichment";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
@@ -76,6 +76,7 @@ export interface IndividualTrackerViewerRenderModel {
   readonly timeline: readonly ViewerTimelineItem[];
   readonly accumulated: ViewerAccumulatedStats;
   readonly statsHighlights: readonly StatsHighlightItem[] | undefined;
+  readonly preSeriesPlayerInfo: PreSeriesPlayerInfo | undefined;
   readonly teamColors: readonly TeamColor[];
 }
 

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -527,13 +527,6 @@ export class IndividualTrackerViewerPresenter {
     this.statusSubscription?.unsubscribe();
     this.connection?.disconnect();
 
-    // Only establish individual-tracker WS connection in managed context (when individualTrackerService is available).
-    // Public pages (follow viewer) should not connect to per-tracker endpoints.
-    if (this.config.individualTrackerService == null) {
-      this.config.store.setConnectionStatus("connected");
-      return;
-    }
-
     const connection = this.config.individualTrackerViewService.connect(this.config.trackerId);
     this.connection = connection;
     this.viewSubscription = connection.subscribe((view) => {

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -527,6 +527,13 @@ export class IndividualTrackerViewerPresenter {
     this.statusSubscription?.unsubscribe();
     this.connection?.disconnect();
 
+    // Only establish individual-tracker WS connection in managed context (when individualTrackerService is available).
+    // Public pages (follow viewer) should not connect to per-tracker endpoints.
+    if (this.config.individualTrackerService == null) {
+      this.config.store.setConnectionStatus("connected");
+      return;
+    }
+
     const connection = this.config.individualTrackerViewService.connect(this.config.trackerId);
     this.connection = connection;
     this.viewSubscription = connection.subscribe((view) => {

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -292,6 +292,7 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
     timeline: [...timelineWithFallback],
     accumulated,
     statsHighlights: view.statsHighlights,
+    preSeriesPlayerInfo: view.preSeriesPlayerInfo,
     teamColors: [getTeamColorOrDefault(preferredTeamColorId, 0), getTeamColorOrDefault(preferredEnemyColorId, 1)],
   };
 }

--- a/pages/src/components/individual-tracker/viewer/viewer-store.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-store.ts
@@ -76,7 +76,11 @@ export class IndividualTrackerViewerStore {
     const isLive = this.snapshot.view?.isLive ?? false;
     const streamerSettings = this.snapshot.view?.streamerSettings;
     const statsHighlights = this.snapshot.view?.statsHighlights;
-    this.update({ status: ComponentLoaderStatus.LOADED, view: { ...view, isLive, streamerSettings, statsHighlights } });
+    const preSeriesPlayerInfo = this.snapshot.view?.preSeriesPlayerInfo;
+    this.update({
+      status: ComponentLoaderStatus.LOADED,
+      view: { ...view, isLive, streamerSettings, statsHighlights, preSeriesPlayerInfo },
+    });
   }
 
   public setConnectionStatus(connectionStatus: TrackerViewConnectionStatus): void {

--- a/pages/src/services/individual-tracker/fakes/view.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/view.fake.ts
@@ -98,6 +98,7 @@ export function aFakeTrackerLiveViewWith(overrides: FakeLiveViewOverrides = {}):
 interface FakeViewStateOverrides extends FakeLiveViewOverrides {
   readonly isLive?: boolean;
   readonly statsHighlights?: readonly StatsHighlightItem[];
+  readonly preSeriesPlayerInfo?: TrackerViewState["preSeriesPlayerInfo"];
 }
 
 export function aFakeTrackerViewStateWith(overrides: FakeViewStateOverrides = {}): TrackerViewState {
@@ -105,6 +106,7 @@ export function aFakeTrackerViewStateWith(overrides: FakeViewStateOverrides = {}
     ...aFakeTrackerLiveViewWith(overrides),
     isLive: overrides.isLive ?? true,
     ...(overrides.statsHighlights !== undefined ? { statsHighlights: [...overrides.statsHighlights] } : {}),
+    ...(overrides.preSeriesPlayerInfo !== undefined ? { preSeriesPlayerInfo: overrides.preSeriesPlayerInfo } : {}),
   };
 }
 

--- a/shared/src/contracts/durable-objects/individual-tracker/management.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/management.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { defineContract } from "../../base";
-import { preSeriesPlayerInfoSchema, statsHighlightItemSchema, trackerLiveViewSchema } from "../../individual-tracker/view";
+import {
+  preSeriesPlayerInfoSchema,
+  statsHighlightItemSchema,
+  trackerLiveViewSchema,
+} from "../../individual-tracker/view";
 import { individualTrackerStateSchema } from "./lifecycle";
 
 export const individualTrackerStatusContract = defineContract(

--- a/shared/src/contracts/durable-objects/individual-tracker/management.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/management.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { defineContract } from "../../base";
-import { statsHighlightItemSchema, trackerLiveViewSchema } from "../../individual-tracker/view";
+import { preSeriesPlayerInfoSchema, statsHighlightItemSchema, trackerLiveViewSchema } from "../../individual-tracker/view";
 import { individualTrackerStateSchema } from "./lifecycle";
 
 export const individualTrackerStatusContract = defineContract(
@@ -10,6 +10,7 @@ export type IndividualTrackerStatusResponse = z.infer<typeof individualTrackerSt
 
 const individualTrackerViewStateSchema = trackerLiveViewSchema.extend({
   statsHighlights: z.array(statsHighlightItemSchema).optional(),
+  preSeriesPlayerInfo: preSeriesPlayerInfoSchema.optional(),
 });
 export type IndividualTrackerViewState = z.infer<typeof individualTrackerViewStateSchema>;
 

--- a/shared/src/contracts/individual-tracker/tests/view.test.ts
+++ b/shared/src/contracts/individual-tracker/tests/view.test.ts
@@ -104,6 +104,35 @@ describe("trackerViewContract", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts preSeriesPlayerInfo", () => {
+    const result = trackerViewContract.safeParse({
+      view: {
+        trackerId: "t4",
+        gamertag: "ProfileTag",
+        status: "active",
+        isLive: true,
+        matches: [],
+        series: [],
+        lastUpdateTime: "2024-11-26T12:00:00.000Z",
+        lastMatchDiscoveredAt: null,
+        hasActiveSeries: false,
+        hasRecentCompletedSeries: false,
+        preSeriesPlayerInfo: {
+          currentRank: 1520,
+          currentRankTier: "Diamond",
+          currentRankSubTier: 1,
+          currentRankMeasurementMatchesRemaining: null,
+          currentRankInitialMeasurementMatches: null,
+          allTimePeakRank: 1650,
+          esra: 1501,
+          lastRankedGamePlayed: "2024-11-26T10:00:00.000Z",
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it("rejects an unknown status", () => {
     const result = trackerViewContract.safeParse({
       ...validResponse,

--- a/shared/src/contracts/individual-tracker/view.ts
+++ b/shared/src/contracts/individual-tracker/view.ts
@@ -86,10 +86,23 @@ export const statsHighlightItemSchema = z.object({
 });
 export type StatsHighlightItem = z.infer<typeof statsHighlightItemSchema>;
 
+export const preSeriesPlayerInfoSchema = z.object({
+  currentRank: z.number().nullable(),
+  currentRankTier: z.string().nullable(),
+  currentRankSubTier: z.number().nullable(),
+  currentRankMeasurementMatchesRemaining: z.number().nullable(),
+  currentRankInitialMeasurementMatches: z.number().nullable(),
+  allTimePeakRank: z.number().nullable(),
+  esra: z.number().nullable(),
+  lastRankedGamePlayed: z.string().nullable(),
+});
+export type PreSeriesPlayerInfo = z.infer<typeof preSeriesPlayerInfoSchema>;
+
 export const trackerViewStateSchema = trackerLiveViewSchema.extend({
   isLive: z.boolean(),
   streamerSettings: streamerViewSettingsSchema.optional(),
   statsHighlights: z.array(statsHighlightItemSchema).optional(),
+  preSeriesPlayerInfo: preSeriesPlayerInfoSchema.optional(),
 });
 export type TrackerViewState = z.infer<typeof trackerViewStateSchema>;
 


### PR DESCRIPTION
## Context
The streamer overlay and user-level follow pages had multiple parity and freshness issues after recent tracker UX changes. Pre-series overlay content was too sparse, overlay stats highlights were missing rank icons, and follow pages could either flicker due to remounts or remain stale after game-selection changes. This PR bundles the fixes needed to stabilize the current behavior while we plan a longer-term architecture cleanup.

## This PR
- enriches individual tracker pre-series overlay data so Player Info includes Current rank, Peak rank, ESRA, and Last ranked match played
- adds rank icon rendering to overlay stats highlights for rank-based slots
- removes follow page remount flicker by using stable tracker-id keys instead of last-update-time keys
- propagates tracker changes through the user-level follow websocket route so directory updates are pushed immediately instead of waiting only on polling cadence
- adds/updates focused tests across API route follow websocket logic and pages follow/viewer/overlay behavior

## Subsequent Work
- align on a single architecture for user-level follow streaming (coordinator strategy and ownership boundaries)
- reduce duplicate update paths and clarify event flow between tracker updates and directory broadcasts
- clean up temporary transition commits once architecture direction is confirmed