### PR TITLE
fix(user-tracker): add reconcile observability context

### DIFF
--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1307,10 +1307,10 @@ describe("UserTrackerDO", () => {
       return Promise.resolve();
     });
     const sharedStorage = aFakeDurableObjectStorageWith({
-      get: (async () => {
+      get: async () => {
         await Promise.resolve();
         throw stateLoadFailure;
-      }),
+      },
       setAlarm: localSetAlarmMock,
       getAlarm: localGetAlarmMock,
       deleteAlarm: localDeleteAlarmMock,

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1295,6 +1295,53 @@ describe("UserTrackerDO", () => {
     expect(loggedContext?.get("tickType")).toBe("reconcile");
   });
 
+  it("logs alarm errors with fallback context when state enrichment fails", async () => {
+    const stateLoadFailure = new Error("state load failed in alarm catch");
+    const localSetAlarmMock = vi.fn<DurableObjectStorage["setAlarm"]>(async () => {
+      return Promise.resolve();
+    });
+    const localGetAlarmMock = vi.fn<DurableObjectStorage["getAlarm"]>(async () => {
+      return Promise.resolve(null);
+    });
+    const localDeleteAlarmMock = vi.fn<DurableObjectStorage["deleteAlarm"]>(async () => {
+      return Promise.resolve();
+    });
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async () => {
+        await Promise.resolve();
+        throw stateLoadFailure;
+      }),
+      setAlarm: localSetAlarmMock,
+      getAlarm: localGetAlarmMock,
+      deleteAlarm: localDeleteAlarmMock,
+    });
+    const localState = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const localEnv = aFakeEnvWith();
+    const logService = aFakeLogServiceWith();
+    const errorSpy = vi.spyOn(logService, "error");
+    const warnSpy = vi.spyOn(logService, "warn");
+    const services = installFakeServicesWith({ env: localEnv, logService });
+    vi.spyOn(localState, "getWebSockets").mockReturnValue([{} as WebSocket]);
+    const localUserTrackerDO = new UserTrackerDO(localState, localEnv, () => services, webSocketAdapter);
+    const alarmFailure = new Error("alarm queue failure");
+    vi.spyOn(
+      localUserTrackerDO as unknown as { queueDirectoryPush: () => Promise<void> },
+      "queueDirectoryPush",
+    ).mockRejectedValueOnce(alarmFailure);
+
+    await localUserTrackerDO.alarm();
+
+    expect(localSetAlarmMock).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalled();
+    const [warnError, warnContext] = warnSpy.mock.calls.at(-1) ?? [];
+    expect(warnError).toBe(stateLoadFailure);
+    expect(warnContext?.get("context")).toBe("UserTracker alarm error context load failed");
+    const [loggedError, loggedContext] = errorSpy.mock.calls.at(-1) ?? [];
+    expect(loggedError).toBe(alarmFailure);
+    expect(loggedContext?.get("context")).toBe("UserTracker alarm error");
+    expect(loggedContext?.get("userId")).toBe("unknown");
+  });
+
   it("logs attempted incremental refresh context when a post-consume refresh fails", async () => {
     const persistedStorage = new Map<string, unknown>();
     const postConsumeFailure = new Error("post-consume store failure");
@@ -1376,6 +1423,68 @@ describe("UserTrackerDO", () => {
     expect(loggedContext?.get("userId")).toBe("user-1");
     expect(loggedContext?.get("refreshMode")).toBe("incremental");
     expect(loggedContext?.get("dirtyTrackerCount")).toBe("1");
+  });
+
+  it("logs refresh errors with fallback context when state enrichment fails", async () => {
+    const refreshFailure = new Error("refresh state load failed");
+    const enrichFailure = new Error("refresh context load failed");
+    let getCalls = 0;
+    let alarmTime: number | null = null;
+    const localSetAlarmMock = vi.fn<DurableObjectStorage["setAlarm"]>(async (scheduledTime) => {
+      alarmTime = typeof scheduledTime === "number" ? scheduledTime : scheduledTime.getTime();
+      return Promise.resolve();
+    });
+    const localGetAlarmMock = vi.fn<DurableObjectStorage["getAlarm"]>(async () => {
+      return Promise.resolve(alarmTime);
+    });
+    const localDeleteAlarmMock = vi.fn<DurableObjectStorage["deleteAlarm"]>(async () => {
+      alarmTime = null;
+      return Promise.resolve();
+    });
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        getCalls += 1;
+        if (getCalls === 1) {
+          throw refreshFailure;
+        }
+        if (getCalls === 2) {
+          throw enrichFailure;
+        }
+        if (typeof key === "string") {
+          await Promise.resolve(undefined);
+          return;
+        }
+
+        return await Promise.resolve(new Map<string, unknown>());
+      }) as DurableObjectStorage["get"],
+      setAlarm: localSetAlarmMock,
+      getAlarm: localGetAlarmMock,
+      deleteAlarm: localDeleteAlarmMock,
+    });
+    const localState = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const localEnv = aFakeEnvWith();
+    const logService = aFakeLogServiceWith();
+    const errorSpy = vi.spyOn(logService, "error");
+    const warnSpy = vi.spyOn(logService, "warn");
+    const services = installFakeServicesWith({ env: localEnv, logService });
+    vi.spyOn(localState, "getWebSockets").mockReturnValue([{} as WebSocket]);
+    const localUserTrackerDO = new UserTrackerDO(localState, localEnv, () => services, webSocketAdapter);
+
+    await localUserTrackerDO.alarm();
+
+    expect(localSetAlarmMock).toHaveBeenCalledOnce();
+    expect(localDeleteAlarmMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+    const [warnError, warnContext] = warnSpy.mock.calls.at(-1) ?? [];
+    expect(warnError).toBe(enrichFailure);
+    expect(warnContext?.get("context")).toBe("UserTracker directory refresh error context load failed");
+    expect(errorSpy).toHaveBeenCalled();
+    const [loggedError, loggedContext] = errorSpy.mock.calls.at(-1) ?? [];
+    expect(loggedError).toBe(refreshFailure);
+    expect(loggedContext?.get("context")).toBe("UserTracker directory refresh error");
+    expect(loggedContext?.get("userId")).toBe("unknown");
+    expect(loggedContext?.get("refreshMode")).toBe("full");
+    expect(loggedContext?.get("dirtyTrackerCount")).toBe("0");
   });
 
   it("stops the update loop through alarm when no websocket clients are connected", async () => {

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1217,6 +1217,9 @@ describe("UserTrackerDO", () => {
     const [loggedError, loggedContext] = errorSpy.mock.calls.at(-1) ?? [];
     expect(loggedError).toBe(transientFailure);
     expect(loggedContext?.get("context")).toBe("UserTracker directory refresh error");
+    expect(loggedContext?.get("userId")).toBe("user-1");
+    expect(loggedContext?.get("refreshMode")).toBe("full");
+    expect(loggedContext?.get("dirtyTrackerCount")).toBe("0");
   });
 
   it("stops the update loop through alarm when no websocket clients are connected", async () => {

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1222,6 +1222,162 @@ describe("UserTrackerDO", () => {
     expect(loggedContext?.get("dirtyTrackerCount")).toBe("0");
   });
 
+  it("logs alarm errors with userId context when state is available", async () => {
+    const persistedStorage = new Map<string, unknown>();
+    const localSetAlarmMock = vi.fn<DurableObjectStorage["setAlarm"]>(async () => {
+      return Promise.resolve();
+    });
+    const localGetAlarmMock = vi.fn<DurableObjectStorage["getAlarm"]>(async () => {
+      return Promise.resolve(null);
+    });
+    const localDeleteAlarmMock = vi.fn<DurableObjectStorage["deleteAlarm"]>(async () => {
+      return Promise.resolve();
+    });
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        if (typeof key !== "string") {
+          const values = new Map<string, unknown>();
+          for (const currentKey of key) {
+            const currentValue = persistedStorage.get(currentKey);
+            if (currentValue !== undefined) {
+              values.set(currentKey, currentValue);
+            }
+          }
+
+          return await Promise.resolve(values);
+        }
+
+        return await Promise.resolve(persistedStorage.get(key));
+      }) as DurableObjectStorage["get"],
+      put: (async (key: string, value: unknown) => {
+        persistedStorage.set(key, value);
+        await Promise.resolve();
+      }) as DurableObjectStorage["put"],
+      setAlarm: localSetAlarmMock,
+      getAlarm: localGetAlarmMock,
+      deleteAlarm: localDeleteAlarmMock,
+    });
+    const localState = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const trackerDo = aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } });
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const logService = aFakeLogServiceWith();
+    const errorSpy = vi.spyOn(logService, "error");
+    const services = installFakeServicesWith({ env: localEnv, logService });
+    vi.spyOn(localState, "getWebSockets").mockReturnValue([]);
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([
+      aFakeIndividualTrackersRow({
+        TrackerId: "t1",
+        UserId: "user-1",
+        Gamertag: "KnownTag",
+        Status: "active",
+        IsLive: 1,
+      }),
+    ]);
+    const localUserTrackerDO = new UserTrackerDO(localState, localEnv, () => services, webSocketAdapter);
+    const alarmFailure = new Error("alarm queue failure");
+    vi.spyOn(
+      localUserTrackerDO as unknown as { queueDirectoryPush: () => Promise<void> },
+      "queueDirectoryPush",
+    ).mockRejectedValueOnce(alarmFailure);
+
+    const initialResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/view-state?userId=user-1", { method: "GET" }),
+    );
+    expect(initialResponse.status).toBe(200);
+
+    await localUserTrackerDO.alarm();
+
+    expect(errorSpy).toHaveBeenCalled();
+    const [loggedError, loggedContext] = errorSpy.mock.calls.at(-1) ?? [];
+    expect(loggedError).toBe(alarmFailure);
+    expect(loggedContext?.get("context")).toBe("UserTracker alarm error");
+    expect(loggedContext?.get("userId")).toBe("user-1");
+    expect(loggedContext?.get("tickType")).toBe("reconcile");
+  });
+
+  it("logs attempted incremental refresh context when a post-consume refresh fails", async () => {
+    const persistedStorage = new Map<string, unknown>();
+    const postConsumeFailure = new Error("post-consume store failure");
+    let shouldFailNextPut = false;
+    let alarmTime: number | null = null;
+    const localSetAlarmMock = vi.fn<DurableObjectStorage["setAlarm"]>(async (scheduledTime) => {
+      alarmTime = typeof scheduledTime === "number" ? scheduledTime : scheduledTime.getTime();
+      return Promise.resolve();
+    });
+    const localGetAlarmMock = vi.fn<DurableObjectStorage["getAlarm"]>(async () => {
+      return Promise.resolve(alarmTime);
+    });
+    const localDeleteAlarmMock = vi.fn<DurableObjectStorage["deleteAlarm"]>(async () => {
+      alarmTime = null;
+      return Promise.resolve();
+    });
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        if (typeof key !== "string") {
+          const values = new Map<string, unknown>();
+          for (const currentKey of key) {
+            const currentValue = persistedStorage.get(currentKey);
+            if (currentValue !== undefined) {
+              values.set(currentKey, currentValue);
+            }
+          }
+
+          return await Promise.resolve(values);
+        }
+
+        return await Promise.resolve(persistedStorage.get(key));
+      }) as DurableObjectStorage["get"],
+      put: (async (key: string, value: unknown) => {
+        if (shouldFailNextPut) {
+          shouldFailNextPut = false;
+          throw postConsumeFailure;
+        }
+
+        persistedStorage.set(key, value);
+        await Promise.resolve();
+      }) as DurableObjectStorage["put"],
+      setAlarm: localSetAlarmMock,
+      getAlarm: localGetAlarmMock,
+      deleteAlarm: localDeleteAlarmMock,
+    });
+    const localState = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const trackerDo = aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } });
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const logService = aFakeLogServiceWith();
+    const errorSpy = vi.spyOn(logService, "error");
+    const services = installFakeServicesWith({ env: localEnv, logService });
+    vi.spyOn(localState, "getWebSockets").mockReturnValue([]);
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([
+      aFakeIndividualTrackersRow({
+        TrackerId: "t1",
+        UserId: "user-1",
+        Gamertag: "KnownTag",
+        Status: "active",
+        IsLive: 1,
+      }),
+    ]);
+    const localUserTrackerDO = new UserTrackerDO(localState, localEnv, () => services, webSocketAdapter);
+
+    const initialResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/view-state?userId=user-1", { method: "GET" }),
+    );
+    expect(initialResponse.status).toBe(200);
+
+    (localUserTrackerDO as unknown as { dirtyTrackerIds: Set<string> }).dirtyTrackerIds.add("t1");
+    shouldFailNextPut = true;
+    await localUserTrackerDO.alarm();
+
+    expect(localSetAlarmMock).toHaveBeenCalledTimes(2);
+    expect(localDeleteAlarmMock).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+    const [loggedError, loggedContext] = errorSpy.mock.calls.at(-1) ?? [];
+    expect(loggedError).toBe(postConsumeFailure);
+    expect(loggedContext?.get("context")).toBe("UserTracker directory refresh error");
+    expect(loggedContext?.get("userId")).toBe("user-1");
+    expect(loggedContext?.get("refreshMode")).toBe("incremental");
+    expect(loggedContext?.get("dirtyTrackerCount")).toBe("1");
+  });
+
   it("stops the update loop through alarm when no websocket clients are connected", async () => {
     vi.spyOn(mockState, "getWebSockets").mockReturnValue([]);
 

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -224,10 +224,12 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       try {
         await this.queueDirectoryPush();
       } catch (error) {
+        const stored = await this.loadState();
         this.logService.error(
           error,
           new Map([
             ["context", "UserTracker alarm error"],
+            ["userId", stored.state?.userId ?? "unknown"],
             ["tickType", tickType],
             ["hasConnectedClients", hasConnectedClients.toString()],
           ]),
@@ -544,18 +546,21 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
     while (this.pendingPush) {
       this.pendingPush = false;
+      const stateAtRefreshStart = await this.loadState();
+      const dirtyTrackerCountAtRefreshStart = this.dirtyTrackerIds.size;
+      const refreshMode =
+        dirtyTrackerCountAtRefreshStart === 0 || stateAtRefreshStart.viewState == null ? "full" : "incremental";
 
       try {
         await this.refreshAndBroadcastIfChanged();
       } catch (error) {
-        const stored = await this.loadState();
         this.logService.error(
           error,
           new Map([
             ["context", "UserTracker directory refresh error"],
-            ["userId", stored.state?.userId ?? "unknown"],
-            ["refreshMode", this.dirtyTrackerIds.size === 0 || stored.viewState == null ? "full" : "incremental"],
-            ["dirtyTrackerCount", this.dirtyTrackerIds.size.toString()],
+            ["userId", stateAtRefreshStart.state?.userId ?? "unknown"],
+            ["refreshMode", refreshMode],
+            ["dirtyTrackerCount", dirtyTrackerCountAtRefreshStart.toString()],
           ]),
         );
       }

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -224,7 +224,14 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       try {
         await this.queueDirectoryPush();
       } catch (error) {
-        this.logService.error(error, new Map([["context", "UserTracker alarm error"]]));
+        this.logService.error(
+          error,
+          new Map([
+            ["context", "UserTracker alarm error"],
+            ["tickType", tickType],
+            ["hasConnectedClients", hasConnectedClients.toString()],
+          ]),
+        );
         Sentry.captureException(error);
       }
 
@@ -541,7 +548,16 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       try {
         await this.refreshAndBroadcastIfChanged();
       } catch (error) {
-        this.logService.error(error, new Map([["context", "UserTracker directory refresh error"]]));
+        const stored = await this.loadState();
+        this.logService.error(
+          error,
+          new Map([
+            ["context", "UserTracker directory refresh error"],
+            ["userId", stored.state?.userId ?? "unknown"],
+            ["refreshMode", this.dirtyTrackerIds.size === 0 || stored.viewState == null ? "full" : "incremental"],
+            ["dirtyTrackerCount", this.dirtyTrackerIds.size.toString()],
+          ])
+        );
       }
     }
   }

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -546,19 +546,18 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
     while (this.pendingPush) {
       this.pendingPush = false;
-      const stateAtRefreshStart = await this.loadState();
       const dirtyTrackerCountAtRefreshStart = this.dirtyTrackerIds.size;
-      const refreshMode =
-        dirtyTrackerCountAtRefreshStart === 0 || stateAtRefreshStart.viewState == null ? "full" : "incremental";
 
       try {
         await this.refreshAndBroadcastIfChanged();
       } catch (error) {
+        const stored = await this.loadState();
+        const refreshMode = dirtyTrackerCountAtRefreshStart === 0 || stored.viewState == null ? "full" : "incremental";
         this.logService.error(
           error,
           new Map([
             ["context", "UserTracker directory refresh error"],
-            ["userId", stateAtRefreshStart.state?.userId ?? "unknown"],
+            ["userId", stored.state?.userId ?? "unknown"],
             ["refreshMode", refreshMode],
             ["dirtyTrackerCount", dirtyTrackerCountAtRefreshStart.toString()],
           ]),

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -556,7 +556,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
             ["userId", stored.state?.userId ?? "unknown"],
             ["refreshMode", this.dirtyTrackerIds.size === 0 || stored.viewState == null ? "full" : "incremental"],
             ["dirtyTrackerCount", this.dirtyTrackerIds.size.toString()],
-          ])
+          ]),
         );
       }
     }

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -224,7 +224,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       try {
         await this.queueDirectoryPush();
       } catch (error) {
-        const stored = await this.loadState();
+        const stored = await this.loadStateForErrorContext("UserTracker alarm error context load failed");
         this.logService.error(
           error,
           new Map([
@@ -551,8 +551,8 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       try {
         await this.refreshAndBroadcastIfChanged();
       } catch (error) {
-        const stored = await this.loadState();
-        const refreshMode = dirtyTrackerCountAtRefreshStart === 0 || stored.viewState == null ? "full" : "incremental";
+        const stored = await this.loadStateForErrorContext("UserTracker directory refresh error context load failed");
+        const refreshMode = stored.viewState == null || dirtyTrackerCountAtRefreshStart === 0 ? "full" : "incremental";
         this.logService.error(
           error,
           new Map([
@@ -563,6 +563,18 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
           ]),
         );
       }
+    }
+  }
+
+  private async loadStateForErrorContext(loadFailureContext: string): Promise<UserTrackerInternalState> {
+    try {
+      return await this.loadState();
+    } catch (error) {
+      this.logService.warn(error, new Map([["context", loadFailureContext]]));
+      return {
+        state: null,
+        viewState: null,
+      };
     }
   }
 


### PR DESCRIPTION
## Context
Phase 2 is complete, the route-level fan-out cleanup is already done, and the remaining work is Phase 3 hardening. The first follow-on slice is observability: make reconcile and directory-refresh failures easier to triage without changing the architecture again.

## This PR
Adds richer context to `UserTrackerDO` error logs for reconcile-alarm failures and directory-refresh failures, including the user ID and refresh mode where available. The existing regression now verifies that the transient rebuild failure path emits those details.

## Subsequent Work
- Add any additional failure-mode coverage if we discover another edge in the reconcile path.
- Keep an eye out for any other observability gaps in the user-tracker hardening slice.
