### PR TITLE
feat(user-tracker): coalesce nudge refreshes by dirty tracker

### DIFF
--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -231,6 +231,202 @@ describe("UserTrackerDO", () => {
     });
   });
 
+  it("restores consumed dirty tracker ids when a full rebuild fails", async () => {
+    const persistedStorage = new Map<string, unknown>();
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        if (typeof key !== "string") {
+          const values = new Map<string, unknown>();
+          for (const currentKey of key) {
+            const currentValue = persistedStorage.get(currentKey);
+            if (currentValue !== undefined) {
+              values.set(currentKey, currentValue);
+            }
+          }
+
+          return await Promise.resolve(values);
+        }
+
+        return await Promise.resolve(persistedStorage.get(key));
+      }) as DurableObjectStorage["get"],
+      put: (async (key: string, value: unknown) => {
+        persistedStorage.set(key, value);
+        await Promise.resolve();
+      }) as DurableObjectStorage["put"],
+    });
+
+    const trackerDo = aFakeIndividualTrackerDOWith({
+      viewStateResponse: {
+        state: aFakeIndividualTrackerViewStateWith({
+          trackerId: "t1",
+          gamertag: "KnownTag",
+          matches: [],
+          lastUpdateTime: "2026-07-05T00:00:00.000Z",
+        }),
+      },
+    });
+    const trackerDoFetchSpy = vi.spyOn(trackerDo, "fetch");
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const services = installFakeServicesWith({ env: localEnv });
+    const findTrackersByUserIdSpy = vi.spyOn(services.databaseService, "findIndividualTrackersByUserId");
+    findTrackersByUserIdSpy
+      .mockResolvedValueOnce([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "active",
+          IsLive: 1,
+        }),
+      ])
+      .mockRejectedValueOnce(new Error("rebuild failed"))
+      .mockResolvedValueOnce([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "active",
+          IsLive: 1,
+        }),
+      ]);
+    const state = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const localUserTrackerDO = new UserTrackerDO(state, localEnv, () => services, webSocketAdapter);
+
+    const initialResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/view-state?userId=user-1", { method: "GET" }),
+    );
+    expect(initialResponse.status).toBe(200);
+    expect(trackerDoFetchSpy).toHaveBeenCalledTimes(1);
+
+    const nudgeResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "user-1",
+          trackerId: "t1",
+          lastUpdateTime: "2026-07-05T00:01:00.000Z",
+        }),
+      }),
+    );
+    expect(nudgeResponse.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(findTrackersByUserIdSpy).toHaveBeenCalledTimes(2);
+    });
+
+    const secondNudgeResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "user-1",
+          trackerId: "t1",
+          lastUpdateTime: "2026-07-05T00:02:00.000Z",
+        }),
+      }),
+    );
+    expect(secondNudgeResponse.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(findTrackersByUserIdSpy).toHaveBeenCalledTimes(3);
+    });
+
+    await vi.waitFor(() => {
+      expect(trackerDoFetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("falls back to full rebuild when stats highlight slots change", async () => {
+    const persistedStorage = new Map<string, unknown>();
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        if (typeof key !== "string") {
+          const values = new Map<string, unknown>();
+          for (const currentKey of key) {
+            const currentValue = persistedStorage.get(currentKey);
+            if (currentValue !== undefined) {
+              values.set(currentKey, currentValue);
+            }
+          }
+
+          return await Promise.resolve(values);
+        }
+
+        return await Promise.resolve(persistedStorage.get(key));
+      }) as DurableObjectStorage["get"],
+      put: (async (key: string, value: unknown) => {
+        persistedStorage.set(key, value);
+        await Promise.resolve();
+      }) as DurableObjectStorage["put"],
+    });
+
+    const trackerDo = aFakeIndividualTrackerDOWith({
+      viewStateResponse: {
+        state: aFakeIndividualTrackerViewStateWith({
+          trackerId: "t1",
+          gamertag: "KnownTag",
+          matches: [],
+          lastUpdateTime: "2026-07-05T00:00:00.000Z",
+        }),
+      },
+    });
+    const trackerDoFetchSpy = vi.spyOn(trackerDo, "fetch");
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const services = installFakeServicesWith({ env: localEnv });
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([
+      aFakeIndividualTrackersRow({
+        TrackerId: "t1",
+        UserId: "user-1",
+        Gamertag: "KnownTag",
+        Status: "active",
+        IsLive: 1,
+      }),
+      aFakeIndividualTrackersRow({
+        TrackerId: "t2",
+        UserId: "user-1",
+        Gamertag: "KnownTag2",
+        Status: "active",
+        IsLive: 0,
+      }),
+    ]);
+    const getSettingsForViewSpy = vi.spyOn(services.individualTrackerService, "getSettingsForView");
+    getSettingsForViewSpy
+      .mockResolvedValueOnce({
+        visibleSections: {
+          statsHighlightSlots: ["kills", "deaths"],
+        },
+      })
+      .mockResolvedValueOnce({
+        visibleSections: {
+          statsHighlightSlots: ["assists", "kda"],
+        },
+      });
+
+    const state = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const localUserTrackerDO = new UserTrackerDO(state, localEnv, () => services, webSocketAdapter);
+
+    const initialResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/view-state?userId=user-1", { method: "GET" }),
+    );
+    expect(initialResponse.status).toBe(200);
+    expect(trackerDoFetchSpy).toHaveBeenCalledTimes(2);
+
+    const nudgeResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "user-1",
+          trackerId: "t1",
+          lastUpdateTime: "2026-07-05T00:01:00.000Z",
+        }),
+      }),
+    );
+    expect(nudgeResponse.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(trackerDoFetchSpy).toHaveBeenCalledTimes(4);
+    });
+  });
+
   it("accepts a valid tracker changed nudge payload", async () => {
     const response = await userTrackerDO.fetch(
       new Request("http://do/nudge", {

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -152,6 +152,85 @@ describe("UserTrackerDO", () => {
     expect(parsed.state?.directory.liveTrackerId).toBe("t-active");
   });
 
+  it("refreshes only dirty tracker entries after nudge when a cached directory exists", async () => {
+    const persistedStorage = new Map<string, unknown>();
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        if (typeof key !== "string") {
+          const values = new Map<string, unknown>();
+          for (const currentKey of key) {
+            const currentValue = persistedStorage.get(currentKey);
+            if (currentValue !== undefined) {
+              values.set(currentKey, currentValue);
+            }
+          }
+
+          return await Promise.resolve(values);
+        }
+
+        return await Promise.resolve(persistedStorage.get(key));
+      }) as DurableObjectStorage["get"],
+      put: (async (key: string, value: unknown) => {
+        persistedStorage.set(key, value);
+        await Promise.resolve();
+      }) as DurableObjectStorage["put"],
+    });
+
+    const trackerDo = aFakeIndividualTrackerDOWith({
+      viewStateResponse: {
+        state: aFakeIndividualTrackerViewStateWith({
+          trackerId: "t1",
+          gamertag: "KnownTag",
+          matches: [],
+          lastUpdateTime: "2026-07-05T00:00:00.000Z",
+        }),
+      },
+    });
+    const trackerDoFetchSpy = vi.spyOn(trackerDo, "fetch");
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const services = installFakeServicesWith({ env: localEnv });
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([
+      aFakeIndividualTrackersRow({
+        TrackerId: "t1",
+        UserId: "user-1",
+        Gamertag: "KnownTag",
+        Status: "active",
+        IsLive: 1,
+      }),
+      aFakeIndividualTrackersRow({
+        TrackerId: "t2",
+        UserId: "user-1",
+        Gamertag: "KnownTag2",
+        Status: "active",
+        IsLive: 0,
+      }),
+    ]);
+    const state = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const localUserTrackerDO = new UserTrackerDO(state, localEnv, () => services, webSocketAdapter);
+
+    const initialResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/view-state?userId=user-1", { method: "GET" }),
+    );
+    expect(initialResponse.status).toBe(200);
+    expect(trackerDoFetchSpy).toHaveBeenCalledTimes(2);
+
+    const nudgeResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "user-1",
+          trackerId: "t1",
+          lastUpdateTime: "2026-07-05T00:01:00.000Z",
+        }),
+      }),
+    );
+    expect(nudgeResponse.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(trackerDoFetchSpy).toHaveBeenCalledTimes(3);
+    });
+  });
+
   it("accepts a valid tracker changed nudge payload", async () => {
     const response = await userTrackerDO.fetch(
       new Request("http://do/nudge", {

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -231,6 +231,100 @@ describe("UserTrackerDO", () => {
     });
   });
 
+  it("adds non-stopped trackers missing from cached directory during incremental refresh", async () => {
+    const persistedStorage = new Map<string, unknown>();
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        if (typeof key !== "string") {
+          const values = new Map<string, unknown>();
+          for (const currentKey of key) {
+            const currentValue = persistedStorage.get(currentKey);
+            if (currentValue !== undefined) {
+              values.set(currentKey, currentValue);
+            }
+          }
+
+          return await Promise.resolve(values);
+        }
+
+        return await Promise.resolve(persistedStorage.get(key));
+      }) as DurableObjectStorage["get"],
+      put: (async (key: string, value: unknown) => {
+        persistedStorage.set(key, value);
+        await Promise.resolve();
+      }) as DurableObjectStorage["put"],
+    });
+
+    const trackerDo = aFakeIndividualTrackerDOWith({
+      viewStateResponse: {
+        state: aFakeIndividualTrackerViewStateWith({
+          trackerId: "t1",
+          gamertag: "KnownTag",
+          matches: [],
+          lastUpdateTime: "2026-07-05T00:00:00.000Z",
+        }),
+      },
+    });
+    const trackerDoFetchSpy = vi.spyOn(trackerDo, "fetch");
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const services = installFakeServicesWith({ env: localEnv });
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId")
+      .mockResolvedValueOnce([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "active",
+          IsLive: 1,
+        }),
+      ])
+      .mockResolvedValue([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "active",
+          IsLive: 1,
+        }),
+        aFakeIndividualTrackersRow({
+          TrackerId: "t2",
+          UserId: "user-1",
+          Gamertag: "KnownTag2",
+          Status: "active",
+          IsLive: 0,
+        }),
+      ]);
+    const state = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const localUserTrackerDO = new UserTrackerDO(state, localEnv, () => services, webSocketAdapter);
+
+    const initialResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/view-state?userId=user-1", { method: "GET" }),
+    );
+    expect(initialResponse.status).toBe(200);
+    expect(trackerDoFetchSpy).toHaveBeenCalledTimes(1);
+
+    const nudgeResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "user-1",
+          trackerId: "t1",
+          lastUpdateTime: "2026-07-05T00:01:00.000Z",
+        }),
+      }),
+    );
+    expect(nudgeResponse.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(trackerDoFetchSpy).toHaveBeenCalledTimes(3);
+    });
+
+    const refreshedResponse = await localUserTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
+    expect(refreshedResponse.status).toBe(200);
+    const refreshed = await userTrackerViewStateContract.fromResponse(refreshedResponse);
+    expect(refreshed.state?.directory.trackers.map((tracker) => tracker.trackerId)).toEqual(["t1", "t2"]);
+  });
+
   it("restores consumed dirty tracker ids when directory refresh fails", async () => {
     const persistedStorage = new Map<string, unknown>();
     const sharedStorage = aFakeDurableObjectStorageWith({

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -231,7 +231,7 @@ describe("UserTrackerDO", () => {
     });
   });
 
-  it("restores consumed dirty tracker ids when a full rebuild fails", async () => {
+  it("restores consumed dirty tracker ids when directory refresh fails", async () => {
     const persistedStorage = new Map<string, unknown>();
     const sharedStorage = aFakeDurableObjectStorageWith({
       get: (async (key: string | string[]) => {

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -55,6 +55,28 @@ function toUpdateTimeMs(value: string): number | null {
   return parsedValue;
 }
 
+function normalizeStatsHighlightSlots(statsHighlightSlots: readonly string[] | undefined): readonly string[] {
+  if (statsHighlightSlots == null) {
+    return DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS.slice(0, INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT);
+  }
+
+  return statsHighlightSlots;
+}
+
+function statsHighlightSlotsAreEqual(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   __DURABLE_OBJECT_BRAND = undefined as never;
   private readonly state: DurableObjectState;
@@ -493,15 +515,15 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     const previousPayload = stored.viewState == null ? null : this.serializeDirectory(stored.viewState.directory);
     const dirtyTrackerIds = this.consumeDirtyTrackerIds();
     let nextDirectory: TrackerDirectory;
-    if (dirtyTrackerIds.size === 0 || stored.viewState == null) {
-      nextDirectory = await this.buildDirectory(userId);
-    } else {
-      try {
+    try {
+      if (dirtyTrackerIds.size === 0 || stored.viewState == null) {
+        nextDirectory = await this.buildDirectory(userId);
+      } else {
         nextDirectory = await this.buildDirectoryWithDirtyTrackers(userId, stored.viewState.directory, dirtyTrackerIds);
-      } catch (error) {
-        this.restoreDirtyTrackerIds(dirtyTrackerIds);
-        throw error;
       }
+    } catch (error) {
+      this.restoreDirtyTrackerIds(dirtyTrackerIds);
+      throw error;
     }
 
     const nextPayload = this.serializeDirectory(nextDirectory);
@@ -593,9 +615,15 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       }
     }
 
-    const statsHighlightSlots =
-      streamerSettings.visibleSections?.statsHighlightSlots ??
-      DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS.slice(0, INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT);
+    const previousStatsHighlightSlots = normalizeStatsHighlightSlots(
+      previousDirectory.streamerSettings?.visibleSections?.statsHighlightSlots,
+    );
+    const nextStatsHighlightSlots = normalizeStatsHighlightSlots(streamerSettings.visibleSections?.statsHighlightSlots);
+    if (!statsHighlightSlotsAreEqual(previousStatsHighlightSlots, nextStatsHighlightSlots)) {
+      return await this.buildDirectory(userId);
+    }
+
+    const statsHighlightSlots = nextStatsHighlightSlots;
 
     for (const trackerId of dirtyTrackerIds) {
       const row = rowsByTrackerId.get(trackerId);

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -71,6 +71,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   private pushCompletionPromise: Promise<void> | null = null;
   private resolvePushCompletion: (() => void) | null = null;
   private trackerSubscriptionsInstalled = false;
+  private readonly dirtyTrackerIds = new Set<string>();
   private readonly trackerUpdateMarkers = new Map<string, string>();
   private trackerUpdateMarkersHydrated = false;
   private trackerUpdateMarkersHydrationPromise: Promise<void> | null = null;
@@ -490,7 +491,19 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     }
 
     const previousPayload = stored.viewState == null ? null : this.serializeDirectory(stored.viewState.directory);
-    const nextDirectory = await this.buildDirectory(userId);
+    const dirtyTrackerIds = this.consumeDirtyTrackerIds();
+    let nextDirectory: TrackerDirectory;
+    if (dirtyTrackerIds.size === 0 || stored.viewState == null) {
+      nextDirectory = await this.buildDirectory(userId);
+    } else {
+      try {
+        nextDirectory = await this.buildDirectoryWithDirtyTrackers(userId, stored.viewState.directory, dirtyTrackerIds);
+      } catch (error) {
+        this.restoreDirtyTrackerIds(dirtyTrackerIds);
+        throw error;
+      }
+    }
+
     const nextPayload = this.serializeDirectory(nextDirectory);
     await this.storeDirectoryState(userId, nextDirectory);
 
@@ -534,9 +547,77 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     // Refresh insertion order for existing keys so frequently-updated trackers are not evicted first.
     this.trackerUpdateMarkers.delete(markerKey);
     this.trackerUpdateMarkers.set(markerKey, payload.lastUpdateTime);
+    this.markTrackerDirty(payload.trackerId);
     this.enforceTrackerMarkerLimit();
     await this.persistTrackerUpdateMarkers();
     return true;
+  }
+
+  private markTrackerDirty(trackerId: string): void {
+    this.dirtyTrackerIds.add(trackerId);
+  }
+
+  private consumeDirtyTrackerIds(): Set<string> {
+    if (this.dirtyTrackerIds.size === 0) {
+      return new Set<string>();
+    }
+
+    const dirtyTrackerIds = new Set(this.dirtyTrackerIds);
+    this.dirtyTrackerIds.clear();
+    return dirtyTrackerIds;
+  }
+
+  private restoreDirtyTrackerIds(trackerIds: Set<string>): void {
+    for (const trackerId of trackerIds) {
+      this.dirtyTrackerIds.add(trackerId);
+    }
+  }
+
+  private async buildDirectoryWithDirtyTrackers(
+    userId: string,
+    previousDirectory: TrackerDirectory,
+    dirtyTrackerIds: Set<string>,
+  ): Promise<TrackerDirectory> {
+    const [allTrackers, streamerSettings] = await Promise.all([
+      this.databaseService.findIndividualTrackersByUserId(userId),
+      this.individualTrackerService.getSettingsForView(userId),
+    ]);
+
+    const nonStoppedRows = allTrackers.filter(isNonStopped);
+    const rowsByTrackerId = new Map(nonStoppedRows.map((row) => [row.TrackerId, row]));
+    const nextTrackersById = new Map(previousDirectory.trackers.map((tracker) => [tracker.trackerId, tracker]));
+
+    for (const trackerId of nextTrackersById.keys()) {
+      if (!rowsByTrackerId.has(trackerId)) {
+        nextTrackersById.delete(trackerId);
+      }
+    }
+
+    const statsHighlightSlots =
+      streamerSettings.visibleSections?.statsHighlightSlots ??
+      DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS.slice(0, INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT);
+
+    for (const trackerId of dirtyTrackerIds) {
+      const row = rowsByTrackerId.get(trackerId);
+      if (row == null) {
+        nextTrackersById.delete(trackerId);
+        continue;
+      }
+
+      const doState = await fetchTrackerDoViewState(this.env, row.UserId, row.TrackerId, statsHighlightSlots);
+      nextTrackersById.set(trackerId, toTrackerView(row, doState));
+    }
+
+    const entries = Array.from(nextTrackersById.values());
+    const liveTracker = entries.find((entry) => entry.isLive);
+    const firstActiveTracker = entries.find((entry) => entry.status === "active");
+    const liveTrackerId = liveTracker?.trackerId ?? firstActiveTracker?.trackerId ?? null;
+
+    return {
+      trackers: entries,
+      liveTrackerId,
+      streamerSettings: Object.keys(streamerSettings).length > 0 ? streamerSettings : undefined,
+    };
   }
 
   private isStaleOrDuplicateMarker(nextMarker: string, previousMarker: string): boolean {

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -615,6 +615,13 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       }
     }
 
+    const trackerIdsToRefresh = new Set(dirtyTrackerIds);
+    for (const trackerId of rowsByTrackerId.keys()) {
+      if (!nextTrackersById.has(trackerId)) {
+        trackerIdsToRefresh.add(trackerId);
+      }
+    }
+
     const previousStatsHighlightSlots = normalizeStatsHighlightSlots(
       previousDirectory.streamerSettings?.visibleSections?.statsHighlightSlots,
     );
@@ -626,7 +633,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     const statsHighlightSlots = nextStatsHighlightSlots;
 
     const dirtyTrackerUpdates = await Promise.all(
-      Array.from(dirtyTrackerIds, async (trackerId) => {
+      Array.from(trackerIdsToRefresh, async (trackerId) => {
         const row = rowsByTrackerId.get(trackerId);
         if (row == null) {
           return { trackerId, tracker: null };

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -625,15 +625,25 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
     const statsHighlightSlots = nextStatsHighlightSlots;
 
-    for (const trackerId of dirtyTrackerIds) {
-      const row = rowsByTrackerId.get(trackerId);
-      if (row == null) {
-        nextTrackersById.delete(trackerId);
+    const dirtyTrackerUpdates = await Promise.all(
+      Array.from(dirtyTrackerIds, async (trackerId) => {
+        const row = rowsByTrackerId.get(trackerId);
+        if (row == null) {
+          return { trackerId, tracker: null };
+        }
+
+        const doState = await fetchTrackerDoViewState(this.env, row.UserId, row.TrackerId, statsHighlightSlots);
+        return { trackerId, tracker: toTrackerView(row, doState) };
+      }),
+    );
+
+    for (const update of dirtyTrackerUpdates) {
+      if (update.tracker == null) {
+        nextTrackersById.delete(update.trackerId);
         continue;
       }
 
-      const doState = await fetchTrackerDoViewState(this.env, row.UserId, row.TrackerId, statsHighlightSlots);
-      nextTrackersById.set(trackerId, toTrackerView(row, doState));
+      nextTrackersById.set(update.trackerId, update.tracker);
     }
 
     const entries = Array.from(nextTrackersById.values());


### PR DESCRIPTION
## Context
Phase 2 of the user-tracker migration is being delivered in small, reviewable slices to tighten correctness around IndividualTrackerDO -> UserTrackerDO update flow while keeping Copilot review loops fast and focused.

## This PR
- adds dirty-tracker coalescing to UserTrackerDO for nudge-driven refreshes
- tracks dirty tracker IDs from accepted nudges
- uses incremental refresh when cached directory state exists, refreshing only affected tracker entries
- preserves a safe full-rebuild fallback when no cached state is available or no dirty IDs are present
- adds a focused regression test proving a nudge after cached view refreshes only one dirty tracker entry

## Subsequent Work
- add periodic reconcile in UserTrackerDO independent of nudge delivery
- add dropped-notify recovery tests for reconcile healing behavior
- tune reconcile interval defaults and logging context for operational visibility