### PR TITLE
refactor(api): move follow routes to user-tracker directory

### DIFF
--- a/api/routes/individual-tracker/individual-tracker.ts
+++ b/api/routes/individual-tracker/individual-tracker.ts
@@ -1,5 +1,4 @@
 import type { RoutesRegisterHandler } from "../base/types";
-import { trackerFollowRoutesRegisterHandler } from "./follow";
 import { trackerManageRoutesRegisterHandler } from "./manage";
 import { trackerProfileRoutesRegisterHandler } from "./profile";
 import { trackerSettingsRoutesRegisterHandler } from "./settings";
@@ -10,5 +9,4 @@ export const individualTrackerRoutesRegisterHandler: RoutesRegisterHandler = (ro
   trackerManageRoutesRegisterHandler(router, installServices);
   trackerSettingsRoutesRegisterHandler(router, installServices);
   trackerViewRoutesRegisterHandler(router, installServices);
-  trackerFollowRoutesRegisterHandler(router, installServices);
 };

--- a/api/routes/user-tracker/follow.ts
+++ b/api/routes/user-tracker/follow.ts
@@ -14,7 +14,7 @@ function getUserTrackerStub(env: Env, userId: string): DurableObjectStub<UserTra
   return env.USER_TRACKER_DO.get(doId);
 }
 
-export const trackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
+export const userTrackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
   router.get("/u/:gamertag/view", async (request, env: Env) => {
     const services = installServices({ env });
     const { databaseService, logService } = services;

--- a/api/routes/user-tracker/tests/follow.test.ts
+++ b/api/routes/user-tracker/tests/follow.test.ts
@@ -7,7 +7,7 @@ import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import { aFakeUserTrackerDOWith } from "../../../durable-objects/user-tracker/fakes/user-tracker-do.fake";
 import { aFakeLinkedIdentitiesRow } from "../../../services/database/fakes/database.fake";
 import { installFakeServicesWith } from "../../../services/fakes/services";
-import { individualTrackerRoutesRegisterHandler } from "../individual-tracker";
+import { userTrackerRoutesRegisterHandler } from "../user-tracker";
 
 function getRequest(path: string): Request {
   return new Request(`http://localhost${path}`, { method: "GET" });
@@ -57,7 +57,7 @@ describe("/u/:gamertag follow routes", () => {
         vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(null);
         return services;
       });
-      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+      userTrackerRoutesRegisterHandler(router, localInstallServices);
 
       const res = (await router.fetch(getRequest("/u/UnknownTag/view"), env)) as Response;
 
@@ -99,7 +99,7 @@ describe("/u/:gamertag follow routes", () => {
         vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
         return services;
       });
-      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+      userTrackerRoutesRegisterHandler(router, localInstallServices);
 
       const res = (await router.fetch(getRequest("/u/KnownTag/view"), localEnv)) as Response;
 
@@ -138,7 +138,7 @@ describe("/u/:gamertag follow routes", () => {
         vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
         return services;
       });
-      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+      userTrackerRoutesRegisterHandler(router, localInstallServices);
 
       const res = (await router.fetch(getRequest("/u/EmptyTag/view"), localEnv)) as Response;
 
@@ -154,7 +154,7 @@ describe("/u/:gamertag follow routes", () => {
         vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(null);
         return services;
       });
-      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+      userTrackerRoutesRegisterHandler(router, localInstallServices);
 
       const res = (await router.fetch(wsRequest("/u/UnknownTag/ws"), env)) as Response;
 
@@ -168,7 +168,7 @@ describe("/u/:gamertag follow routes", () => {
         vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
         return services;
       });
-      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+      userTrackerRoutesRegisterHandler(router, localInstallServices);
 
       const res = (await router.fetch(getRequest("/u/SomeTag/ws"), env)) as Response;
 
@@ -186,7 +186,7 @@ describe("/u/:gamertag follow routes", () => {
         vi.spyOn(services.databaseService, "findActiveXboxIdentityByGamertag").mockResolvedValue(identity);
         return services;
       });
-      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+      userTrackerRoutesRegisterHandler(router, localInstallServices);
 
       const res = (await router.fetch(wsRequest("/u/WsTag/ws"), localEnv)) as Response;
 

--- a/api/routes/user-tracker/user-tracker.ts
+++ b/api/routes/user-tracker/user-tracker.ts
@@ -1,0 +1,6 @@
+import type { RoutesRegisterHandler } from "../base/types";
+import { userTrackerFollowRoutesRegisterHandler } from "./follow";
+
+export const userTrackerRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
+  userTrackerFollowRoutesRegisterHandler(router, installServices);
+};

--- a/api/server.ts
+++ b/api/server.ts
@@ -3,6 +3,7 @@ import type { installServices } from "./services/install";
 import { authRoutesRegisterHandler } from "./routes/auth/auth";
 import { discordInteractionsRoute } from "./routes/discord/interactions";
 import { individualTrackerRoutesRegisterHandler } from "./routes/individual-tracker/individual-tracker";
+import { userTrackerRoutesRegisterHandler } from "./routes/user-tracker/user-tracker";
 import { haloProxyRoutesRegisterHandler } from "./routes/halo-proxy/halo-proxy";
 import { statsRoutesRegisterHandler } from "./routes/stats/stats";
 
@@ -30,6 +31,8 @@ export class Server {
     });
 
     authRoutesRegisterHandler(this.router, this.installServices);
+
+    userTrackerRoutesRegisterHandler(this.router, this.installServices);
 
     individualTrackerRoutesRegisterHandler(this.router, this.installServices);
 


### PR DESCRIPTION
Context:
The follow routes (`/u/:gamertag/view` and `/u/:gamertag/ws`) now route through UserTrackerDO as of PR #631. These routes should live in the `/api/routes/user-tracker/` directory to reflect the new ownership model, rather than in `/api/routes/individual-tracker/`.

This PR:
- Creates `/api/routes/user-tracker/` directory structure
- Moves follow.ts and follow.test.ts from individual-tracker to user-tracker
- Renames `trackerFollowRoutesRegisterHandler` to `userTrackerFollowRoutesRegisterHandler` for clarity
- Creates `user-tracker.ts` as the composite route registration entry point
- Updates server.ts to register user-tracker routes before individual-tracker routes
- All 2813 tests passing

Subsequent Work:
- Phase 2: Implement notify + reconcile for individual-tracker → user-tracker updates
- Phase 3: Cleanup and hardening
- Phase 4: Additional route ownership refactor if needed