### PR TITLE
feat(api): phase 2 user-tracker notify + nudge idempotency foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,10 +272,14 @@ Prefer typed fake instances plus `vi.spyOn` over ad hoc test doubles. Avoid `as 
 3. If set of requirements exceeds 3 pull requests, create a plan document but do not check it in. Ensure this plan records all decisions that may be discussed throughout any conversing with the prompter.
 4. If working with a plan, prompt on whether to work as a single agent, or an orchestrator delegating possible parallelized tasks with the main agent taking on the responsibilities of ensuring adherence to this file
 5. Building a feature:
-   1. Follow nearest neighbor approach in terms of software engineering patterns, practices, and architecture
-   2. When feature is deemed "complete", commit the change
-   3. Then put yourself (or a subagent) into a loop of doing "/code-review" and fixing issues that are identified until clean. Commit each iteration.
-   4. Run format + lint + typecheck + test ensuring all pass and commit any outstanding issues.
-6. If instructed by prompter, raise PR with concise description of the feature.
-7. Provide summary of changes, link to pull request, and confirmation that `/code-review` has ran until clean with what fixes were done.
+   1. Ensure all work starts on a new branch, never commit or push to main
+   2. Follow nearest neighbor approach in terms of software engineering patterns, practices, and architecture
+   3. When feature is deemed "complete", commit the change
+   4. If `/code-review` is available, put yourself (or a subagent) into a loop of doing "/code-review" and fixing issues that are identified until clean. Commit each iteration.
+   5. Run format + lint + typecheck + test ensuring all pass and commit any outstanding issues.
+6. If instructed by prompter, raise PR using `gh` with 3 sections
+   1. Context - describe the overarching feature (summary of the plan if it is from a plan)
+   2. This change - what does this PR do in context of the overall plan
+   3. [Optional] Subsequent work - dot point summary of work to happen after this
+7. Provide summary of changes, link to pull request, suggest to kick off copilot loop
 8. If work is based on a plan, update the plan with the progress, and prompt for next action.

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -898,7 +898,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.lastUpdateTime = new Date().toISOString();
     await this.state.storage.deleteAlarm();
     await this.setState(trackerState);
-    this.notifyUserTracker(trackerState);
     this.broadcastViewState(trackerState);
 
     this.logService.info(
@@ -922,7 +921,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.status = "active";
     trackerState.lastUpdateTime = new Date().toISOString();
     await this.setState(trackerState);
-    this.notifyUserTracker(trackerState);
     const resumeAlarmDelay = this.hasPendingRecompute(trackerState) ? 0 : ALARM_INTERVAL_MS;
     await this.state.storage.setAlarm(addMilliseconds(new Date(), resumeAlarmDelay).getTime());
     this.broadcastViewState(trackerState);
@@ -947,7 +945,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     if (trackerState != null) {
       trackerState.status = "stopped";
       trackerState.lastUpdateTime = new Date().toISOString();
-      this.notifyUserTracker(trackerState);
       this.broadcastViewState(trackerState);
       this.closeWebSockets("Tracker stopped");
       this.logService.info(

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -304,10 +304,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         trackerState.lastUpdateTime = new Date().toISOString();
         await this.state.storage.deleteAlarm();
         await this.setState(trackerState);
-        this.notifyUserTracker(trackerState);
         this.broadcastViewState(trackerState);
         this.closeWebSockets("Tracker idle timeout");
         await this.markRegistryStopped(trackerState);
+        this.notifyUserTracker(trackerState);
         return;
       }
 
@@ -328,9 +328,13 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       this.handleError(trackerState, error);
     }
 
+    const shouldNotifyUserTracker = broadcastWhenUnchanged || discoveredNewMatch;
+
     await this.setState(trackerState);
-    this.notifyUserTracker(trackerState);
-    if (broadcastWhenUnchanged || discoveredNewMatch) {
+    if (shouldNotifyUserTracker) {
+      this.notifyUserTracker(trackerState);
+    }
+    if (shouldNotifyUserTracker) {
       this.broadcastViewState(trackerState);
     }
     await this.state.storage.setAlarm(addMilliseconds(new Date(), this.getNextAlarmInterval(trackerState)).getTime());

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -151,6 +151,7 @@ function normalizeRankTier(rankTier: string | null | undefined): string | null {
 export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   __DURABLE_OBJECT_BRAND = undefined as never;
   private readonly state: DurableObjectState;
+  private readonly env: Env;
   private readonly services: Services;
   private readonly logService: LogService;
   private readonly webSocketAdapter: WebSocketHibernationAdapter;
@@ -167,6 +168,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     webSocketAdapter: WebSocketHibernationAdapter = new CloudflareWebSocketHibernationAdapter(),
   ) {
     this.state = state;
+    this.env = env;
 
     this.services = installServices({ env });
     this.logService = this.services.logService;
@@ -302,6 +304,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         trackerState.lastUpdateTime = new Date().toISOString();
         await this.state.storage.deleteAlarm();
         await this.setState(trackerState);
+        this.notifyUserTracker(trackerState);
         this.broadcastViewState(trackerState);
         this.closeWebSockets("Tracker idle timeout");
         await this.markRegistryStopped(trackerState);
@@ -326,6 +329,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
 
     await this.setState(trackerState);
+    this.notifyUserTracker(trackerState);
     if (broadcastWhenUnchanged || discoveredNewMatch) {
       this.broadcastViewState(trackerState);
     }
@@ -867,6 +871,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     };
 
     await this.setState(trackerState);
+  this.notifyUserTracker(trackerState);
     await this.state.storage.setAlarm(addMilliseconds(new Date(), ALARM_INTERVAL_MS).getTime());
 
     this.logService.info(
@@ -893,6 +898,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.lastUpdateTime = new Date().toISOString();
     await this.state.storage.deleteAlarm();
     await this.setState(trackerState);
+    this.notifyUserTracker(trackerState);
     this.broadcastViewState(trackerState);
 
     this.logService.info(
@@ -916,6 +922,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.status = "active";
     trackerState.lastUpdateTime = new Date().toISOString();
     await this.setState(trackerState);
+    this.notifyUserTracker(trackerState);
     const resumeAlarmDelay = this.hasPendingRecompute(trackerState) ? 0 : ALARM_INTERVAL_MS;
     await this.state.storage.setAlarm(addMilliseconds(new Date(), resumeAlarmDelay).getTime());
     this.broadcastViewState(trackerState);
@@ -940,6 +947,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     if (trackerState != null) {
       trackerState.status = "stopped";
       trackerState.lastUpdateTime = new Date().toISOString();
+      this.notifyUserTracker(trackerState);
       this.broadcastViewState(trackerState);
       this.closeWebSockets("Tracker stopped");
       this.logService.info(
@@ -994,6 +1002,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     this.applySelectMatchesChanges(trackerState, incoming, body.seriesGroups, selectionChanged);
 
     await this.setState(trackerState);
+  this.notifyUserTracker(trackerState);
     this.broadcastViewState(trackerState);
     if (selectionChanged && !trackerState.isPaused) {
       await this.state.storage.setAlarm(Date.now());
@@ -1378,6 +1387,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.lastUpdateTime = new Date().toISOString();
 
     await this.setState(trackerState);
+  this.notifyUserTracker(trackerState);
     this.broadcastViewState(trackerState);
 
     this.logService.info(
@@ -1405,6 +1415,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.lastUpdateTime = new Date().toISOString();
 
     await this.setState(trackerState);
+  this.notifyUserTracker(trackerState);
     this.broadcastViewState(trackerState);
 
     this.logService.info(
@@ -1446,6 +1457,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.lastUpdateTime = new Date().toISOString();
 
     await this.setState(trackerState);
+  this.notifyUserTracker(trackerState);
     this.broadcastViewState(trackerState);
 
     return editSeriesContract.toResponse({ success: true });
@@ -1601,6 +1613,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.lastUpdateTime = new Date().toISOString();
 
     await this.setState(trackerState);
+  this.notifyUserTracker(trackerState);
     this.broadcastViewState(trackerState);
     await this.state.storage.setAlarm(Date.now());
 
@@ -1786,6 +1799,51 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
   private async setState(state: IndividualTrackerInternalState): Promise<void> {
     await this.state.storage.put(STATE_STORAGE_KEY, state);
+  }
+
+  private notifyUserTracker(state: IndividualTrackerInternalState): void {
+    void this.notifyUserTrackerAsync(state);
+  }
+
+  private async notifyUserTrackerAsync(state: IndividualTrackerInternalState): Promise<void> {
+    try {
+      const doId = this.env.USER_TRACKER_DO.idFromName(state.userId);
+      const stub = this.env.USER_TRACKER_DO.get(doId);
+      const response = await stub.fetch(
+        new Request("http://do/nudge", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            userId: state.userId,
+            trackerId: state.trackerId,
+            lastUpdateTime: state.lastUpdateTime,
+          }),
+        }),
+      );
+
+      if (!response.ok) {
+        this.logService.warn(
+          `UserTracker nudge returned status ${response.status.toString()}`,
+          new Map([
+            ["context", "IndividualTracker: UserTracker nudge error"],
+            ["userId", state.userId],
+            ["trackerId", state.trackerId],
+            ["status", response.status.toString()],
+          ]),
+        );
+      }
+    } catch (error) {
+      this.logService.warn(
+        error,
+        new Map([
+          ["context", "IndividualTracker: UserTracker nudge exception"],
+          ["userId", state.userId],
+          ["trackerId", state.trackerId],
+        ]),
+      );
+    }
   }
 
   private applySubstitutionToSeries(series: ActiveSeries, payload: SeriesSubstitutedPayload): ActiveSeries {

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -871,7 +871,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     };
 
     await this.setState(trackerState);
-  this.notifyUserTracker(trackerState);
+    this.notifyUserTracker(trackerState);
     await this.state.storage.setAlarm(addMilliseconds(new Date(), ALARM_INTERVAL_MS).getTime());
 
     this.logService.info(
@@ -1002,7 +1002,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     this.applySelectMatchesChanges(trackerState, incoming, body.seriesGroups, selectionChanged);
 
     await this.setState(trackerState);
-  this.notifyUserTracker(trackerState);
+    this.notifyUserTracker(trackerState);
     this.broadcastViewState(trackerState);
     if (selectionChanged && !trackerState.isPaused) {
       await this.state.storage.setAlarm(Date.now());
@@ -1387,7 +1387,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.lastUpdateTime = new Date().toISOString();
 
     await this.setState(trackerState);
-  this.notifyUserTracker(trackerState);
+    this.notifyUserTracker(trackerState);
     this.broadcastViewState(trackerState);
 
     this.logService.info(
@@ -1415,7 +1415,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.lastUpdateTime = new Date().toISOString();
 
     await this.setState(trackerState);
-  this.notifyUserTracker(trackerState);
+    this.notifyUserTracker(trackerState);
     this.broadcastViewState(trackerState);
 
     this.logService.info(
@@ -1457,7 +1457,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.lastUpdateTime = new Date().toISOString();
 
     await this.setState(trackerState);
-  this.notifyUserTracker(trackerState);
+    this.notifyUserTracker(trackerState);
     this.broadcastViewState(trackerState);
 
     return editSeriesContract.toResponse({ success: true });
@@ -1613,7 +1613,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.lastUpdateTime = new Date().toISOString();
 
     await this.setState(trackerState);
-  this.notifyUserTracker(trackerState);
+    this.notifyUserTracker(trackerState);
     this.broadcastViewState(trackerState);
     await this.state.storage.setAlarm(Date.now());
 

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -22,17 +22,19 @@ import type {
   SeriesStartedPayload,
   SeriesSubstitutedPayload,
 } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
+import { trackerChangedPayloadSchema } from "@guilty-spark/shared/contracts/durable-objects/user-tracker/nudge";
 import { IndividualTrackerDO } from "../individual-tracker-do";
 import { aFakeMapAssetWith } from "../../../services/halo/fakes/data";
 import { installFakeServicesWith } from "../../../services/fakes/services";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import type { Services } from "../../../services/install";
 import type { UserTokenProvider } from "../../../services/halo/user-token-provider";
-import { aFakeDurableObjectStateWith, aFakeWebSocket } from "../../../base/fakes/do.fake";
+import { aFakeDurableObjectNamespaceWith, aFakeDurableObjectStateWith, aFakeWebSocket } from "../../../base/fakes/do.fake";
 import {
   aFakeWebSocketHibernationAdapter,
   type FakeWebSocketHibernationAdapter,
 } from "../../../base/fakes/websocket-hibernation-adapter.fake";
+import { aFakeUserTrackerDOWith } from "../../user-tracker/fakes/user-tracker-do.fake";
 import type {
   IndividualTrackerInternalState,
   IndividualTrackerStartResponse,
@@ -223,6 +225,38 @@ describe("IndividualTrackerDO", () => {
       await individualTrackerDO.fetch(request);
 
       expect(storageSetAlarmSpy).toHaveBeenCalled();
+    });
+
+    it("notifies UserTrackerDO after start state is persisted", async () => {
+      const userTrackerDo = aFakeUserTrackerDOWith();
+      const userTrackerFetchSpy = vi.spyOn(userTrackerDo, "fetch");
+      const localEnv = aFakeEnvWith({ USER_TRACKER_DO: aFakeDurableObjectNamespaceWith(userTrackerDo) });
+      const localDO = new IndividualTrackerDO(mockState, localEnv, () => services);
+      const request = new Request("http://do/start", {
+        method: "POST",
+        body: JSON.stringify(createMockStartRequest()),
+      });
+
+      const response = await localDO.fetch(request);
+      expect(response.status).toBe(200);
+
+      await vi.waitFor(() => {
+        expect(userTrackerFetchSpy).toHaveBeenCalled();
+      });
+
+      const requestArg = userTrackerFetchSpy.mock.calls[0]?.[0];
+      expect(requestArg).toBeInstanceOf(Request);
+      const nudgeRequest = requestArg as Request;
+      expect(new URL(nudgeRequest.url).pathname).toBe("/nudge");
+
+      const parsedPayload = trackerChangedPayloadSchema.safeParse(await nudgeRequest.json());
+      expect(parsedPayload.success).toBe(true);
+      if (!parsedPayload.success) {
+        return;
+      }
+      expect(parsedPayload.data.userId).toBe("test-user-id");
+      expect(parsedPayload.data.trackerId).toBe("test-tracker-id");
+      expect(typeof parsedPayload.data.lastUpdateTime).toBe("string");
     });
 
     it("does not include internal-only fields in the returned state", async () => {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -29,7 +29,11 @@ import { installFakeServicesWith } from "../../../services/fakes/services";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import type { Services } from "../../../services/install";
 import type { UserTokenProvider } from "../../../services/halo/user-token-provider";
-import { aFakeDurableObjectNamespaceWith, aFakeDurableObjectStateWith, aFakeWebSocket } from "../../../base/fakes/do.fake";
+import {
+  aFakeDurableObjectNamespaceWith,
+  aFakeDurableObjectStateWith,
+  aFakeWebSocket,
+} from "../../../base/fakes/do.fake";
 import {
   aFakeWebSocketHibernationAdapter,
   type FakeWebSocketHibernationAdapter,

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2052,6 +2052,70 @@ describe("IndividualTrackerDO", () => {
       expect(markSpy).toHaveBeenCalledWith(row, "stopped");
     });
 
+    it("notifies UserTrackerDO only after idle-timeout registry status is persisted", async () => {
+      const row = aFakeIndividualTrackersRow({ TrackerId: "idle-tracker", Status: "active" });
+      vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(row);
+      const markSpy = vi.spyOn(services.individualTrackerService, "markTrackerStatus");
+      const userTrackerDo = aFakeUserTrackerDOWith();
+      const userTrackerFetchSpy = vi.spyOn(userTrackerDo, "fetch");
+      const localEnv = aFakeEnvWith({ USER_TRACKER_DO: aFakeDurableObjectNamespaceWith(userTrackerDo) });
+      const localDO = new IndividualTrackerDO(mockState, localEnv, () => services);
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          trackerId: "idle-tracker",
+          idleTimeoutHours: 6,
+          startTime: "2024-11-26T05:00:00.000Z",
+          lastMatchDiscoveredAt: "2024-11-26T05:00:00.000Z",
+        }),
+      );
+
+      await localDO.alarm();
+
+      await vi.waitFor(() => {
+        expect(userTrackerFetchSpy).toHaveBeenCalled();
+      });
+
+      expect(markSpy).toHaveBeenCalledWith(row, "stopped");
+      const markStatusCallOrder = Preconditions.checkExists(markSpy.mock.invocationCallOrder[0]);
+      const userTrackerNudgeCallOrder = Preconditions.checkExists(userTrackerFetchSpy.mock.invocationCallOrder[0]);
+      expect(markStatusCallOrder).toBeLessThan(userTrackerNudgeCallOrder);
+    });
+
+    it("does not notify UserTrackerDO on steady-state polls without new matches", async () => {
+      ownerClient.getPlayerMatches.mockResolvedValueOnce([]);
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ matchIds: [] }));
+      const userTrackerDo = aFakeUserTrackerDOWith();
+      const userTrackerFetchSpy = vi.spyOn(userTrackerDo, "fetch");
+      const localEnv = aFakeEnvWith({ USER_TRACKER_DO: aFakeDurableObjectNamespaceWith(userTrackerDo) });
+      const localDO = new IndividualTrackerDO(mockState, localEnv, () => services);
+
+      await localDO.alarm();
+
+      expect(userTrackerFetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("notifies UserTrackerDO on manual refresh even when no new matches are discovered", async () => {
+      ownerClient.getPlayerMatches.mockResolvedValueOnce([]);
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ matchIds: [] }));
+      const userTrackerDo = aFakeUserTrackerDOWith();
+      const userTrackerFetchSpy = vi.spyOn(userTrackerDo, "fetch");
+      const localEnv = aFakeEnvWith({ USER_TRACKER_DO: aFakeDurableObjectNamespaceWith(userTrackerDo) });
+      const localDO = new IndividualTrackerDO(mockState, localEnv, () => services);
+
+      const response = await localDO.fetch(new Request("http://do/refresh", { method: "POST" }));
+      expect(response.status).toBe(200);
+
+      await vi.waitFor(() => {
+        expect(userTrackerFetchSpy).toHaveBeenCalled();
+      });
+
+      const nudgeRequestArg = userTrackerFetchSpy.mock.calls[0]?.[0];
+      expect(nudgeRequestArg).toBeInstanceOf(Request);
+      const nudgeRequest = nudgeRequestArg as Request;
+      expect(new URL(nudgeRequest.url).pathname).toBe("/nudge");
+      expect(nudgeRequest.method).toBe("POST");
+    });
+
     it("increments consecutiveErrors, grows backoff, reschedules at backoff and does not throw on poll failure", async () => {
       ownerClient.getPlayerMatches.mockRejectedValue(new Error("Halo unavailable"));
       storageGetSpy.mockResolvedValue(

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -328,6 +328,92 @@ describe("UserTrackerDO", () => {
     expect(findTrackersByUserIdSpy.mock.calls.length).toBe(callsAfterFirstInstanceNudge);
   });
 
+  it("persists the latest marker when nudges overlap", async () => {
+    const persistedStorage = new Map<string, unknown>();
+    persistedStorage.set("userTrackerState", {
+      state: {
+        userId: "user-1",
+        lastUpdateTime: "2026-07-04T00:00:00.000Z",
+      },
+      viewState: null,
+    });
+
+    let releaseFirstMarkerWrite: () => void = () => {
+      // replaced when first marker write blocks
+    };
+    let firstMarkerWriteBlocked = false;
+    let markerWriteCount = 0;
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        if (typeof key !== "string") {
+          const values = new Map<string, unknown>();
+          for (const currentKey of key) {
+            const currentValue = persistedStorage.get(currentKey);
+            if (currentValue !== undefined) {
+              values.set(currentKey, currentValue);
+            }
+          }
+
+          return await Promise.resolve(values);
+        }
+
+        return await Promise.resolve(persistedStorage.get(key));
+      }) as DurableObjectStorage["get"],
+      put: (async (key: string, value: unknown) => {
+        if (key === "userTrackerMarkers") {
+          markerWriteCount += 1;
+          if (markerWriteCount === 1) {
+            await new Promise<void>((resolve) => {
+              firstMarkerWriteBlocked = true;
+              releaseFirstMarkerWrite = resolve;
+            });
+          }
+        }
+
+        persistedStorage.set(key, value);
+        await Promise.resolve();
+      }) as DurableObjectStorage["put"],
+    });
+
+    const localEnv = aFakeEnvWith();
+    const state = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const localUserTrackerDO = new UserTrackerDO(state, localEnv, installFakeServicesWith, webSocketAdapter);
+
+    const firstNudgePromise = localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "user-1",
+          trackerId: "t1",
+          lastUpdateTime: "2026-07-04T00:00:00.000Z",
+        }),
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(firstMarkerWriteBlocked).toBe(true);
+    });
+
+    const secondNudgePromise = localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "user-1",
+          trackerId: "t1",
+          lastUpdateTime: "2026-07-04T00:01:00.000Z",
+        }),
+      }),
+    );
+
+    releaseFirstMarkerWrite();
+    const [firstNudgeResponse, secondNudgeResponse] = await Promise.all([firstNudgePromise, secondNudgePromise]);
+    expect(firstNudgeResponse.status).toBe(200);
+    expect(secondNudgeResponse.status).toBe(200);
+
+    const storedMarkers = persistedStorage.get("userTrackerMarkers");
+    expect(storedMarkers).toEqual([["user-1:t1", "2026-07-04T00:01:00.000Z"]]);
+  });
+
   it("ignores nudges when payload userId does not match stored userId", async () => {
     mockState.storage.get = (async (key: string | string[]) => {
       if (typeof key !== "string") {

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -169,19 +169,42 @@ describe("UserTrackerDO", () => {
   });
 
   it("deduplicates repeated tracker nudges with the same marker", async () => {
-    mockState.storage.get = (async (key: string | string[]) => {
-      if (typeof key !== "string") {
-        return await Promise.resolve(new Map<string, unknown>());
-      }
+    const persistedStorage = new Map<string, unknown>();
+    persistedStorage.set("userTrackerState", {
+      state: {
+        userId: "user-1",
+        lastUpdateTime: "2026-07-04T00:00:00.000Z",
+      },
+      viewState: null,
+    });
 
-      return await Promise.resolve({
-        state: {
-          userId: "user-1",
-          lastUpdateTime: "2026-07-04T00:00:00.000Z",
-        },
-        viewState: null,
-      });
-    }) as DurableObjectStorage["get"];
+    let markerWriteCount = 0;
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        if (typeof key !== "string") {
+          const values = new Map<string, unknown>();
+          for (const currentKey of key) {
+            const currentValue = persistedStorage.get(currentKey);
+            if (currentValue !== undefined) {
+              values.set(currentKey, currentValue);
+            }
+          }
+
+          return await Promise.resolve(values);
+        }
+
+        return await Promise.resolve(persistedStorage.get(key));
+      }) as DurableObjectStorage["get"],
+      put: (async (key: string, value: unknown) => {
+        if (key === "userTrackerMarkers") {
+          markerWriteCount += 1;
+        }
+
+        persistedStorage.set(key, value);
+        await Promise.resolve();
+      }) as DurableObjectStorage["put"],
+    });
+
     const trackerDo = aFakeIndividualTrackerDOWith({
       viewStateResponse: {
         state: aFakeIndividualTrackerViewStateWith({
@@ -194,8 +217,7 @@ describe("UserTrackerDO", () => {
     });
     const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
     const services = installFakeServicesWith({ env: localEnv });
-    const findTrackersByUserIdSpy = vi.spyOn(services.databaseService, "findIndividualTrackersByUserId");
-    findTrackersByUserIdSpy.mockResolvedValue([
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([
       aFakeIndividualTrackersRow({
         TrackerId: "t1",
         UserId: "user-1",
@@ -204,9 +226,9 @@ describe("UserTrackerDO", () => {
         IsLive: 1,
       }),
     ]);
-    const localUserTrackerDO = new UserTrackerDO(mockState, localEnv, () => services, webSocketAdapter);
+    const state = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const localUserTrackerDO = new UserTrackerDO(state, localEnv, () => services, webSocketAdapter);
 
-    const baselineCalls = findTrackersByUserIdSpy.mock.calls.length;
     const payload = {
       userId: "user-1",
       trackerId: "t1",
@@ -221,11 +243,6 @@ describe("UserTrackerDO", () => {
     );
     expect(firstResponse.status).toBe(200);
 
-    await vi.waitFor(() => {
-      expect(findTrackersByUserIdSpy.mock.calls.length).toBeGreaterThan(baselineCalls);
-    });
-    const callsAfterFirstNudge = findTrackersByUserIdSpy.mock.calls.length;
-
     const secondResponse = await localUserTrackerDO.fetch(
       new Request("http://do/nudge", {
         method: "POST",
@@ -234,8 +251,8 @@ describe("UserTrackerDO", () => {
     );
     expect(secondResponse.status).toBe(200);
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(findTrackersByUserIdSpy.mock.calls.length).toBe(callsAfterFirstNudge);
+    expect(markerWriteCount).toBe(1);
+    expect(persistedStorage.get("userTrackerMarkers")).toEqual([["user-1:t1", "2026-07-04T00:00:00.000Z"]]);
   });
 
   it("deduplicates stale tracker nudges after a DO restart", async () => {
@@ -415,19 +432,42 @@ describe("UserTrackerDO", () => {
   });
 
   it("ignores nudges when payload userId does not match stored userId", async () => {
-    mockState.storage.get = (async (key: string | string[]) => {
-      if (typeof key !== "string") {
-        return await Promise.resolve(new Map<string, unknown>());
-      }
+    const persistedStorage = new Map<string, unknown>();
+    persistedStorage.set("userTrackerState", {
+      state: {
+        userId: "user-1",
+        lastUpdateTime: "2026-07-04T00:00:00.000Z",
+      },
+      viewState: null,
+    });
 
-      return await Promise.resolve({
-        state: {
-          userId: "user-1",
-          lastUpdateTime: "2026-07-04T00:00:00.000Z",
-        },
-        viewState: null,
-      });
-    }) as DurableObjectStorage["get"];
+    let markerWriteCount = 0;
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        if (typeof key !== "string") {
+          const values = new Map<string, unknown>();
+          for (const currentKey of key) {
+            const currentValue = persistedStorage.get(currentKey);
+            if (currentValue !== undefined) {
+              values.set(currentKey, currentValue);
+            }
+          }
+
+          return await Promise.resolve(values);
+        }
+
+        return await Promise.resolve(persistedStorage.get(key));
+      }) as DurableObjectStorage["get"],
+      put: (async (key: string, value: unknown) => {
+        if (key === "userTrackerMarkers") {
+          markerWriteCount += 1;
+        }
+
+        persistedStorage.set(key, value);
+        await Promise.resolve();
+      }) as DurableObjectStorage["put"],
+    });
+
     const trackerDo = aFakeIndividualTrackerDOWith({
       viewStateResponse: {
         state: aFakeIndividualTrackerViewStateWith({
@@ -439,8 +479,7 @@ describe("UserTrackerDO", () => {
     });
     const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
     const services = installFakeServicesWith({ env: localEnv });
-    const findTrackersByUserIdSpy = vi.spyOn(services.databaseService, "findIndividualTrackersByUserId");
-    findTrackersByUserIdSpy.mockResolvedValue([
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([
       aFakeIndividualTrackersRow({
         TrackerId: "t1",
         UserId: "user-1",
@@ -449,9 +488,8 @@ describe("UserTrackerDO", () => {
         IsLive: 1,
       }),
     ]);
-    const localUserTrackerDO = new UserTrackerDO(mockState, localEnv, () => services, webSocketAdapter);
-
-    const baselineCalls = findTrackersByUserIdSpy.mock.calls.length;
+    const state = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const localUserTrackerDO = new UserTrackerDO(state, localEnv, () => services, webSocketAdapter);
 
     const response = await localUserTrackerDO.fetch(
       new Request("http://do/nudge", {
@@ -467,8 +505,8 @@ describe("UserTrackerDO", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ success: true });
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(findTrackersByUserIdSpy.mock.calls.length).toBe(baselineCalls);
+    expect(markerWriteCount).toBe(0);
+    expect(persistedStorage.get("userTrackerMarkers")).toBeUndefined();
   });
 
   it("returns 405 when nudge is called with a non-POST method", async () => {

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -341,8 +341,72 @@ describe("UserTrackerDO", () => {
     );
     expect(secondResponse.status).toBe(200);
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    const markersAfterSecondNudge = persistedStorage.get("userTrackerMarkers");
+    expect(markersAfterSecondNudge).toEqual([["user-1:t1", "2026-07-04T00:00:00.000Z"]]);
     expect(findTrackersByUserIdSpy.mock.calls.length).toBe(callsAfterFirstInstanceNudge);
+  });
+
+  it("accepts a newer marker when timestamps are not lexicographically ordered", async () => {
+    const persistedStorage = new Map<string, unknown>();
+    persistedStorage.set("userTrackerState", {
+      state: {
+        userId: "user-1",
+        lastUpdateTime: "2026-07-04T00:00:00.000Z",
+      },
+      viewState: null,
+    });
+
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        if (typeof key !== "string") {
+          const values = new Map<string, unknown>();
+          for (const currentKey of key) {
+            const currentValue = persistedStorage.get(currentKey);
+            if (currentValue !== undefined) {
+              values.set(currentKey, currentValue);
+            }
+          }
+
+          return await Promise.resolve(values);
+        }
+
+        return await Promise.resolve(persistedStorage.get(key));
+      }) as DurableObjectStorage["get"],
+      put: (async (key: string, value: unknown) => {
+        persistedStorage.set(key, value);
+        await Promise.resolve();
+      }) as DurableObjectStorage["put"],
+    });
+
+    const localEnv = aFakeEnvWith();
+    const state = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const localUserTrackerDO = new UserTrackerDO(state, localEnv, installFakeServicesWith, webSocketAdapter);
+
+    const firstResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "user-1",
+          trackerId: "t1",
+          lastUpdateTime: "2026-07-04T00:00:00+02:00",
+        }),
+      }),
+    );
+    expect(firstResponse.status).toBe(200);
+
+    const secondResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "user-1",
+          trackerId: "t1",
+          lastUpdateTime: "2026-07-03T23:30:00Z",
+        }),
+      }),
+    );
+    expect(secondResponse.status).toBe(200);
+
+    expect(persistedStorage.get("userTrackerMarkers")).toEqual([["user-1:t1", "2026-07-03T23:30:00Z"]]);
   });
 
   it("persists the latest marker when nudges overlap", async () => {

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -238,6 +238,96 @@ describe("UserTrackerDO", () => {
     expect(findTrackersByUserIdSpy.mock.calls.length).toBe(callsAfterFirstNudge);
   });
 
+  it("deduplicates stale tracker nudges after a DO restart", async () => {
+    const persistedStorage = new Map<string, unknown>();
+    persistedStorage.set("userTrackerState", {
+      state: {
+        userId: "user-1",
+        lastUpdateTime: "2026-07-04T00:00:00.000Z",
+      },
+      viewState: null,
+    });
+
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        if (typeof key !== "string") {
+          const values = new Map<string, unknown>();
+          for (const currentKey of key) {
+            const currentValue = persistedStorage.get(currentKey);
+            if (currentValue !== undefined) {
+              values.set(currentKey, currentValue);
+            }
+          }
+
+          return await Promise.resolve(values);
+        }
+
+        return await Promise.resolve(persistedStorage.get(key));
+      }) as DurableObjectStorage["get"],
+      put: (async (key: string, value: unknown) => {
+        persistedStorage.set(key, value);
+        await Promise.resolve();
+      }) as DurableObjectStorage["put"],
+    });
+
+    const trackerDo = aFakeIndividualTrackerDOWith({
+      viewStateResponse: {
+        state: aFakeIndividualTrackerViewStateWith({
+          trackerId: "t1",
+          gamertag: "KnownTag",
+          matches: [],
+          lastUpdateTime: "2026-07-04T00:00:00.000Z",
+        }),
+      },
+    });
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const services = installFakeServicesWith({ env: localEnv });
+    const findTrackersByUserIdSpy = vi.spyOn(services.databaseService, "findIndividualTrackersByUserId");
+    findTrackersByUserIdSpy.mockResolvedValue([
+      aFakeIndividualTrackersRow({
+        TrackerId: "t1",
+        UserId: "user-1",
+        Gamertag: "KnownTag",
+        Status: "active",
+        IsLive: 1,
+      }),
+    ]);
+
+    const stateForFirstInstance = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const firstInstance = new UserTrackerDO(stateForFirstInstance, localEnv, () => services, webSocketAdapter);
+    const nudgePayload = {
+      userId: "user-1",
+      trackerId: "t1",
+      lastUpdateTime: "2026-07-04T00:00:00.000Z",
+    };
+
+    const firstResponse = await firstInstance.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify(nudgePayload),
+      }),
+    );
+    expect(firstResponse.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(findTrackersByUserIdSpy.mock.calls.length).toBeGreaterThan(0);
+    });
+    const callsAfterFirstInstanceNudge = findTrackersByUserIdSpy.mock.calls.length;
+
+    const stateForSecondInstance = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const secondInstance = new UserTrackerDO(stateForSecondInstance, localEnv, () => services, webSocketAdapter);
+    const secondResponse = await secondInstance.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify(nudgePayload),
+      }),
+    );
+    expect(secondResponse.status).toBe(200);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(findTrackersByUserIdSpy.mock.calls.length).toBe(callsAfterFirstInstanceNudge);
+  });
+
   it("ignores nudges when payload userId does not match stored userId", async () => {
     mockState.storage.get = (async (key: string | string[]) => {
       if (typeof key !== "string") {

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -168,6 +168,133 @@ describe("UserTrackerDO", () => {
     await expect(response.json()).resolves.toEqual({ success: true });
   });
 
+  it("deduplicates repeated tracker nudges with the same marker", async () => {
+    mockState.storage.get = (async (key: string | string[]) => {
+      if (typeof key !== "string") {
+        return await Promise.resolve(new Map<string, unknown>());
+      }
+
+      return await Promise.resolve({
+        state: {
+          userId: "user-1",
+          lastUpdateTime: "2026-07-04T00:00:00.000Z",
+        },
+        viewState: null,
+      });
+    }) as DurableObjectStorage["get"];
+    const trackerDo = aFakeIndividualTrackerDOWith({
+      viewStateResponse: {
+        state: aFakeIndividualTrackerViewStateWith({
+          trackerId: "t1",
+          gamertag: "KnownTag",
+          matches: [],
+          lastUpdateTime: "2026-07-04T00:00:00.000Z",
+        }),
+      },
+    });
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const services = installFakeServicesWith({ env: localEnv });
+    const findTrackersByUserIdSpy = vi.spyOn(services.databaseService, "findIndividualTrackersByUserId");
+    findTrackersByUserIdSpy.mockResolvedValue([
+      aFakeIndividualTrackersRow({
+        TrackerId: "t1",
+        UserId: "user-1",
+        Gamertag: "KnownTag",
+        Status: "active",
+        IsLive: 1,
+      }),
+    ]);
+    const localUserTrackerDO = new UserTrackerDO(mockState, localEnv, () => services, webSocketAdapter);
+
+    const baselineCalls = findTrackersByUserIdSpy.mock.calls.length;
+    const payload = {
+      userId: "user-1",
+      trackerId: "t1",
+      lastUpdateTime: "2026-07-04T00:00:00.000Z",
+    };
+
+    const firstResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }),
+    );
+    expect(firstResponse.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(findTrackersByUserIdSpy.mock.calls.length).toBeGreaterThan(baselineCalls);
+    });
+    const callsAfterFirstNudge = findTrackersByUserIdSpy.mock.calls.length;
+
+    const secondResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }),
+    );
+    expect(secondResponse.status).toBe(200);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(findTrackersByUserIdSpy.mock.calls.length).toBe(callsAfterFirstNudge);
+  });
+
+  it("ignores nudges when payload userId does not match stored userId", async () => {
+    mockState.storage.get = (async (key: string | string[]) => {
+      if (typeof key !== "string") {
+        return await Promise.resolve(new Map<string, unknown>());
+      }
+
+      return await Promise.resolve({
+        state: {
+          userId: "user-1",
+          lastUpdateTime: "2026-07-04T00:00:00.000Z",
+        },
+        viewState: null,
+      });
+    }) as DurableObjectStorage["get"];
+    const trackerDo = aFakeIndividualTrackerDOWith({
+      viewStateResponse: {
+        state: aFakeIndividualTrackerViewStateWith({
+          trackerId: "t1",
+          gamertag: "KnownTag",
+          matches: [],
+        }),
+      },
+    });
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const services = installFakeServicesWith({ env: localEnv });
+    const findTrackersByUserIdSpy = vi.spyOn(services.databaseService, "findIndividualTrackersByUserId");
+    findTrackersByUserIdSpy.mockResolvedValue([
+      aFakeIndividualTrackersRow({
+        TrackerId: "t1",
+        UserId: "user-1",
+        Gamertag: "KnownTag",
+        Status: "active",
+        IsLive: 1,
+      }),
+    ]);
+    const localUserTrackerDO = new UserTrackerDO(mockState, localEnv, () => services, webSocketAdapter);
+
+    const baselineCalls = findTrackersByUserIdSpy.mock.calls.length;
+
+    const response = await localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "different-user",
+          trackerId: "t1",
+          lastUpdateTime: "2026-07-04T00:00:00.000Z",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(findTrackersByUserIdSpy.mock.calls.length).toBe(baselineCalls);
+  });
+
   it("returns 405 when nudge is called with a non-POST method", async () => {
     const response = await userTrackerDO.fetch(new Request("http://do/nudge", { method: "GET" }));
 

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -64,6 +64,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   private trackerSubscriptionsInstalled = false;
   private readonly trackerUpdateMarkers = new Map<string, string>();
   private trackerUpdateMarkersHydrated = false;
+  private trackerMarkerPersistenceChain: Promise<void> = Promise.resolve();
 
   constructor(
     state: DurableObjectState,
@@ -560,18 +561,25 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   }
 
   private async persistTrackerUpdateMarkers(): Promise<void> {
-    try {
-      const markerEntries = Array.from(this.trackerUpdateMarkers.entries());
-      await this.state.storage.put(USER_TRACKER_MARKERS_KEY, markerEntries);
-    } catch (error) {
-      this.logService.warn(
-        error,
-        new Map([
-          ["context", "UserTracker marker persistence error"],
-          ["markerCount", this.trackerUpdateMarkers.size.toString()],
-        ]),
-      );
-    }
+    this.trackerMarkerPersistenceChain = this.trackerMarkerPersistenceChain
+      .catch(() => {
+        // previous persistence errors are already logged; keep chain alive
+      })
+      .then(async () => {
+        const markerEntries = Array.from(this.trackerUpdateMarkers.entries());
+        await this.state.storage.put(USER_TRACKER_MARKERS_KEY, markerEntries);
+      })
+      .catch((error: unknown) => {
+        this.logService.warn(
+          error,
+          new Map([
+            ["context", "UserTracker marker persistence error"],
+            ["markerCount", this.trackerUpdateMarkers.size.toString()],
+          ]),
+        );
+      });
+
+    await this.trackerMarkerPersistenceChain;
   }
 
   private serializeDirectory(directory: TrackerDirectory): string {

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -46,6 +46,15 @@ function isTrackerMarkerEntry(value: unknown): value is [string, string] {
   return typeof value[0] === "string" && typeof value[1] === "string";
 }
 
+function toUpdateTimeMs(value: string): number | null {
+  const parsedValue = Date.parse(value);
+  if (Number.isNaN(parsedValue)) {
+    return null;
+  }
+
+  return parsedValue;
+}
+
 export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   __DURABLE_OBJECT_BRAND = undefined as never;
   private readonly state: DurableObjectState;
@@ -517,14 +526,27 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
     const markerKey = `${payload.userId}:${payload.trackerId}`;
     const previousMarker = this.trackerUpdateMarkers.get(markerKey);
-    if (previousMarker != null && payload.lastUpdateTime <= previousMarker) {
+    if (previousMarker != null && this.isStaleOrDuplicateMarker(payload.lastUpdateTime, previousMarker)) {
       return false;
     }
 
+    // Refresh insertion order for existing keys so frequently-updated trackers are not evicted first.
+    this.trackerUpdateMarkers.delete(markerKey);
     this.trackerUpdateMarkers.set(markerKey, payload.lastUpdateTime);
     this.enforceTrackerMarkerLimit();
     await this.persistTrackerUpdateMarkers();
     return true;
+  }
+
+  private isStaleOrDuplicateMarker(nextMarker: string, previousMarker: string): boolean {
+    const nextMarkerMs = toUpdateTimeMs(nextMarker);
+    const previousMarkerMs = toUpdateTimeMs(previousMarker);
+    if (nextMarkerMs != null && previousMarkerMs != null) {
+      return nextMarkerMs <= previousMarkerMs;
+    }
+
+    // If either marker is not parseable as a date, only exact duplicates are considered stale.
+    return nextMarker === previousMarker;
   }
 
   private async hydrateTrackerUpdateMarkers(): Promise<void> {

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -220,11 +220,13 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     }
 
     const payload = parsedBody.data;
-    if (!(await this.shouldAcceptNudge(payload))) {
+    const shouldAcceptNudge = await this.shouldAcceptNudge(payload);
+    if (!shouldAcceptNudge) {
       return userTrackerNudgeContract.toResponse({ success: true }, { noStore: true });
     }
 
-    if (!(await this.shouldQueuePushForNudge(payload))) {
+    const shouldQueuePushForNudge = await this.shouldQueuePushForNudge(payload);
+    if (!shouldQueuePushForNudge) {
       return userTrackerNudgeContract.toResponse({ success: true }, { noStore: true });
     }
 

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -9,6 +9,7 @@ import {
 } from "@guilty-spark/shared/contracts/durable-objects/user-tracker/management";
 import type { TrackerDirectory, TrackerDirectoryEntry } from "@guilty-spark/shared/contracts/individual-tracker/follow";
 import {
+  type TrackerChangedPayload,
   trackerChangedPayloadSchema,
   userTrackerNudgeContract,
 } from "@guilty-spark/shared/contracts/durable-objects/user-tracker/nudge";
@@ -51,6 +52,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   private pushCompletionPromise: Promise<void> | null = null;
   private resolvePushCompletion: (() => void) | null = null;
   private trackerSubscriptionsInstalled = false;
+  private readonly trackerUpdateMarkers = new Map<string, string>();
 
   constructor(
     state: DurableObjectState,
@@ -204,6 +206,15 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     const parsedBody = await parseJsonBody(request, trackerChangedPayloadSchema, "Invalid user tracker nudge payload");
     if (!parsedBody.success) {
       return parsedBody.response;
+    }
+
+    const payload = parsedBody.data;
+    if (!(await this.shouldAcceptNudge(payload))) {
+      return userTrackerNudgeContract.toResponse({ success: true }, { noStore: true });
+    }
+
+    if (!this.shouldQueuePushForNudge(payload)) {
+      return userTrackerNudgeContract.toResponse({ success: true }, { noStore: true });
     }
 
     void this.queueDirectoryPush();
@@ -466,6 +477,35 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
   private async scheduleNextAlarm(): Promise<void> {
     await this.state.storage.setAlarm(Date.now() + FOLLOW_WS_POLL_INTERVAL_MS);
+  }
+
+  private async shouldAcceptNudge(payload: TrackerChangedPayload): Promise<boolean> {
+    const stored = await this.loadState();
+    const storedUserId = stored.state?.userId;
+    if (storedUserId == null || storedUserId === payload.userId) {
+      return true;
+    }
+
+    this.logService.warn(
+      "UserTracker nudge ignored due to user mismatch",
+      new Map([
+        ["context", "UserTracker nudge ignored"],
+        ["storedUserId", storedUserId],
+        ["payloadUserId", payload.userId],
+        ["trackerId", payload.trackerId],
+      ]),
+    );
+    return false;
+  }
+
+  private shouldQueuePushForNudge(payload: TrackerChangedPayload): boolean {
+    const previousMarker = this.trackerUpdateMarkers.get(payload.trackerId);
+    if (previousMarker != null && payload.lastUpdateTime <= previousMarker) {
+      return false;
+    }
+
+    this.trackerUpdateMarkers.set(payload.trackerId, payload.lastUpdateTime);
+    return true;
   }
 
   private serializeDirectory(directory: TrackerDirectory): string {

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -30,10 +30,20 @@ import type { LogService } from "../../services/log/types";
 import { emptyTrackerDirectory, type UserTrackerInternalState } from "./types";
 
 const USER_TRACKER_STATE_KEY = "userTrackerState";
+const USER_TRACKER_MARKERS_KEY = "userTrackerMarkers";
 const FOLLOW_WS_POLL_INTERVAL_MS = 3000;
+const TRACKER_MARKER_LIMIT = 500;
 
 function isNonStopped(row: IndividualTrackersRow): boolean {
   return row.Status !== "stopped";
+}
+
+function isTrackerMarkerEntry(value: unknown): value is [string, string] {
+  if (!Array.isArray(value) || value.length !== 2) {
+    return false;
+  }
+
+  return typeof value[0] === "string" && typeof value[1] === "string";
 }
 
 export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
@@ -53,6 +63,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   private resolvePushCompletion: (() => void) | null = null;
   private trackerSubscriptionsInstalled = false;
   private readonly trackerUpdateMarkers = new Map<string, string>();
+  private trackerUpdateMarkersHydrated = false;
 
   constructor(
     state: DurableObjectState,
@@ -213,7 +224,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       return userTrackerNudgeContract.toResponse({ success: true }, { noStore: true });
     }
 
-    if (!this.shouldQueuePushForNudge(payload)) {
+    if (!(await this.shouldQueuePushForNudge(payload))) {
       return userTrackerNudgeContract.toResponse({ success: true }, { noStore: true });
     }
 
@@ -498,14 +509,67 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     return false;
   }
 
-  private shouldQueuePushForNudge(payload: TrackerChangedPayload): boolean {
-    const previousMarker = this.trackerUpdateMarkers.get(payload.trackerId);
+  private async shouldQueuePushForNudge(payload: TrackerChangedPayload): Promise<boolean> {
+    await this.hydrateTrackerUpdateMarkers();
+
+    const markerKey = `${payload.userId}:${payload.trackerId}`;
+    const previousMarker = this.trackerUpdateMarkers.get(markerKey);
     if (previousMarker != null && payload.lastUpdateTime <= previousMarker) {
       return false;
     }
 
-    this.trackerUpdateMarkers.set(payload.trackerId, payload.lastUpdateTime);
+    this.trackerUpdateMarkers.set(markerKey, payload.lastUpdateTime);
+    this.enforceTrackerMarkerLimit();
+    await this.persistTrackerUpdateMarkers();
     return true;
+  }
+
+  private async hydrateTrackerUpdateMarkers(): Promise<void> {
+    if (this.trackerUpdateMarkersHydrated) {
+      return;
+    }
+
+    this.trackerUpdateMarkersHydrated = true;
+    const storedEntries = await this.state.storage.get(USER_TRACKER_MARKERS_KEY);
+    if (!Array.isArray(storedEntries)) {
+      return;
+    }
+
+    for (const entry of storedEntries) {
+      if (!isTrackerMarkerEntry(entry)) {
+        continue;
+      }
+
+      const [markerKey, markerValue] = entry;
+
+      this.trackerUpdateMarkers.set(markerKey, markerValue);
+    }
+  }
+
+  private enforceTrackerMarkerLimit(): void {
+    while (this.trackerUpdateMarkers.size > TRACKER_MARKER_LIMIT) {
+      const oldestMarkerKey = this.trackerUpdateMarkers.keys().next().value;
+      if (oldestMarkerKey == null) {
+        break;
+      }
+
+      this.trackerUpdateMarkers.delete(oldestMarkerKey);
+    }
+  }
+
+  private async persistTrackerUpdateMarkers(): Promise<void> {
+    try {
+      const markerEntries = Array.from(this.trackerUpdateMarkers.entries());
+      await this.state.storage.put(USER_TRACKER_MARKERS_KEY, markerEntries);
+    } catch (error) {
+      this.logService.warn(
+        error,
+        new Map([
+          ["context", "UserTracker marker persistence error"],
+          ["markerCount", this.trackerUpdateMarkers.size.toString()],
+        ]),
+      );
+    }
   }
 
   private serializeDirectory(directory: TrackerDirectory): string {

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -73,6 +73,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   private trackerSubscriptionsInstalled = false;
   private readonly trackerUpdateMarkers = new Map<string, string>();
   private trackerUpdateMarkersHydrated = false;
+  private trackerUpdateMarkersHydrationPromise: Promise<void> | null = null;
   private trackerMarkerPersistenceChain: Promise<void> = Promise.resolve();
 
   constructor(
@@ -554,21 +555,34 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       return;
     }
 
-    this.trackerUpdateMarkersHydrated = true;
-    const storedEntries = await this.state.storage.get(USER_TRACKER_MARKERS_KEY);
-    if (!Array.isArray(storedEntries)) {
+    if (this.trackerUpdateMarkersHydrationPromise != null) {
+      await this.trackerUpdateMarkersHydrationPromise;
       return;
     }
 
-    for (const entry of storedEntries) {
-      if (!isTrackerMarkerEntry(entry)) {
-        continue;
+    this.trackerUpdateMarkersHydrationPromise = (async (): Promise<void> => {
+      const storedEntries = await this.state.storage.get(USER_TRACKER_MARKERS_KEY);
+      if (!Array.isArray(storedEntries)) {
+        this.trackerUpdateMarkersHydrated = true;
+        return;
       }
 
-      const [markerKey, markerValue] = entry;
+      for (const entry of storedEntries) {
+        if (!isTrackerMarkerEntry(entry)) {
+          continue;
+        }
 
-      this.trackerUpdateMarkers.set(markerKey, markerValue);
-    }
+        const [markerKey, markerValue] = entry;
+
+        this.trackerUpdateMarkers.set(markerKey, markerValue);
+      }
+
+      this.trackerUpdateMarkersHydrated = true;
+    })().finally(() => {
+      this.trackerUpdateMarkersHydrationPromise = null;
+    });
+
+    await this.trackerUpdateMarkersHydrationPromise;
   }
 
   private enforceTrackerMarkerLimit(): void {

--- a/api/routes/individual-tracker/manage.ts
+++ b/api/routes/individual-tracker/manage.ts
@@ -29,6 +29,10 @@ import {
   type IndividualTrackerStartRequest,
 } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/lifecycle";
 import { individualTrackerStatusContract } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/management";
+import {
+  trackerChangedPayloadSchema,
+  userTrackerNudgeContract,
+} from "@guilty-spark/shared/contracts/durable-objects/user-tracker/nudge";
 import { parseJsonBody, parsePathParams } from "@guilty-spark/shared/base/request-parsing";
 import type { IndividualTrackersRow } from "../../services/database/types/individual_trackers";
 import {
@@ -62,6 +66,11 @@ class RefreshTrackerConflictError extends Error {
 function trackerDoStub(env: Env, userId: string, trackerId: string): DurableObjectStub {
   const doId = env.INDIVIDUAL_TRACKER_DO.idFromName(`${userId}:${trackerId}`);
   return env.INDIVIDUAL_TRACKER_DO.get(doId);
+}
+
+function userTrackerDoStub(env: Env, userId: string): DurableObjectStub {
+  const doId = env.USER_TRACKER_DO.idFromName(userId);
+  return env.USER_TRACKER_DO.get(doId);
 }
 
 function assertDoOk(response: Response): void {
@@ -106,6 +115,21 @@ async function stopTrackerDo(env: Env, userId: string, trackerId: string): Promi
   const response = await stub.fetch("http://do/stop", { method: "POST" });
   assertDoOk(response);
   await individualTrackerStopContract.fromResponse(response);
+}
+
+async function nudgeUserTrackerDo(
+  env: Env,
+  payload: { userId: string; trackerId: string; lastUpdateTime: string },
+): Promise<void> {
+  const parsedPayload = trackerChangedPayloadSchema.parse(payload);
+  const stub = userTrackerDoStub(env, parsedPayload.userId);
+  const response = await stub.fetch("http://do/nudge", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(parsedPayload),
+  });
+  assertDoOk(response);
+  await userTrackerNudgeContract.fromResponse(response);
 }
 
 async function statusTrackerDo(env: Env, userId: string, trackerId: string): Promise<IndividualTrackerDoState | null> {
@@ -307,6 +331,11 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       await stopTrackerDo(env, auth.session.userId, tracker.TrackerId);
       await individualTrackerService.markTrackerStatus(tracker, "stopped");
+      await nudgeUserTrackerDo(env, {
+        userId: auth.session.userId,
+        trackerId: tracker.TrackerId,
+        lastUpdateTime: new Date().toISOString(),
+      });
 
       logService.info("Individual tracker stopped", new Map([["trackerId", tracker.TrackerId]]));
 
@@ -345,6 +374,11 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       const state = await pauseTrackerDo(env, auth.session.userId, tracker.TrackerId);
       const paused = await individualTrackerService.markTrackerStatus(tracker, "paused");
+      await nudgeUserTrackerDo(env, {
+        userId: auth.session.userId,
+        trackerId: tracker.TrackerId,
+        lastUpdateTime: state.lastUpdateTime,
+      });
 
       logService.info("Individual tracker paused", new Map([["trackerId", tracker.TrackerId]]));
 
@@ -383,6 +417,11 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       const state = await resumeTrackerDo(env, auth.session.userId, tracker.TrackerId);
       const resumed = await individualTrackerService.markTrackerStatus(tracker, "active");
+      await nudgeUserTrackerDo(env, {
+        userId: auth.session.userId,
+        trackerId: tracker.TrackerId,
+        lastUpdateTime: state.lastUpdateTime,
+      });
 
       logService.info("Individual tracker resumed", new Map([["trackerId", tracker.TrackerId]]));
 

--- a/api/routes/individual-tracker/manage.ts
+++ b/api/routes/individual-tracker/manage.ts
@@ -42,6 +42,7 @@ import {
   TrackerLimitReachedError,
   TrackerNotFoundError,
 } from "../../services/individual-tracker/errors";
+import type { LogService } from "../../services/log/types";
 import type { CreateTrackerOptions } from "../../services/individual-tracker/types";
 import { toTracker } from "../../individual-tracker/mapper";
 import type { RoutesRegisterHandler } from "../base/types";
@@ -130,6 +131,27 @@ async function nudgeUserTrackerDo(
   });
   assertDoOk(response);
   await userTrackerNudgeContract.fromResponse(response);
+}
+
+async function nudgeUserTrackerDoBestEffort(
+  env: Env,
+  payload: { userId: string; trackerId: string; lastUpdateTime: string },
+  logService: LogService,
+  action: "stop" | "pause" | "resume",
+): Promise<void> {
+  try {
+    await nudgeUserTrackerDo(env, payload);
+  } catch (error) {
+    logService.warn(
+      error,
+      new Map([
+        ["context", "Individual tracker user tracker nudge warning"],
+        ["action", action],
+        ["trackerId", payload.trackerId],
+        ["userId", payload.userId],
+      ]),
+    );
+  }
 }
 
 async function statusTrackerDo(env: Env, userId: string, trackerId: string): Promise<IndividualTrackerDoState | null> {
@@ -331,11 +353,16 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       await stopTrackerDo(env, auth.session.userId, tracker.TrackerId);
       await individualTrackerService.markTrackerStatus(tracker, "stopped");
-      await nudgeUserTrackerDo(env, {
-        userId: auth.session.userId,
-        trackerId: tracker.TrackerId,
-        lastUpdateTime: new Date().toISOString(),
-      });
+      await nudgeUserTrackerDoBestEffort(
+        env,
+        {
+          userId: auth.session.userId,
+          trackerId: tracker.TrackerId,
+          lastUpdateTime: new Date().toISOString(),
+        },
+        logService,
+        "stop",
+      );
 
       logService.info("Individual tracker stopped", new Map([["trackerId", tracker.TrackerId]]));
 
@@ -374,11 +401,16 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       const state = await pauseTrackerDo(env, auth.session.userId, tracker.TrackerId);
       const paused = await individualTrackerService.markTrackerStatus(tracker, "paused");
-      await nudgeUserTrackerDo(env, {
-        userId: auth.session.userId,
-        trackerId: tracker.TrackerId,
-        lastUpdateTime: state.lastUpdateTime,
-      });
+      await nudgeUserTrackerDoBestEffort(
+        env,
+        {
+          userId: auth.session.userId,
+          trackerId: tracker.TrackerId,
+          lastUpdateTime: state.lastUpdateTime,
+        },
+        logService,
+        "pause",
+      );
 
       logService.info("Individual tracker paused", new Map([["trackerId", tracker.TrackerId]]));
 
@@ -417,11 +449,16 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
 
       const state = await resumeTrackerDo(env, auth.session.userId, tracker.TrackerId);
       const resumed = await individualTrackerService.markTrackerStatus(tracker, "active");
-      await nudgeUserTrackerDo(env, {
-        userId: auth.session.userId,
-        trackerId: tracker.TrackerId,
-        lastUpdateTime: state.lastUpdateTime,
-      });
+      await nudgeUserTrackerDoBestEffort(
+        env,
+        {
+          userId: auth.session.userId,
+          trackerId: tracker.TrackerId,
+          lastUpdateTime: state.lastUpdateTime,
+        },
+        logService,
+        "resume",
+      );
 
       logService.info("Individual tracker resumed", new Map([["trackerId", tracker.TrackerId]]));
 

--- a/api/routes/individual-tracker/tests/manage.test.ts
+++ b/api/routes/individual-tracker/tests/manage.test.ts
@@ -22,6 +22,10 @@ import {
   aFakeIndividualTrackerStateWith,
   type FakeIndividualTrackerDO,
 } from "../../../durable-objects/individual-tracker/fakes/individual-tracker-do.fake";
+import {
+  aFakeUserTrackerDOWith,
+  type FakeUserTrackerDO,
+} from "../../../durable-objects/user-tracker/fakes/user-tracker-do.fake";
 import { aFakeIndividualTrackersRow } from "../../../services/database/fakes/database.fake";
 import { installFakeServicesWith } from "../../../services/fakes/services";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/individual-tracker";
@@ -178,7 +182,12 @@ describe("/api/individual-tracker manage routes", () => {
   it("stops a tracker: calls the DO stop and marks the registry row stopped", async () => {
     const doStub = aFakeIndividualTrackerDOWith();
     const stopSpy: MockInstance<FakeIndividualTrackerDO["fetch"]> = vi.spyOn(doStub, "fetch");
-    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+    const userTrackerDo = aFakeUserTrackerDOWith();
+    const userTrackerNudgeSpy: MockInstance<FakeUserTrackerDO["fetch"]> = vi.spyOn(userTrackerDo, "fetch");
+    const localEnv = aFakeEnvWith({
+      INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub),
+      USER_TRACKER_DO: aFakeDurableObjectNamespaceWith(userTrackerDo),
+    });
 
     const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "active" });
     let markStatusSpy: MockInstance<IndividualTrackerService["markTrackerStatus"]> | null = null;
@@ -199,7 +208,10 @@ describe("/api/individual-tracker manage routes", () => {
     const body = await res.json<StopTrackerResponse>();
     expect(body.success).toBe(true);
     expect(stopSpy).toHaveBeenCalledWith("http://do/stop", expect.objectContaining({ method: "POST" }));
-    expect(Preconditions.checkExists(markStatusSpy, "markStatus spy")).toHaveBeenCalledWith(row, "stopped");
+    const requiredMarkStatusSpy = Preconditions.checkExists(markStatusSpy, "markStatus spy");
+    expect(requiredMarkStatusSpy).toHaveBeenCalledWith(row, "stopped");
+
+    expect(userTrackerNudgeSpy).toHaveBeenCalledWith("http://do/nudge", expect.objectContaining({ method: "POST" }));
   });
 
   it("returns 404 on pause when the tracker is not owned", async () => {
@@ -224,7 +236,12 @@ describe("/api/individual-tracker manage routes", () => {
       },
     });
     const pauseSpy: MockInstance<FakeIndividualTrackerDO["fetch"]> = vi.spyOn(doStub, "fetch");
-    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+    const userTrackerDo = aFakeUserTrackerDOWith();
+    const userTrackerNudgeSpy: MockInstance<FakeUserTrackerDO["fetch"]> = vi.spyOn(userTrackerDo, "fetch");
+    const localEnv = aFakeEnvWith({
+      INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub),
+      USER_TRACKER_DO: aFakeDurableObjectNamespaceWith(userTrackerDo),
+    });
 
     const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "active" });
     let markStatusSpy: MockInstance<IndividualTrackerService["markTrackerStatus"]> | null = null;
@@ -245,7 +262,10 @@ describe("/api/individual-tracker manage routes", () => {
     const body = await res.json<TrackerResponse>();
     expect(body.tracker.status).toBe("paused");
     expect(pauseSpy).toHaveBeenCalledWith("http://do/pause", expect.objectContaining({ method: "POST" }));
-    expect(Preconditions.checkExists(markStatusSpy, "markStatus spy")).toHaveBeenCalledWith(row, "paused");
+    const requiredMarkStatusSpy = Preconditions.checkExists(markStatusSpy, "markStatus spy");
+    expect(requiredMarkStatusSpy).toHaveBeenCalledWith(row, "paused");
+
+    expect(userTrackerNudgeSpy).toHaveBeenCalledWith("http://do/nudge", expect.objectContaining({ method: "POST" }));
   });
 
   it("returns 404 on resume when the tracker is not owned", async () => {
@@ -270,7 +290,12 @@ describe("/api/individual-tracker manage routes", () => {
       },
     });
     const resumeSpy: MockInstance<FakeIndividualTrackerDO["fetch"]> = vi.spyOn(doStub, "fetch");
-    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+    const userTrackerDo = aFakeUserTrackerDOWith();
+    const userTrackerNudgeSpy: MockInstance<FakeUserTrackerDO["fetch"]> = vi.spyOn(userTrackerDo, "fetch");
+    const localEnv = aFakeEnvWith({
+      INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub),
+      USER_TRACKER_DO: aFakeDurableObjectNamespaceWith(userTrackerDo),
+    });
 
     const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "paused" });
     let markStatusSpy: MockInstance<IndividualTrackerService["markTrackerStatus"]> | null = null;
@@ -291,7 +316,10 @@ describe("/api/individual-tracker manage routes", () => {
     const body = await res.json<TrackerResponse>();
     expect(body.tracker.status).toBe("active");
     expect(resumeSpy).toHaveBeenCalledWith("http://do/resume", expect.objectContaining({ method: "POST" }));
-    expect(Preconditions.checkExists(markStatusSpy, "markStatus spy")).toHaveBeenCalledWith(row, "active");
+    const requiredMarkStatusSpy = Preconditions.checkExists(markStatusSpy, "markStatus spy");
+    expect(requiredMarkStatusSpy).toHaveBeenCalledWith(row, "active");
+
+    expect(userTrackerNudgeSpy).toHaveBeenCalledWith("http://do/nudge", expect.objectContaining({ method: "POST" }));
   });
 
   it("returns 404 on select-active when the tracker is not owned", async () => {

--- a/api/routes/individual-tracker/tests/manage.test.ts
+++ b/api/routes/individual-tracker/tests/manage.test.ts
@@ -214,6 +214,29 @@ describe("/api/individual-tracker manage routes", () => {
     expect(userTrackerNudgeSpy).toHaveBeenCalledWith("http://do/nudge", expect.objectContaining({ method: "POST" }));
   });
 
+  it("still stops a tracker when UserTracker nudge fails", async () => {
+    const doStub = aFakeIndividualTrackerDOWith();
+    const localEnv = aFakeEnvWith({
+      INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub),
+      USER_TRACKER_DO: aFakeDurableObjectNamespaceWith(aFakeUserTrackerDOWith({ shouldThrowError: true })),
+    });
+
+    const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "active" });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env: localEnv });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-123" }));
+      vi.spyOn(services.individualTrackerService, "getOwnedTracker").mockResolvedValue(row);
+      vi.spyOn(services.individualTrackerService, "markTrackerStatus").mockResolvedValue({ ...row, Status: "stopped" });
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(postRequest("/api/individual-tracker/t1/stop", {}), localEnv)) as Response;
+
+    expect(res.status).toBe(200);
+    await expect(res.json<StopTrackerResponse>()).resolves.toEqual({ success: true });
+  });
+
   it("returns 404 on pause when the tracker is not owned", async () => {
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });
@@ -268,6 +291,35 @@ describe("/api/individual-tracker manage routes", () => {
     expect(userTrackerNudgeSpy).toHaveBeenCalledWith("http://do/nudge", expect.objectContaining({ method: "POST" }));
   });
 
+  it("still pauses a tracker when UserTracker nudge fails", async () => {
+    const doStub = aFakeIndividualTrackerDOWith({
+      pauseResponse: {
+        success: true,
+        state: aFakeIndividualTrackerStateWith({ trackerId: "t1", status: "paused", isPaused: true }),
+      },
+    });
+    const localEnv = aFakeEnvWith({
+      INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub),
+      USER_TRACKER_DO: aFakeDurableObjectNamespaceWith(aFakeUserTrackerDOWith({ shouldThrowError: true })),
+    });
+
+    const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "active" });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env: localEnv });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-123" }));
+      vi.spyOn(services.individualTrackerService, "getOwnedTracker").mockResolvedValue(row);
+      vi.spyOn(services.individualTrackerService, "markTrackerStatus").mockResolvedValue({ ...row, Status: "paused" });
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(postRequest("/api/individual-tracker/t1/pause", {}), localEnv)) as Response;
+
+    expect(res.status).toBe(200);
+    const body = await res.json<TrackerResponse>();
+    expect(body.tracker.status).toBe("paused");
+  });
+
   it("returns 404 on resume when the tracker is not owned", async () => {
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });
@@ -320,6 +372,35 @@ describe("/api/individual-tracker manage routes", () => {
     expect(requiredMarkStatusSpy).toHaveBeenCalledWith(row, "active");
 
     expect(userTrackerNudgeSpy).toHaveBeenCalledWith("http://do/nudge", expect.objectContaining({ method: "POST" }));
+  });
+
+  it("still resumes a tracker when UserTracker nudge fails", async () => {
+    const doStub = aFakeIndividualTrackerDOWith({
+      resumeResponse: {
+        success: true,
+        state: aFakeIndividualTrackerStateWith({ trackerId: "t1", status: "active", isPaused: false }),
+      },
+    });
+    const localEnv = aFakeEnvWith({
+      INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub),
+      USER_TRACKER_DO: aFakeDurableObjectNamespaceWith(aFakeUserTrackerDOWith({ shouldThrowError: true })),
+    });
+
+    const row = aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-123", Status: "paused" });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env: localEnv });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: "user-123" }));
+      vi.spyOn(services.individualTrackerService, "getOwnedTracker").mockResolvedValue(row);
+      vi.spyOn(services.individualTrackerService, "markTrackerStatus").mockResolvedValue({ ...row, Status: "active" });
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(postRequest("/api/individual-tracker/t1/resume", {}), localEnv)) as Response;
+
+    expect(res.status).toBe(200);
+    const body = await res.json<TrackerResponse>();
+    expect(body.tracker.status).toBe("active");
   });
 
   it("returns 404 on select-active when the tracker is not owned", async () => {


### PR DESCRIPTION
Context:
Phase 2 (notify + reconcile) requires a reliable, centralized notification flow from IndividualTrackerDO to UserTrackerDO, plus idempotent nudge handling on the user-tracker side so repeated updates do not fan out unnecessary rebuild work.

This change:
- Adds a centralized fire-and-forget notifyUserTracker path in IndividualTrackerDO and wires it into core persisted state mutation paths
- Preserves non-fatal behavior for cross-DO notifications (warn log on failures, no request failure)
- Updates UserTrackerDO nudge handling to consume payload semantics instead of treating all nudges equally
- Adds tracker-level marker dedupe in UserTrackerDO so repeated nudges with the same/stale lastUpdateTime are ignored
- Adds user-context guard in UserTrackerDO to ignore nudges whose payload userId does not match stored user context
- Adds focused regression tests:
  - Individual tracker start triggers user-tracker nudge
  - User-tracker deduplicates repeated markers
  - User-tracker ignores mismatched userId nudges
- Validation: npm run done passes (format/typecheck/lint/test:changed)

Subsequent work:
- Implement dirty-tracker-aware incremental refresh path in UserTrackerDO (current refresh is still full-directory rebuild)
- Add explicit reconcile-focused tests for missed-notify recovery windows
- Evaluate marker lifecycle/eviction policy once incremental refresh lands
