### PR TITLE
fix(user-tracker): keep reconcile alarm active without ws clients

### DIFF
--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1130,6 +1130,7 @@ describe("UserTrackerDO", () => {
     expect(initialPayload.state?.directory.trackers).toHaveLength(1);
     expect(localSetAlarmMock).toHaveBeenCalledOnce();
 
+    alarmTime = null;
     await localUserTrackerDO.alarm();
 
     const reconciledResponse = await localUserTrackerDO.fetch(

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1061,6 +1061,18 @@ describe("UserTrackerDO", () => {
 
   it("reconciles through alarm when no websocket clients are connected but state exists", async () => {
     const persistedStorage = new Map<string, unknown>();
+    let alarmTime: number | null = null;
+    const localSetAlarmMock = vi.fn<DurableObjectStorage["setAlarm"]>(async (scheduledTime) => {
+      alarmTime = typeof scheduledTime === "number" ? scheduledTime : scheduledTime.getTime();
+      return Promise.resolve();
+    });
+    const localGetAlarmMock = vi.fn<DurableObjectStorage["getAlarm"]>(async () => {
+      return Promise.resolve(alarmTime);
+    });
+    const localDeleteAlarmMock = vi.fn<DurableObjectStorage["deleteAlarm"]>(async () => {
+      alarmTime = null;
+      return Promise.resolve();
+    });
     const sharedStorage = aFakeDurableObjectStorageWith({
       get: (async (key: string | string[]) => {
         if (typeof key !== "string") {
@@ -1081,8 +1093,9 @@ describe("UserTrackerDO", () => {
         persistedStorage.set(key, value);
         await Promise.resolve();
       }) as DurableObjectStorage["put"],
-      setAlarm: setAlarmMock,
-      deleteAlarm: deleteAlarmMock,
+      setAlarm: localSetAlarmMock,
+      getAlarm: localGetAlarmMock,
+      deleteAlarm: localDeleteAlarmMock,
     });
     const localState = aFakeDurableObjectStateWith({ storage: sharedStorage });
     const trackerDo = aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } });
@@ -1115,6 +1128,7 @@ describe("UserTrackerDO", () => {
     );
     const initialPayload = await userTrackerViewStateContract.fromResponse(initialResponse);
     expect(initialPayload.state?.directory.trackers).toHaveLength(1);
+    expect(localSetAlarmMock).toHaveBeenCalledOnce();
 
     await localUserTrackerDO.alarm();
 
@@ -1123,8 +1137,8 @@ describe("UserTrackerDO", () => {
     );
     const reconciledPayload = await userTrackerViewStateContract.fromResponse(reconciledResponse);
     expect(reconciledPayload.state?.directory.trackers).toHaveLength(0);
-    expect(setAlarmMock).toHaveBeenCalled();
-    expect(deleteAlarmMock).not.toHaveBeenCalled();
+    expect(localSetAlarmMock).toHaveBeenCalledTimes(2);
+    expect(localDeleteAlarmMock).not.toHaveBeenCalled();
   });
 
   it("stops the update loop through alarm when no websocket clients are connected", async () => {

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1059,6 +1059,74 @@ describe("UserTrackerDO", () => {
     expect(setAlarmMock).toHaveBeenCalledTimes(1);
   });
 
+  it("reconciles through alarm when no websocket clients are connected but state exists", async () => {
+    const persistedStorage = new Map<string, unknown>();
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        if (typeof key !== "string") {
+          const values = new Map<string, unknown>();
+          for (const currentKey of key) {
+            const currentValue = persistedStorage.get(currentKey);
+            if (currentValue !== undefined) {
+              values.set(currentKey, currentValue);
+            }
+          }
+
+          return await Promise.resolve(values);
+        }
+
+        return await Promise.resolve(persistedStorage.get(key));
+      }) as DurableObjectStorage["get"],
+      put: (async (key: string, value: unknown) => {
+        persistedStorage.set(key, value);
+        await Promise.resolve();
+      }) as DurableObjectStorage["put"],
+      setAlarm: setAlarmMock,
+      deleteAlarm: deleteAlarmMock,
+    });
+    const localState = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const trackerDo = aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } });
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const services = installFakeServicesWith({ env: localEnv });
+    vi.spyOn(localState, "getWebSockets").mockReturnValue([]);
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId")
+      .mockResolvedValueOnce([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "active",
+          IsLive: 1,
+        }),
+      ])
+      .mockResolvedValueOnce([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "stopped",
+          IsLive: 1,
+        }),
+      ]);
+    const localUserTrackerDO = new UserTrackerDO(localState, localEnv, () => services, webSocketAdapter);
+
+    const initialResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/view-state?userId=user-1", { method: "GET" }),
+    );
+    const initialPayload = await userTrackerViewStateContract.fromResponse(initialResponse);
+    expect(initialPayload.state?.directory.trackers).toHaveLength(1);
+
+    await localUserTrackerDO.alarm();
+
+    const reconciledResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/view-state?userId=user-1", { method: "GET" }),
+    );
+    const reconciledPayload = await userTrackerViewStateContract.fromResponse(reconciledResponse);
+    expect(reconciledPayload.state?.directory.trackers).toHaveLength(0);
+    expect(setAlarmMock).toHaveBeenCalled();
+    expect(deleteAlarmMock).not.toHaveBeenCalled();
+  });
+
   it("stops the update loop through alarm when no websocket clients are connected", async () => {
     vi.spyOn(mockState, "getWebSockets").mockReturnValue([]);
 

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -255,7 +255,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   private async handleViewState(request: Request): Promise<Response> {
     const stored = await this.getOrBuildState(request);
     if (stored?.state?.userId != null && this.state.getWebSockets().length === 0) {
-      await this.scheduleNextAlarm(USER_TRACKER_RECONCILE_INTERVAL_MS);
+      await this.scheduleReconcileAlarmIfNeeded();
     }
 
     const response: UserTrackerViewStateResponse = {
@@ -400,6 +400,15 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     const stored = await this.loadState();
     if (stored.state?.userId == null) {
       await this.state.storage.deleteAlarm();
+      return;
+    }
+
+    await this.scheduleReconcileAlarmIfNeeded();
+  }
+
+  private async scheduleReconcileAlarmIfNeeded(): Promise<void> {
+    const nextAlarmTime = await this.state.storage.getAlarm();
+    if (nextAlarmTime != null) {
       return;
     }
 

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -214,8 +214,9 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
         }
       }
 
+      const tickType = hasConnectedClients ? "follow" : "reconcile";
       this.logService.debug(
-        "UserTracker reconcile tick",
+        `UserTracker ${tickType} tick`,
         new Map([["hasConnectedClients", hasConnectedClients.toString()]]),
       );
 

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -32,6 +32,7 @@ import { emptyTrackerDirectory, type UserTrackerInternalState } from "./types";
 const USER_TRACKER_STATE_KEY = "userTrackerState";
 const USER_TRACKER_MARKERS_KEY = "userTrackerMarkers";
 const FOLLOW_WS_POLL_INTERVAL_MS = 3000;
+const USER_TRACKER_RECONCILE_INTERVAL_MS = 30000;
 const TRACKER_MARKER_LIMIT = 500;
 
 function isNonStopped(row: IndividualTrackersRow): boolean {
@@ -203,10 +204,20 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       Sentry.setTag("durableObject", "UserTrackerDO");
       Sentry.setTag("method", "alarm");
 
-      if (this.state.getWebSockets().length === 0) {
+      const hasConnectedClients = this.state.getWebSockets().length > 0;
+      if (!hasConnectedClients) {
         await this.stopUpdateLoop();
-        return;
+
+        const stored = await this.loadState();
+        if (stored.state?.userId == null) {
+          return;
+        }
       }
+
+      this.logService.debug(
+        "UserTracker reconcile tick",
+        new Map([["hasConnectedClients", hasConnectedClients.toString()]]),
+      );
 
       try {
         await this.queueDirectoryPush();
@@ -215,7 +226,9 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
         Sentry.captureException(error);
       }
 
-      await this.scheduleNextAlarm();
+      await this.scheduleNextAlarm(
+        hasConnectedClients ? FOLLOW_WS_POLL_INTERVAL_MS : USER_TRACKER_RECONCILE_INTERVAL_MS,
+      );
     });
   }
 
@@ -241,6 +254,10 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
   private async handleViewState(request: Request): Promise<Response> {
     const stored = await this.getOrBuildState(request);
+    if (stored?.state?.userId != null && this.state.getWebSockets().length === 0) {
+      await this.scheduleNextAlarm(USER_TRACKER_RECONCILE_INTERVAL_MS);
+    }
+
     const response: UserTrackerViewStateResponse = {
       state: stored?.viewState ?? null,
     };
@@ -363,7 +380,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   }
 
   private async ensureUpdateLoopStarted(): Promise<void> {
-    await this.scheduleNextAlarm();
+    await this.scheduleNextAlarm(FOLLOW_WS_POLL_INTERVAL_MS);
 
     if (this.trackerSubscriptionsInstalled) {
       return;
@@ -379,7 +396,14 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       // reset after closing
     };
     this.trackerSubscriptionsInstalled = false;
-    await this.state.storage.deleteAlarm();
+
+    const stored = await this.loadState();
+    if (stored.state?.userId == null) {
+      await this.state.storage.deleteAlarm();
+      return;
+    }
+
+    await this.scheduleNextAlarm(USER_TRACKER_RECONCILE_INTERVAL_MS);
   }
 
   private async installTrackerSubscriptionsAsync(): Promise<void> {
@@ -534,8 +558,8 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     }
   }
 
-  private async scheduleNextAlarm(): Promise<void> {
-    await this.state.storage.setAlarm(Date.now() + FOLLOW_WS_POLL_INTERVAL_MS);
+  private async scheduleNextAlarm(intervalMs: number): Promise<void> {
+    await this.state.storage.setAlarm(Date.now() + intervalMs);
   }
 
   private async shouldAcceptNudge(payload: TrackerChangedPayload): Promise<boolean> {

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -206,7 +206,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
       const hasConnectedClients = this.state.getWebSockets().length > 0;
       if (!hasConnectedClients) {
-        await this.stopUpdateLoop();
+        await this.stopUpdateLoop({ scheduleReconcile: false });
 
         const stored = await this.loadState();
         if (stored.state?.userId == null) {
@@ -390,7 +390,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     void this.installTrackerSubscriptionsAsync();
   }
 
-  private async stopUpdateLoop(): Promise<void> {
+  private async stopUpdateLoop(options: { scheduleReconcile: boolean } = { scheduleReconcile: true }): Promise<void> {
     this.closeTrackerSubscriptions();
     this.closeTrackerSubscriptions = (): void => {
       // reset after closing
@@ -400,6 +400,10 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     const stored = await this.loadState();
     if (stored.state?.userId == null) {
       await this.state.storage.deleteAlarm();
+      return;
+    }
+
+    if (!options.scheduleReconcile) {
       return;
     }
 

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -206,12 +206,13 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
       const hasConnectedClients = this.state.getWebSockets().length > 0;
       if (!hasConnectedClients) {
-        await this.stopUpdateLoop({ scheduleReconcile: false });
-
         const stored = await this.loadState();
         if (stored.state?.userId == null) {
+          await this.stopUpdateLoop({ scheduleReconcile: false, stored });
           return;
         }
+
+        await this.stopUpdateLoop({ scheduleReconcile: false, stored });
       }
 
       const tickType = hasConnectedClients ? "follow" : "reconcile";
@@ -391,14 +392,16 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     void this.installTrackerSubscriptionsAsync();
   }
 
-  private async stopUpdateLoop(options: { scheduleReconcile: boolean } = { scheduleReconcile: true }): Promise<void> {
+  private async stopUpdateLoop(
+    options: { scheduleReconcile: boolean; stored?: UserTrackerInternalState } = { scheduleReconcile: true },
+  ): Promise<void> {
     this.closeTrackerSubscriptions();
     this.closeTrackerSubscriptions = (): void => {
       // reset after closing
     };
     this.trackerSubscriptionsInstalled = false;
 
-    const stored = await this.loadState();
+    const stored = options.stored ?? (await this.loadState());
     if (stored.state?.userId == null) {
       await this.state.storage.deleteAlarm();
       return;


### PR DESCRIPTION
## Context
Phase 2 of the user-tracker migration is focused on healing missed IndividualTracker -> UserTracker notifications. The previous dirty-coalescing work improved nudge-driven refresh, but reconcile behavior still depended on active websocket sessions.

## This PR
- Keeps UserTrackerDO alarm scheduling active in reconcile mode when no websocket clients are connected but user state exists.
- Starts reconcile alarm scheduling from view-state reads when cached user state exists and there are no websocket clients.
- Uses a conservative reconcile interval for non-realtime mode.
- Adds reconcile operational logging in alarm ticks.
- Adds a focused regression test proving alarm-driven refresh can heal stale directory state without websocket clients.

## Subsequent Work
- Continue Phase 2 hardening by expanding reconcile/failure-mode coverage around intentionally dropped notifications and transient dependency failures.
- Run Copilot review loops on this PR and fold any feedback into follow-up incremental commits.