### PR TITLE
Update Copilot loop prompt for scheduling

### DIFF
--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -1,33 +1,28 @@
 # Copilot Review Loop
 
-Processes the latest Copilot PR review: fixes valid issues, replies to all comments, resolves threads, requests a new review, then polls every minute for up to 15 minutes for the new review to arrive before falling back to a 10-minute reschedule.
-
-Keep the loop quiet. Accumulate a running findings ledger in the session context. Poll every 1 minute for up to 15 minutes, then fall back to 10 minutes. Track polling start time and active schedule ID in the SQL session database (`sql` tool) — see Steps 1 and 4. Emit the final report only when the review is clean.
+Processes the latest Copilot PR review: fixes valid issues, replies to all comments, resolves threads, requests a new review, then polls until clean. Poll state (PR, iteration, last review ID) is carried forward in the scheduled prompt string — no external storage needed. Keep the loop quiet. Emit the final report only when the review is clean.
 
 ## Setup
 
-Identify the current PR number:
+Resolve `PR` using the first match:
 
-```bash
-gh pr view --json number --jq '.number'
+1. Direct argument — e.g. `/copilot-loop 643`
+2. `PR:` key in the invocation prompt — e.g. `PR:643` (present on scheduled runs)
+3. Fallback — `gh pr view --json number --jq '.number'`
+
+Also parse these from the invocation prompt if present (all default to their zero values on manual runs):
+
+- `scheduleId` — schedule to stop on entry (e.g. `scheduleId:5`; default absent)
+- `iteration` — consecutive polls without a new review (e.g. `iteration:3`; default `0`)
+- `lastReviewId` — ID of the last processed review (e.g. `lastReviewId:4631032003`; default empty)
+
+If `scheduleId` is present, stop it immediately:
+
 ```
-
-Use that number throughout (referred to as `{PR}` below).
+manage_schedule(action: 'stop', id: <scheduleId>)
+```
 
 ## Step 1 — Find the latest Copilot PR review
-
-**First, stop the schedule that triggered this run:**
-
-```sql
-CREATE TABLE IF NOT EXISTS poll_state (key TEXT PRIMARY KEY, value TEXT);
-SELECT value FROM poll_state WHERE key = 'scheduleId:{PR}';
-```
-
-If a row is returned, call `manage_schedule(action: 'stop', id: <value>)`, then delete it:
-
-```sql
-DELETE FROM poll_state WHERE key = 'scheduleId:{PR}';
-```
 
 ```bash
 gh api "repos/{owner}/{repo}/pulls/{PR}/reviews?per_page=100" | python3 -c "
@@ -45,29 +40,25 @@ else:
 "
 ```
 
-If `NO_REVIEW`: request one (Step 4) and record the polling start time if not already set:
+**If `NO_REVIEW`:** request a review (Step 4) then schedule the next poll and stop:
 
-```sql
-INSERT OR IGNORE INTO poll_state (key, value) VALUES ('pollingStartedAt:{PR}', datetime('now'));
+```
+manage_schedule(action: 'create', interval: '1m',
+  prompt: 'Run the copilot-loop skill to process the Copilot PR review. PR:{PR} scheduleId:{returnedId} iteration:1 lastReviewId:')
 ```
 
-Then schedule the next poll with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`) and store the returned schedule ID:
+## Step 2 — Check if a new review has arrived
 
-```sql
-INSERT OR REPLACE INTO poll_state (key, value) VALUES ('scheduleId:{PR}', '<id returned by manage_schedule>');
+If `{REVIEW_ID}` equals `lastReviewId`, the new review hasn't arrived yet.
+
+Compute `nextIteration = iteration + 1`. Use interval `1m` if `nextIteration ≤ 15`, else `10m`. Reschedule and stop:
+
+```
+manage_schedule(action: 'create', interval: '{interval}',
+  prompt: 'Run the copilot-loop skill to process the Copilot PR review. PR:{PR} scheduleId:{returnedId} iteration:{nextIteration} lastReviewId:{lastReviewId}')
 ```
 
-On each subsequent run, compute elapsed minutes with `SELECT CAST((julianday('now') - julianday(value)) * 24 * 60 AS INTEGER) FROM poll_state WHERE key = 'pollingStartedAt:{PR}'`; if ≥ 15, use interval `10m` instead. Do not give a user-facing status update.
-
-## Step 2 — Check if the review is clean
-
-**Before checking clean — confirm this is a new review:**
-
-```sql
-SELECT value FROM poll_state WHERE key = 'lastProcessedReviewId:{PR}';
-```
-
-If the returned value equals `{REVIEW_ID}`, a new review has not yet arrived. Compute elapsed time and reschedule (same 1m/10m logic based on `pollingStartedAt`) and stop.
+## Step 3 — Check if the review is clean
 
 Fetch the review's inline comments:
 
@@ -77,19 +68,13 @@ gh api "repos/{owner}/{repo}/pulls/{PR}/reviews/{REVIEW_ID}/comments"
 
 **Clean** if the JSON array is empty (`[]`), OR if the `BODY:` line printed in Step 1 contains "generated no new comments".
 
-**If clean:** clean up remaining SQL state:
-
-```sql
-DELETE FROM poll_state WHERE key IN ('pollingStartedAt:{PR}', 'lastProcessedReviewId:{PR}');
-```
-
-Emit the final report:
+If clean: emit the final report and stop — do not reschedule.
 
 | Round | Finding | Status | How handled | Evidence |
 | ----- | ------- | ------ | ----------- | -------- |
 | 1 | ... | fixed/refuted | ... | thread id, commit SHA, or path |
 
-## Step 3 — Process each comment
+## Step 4 — Process each comment
 
 For each inline comment from the review:
 
@@ -112,7 +97,7 @@ For each inline comment from the review:
    git commit -m "fix(...): <description>"
    ```
 
-## Step 4 — Push, reply, resolve, request
+## Step 5 — Push, reply, resolve, request
 
 Once all comments are addressed (or refuted):
 
@@ -161,29 +146,14 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE
 gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 ```
 
-Store the just-processed review ID so polling can detect when a new review arrives:
-
-```sql
-INSERT OR REPLACE INTO poll_state (key, value) VALUES ('lastProcessedReviewId:{PR}', '{REVIEW_ID}');
-```
-
-Reset `pollingStartedAt` and schedule the next poll (1m if < 15 min elapsed, else 10m):
-
-```sql
-INSERT OR REPLACE INTO poll_state (key, value) VALUES ('pollingStartedAt:{PR}', datetime('now'));
-```
-
-```sql
-SELECT CAST((julianday('now') - julianday(value)) * 24 * 60 AS INTEGER) FROM poll_state WHERE key = 'pollingStartedAt:{PR}';
-```
-
-`manage_schedule` (action: `create`, interval: `1m` or `10m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`). Store the returned ID:
-
-```sql
-INSERT OR REPLACE INTO poll_state (key, value) VALUES ('scheduleId:{PR}', '<returned id>');
-```
-
 Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work. Use `copilot-pull-request-reviewer`. Do **not** post `@copilot review` — that triggers `copilot-swe-agent[bot]`.
+
+Schedule the next poll at 1m, carrying the just-processed review ID forward so Step 2 can detect when a new review arrives:
+
+```
+manage_schedule(action: 'create', interval: '1m',
+  prompt: 'Run the copilot-loop skill to process the Copilot PR review. PR:{PR} scheduleId:{returnedId} iteration:1 lastReviewId:{REVIEW_ID}')
+```
 
 ## Repo-specific notes
 

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -15,7 +15,7 @@ Parse these from the invocation prompt if present (default to zero values on man
 - `iteration` — consecutive polls without a new review (e.g. `iteration:3`; default `0`)
 - `lastReviewId` — ID of the last processed review (e.g. `lastReviewId:4631032003`; default empty)
 
-Stop any active loop schedule by listing and stopping the one whose prompt contains "copilot-loop skill to process the Copilot PR review":
+Stop any active loop schedule by listing and stopping the one whose prompt contains "copilot-loop skill to process the Copilot PR review. PR:{PR}":
 
 ```
 manage_schedule(action: 'list')
@@ -33,8 +33,10 @@ for r in reviews:
     if 'copilot' in r.get('user', {}).get('login', ''):
         last = r
 if last:
+    body = last.get('body') or ''
     print(last['id'], last['submitted_at'], last['commit_id'][:8])
-    print('BODY:', (last.get('body') or '').replace('\n', ' ')[:500])
+    print('BODY_CLEAN:', 'generated no new comments' in body)
+    print('BODY:', body.replace('\n', ' ')[:500])
 else:
     print('NO_REVIEW')
 "
@@ -72,7 +74,7 @@ Fetch the review's inline comments:
 gh api "repos/{owner}/{repo}/pulls/{PR}/reviews/{REVIEW_ID}/comments"
 ```
 
-**Clean** if the JSON array is empty (`[]`), OR if the `BODY:` line printed in Step 1 contains "generated no new comments".
+**Clean** if the JSON array is empty (`[]`), OR if `BODY_CLEAN: True` was printed in Step 1.
 
 If clean: emit the final report and stop — do not reschedule.
 

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -1,6 +1,8 @@
 # Copilot Review Loop
 
-Processes the latest Copilot PR review: fixes valid issues, replies to all comments, resolves threads, then requests a new review. Copilot does **not** auto-fire on push — the user manually invokes this command each time they want to run a loop iteration.
+Processes the latest Copilot PR review: fixes valid issues, replies to all comments, resolves threads, requests a new review, then polls every minute for up to 15 minutes for the new review to arrive before falling back to a 10-minute reschedule.
+
+Keep the loop quiet between iterations. Do not give a per-iteration handoff message to the user. Instead, accumulate a running findings ledger in the session context. While waiting for a fresh Copilot review, poll the PR every 1 minute for up to 15 minutes by scheduling the next run with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`). If no new review arrives in that window, fall back to `manage_schedule` with interval `10m`. Only when the review is clean should you produce the final report, including a markdown table of every Copilot review finding from the whole loop, whether it was fixed or refuted, and how it was handled.
 
 ## Setup
 
@@ -29,7 +31,7 @@ else:
 "
 ```
 
-If `NO_REVIEW`: request one (Step 4) and stop — tell the user to re-run `/copilot-loop` once the review arrives in ~10 minutes.
+If `NO_REVIEW`: request one (Step 4) and schedule the next poll with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`). Keep polling every minute until a new review appears or 15 minutes have elapsed; if the 15-minute window expires with no review, reschedule with interval `10m`. Do not give a user-facing status update.
 
 ## Step 2 — Check if the review is clean
 
@@ -41,7 +43,7 @@ gh api "repos/{owner}/{repo}/pulls/{PR}/reviews/{REVIEW_ID}/comments"
 
 **Clean** if the JSON array is empty (`[]`), OR if the review body contains "generated no new comments".
 
-**If clean: stop and tell the user Copilot found no issues. The loop is complete.**
+**If clean: stop scheduling, preserve the accumulated findings ledger, and emit the final report with a markdown table of all findings from the loop.**
 
 ## Step 3 — Process each comment
 
@@ -59,7 +61,9 @@ For each inline comment from the review:
 
 3. **If invalid/refuted:** Note the reason clearly. Do not make code changes for this comment.
 
-4. Commit all fixes together once all comments are processed:
+4. Add one row to the findings ledger for every comment you process. Include the review round, the finding, whether it was fixed or refuted, and how it was handled.
+
+5. Commit all fixes together once all comments are processed:
 
    ```bash
    git add <changed files>
@@ -115,7 +119,13 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE
 gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 ```
 
-The review may take up to a few hours to arrive. Stop here and tell the user to re-run `/copilot-loop` once the new review appears.
+The review may take up to a few minutes to arrive. Schedule the next poll with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`) while within the 15-minute polling window; otherwise use interval `10m`. Do not give a user-facing handoff.
+
+If the review is clean, do not schedule another run. Produce the final report only once, with this shape:
+
+| Round | Finding | Status        | How handled | Evidence                                |
+| ----- | ------- | ------------- | ----------- | --------------------------------------- |
+| 1     | ...     | fixed/refuted | ...         | thread id, commit SHA, or relevant path |
 
 Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work (GraphQL cannot resolve those logins). Do **not** post `@copilot review` — that triggers the unrelated `copilot-swe-agent[bot]` bot.
 

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -42,13 +42,14 @@ else:
 "
 ```
 
-**If `NO_REVIEW`:** request a new review:
+**If `NO_REVIEW`:** only request a new review on the first poll (`iteration == 0`):
 
 ```bash
+# run only when iteration is 0
 gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 ```
 
-Then compute `nextIteration = iteration + 1`, use interval `1m` if `nextIteration ≤ 15` else `10m`, schedule the next poll, and stop:
+Subsequent NO_REVIEW polls (iteration > 0) skip the reviewer request. Compute `nextIteration = iteration + 1`, use interval `1m` if `nextIteration ≤ 15` else `10m`, schedule the next poll, and stop:
 
 ```
 manage_schedule(action: 'create', interval: '{interval}',

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -39,6 +39,7 @@ for r in reviews:
         last = r
 if last:
     print(last['id'], last['submitted_at'], last['commit_id'][:8])
+    print('BODY:', (last.get('body') or '').replace('\n', ' ')[:500])
 else:
     print('NO_REVIEW')
 "
@@ -60,18 +61,26 @@ On each subsequent run, compute elapsed minutes with `SELECT CAST((julianday('no
 
 ## Step 2 — Check if the review is clean
 
+**Before checking clean — confirm this is a new review:**
+
+```sql
+SELECT value FROM poll_state WHERE key = 'lastProcessedReviewId:{PR}';
+```
+
+If the returned value equals `{REVIEW_ID}`, a new review has not yet arrived. Compute elapsed time and reschedule (same 1m/10m logic based on `pollingStartedAt`) and stop.
+
 Fetch the review's inline comments:
 
 ```bash
 gh api "repos/{owner}/{repo}/pulls/{PR}/reviews/{REVIEW_ID}/comments"
 ```
 
-**Clean** if the JSON array is empty (`[]`), OR if the review body contains "generated no new comments".
+**Clean** if the JSON array is empty (`[]`), OR if the `BODY:` line printed in Step 1 contains "generated no new comments".
 
 **If clean:** clean up remaining SQL state:
 
 ```sql
-DELETE FROM poll_state WHERE key = 'pollingStartedAt:{PR}';
+DELETE FROM poll_state WHERE key IN ('pollingStartedAt:{PR}', 'lastProcessedReviewId:{PR}');
 ```
 
 Emit the final report:
@@ -150,6 +159,12 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE
 
 ```bash
 gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
+```
+
+Store the just-processed review ID so polling can detect when a new review arrives:
+
+```sql
+INSERT OR REPLACE INTO poll_state (key, value) VALUES ('lastProcessedReviewId:{PR}', '{REVIEW_ID}');
 ```
 
 Reset `pollingStartedAt` and schedule the next poll (1m if < 15 min elapsed, else 10m):

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -15,10 +15,11 @@ Parse these from the invocation prompt if present (tokens follow the format `key
 - `iteration` — consecutive polls without a new review (e.g. `iteration:3`; default `0`)
 - `lastReviewId` — ID of the last processed review (e.g. `lastReviewId:4631032003`; default empty)
 
-Stop any active loop schedule by listing and stopping the one whose prompt contains "copilot-loop skill to process the Copilot PR review. PR:{PR}":
+Stop all active loop schedules for this PR by listing and stopping every schedule whose prompt contains "copilot-loop skill to process the Copilot PR review. PR:{PR}":
 
 ```
 manage_schedule(action: 'list')
+// for each matching schedule:
 manage_schedule(action: 'stop', id: <matching id>)
 ```
 

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -2,7 +2,7 @@
 
 Processes the latest Copilot PR review: fixes valid issues, replies to all comments, resolves threads, requests a new review, then polls every minute for up to 15 minutes for the new review to arrive before falling back to a 10-minute reschedule.
 
-Keep the loop quiet between iterations. Do not give a per-iteration handoff message to the user. Instead, accumulate a running findings ledger in the session context. While waiting for a fresh Copilot review, poll the PR every 1 minute for up to 15 minutes by scheduling the next run with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`). If no new review arrives in that window, fall back to `manage_schedule` with interval `10m`. Only when the review is clean should you produce the final report, including a markdown table of every Copilot review finding from the whole loop, whether it was fixed or refuted, and how it was handled.
+Keep the loop quiet between iterations. Do not give a per-iteration handoff message to the user. Instead, accumulate a running findings ledger in the session context. While waiting for a fresh Copilot review, poll the PR every 1 minute for up to 15 minutes by scheduling the next run with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`). Track the polling start time in the SQL session database (`sql` tool) so elapsed time can be computed reliably across stateless invocations — see Step 1 and Step 4 for details. If no new review arrives in that window, fall back to `manage_schedule` with interval `10m`. Only when the review is clean should you produce the final report, including a markdown table of every Copilot review finding from the whole loop, whether it was fixed or refuted, and how it was handled.
 
 ## Setup
 
@@ -31,7 +31,14 @@ else:
 "
 ```
 
-If `NO_REVIEW`: request one (Step 4) and schedule the next poll with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`). Keep polling every minute until a new review appears or 15 minutes have elapsed; if the 15-minute window expires with no review, reschedule with interval `10m`. Do not give a user-facing status update.
+If `NO_REVIEW`: request one (Step 4) and record the polling start time in the SQL session database if not already set:
+
+```sql
+CREATE TABLE IF NOT EXISTS poll_state (key TEXT PRIMARY KEY, value TEXT);
+INSERT OR IGNORE INTO poll_state (key, value) VALUES ('pollingStartedAt', datetime('now'));
+```
+
+Then schedule the next poll with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`). On each subsequent run, compute elapsed minutes with `SELECT CAST((julianday('now') - julianday(value)) * 24 * 60 AS INTEGER) FROM poll_state WHERE key = 'pollingStartedAt'`; if ≥ 15, use interval `10m` instead. Do not give a user-facing status update.
 
 ## Step 2 — Check if the review is clean
 
@@ -119,7 +126,7 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE
 gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 ```
 
-The review may take up to a few minutes to arrive. Schedule the next poll with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`) while within the 15-minute polling window; otherwise use interval `10m`. Do not give a user-facing handoff.
+The review may take up to a few minutes to arrive. Set `pollingStartedAt` in the SQL session database if not already set (same `INSERT OR IGNORE` as in Step 1). Then compute elapsed minutes with `SELECT CAST((julianday('now') - julianday(value)) * 24 * 60 AS INTEGER) FROM poll_state WHERE key = 'pollingStartedAt'`; if < 15, schedule the next poll with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`); otherwise use interval `10m`. Do not give a user-facing handoff.
 
 If the review is clean, do not schedule another run. Produce the final report only once, with this shape:
 

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -2,7 +2,7 @@
 
 Processes the latest Copilot PR review: fixes valid issues, replies to all comments, resolves threads, requests a new review, then polls every minute for up to 15 minutes for the new review to arrive before falling back to a 10-minute reschedule.
 
-Keep the loop quiet between iterations. Do not give a per-iteration handoff message to the user. Instead, accumulate a running findings ledger in the session context. While waiting for a fresh Copilot review, poll the PR every 1 minute for up to 15 minutes by scheduling the next run with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`). Track the polling start time in the SQL session database (`sql` tool) so elapsed time can be computed reliably across stateless invocations — see Step 1 and Step 4 for details. If no new review arrives in that window, fall back to `manage_schedule` with interval `10m`. Only when the review is clean should you produce the final report, including a markdown table of every Copilot review finding from the whole loop, whether it was fixed or refuted, and how it was handled.
+Keep the loop quiet. Accumulate a running findings ledger in the session context. Poll every 1 minute for up to 15 minutes, then fall back to 10 minutes. Track polling start time and active schedule ID in the SQL session database (`sql` tool) — see Steps 1 and 4. Emit the final report only when the review is clean.
 
 ## Setup
 
@@ -15,6 +15,19 @@ gh pr view --json number --jq '.number'
 Use that number throughout (referred to as `{PR}` below).
 
 ## Step 1 — Find the latest Copilot PR review
+
+**First, stop the schedule that triggered this run:**
+
+```sql
+CREATE TABLE IF NOT EXISTS poll_state (key TEXT PRIMARY KEY, value TEXT);
+SELECT value FROM poll_state WHERE key = 'scheduleId:{PR}';
+```
+
+If a row is returned, call `manage_schedule(action: 'stop', id: <value>)`, then delete it:
+
+```sql
+DELETE FROM poll_state WHERE key = 'scheduleId:{PR}';
+```
 
 ```bash
 gh api "repos/{owner}/{repo}/pulls/{PR}/reviews?per_page=100" | python3 -c "
@@ -31,14 +44,19 @@ else:
 "
 ```
 
-If `NO_REVIEW`: request one (Step 4) and record the polling start time in the SQL session database if not already set:
+If `NO_REVIEW`: request one (Step 4) and record the polling start time if not already set:
 
 ```sql
-CREATE TABLE IF NOT EXISTS poll_state (key TEXT PRIMARY KEY, value TEXT);
 INSERT OR IGNORE INTO poll_state (key, value) VALUES ('pollingStartedAt:{PR}', datetime('now'));
 ```
 
-Then schedule the next poll with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`). On each subsequent run, compute elapsed minutes with `SELECT CAST((julianday('now') - julianday(value)) * 24 * 60 AS INTEGER) FROM poll_state WHERE key = 'pollingStartedAt:{PR}'`; if ≥ 15, use interval `10m` instead. Do not give a user-facing status update.
+Then schedule the next poll with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`) and store the returned schedule ID:
+
+```sql
+INSERT OR REPLACE INTO poll_state (key, value) VALUES ('scheduleId:{PR}', '<id returned by manage_schedule>');
+```
+
+On each subsequent run, compute elapsed minutes with `SELECT CAST((julianday('now') - julianday(value)) * 24 * 60 AS INTEGER) FROM poll_state WHERE key = 'pollingStartedAt:{PR}'`; if ≥ 15, use interval `10m` instead. Do not give a user-facing status update.
 
 ## Step 2 — Check if the review is clean
 
@@ -50,7 +68,17 @@ gh api "repos/{owner}/{repo}/pulls/{PR}/reviews/{REVIEW_ID}/comments"
 
 **Clean** if the JSON array is empty (`[]`), OR if the review body contains "generated no new comments".
 
-**If clean: stop scheduling, preserve the accumulated findings ledger, and emit the final report with a markdown table of all findings from the loop.**
+**If clean:** clean up remaining SQL state:
+
+```sql
+DELETE FROM poll_state WHERE key = 'pollingStartedAt:{PR}';
+```
+
+Emit the final report:
+
+| Round | Finding | Status | How handled | Evidence |
+| ----- | ------- | ------ | ----------- | -------- |
+| 1 | ... | fixed/refuted | ... | thread id, commit SHA, or path |
 
 ## Step 3 — Process each comment
 
@@ -63,8 +91,6 @@ For each inline comment from the review:
    ```bash
    npm run done
    ```
-
-   `npm run done` runs: prettier → typecheck → eslint --fix → vitest run related. Fix any errors it reports and re-run until clean.
 
 3. **If invalid/refuted:** Note the reason clearly. Do not make code changes for this comment.
 
@@ -126,15 +152,23 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE
 gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 ```
 
-The review may take up to a few minutes to arrive. Reset `pollingStartedAt` for this PR in the SQL session database to restart the polling window: `INSERT OR REPLACE INTO poll_state (key, value) VALUES ('pollingStartedAt:{PR}', datetime('now'))`. Then compute elapsed minutes with `SELECT CAST((julianday('now') - julianday(value)) * 24 * 60 AS INTEGER) FROM poll_state WHERE key = 'pollingStartedAt:{PR}'`; if < 15, schedule the next poll with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`); otherwise use interval `10m`. Do not give a user-facing handoff.
+Reset `pollingStartedAt` and schedule the next poll (1m if < 15 min elapsed, else 10m):
 
-If the review is clean, do not schedule another run. Produce the final report only once, with this shape:
+```sql
+INSERT OR REPLACE INTO poll_state (key, value) VALUES ('pollingStartedAt:{PR}', datetime('now'));
+```
 
-| Round | Finding | Status        | How handled | Evidence                                |
-| ----- | ------- | ------------- | ----------- | --------------------------------------- |
-| 1     | ...     | fixed/refuted | ...         | thread id, commit SHA, or relevant path |
+```sql
+SELECT CAST((julianday('now') - julianday(value)) * 24 * 60 AS INTEGER) FROM poll_state WHERE key = 'pollingStartedAt:{PR}';
+```
 
-Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work (GraphQL cannot resolve those logins). Do **not** post `@copilot review` — that triggers the unrelated `copilot-swe-agent[bot]` bot.
+`manage_schedule` (action: `create`, interval: `1m` or `10m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`). Store the returned ID:
+
+```sql
+INSERT OR REPLACE INTO poll_state (key, value) VALUES ('scheduleId:{PR}', '<returned id>');
+```
+
+Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work. Use `copilot-pull-request-reviewer`. Do **not** post `@copilot review` — that triggers `copilot-swe-agent[bot]`.
 
 ## Repo-specific notes
 

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -10,16 +10,16 @@ Resolve `PR` using the first match:
 2. `PR:` key in the invocation prompt — e.g. `PR:643` (present on scheduled runs)
 3. Fallback — `gh pr view --json number --jq '.number'`
 
-Also parse these from the invocation prompt if present (all default to their zero values on manual runs):
+Parse these from the invocation prompt if present (default to zero values on manual runs):
 
-- `scheduleId` — schedule to stop on entry (e.g. `scheduleId:5`; default absent)
 - `iteration` — consecutive polls without a new review (e.g. `iteration:3`; default `0`)
 - `lastReviewId` — ID of the last processed review (e.g. `lastReviewId:4631032003`; default empty)
 
-If `scheduleId` is present, stop it immediately:
+Stop any active loop schedule by listing and stopping the one whose prompt contains "copilot-loop skill to process the Copilot PR review":
 
 ```
-manage_schedule(action: 'stop', id: <scheduleId>)
+manage_schedule(action: 'list')
+manage_schedule(action: 'stop', id: <matching id>)
 ```
 
 ## Step 1 — Find the latest Copilot PR review
@@ -40,11 +40,11 @@ else:
 "
 ```
 
-**If `NO_REVIEW`:** request a review (Step 4) then schedule the next poll and stop:
+**If `NO_REVIEW`:** request a review (Step 4) then compute `nextIteration = iteration + 1`, use interval `1m` if `nextIteration ≤ 15` else `10m`, schedule the next poll, and stop:
 
 ```
-manage_schedule(action: 'create', interval: '1m',
-  prompt: 'Run the copilot-loop skill to process the Copilot PR review. PR:{PR} scheduleId:{returnedId} iteration:1 lastReviewId:')
+manage_schedule(action: 'create', interval: '{interval}',
+  prompt: 'Run the copilot-loop skill to process the Copilot PR review. PR:{PR} iteration:{nextIteration} lastReviewId:')
 ```
 
 ## Step 2 — Check if a new review has arrived
@@ -55,7 +55,7 @@ Compute `nextIteration = iteration + 1`. Use interval `1m` if `nextIteration ≤
 
 ```
 manage_schedule(action: 'create', interval: '{interval}',
-  prompt: 'Run the copilot-loop skill to process the Copilot PR review. PR:{PR} scheduleId:{returnedId} iteration:{nextIteration} lastReviewId:{lastReviewId}')
+  prompt: 'Run the copilot-loop skill to process the Copilot PR review. PR:{PR} iteration:{nextIteration} lastReviewId:{lastReviewId}')
 ```
 
 ## Step 3 — Check if the review is clean
@@ -152,7 +152,7 @@ Schedule the next poll at 1m, carrying the just-processed review ID forward so S
 
 ```
 manage_schedule(action: 'create', interval: '1m',
-  prompt: 'Run the copilot-loop skill to process the Copilot PR review. PR:{PR} scheduleId:{returnedId} iteration:1 lastReviewId:{REVIEW_ID}')
+  prompt: 'Run the copilot-loop skill to process the Copilot PR review. PR:{PR} iteration:1 lastReviewId:{REVIEW_ID}')
 ```
 
 ## Repo-specific notes

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -42,14 +42,13 @@ else:
 "
 ```
 
-**If `NO_REVIEW`:** only request a new review on the first poll (`iteration == 0`):
+**If `NO_REVIEW`:** on the first poll only (`iteration == 0`), request a review:
 
 ```bash
-# run only when iteration is 0
 gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 ```
 
-Subsequent NO_REVIEW polls (iteration > 0) skip the reviewer request. Compute `nextIteration = iteration + 1`, use interval `1m` if `nextIteration ≤ 15` else `10m`, schedule the next poll, and stop:
+Then (for all NO_REVIEW polls), compute `nextIteration = iteration + 1`, use interval `1m` if `nextIteration ≤ 15` else `10m`, schedule the next poll, and stop:
 
 ```
 manage_schedule(action: 'create', interval: '{interval}',

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -40,7 +40,13 @@ else:
 "
 ```
 
-**If `NO_REVIEW`:** request a review (Step 4) then compute `nextIteration = iteration + 1`, use interval `1m` if `nextIteration ≤ 15` else `10m`, schedule the next poll, and stop:
+**If `NO_REVIEW`:** request a new review:
+
+```bash
+gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
+```
+
+Then compute `nextIteration = iteration + 1`, use interval `1m` if `nextIteration ≤ 15` else `10m`, schedule the next poll, and stop:
 
 ```
 manage_schedule(action: 'create', interval: '{interval}',

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -10,7 +10,7 @@ Resolve `PR` using the first match:
 2. `PR:` key in the invocation prompt — e.g. `PR:643` (present on scheduled runs)
 3. Fallback — `gh pr view --json number --jq '.number'`
 
-Parse these from the invocation prompt if present (default to zero values on manual runs):
+Parse these from the invocation prompt if present (tokens follow the format `key:value` and can appear anywhere in the prompt text; default to zero values on manual runs):
 
 - `iteration` — consecutive polls without a new review (e.g. `iteration:3`; default `0`)
 - `lastReviewId` — ID of the last processed review (e.g. `lastReviewId:4631032003`; default empty)

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -53,7 +53,7 @@ Then (for all NO_REVIEW polls), compute `nextIteration = iteration + 1`, use int
 
 ```
 manage_schedule(action: 'create', interval: '{interval}',
-  prompt: 'Run the copilot-loop skill to process the Copilot PR review. PR:{PR} iteration:{nextIteration} lastReviewId:')
+  prompt: 'Run the copilot-loop skill to process the Copilot PR review. PR:{PR} iteration:{nextIteration}')
 ```
 
 ## Step 2 — Check if a new review has arrived

--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -35,10 +35,10 @@ If `NO_REVIEW`: request one (Step 4) and record the polling start time in the SQ
 
 ```sql
 CREATE TABLE IF NOT EXISTS poll_state (key TEXT PRIMARY KEY, value TEXT);
-INSERT OR IGNORE INTO poll_state (key, value) VALUES ('pollingStartedAt', datetime('now'));
+INSERT OR IGNORE INTO poll_state (key, value) VALUES ('pollingStartedAt:{PR}', datetime('now'));
 ```
 
-Then schedule the next poll with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`). On each subsequent run, compute elapsed minutes with `SELECT CAST((julianday('now') - julianday(value)) * 24 * 60 AS INTEGER) FROM poll_state WHERE key = 'pollingStartedAt'`; if ≥ 15, use interval `10m` instead. Do not give a user-facing status update.
+Then schedule the next poll with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`). On each subsequent run, compute elapsed minutes with `SELECT CAST((julianday('now') - julianday(value)) * 24 * 60 AS INTEGER) FROM poll_state WHERE key = 'pollingStartedAt:{PR}'`; if ≥ 15, use interval `10m` instead. Do not give a user-facing status update.
 
 ## Step 2 — Check if the review is clean
 
@@ -126,7 +126,7 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE
 gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 ```
 
-The review may take up to a few minutes to arrive. Set `pollingStartedAt` in the SQL session database if not already set (same `INSERT OR IGNORE` as in Step 1). Then compute elapsed minutes with `SELECT CAST((julianday('now') - julianday(value)) * 24 * 60 AS INTEGER) FROM poll_state WHERE key = 'pollingStartedAt'`; if < 15, schedule the next poll with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`); otherwise use interval `10m`. Do not give a user-facing handoff.
+The review may take up to a few minutes to arrive. Reset `pollingStartedAt` for this PR in the SQL session database to restart the polling window: `INSERT OR REPLACE INTO poll_state (key, value) VALUES ('pollingStartedAt:{PR}', datetime('now'))`. Then compute elapsed minutes with `SELECT CAST((julianday('now') - julianday(value)) * 24 * 60 AS INTEGER) FROM poll_state WHERE key = 'pollingStartedAt:{PR}'`; if < 15, schedule the next poll with `manage_schedule` (action: `create`, interval: `1m`, prompt: `Run the copilot-loop skill to process the Copilot PR review on this repository`); otherwise use interval `10m`. Do not give a user-facing handoff.
 
 If the review is clean, do not schedule another run. Produce the final report only once, with this shape:
 

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -40,8 +40,13 @@ If `NO_REVIEW`: request a review (Step 6). On first poll, write the current ISO 
 Schedule the next poll with `/after 1m #copilot-loop.prompt.md`. On each subsequent run, read the start time and compute elapsed minutes:
 
 ```bash
-start=$(sed -n '1p' /tmp/copilot-loop-{PR}.txt)
-echo $(( ( $(date -u +%s) - $(date -u -d "$start" +%s) ) / 60 ))
+python3 -c "
+from datetime import datetime, timezone
+start = open('/tmp/copilot-loop-{PR}.txt').readlines()[0].strip()
+now = datetime.now(timezone.utc)
+then = datetime.fromisoformat(start.replace('Z', '+00:00'))
+print(int((now - then).total_seconds() / 60))
+"
 ```
 
 If ≥ 15 minutes have elapsed, reschedule with `/after 10m #copilot-loop.prompt.md` instead.

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -5,7 +5,7 @@ description: "Process the latest Copilot PR review: fix valid issues, reply to a
 
 Run one iteration of the Copilot review loop on the current PR in the GitHub Copilot CLI interactive session. From the VS Code integrated terminal, start that session with `copilot`. Experimental scheduling must be enabled first with `/experimental on` or `--experimental`.
 
-Keep the loop quiet between iterations. Do not give a per-iteration handoff message to the user. Instead, accumulate a running findings ledger in the session context. While waiting for a fresh Copilot review, poll the PR every 1 minute for up to 15 minutes by scheduling the next run with `/after 1m #copilot-loop.prompt.md`. If no new review arrives in that window, fall back to `/after 10m #copilot-loop.prompt.md`. Only when the review is clean should you produce the final report, including a markdown table of every Copilot review finding from the whole loop, whether it was fixed or refuted, and how it was handled.
+Keep the loop quiet between iterations. Do not give a per-iteration handoff message to the user. Instead, accumulate a running findings ledger in the session context — include a `pollingStartedAt` field (ISO timestamp) that is set once when polling first begins and used on every subsequent iteration to determine whether the 15-minute window has elapsed. While waiting for a fresh Copilot review, poll the PR every 1 minute for up to 15 minutes by scheduling the next run with `/after 1m #copilot-loop.prompt.md`. If no new review arrives in that window, fall back to `/after 10m #copilot-loop.prompt.md`. Only when the review is clean should you produce the final report, including a markdown table of every Copilot review finding from the whole loop, whether it was fixed or refuted, and how it was handled.
 
 ## Step 1 — Identify the PR
 
@@ -25,12 +25,13 @@ for r in reviews:
         last = r
 if last:
     print(last['id'], last['submitted_at'], last['commit_id'][:8])
+    print('BODY:', last.get('body', ''))
 else:
     print('NO_REVIEW')
 "
 ```
 
-If `NO_REVIEW`: request a review (Step 6) and schedule this same prompt again with `/after 1m #copilot-loop.prompt.md`. Keep polling every minute until either a new review appears or 15 minutes have elapsed; if the 15-minute polling window expires with no new review, reschedule with `/after 10m #copilot-loop.prompt.md`.
+If `NO_REVIEW`: request a review (Step 6), set `pollingStartedAt` in the session findings ledger (ISO timestamp, set once on first poll), and schedule this same prompt again with `/after 1m #copilot-loop.prompt.md`. On each subsequent run, compare the current time to `pollingStartedAt`; if ≥ 15 minutes have elapsed, reschedule with `/after 10m #copilot-loop.prompt.md` instead.
 
 ## Step 3 — Check if the review is clean
 
@@ -40,7 +41,7 @@ If `NO_REVIEW`: request a review (Step 6) and schedule this same prompt again wi
 gh api "repos/{owner}/{repo}/pulls/{PR}/reviews/{REVIEW_ID}/comments"
 ```
 
-Clean if the array is empty or the review body contains "generated no new comments".
+Clean if the array is empty or the `BODY:` line printed in Step 2 contains "generated no new comments".
 
 **Check 2 — latest `copilot-swe-agent[bot]` issue comment:**
 
@@ -135,7 +136,7 @@ gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 
 Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work — use `copilot-pull-request-reviewer` exactly. Do **not** post `@copilot review` — that triggers the unrelated `copilot-swe-agent[bot]` bot.
 
-If the review is not clean, schedule the next iteration with `/after 1m #copilot-loop.prompt.md` while you are still within the 15-minute polling window; otherwise schedule with `/after 10m #copilot-loop.prompt.md`. Do not give a user-facing handoff.
+If the review is not clean, check `pollingStartedAt` in the session findings ledger. If the current time minus `pollingStartedAt` is less than 15 minutes, schedule the next iteration with `/after 1m #copilot-loop.prompt.md`; otherwise schedule with `/after 10m #copilot-loop.prompt.md`. Do not give a user-facing handoff.
 
 If the review is clean, do not schedule another run. Produce the final report only once, with this shape:
 

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -139,9 +139,9 @@ If the review is not clean, schedule the next iteration with `/after 10m` and st
 
 If the review is clean, do not schedule another run. Produce the final report only once, with this shape:
 
-| Round | Finding | Status | How handled | Evidence |
-| --- | --- | --- | --- | --- |
-| 1 | ... | fixed/refuted | ... | thread id, commit SHA, or relevant path |
+| Round | Finding | Status        | How handled | Evidence                                |
+| ----- | ------- | ------------- | ----------- | --------------------------------------- |
+| 1     | ...     | fixed/refuted | ...         | thread id, commit SHA, or relevant path |
 
 ## How To Start
 

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -40,13 +40,23 @@ If `NO_REVIEW`: request a review (Step 6). On first poll, write the current ISO 
 Schedule the next poll with `/after 1m #copilot-loop.prompt.md`. On each subsequent run, read the start time and compute elapsed minutes:
 
 ```bash
-start=$(cat /tmp/copilot-loop-{PR}.txt)
+start=$(sed -n '1p' /tmp/copilot-loop-{PR}.txt)
 echo $(( ( $(date -u +%s) - $(date -u -d "$start" +%s) ) / 60 ))
 ```
 
 If ≥ 15 minutes have elapsed, reschedule with `/after 10m #copilot-loop.prompt.md` instead.
 
 ## Step 3 — Check if the review is clean
+
+**Before checking clean — confirm this is a new review:**
+
+Read the last processed review ID from line 2 of the temp file:
+
+```bash
+[ -f /tmp/copilot-loop-{PR}.txt ] && sed -n '2p' /tmp/copilot-loop-{PR}.txt || echo ""
+```
+
+If the output equals `{REVIEW_ID}`, a new review has not yet arrived. Read line 1 for the polling start time, compute elapsed minutes, and reschedule (same 1m/10m logic as above). Stop — do not process.
 
 **Check 1 — inline comments on the PR review:**
 
@@ -157,13 +167,13 @@ gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 
 Note: use `copilot-pull-request-reviewer` exactly — `copilot` and `github-copilot` do not resolve. Do **not** post `@copilot review` — that triggers `copilot-swe-agent[bot]`.
 
-Reset the polling window by overwriting the temp file:
+Reset the polling window by overwriting the temp file with the current timestamp on line 1 and the just-processed review ID on line 2:
 
 ```bash
-date -u +%Y-%m-%dT%H:%M:%SZ > /tmp/copilot-loop-{PR}.txt
+printf "%s\n%s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "{REVIEW_ID}" > /tmp/copilot-loop-{PR}.txt
 ```
 
-Then schedule the next iteration with `/after 1m #copilot-loop.prompt.md`. On subsequent polls where no new review has arrived, compare the current time to `/tmp/copilot-loop-{PR}.txt`; if ≥ 15 minutes have elapsed, use `/after 10m #copilot-loop.prompt.md` instead.
+Then schedule the next iteration with `/after 1m #copilot-loop.prompt.md`. On subsequent polls where Step 3 detects the same review ID (no new review yet), compare the current time to line 1 of the temp file; if ≥ 15 minutes have elapsed, use `/after 10m #copilot-loop.prompt.md` instead.
 
 ## Repo-specific notes
 

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -5,7 +5,7 @@ description: "Process the latest Copilot PR review: fix valid issues, reply to a
 
 Run one iteration of the Copilot review loop on the current PR in the GitHub Copilot CLI interactive session. From the VS Code integrated terminal, start that session with `copilot`. Experimental scheduling must be enabled first with `/experimental on` or `--experimental`.
 
-Keep the loop quiet between iterations. Do not give a per-iteration handoff message to the user. Instead, accumulate a running findings ledger in the session context — include a `pollingStartedAt` field (ISO timestamp) that is reset each time a new review is requested; on poll iterations that find no new review yet, compare the current time to `pollingStartedAt` to determine whether to use the 1m or 10m cadence. While waiting for a fresh Copilot review, poll the PR every 1 minute for up to 15 minutes by scheduling the next run with `/after 1m #copilot-loop.prompt.md`. If no new review arrives in that window, fall back to `/after 10m #copilot-loop.prompt.md`. Only when the review is clean should you produce the final report, including a markdown table of every Copilot review finding from the whole loop, whether it was fixed or refuted, and how it was handled.
+Keep the loop quiet. Accumulate a running findings ledger in the session context. Persist `pollingStartedAt` to `/tmp/copilot-loop-{PR}.txt` (each `/after` invocation is stateless). Poll every 1 minute for up to 15 minutes, then fall back to 10 minutes. Emit the final report only when the review is clean.
 
 ## Step 1 — Identify the PR
 
@@ -31,7 +31,20 @@ else:
 "
 ```
 
-If `NO_REVIEW`: request a review (Step 6), set `pollingStartedAt` in the session findings ledger (ISO timestamp, set once on first poll), and schedule this same prompt again with `/after 1m #copilot-loop.prompt.md`. On each subsequent run, compare the current time to `pollingStartedAt`; if ≥ 15 minutes have elapsed, reschedule with `/after 10m #copilot-loop.prompt.md` instead.
+If `NO_REVIEW`: request a review (Step 6). On first poll, write the current ISO timestamp to the temp file if it does not already exist:
+
+```bash
+[ -f /tmp/copilot-loop-{PR}.txt ] || date -u +%Y-%m-%dT%H:%M:%SZ > /tmp/copilot-loop-{PR}.txt
+```
+
+Schedule the next poll with `/after 1m #copilot-loop.prompt.md`. On each subsequent run, read the start time and compute elapsed minutes:
+
+```bash
+start=$(cat /tmp/copilot-loop-{PR}.txt)
+echo $(( ( $(date -u +%s) - $(date -u -d "$start" +%s) ) / 60 ))
+```
+
+If ≥ 15 minutes have elapsed, reschedule with `/after 10m #copilot-loop.prompt.md` instead.
 
 ## Step 3 — Check if the review is clean
 
@@ -58,7 +71,17 @@ for c in reversed(comments):
 
 Clean if the body contains any of: `clean`, `no issues`, `good to merge`, `no new comments`, `all.*tests pass`.
 
-If clean: stop scheduling, preserve the accumulated findings ledger, and emit the final report with a markdown table of all findings from the loop.
+If clean: do not schedule another run. Delete the temp file:
+
+```bash
+rm -f /tmp/copilot-loop-{PR}.txt
+```
+
+Emit the final report:
+
+| Round | Finding | Status        | How handled | Evidence                       |
+| ----- | ------- | ------------- | ----------- | ------------------------------ |
+| 1     | ...     | fixed/refuted | ...         | thread id, commit SHA, or path |
 
 ## Step 4 — Process each inline comment
 
@@ -71,8 +94,6 @@ For each comment:
    ```bash
    npm run done
    ```
-
-   (`npm run done` = prettier → typecheck → eslint --fix → vitest run related.) Fix any errors it reports and re-run until clean.
 
 3. **If invalid/refuted:** Note the reason. No code changes.
 
@@ -134,25 +155,15 @@ Request a new review:
 gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 ```
 
-Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work — use `copilot-pull-request-reviewer` exactly. Do **not** post `@copilot review` — that triggers the unrelated `copilot-swe-agent[bot]` bot.
+Note: use `copilot-pull-request-reviewer` exactly — `copilot` and `github-copilot` do not resolve. Do **not** post `@copilot review` — that triggers `copilot-swe-agent[bot]`.
 
-If the review is not clean, reset `pollingStartedAt` in the session findings ledger to the current ISO timestamp (this restarts the 15-minute polling window). Then schedule the next iteration with `/after 1m #copilot-loop.prompt.md`. On subsequent poll iterations where no new review has arrived yet, compare the current time to `pollingStartedAt`; if 15 or more minutes have elapsed, use `/after 10m #copilot-loop.prompt.md` instead. Do not give a user-facing handoff.
+Reset the polling window by overwriting the temp file:
 
-If the review is clean, do not schedule another run. Produce the final report only once, with this shape:
-
-| Round | Finding | Status        | How handled | Evidence                                |
-| ----- | ------- | ------------- | ----------- | --------------------------------------- |
-| 1     | ...     | fixed/refuted | ...         | thread id, commit SHA, or relevant path |
-
-## How To Start
-
-In the VS Code integrated terminal, run `copilot` to open the interactive CLI session, then enable experimental scheduling:
-
-```copilot
-/experimental on
+```bash
+date -u +%Y-%m-%dT%H:%M:%SZ > /tmp/copilot-loop-{PR}.txt
 ```
 
-After that, run this prompt once and let the loop reschedule itself with `/after 1m #copilot-loop.prompt.md` while polling for up to 15 minutes, then `/after 10m #copilot-loop.prompt.md` if no new review appears.
+Then schedule the next iteration with `/after 1m #copilot-loop.prompt.md`. On subsequent polls where no new review has arrived, compare the current time to `/tmp/copilot-loop-{PR}.txt`; if ≥ 15 minutes have elapsed, use `/after 10m #copilot-loop.prompt.md` instead.
 
 ## Repo-specific notes
 

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -1,11 +1,11 @@
 ---
 agent: agent
-description: "Process the latest Copilot PR review: fix valid issues, reply to all comments, resolve threads, request a new review, and reschedule itself with /after until the review is clean."
+description: "Process the latest Copilot PR review: fix valid issues, reply to all comments, resolve threads, request a new review, poll every minute for up to 15 minutes, and reschedule itself with /after until the review is clean."
 ---
 
 Run one iteration of the Copilot review loop on the current PR in the GitHub Copilot CLI interactive session. From the VS Code integrated terminal, start that session with `copilot`. Experimental scheduling must be enabled first with `/experimental on` or `--experimental`.
 
-Keep the loop quiet between iterations. Do not give a per-iteration handoff message to the user. Instead, accumulate a running findings ledger in the session context and continue rescheduling with `/after 10m` until the review is clean. Only when the review is clean should you produce the final report, including a markdown table of every Copilot review finding from the whole loop, whether it was fixed or refuted, and how it was handled.
+Keep the loop quiet between iterations. Do not give a per-iteration handoff message to the user. Instead, accumulate a running findings ledger in the session context. While waiting for a fresh Copilot review, poll the PR every 1 minute for up to 15 minutes using `/after 1m`. If no new review arrives in that window, fall back to `/after 10m`. Only when the review is clean should you produce the final report, including a markdown table of every Copilot review finding from the whole loop, whether it was fixed or refuted, and how it was handled.
 
 ## Step 1 — Identify the PR
 
@@ -30,7 +30,7 @@ else:
 "
 ```
 
-If `NO_REVIEW`: request a review (Step 6), schedule this same prompt again with `/after 10m`, and continue the loop without a user-facing status update.
+If `NO_REVIEW`: request a review (Step 6) and schedule this same prompt again with `/after 1m`. Keep polling every minute until either a new review appears or 15 minutes have elapsed; if the 15-minute polling window expires with no new review, reschedule with `/after 10m`.
 
 ## Step 3 — Check if the review is clean
 
@@ -135,7 +135,7 @@ gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 
 Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work — use `copilot-pull-request-reviewer` exactly. Do **not** post `@copilot review` — that triggers the unrelated `copilot-swe-agent[bot]` bot.
 
-If the review is not clean, schedule the next iteration with `/after 10m` and stop without a user-facing handoff.
+If the review is not clean, schedule the next iteration with `/after 1m` while you are still within the 15-minute polling window; otherwise schedule with `/after 10m`. Do not give a user-facing handoff.
 
 If the review is clean, do not schedule another run. Produce the final report only once, with this shape:
 
@@ -151,7 +151,7 @@ In the VS Code integrated terminal, run `copilot` to open the interactive CLI se
 /experimental on
 ```
 
-After that, run this prompt once and let the loop reschedule itself with `/after 10m` until Copilot reports no issues.
+After that, run this prompt once and let the loop reschedule itself with `/after 1m` while polling for up to 15 minutes, then `/after 10m` if no new review appears.
 
 ## Repo-specific notes
 

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -5,7 +5,7 @@ description: "Process the latest Copilot PR review: fix valid issues, reply to a
 
 Run one iteration of the Copilot review loop on the current PR in the GitHub Copilot CLI interactive session. From the VS Code integrated terminal, start that session with `copilot`. Experimental scheduling must be enabled first with `/experimental on` or `--experimental`.
 
-Keep the loop quiet. Accumulate a running findings ledger in the session context. Persist state to `/tmp/copilot-loop-{PR}.txt` (each `/after` invocation is stateless): line 1 is `pollingStartedAt` (ISO timestamp), line 2 is `lastProcessedReviewId`. Poll every 1 minute for up to 15 minutes, then fall back to 10 minutes. Emit the final report only when the review is clean.
+Keep the loop quiet. Polling state is persisted to `/tmp/copilot-loop-{PR}.txt` (each `/after` invocation is stateless): line 1 is `pollingStartedAt` (ISO timestamp), line 2 is `lastProcessedReviewId`. The findings ledger is only maintained within a single continuous session; emit the final report only when the review is clean. Poll every 1 minute for up to 15 minutes, then fall back to 10 minutes.
 
 ## Step 1 — Identify the PR
 
@@ -42,7 +42,7 @@ if [ ! -f /tmp/copilot-loop-{PR}.txt ]; then
 fi
 ```
 
-Schedule the next poll with `/after 1m #copilot-loop.prompt.md`. On each subsequent run, read the start time and compute elapsed minutes:
+Compute elapsed minutes since polling started:
 
 ```bash
 python3 -c "
@@ -54,7 +54,7 @@ print(int((now - then).total_seconds() / 60))
 "
 ```
 
-If ≥ 15 minutes have elapsed, reschedule with `/after 10m #copilot-loop.prompt.md` instead. Stop — do not proceed further.
+Then schedule exactly one next poll: `/after 1m #copilot-loop.prompt.md` if < 15 minutes have elapsed, `/after 10m #copilot-loop.prompt.md` if ≥ 15. Stop — do not proceed further.
 
 ## Step 3 — Check if the review is clean
 

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -5,7 +5,7 @@ description: "Process the latest Copilot PR review: fix valid issues, reply to a
 
 Run one iteration of the Copilot review loop on the current PR in the GitHub Copilot CLI interactive session. From the VS Code integrated terminal, start that session with `copilot`. Experimental scheduling must be enabled first with `/experimental on` or `--experimental`.
 
-Keep the loop quiet. Accumulate a running findings ledger in the session context. Persist `pollingStartedAt` to `/tmp/copilot-loop-{PR}.txt` (each `/after` invocation is stateless). Poll every 1 minute for up to 15 minutes, then fall back to 10 minutes. Emit the final report only when the review is clean.
+Keep the loop quiet. Accumulate a running findings ledger in the session context. Persist state to `/tmp/copilot-loop-{PR}.txt` (each `/after` invocation is stateless): line 1 is `pollingStartedAt` (ISO timestamp), line 2 is `lastProcessedReviewId`. Poll every 1 minute for up to 15 minutes, then fall back to 10 minutes. Emit the final report only when the review is clean.
 
 ## Step 1 — Identify the PR
 

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -5,7 +5,7 @@ description: "Process the latest Copilot PR review: fix valid issues, reply to a
 
 Run one iteration of the Copilot review loop on the current PR in the GitHub Copilot CLI interactive session. From the VS Code integrated terminal, start that session with `copilot`. Experimental scheduling must be enabled first with `/experimental on` or `--experimental`.
 
-Keep the loop quiet between iterations. Do not give a per-iteration handoff message to the user. Instead, accumulate a running findings ledger in the session context — include a `pollingStartedAt` field (ISO timestamp) that is set once when polling first begins and used on every subsequent iteration to determine whether the 15-minute window has elapsed. While waiting for a fresh Copilot review, poll the PR every 1 minute for up to 15 minutes by scheduling the next run with `/after 1m #copilot-loop.prompt.md`. If no new review arrives in that window, fall back to `/after 10m #copilot-loop.prompt.md`. Only when the review is clean should you produce the final report, including a markdown table of every Copilot review finding from the whole loop, whether it was fixed or refuted, and how it was handled.
+Keep the loop quiet between iterations. Do not give a per-iteration handoff message to the user. Instead, accumulate a running findings ledger in the session context — include a `pollingStartedAt` field (ISO timestamp) that is reset each time a new review is requested; on poll iterations that find no new review yet, compare the current time to `pollingStartedAt` to determine whether to use the 1m or 10m cadence. While waiting for a fresh Copilot review, poll the PR every 1 minute for up to 15 minutes by scheduling the next run with `/after 1m #copilot-loop.prompt.md`. If no new review arrives in that window, fall back to `/after 10m #copilot-loop.prompt.md`. Only when the review is clean should you produce the final report, including a markdown table of every Copilot review finding from the whole loop, whether it was fixed or refuted, and how it was handled.
 
 ## Step 1 — Identify the PR
 
@@ -25,7 +25,7 @@ for r in reviews:
         last = r
 if last:
     print(last['id'], last['submitted_at'], last['commit_id'][:8])
-    print('BODY:', last.get('body', ''))
+    print('BODY:', (last.get('body') or '').replace('\n', ' ')[:500])
 else:
     print('NO_REVIEW')
 "
@@ -136,7 +136,7 @@ gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 
 Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work — use `copilot-pull-request-reviewer` exactly. Do **not** post `@copilot review` — that triggers the unrelated `copilot-swe-agent[bot]` bot.
 
-If the review is not clean, check `pollingStartedAt` in the session findings ledger. If the current time minus `pollingStartedAt` is less than 15 minutes, schedule the next iteration with `/after 1m #copilot-loop.prompt.md`; otherwise schedule with `/after 10m #copilot-loop.prompt.md`. Do not give a user-facing handoff.
+If the review is not clean, reset `pollingStartedAt` in the session findings ledger to the current ISO timestamp (this restarts the 15-minute polling window). Then schedule the next iteration with `/after 1m #copilot-loop.prompt.md`. On subsequent poll iterations where no new review has arrived yet, compare the current time to `pollingStartedAt`; if 15 or more minutes have elapsed, use `/after 10m #copilot-loop.prompt.md` instead. Do not give a user-facing handoff.
 
 If the review is clean, do not schedule another run. Produce the final report only once, with this shape:
 

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -1,9 +1,11 @@
 ---
 agent: agent
-description: "Process the latest Copilot PR review: fix valid issues, reply to all comments, resolve threads, request a new review. Copilot does not auto-fire — re-run this prompt manually each iteration once the new review arrives."
+description: "Process the latest Copilot PR review: fix valid issues, reply to all comments, resolve threads, request a new review, and reschedule itself with /after until the review is clean."
 ---
 
-Run one iteration of the Copilot review loop on the current PR. Copilot does **not** auto-fire on push — I will manually re-run this prompt each time. At the end, request a new review and tell me when to come back.
+Run one iteration of the Copilot review loop on the current PR in the GitHub Copilot CLI interactive session. From the VS Code integrated terminal, start that session with `copilot`. Experimental scheduling must be enabled first with `/experimental on` or `--experimental`.
+
+Keep the loop quiet between iterations. Do not give a per-iteration handoff message to the user. Instead, accumulate a running findings ledger in the session context and continue rescheduling with `/after 10m` until the review is clean. Only when the review is clean should you produce the final report, including a markdown table of every Copilot review finding from the whole loop, whether it was fixed or refuted, and how it was handled.
 
 ## Step 1 — Identify the PR
 
@@ -28,7 +30,7 @@ else:
 "
 ```
 
-If `NO_REVIEW`: request a review (Step 6) and stop — tell me to re-run this prompt once the review arrives in ~10 minutes.
+If `NO_REVIEW`: request a review (Step 6), schedule this same prompt again with `/after 10m`, and continue the loop without a user-facing status update.
 
 ## Step 3 — Check if the review is clean
 
@@ -55,7 +57,7 @@ for c in reversed(comments):
 
 Clean if the body contains any of: `clean`, `no issues`, `good to merge`, `no new comments`, `all.*tests pass`.
 
-**If clean: stop. Tell me Copilot found no issues and the loop is complete.**
+If clean: stop scheduling, preserve the accumulated findings ledger, and emit the final report with a markdown table of all findings from the loop.
 
 ## Step 4 — Process each inline comment
 
@@ -73,7 +75,9 @@ For each comment:
 
 3. **If invalid/refuted:** Note the reason. No code changes.
 
-4. Commit all fixes together once all comments are processed:
+4. Add one row to the findings ledger for every comment you process. Include the review round, the finding, whether it was fixed or refuted, and how it was handled.
+
+5. Commit all fixes together once all comments are processed:
 
    ```bash
    git add <changed files>
@@ -121,7 +125,7 @@ Resolve each unresolved thread whose first comment author login contains `"copil
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{NODE_ID}"}) { thread { isResolved } } }'
 ```
 
-## Step 6 — Request review and hand back
+## Step 6 — Request review and reschedule
 
 Request a new review:
 
@@ -131,15 +135,23 @@ gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 
 Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work — use `copilot-pull-request-reviewer` exactly. Do **not** post `@copilot review` — that triggers the unrelated `copilot-swe-agent[bot]` bot.
 
-**Report back:**
+If the review is not clean, schedule the next iteration with `/after 10m` and stop without a user-facing handoff.
 
-If fixes were committed and pushed:
+If the review is clean, do not schedule another run. Produce the final report only once, with this shape:
 
-> "Done. Fixes committed as {SHA} and pushed. New review requested — re-run this prompt once the Copilot review arrives in ~10 minutes."
+| Round | Finding | Status | How handled | Evidence |
+| --- | --- | --- | --- | --- |
+| 1 | ... | fixed/refuted | ... | thread id, commit SHA, or relevant path |
 
-If all comments were refuted (no code changes):
+## How To Start
 
-> "Done. All comments refuted — no code changes. New review requested — re-run this prompt once the Copilot review arrives."
+In the VS Code integrated terminal, run `copilot` to open the interactive CLI session, then enable experimental scheduling:
+
+```copilot
+/experimental on
+```
+
+After that, run this prompt once and let the loop reschedule itself with `/after 10m` until Copilot reports no issues.
 
 ## Repo-specific notes
 

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -31,10 +31,16 @@ else:
 "
 ```
 
-If `NO_REVIEW`: request a review (Step 6). On first poll, write the current ISO timestamp to the temp file if it does not already exist:
+If `NO_REVIEW`: request a new review:
 
 ```bash
-[ -f /tmp/copilot-loop-{PR}.txt ] || date -u +%Y-%m-%dT%H:%M:%SZ > /tmp/copilot-loop-{PR}.txt
+gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
+```
+
+On first poll, initialize the temp file with the current timestamp (line 1) and a blank review ID (line 2) if it does not already exist:
+
+```bash
+[ -f /tmp/copilot-loop-{PR}.txt ] || printf "%s\n\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /tmp/copilot-loop-{PR}.txt
 ```
 
 Schedule the next poll with `/after 1m #copilot-loop.prompt.md`. On each subsequent run, read the start time and compute elapsed minutes:

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -24,8 +24,10 @@ for r in reviews:
     if 'copilot' in r.get('user', {}).get('login', ''):
         last = r
 if last:
+    body = last.get('body') or ''
     print(last['id'], last['submitted_at'], last['commit_id'][:8])
-    print('BODY:', (last.get('body') or '').replace('\n', ' ')[:500])
+    print('BODY_CLEAN:', 'generated no new comments' in body)
+    print('BODY:', body.replace('\n', ' ')[:500])
 else:
     print('NO_REVIEW')
 "
@@ -55,7 +57,7 @@ print(int((now - then).total_seconds() / 60))
 "
 ```
 
-If ≥ 15 minutes have elapsed, reschedule with `/after 10m #copilot-loop.prompt.md` instead.
+If ≥ 15 minutes have elapsed, reschedule with `/after 10m #copilot-loop.prompt.md` instead. Stop — do not proceed further.
 
 ## Step 3 — Check if the review is clean
 
@@ -75,7 +77,7 @@ If the output equals `{REVIEW_ID}`, a new review has not yet arrived. Read line 
 gh api "repos/{owner}/{repo}/pulls/{PR}/reviews/{REVIEW_ID}/comments"
 ```
 
-Clean if the array is empty or the `BODY:` line printed in Step 2 contains "generated no new comments".
+Clean if the array is empty or `BODY_CLEAN: True` was printed in Step 2.
 
 **Check 2 — latest `copilot-swe-agent[bot]` issue comment:**
 

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -5,7 +5,7 @@ description: "Process the latest Copilot PR review: fix valid issues, reply to a
 
 Run one iteration of the Copilot review loop on the current PR in the GitHub Copilot CLI interactive session. From the VS Code integrated terminal, start that session with `copilot`. Experimental scheduling must be enabled first with `/experimental on` or `--experimental`.
 
-Keep the loop quiet. Polling state is persisted to `/tmp/copilot-loop-{PR}.txt` (each `/after` invocation is stateless): line 1 is `pollingStartedAt` (ISO timestamp), line 2 is `lastProcessedReviewId`. The findings ledger is only maintained within a single continuous session; emit the final report only when the review is clean. Poll every 1 minute for up to 15 minutes, then fall back to 10 minutes.
+Keep the loop quiet. Each `/after` invocation runs in a fresh stateless context — only `/tmp/copilot-loop-{PR}.txt` persists across runs (line 1: `pollingStartedAt` ISO timestamp; line 2: `lastProcessedReviewId`). The findings ledger lives in session memory and is lost between invocations; rebuild it from git log if needed. Emit the final report only when the review is clean. Poll every 1 minute for up to 15 minutes, then fall back to 10 minutes.
 
 ## Step 1 — Identify the PR
 

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -33,16 +33,13 @@ else:
 "
 ```
 
-If `NO_REVIEW`: request a new review:
+If `NO_REVIEW`: on the first poll (temp file does not yet exist), request a review and initialize the temp file:
 
 ```bash
-gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
-```
-
-On first poll, initialize the temp file with the current timestamp (line 1) and a blank review ID (line 2) if it does not already exist:
-
-```bash
-[ -f /tmp/copilot-loop-{PR}.txt ] || printf "%s\n\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /tmp/copilot-loop-{PR}.txt
+if [ ! -f /tmp/copilot-loop-{PR}.txt ]; then
+  gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
+  printf "%s\n\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /tmp/copilot-loop-{PR}.txt
+fi
 ```
 
 Schedule the next poll with `/after 1m #copilot-loop.prompt.md`. On each subsequent run, read the start time and compute elapsed minutes:

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -5,7 +5,7 @@ description: "Process the latest Copilot PR review: fix valid issues, reply to a
 
 Run one iteration of the Copilot review loop on the current PR in the GitHub Copilot CLI interactive session. From the VS Code integrated terminal, start that session with `copilot`. Experimental scheduling must be enabled first with `/experimental on` or `--experimental`.
 
-Keep the loop quiet between iterations. Do not give a per-iteration handoff message to the user. Instead, accumulate a running findings ledger in the session context. While waiting for a fresh Copilot review, poll the PR every 1 minute for up to 15 minutes using `/after 1m`. If no new review arrives in that window, fall back to `/after 10m`. Only when the review is clean should you produce the final report, including a markdown table of every Copilot review finding from the whole loop, whether it was fixed or refuted, and how it was handled.
+Keep the loop quiet between iterations. Do not give a per-iteration handoff message to the user. Instead, accumulate a running findings ledger in the session context. While waiting for a fresh Copilot review, poll the PR every 1 minute for up to 15 minutes by scheduling the next run with `/after 1m #copilot-loop.prompt.md`. If no new review arrives in that window, fall back to `/after 10m #copilot-loop.prompt.md`. Only when the review is clean should you produce the final report, including a markdown table of every Copilot review finding from the whole loop, whether it was fixed or refuted, and how it was handled.
 
 ## Step 1 — Identify the PR
 
@@ -30,7 +30,7 @@ else:
 "
 ```
 
-If `NO_REVIEW`: request a review (Step 6) and schedule this same prompt again with `/after 1m`. Keep polling every minute until either a new review appears or 15 minutes have elapsed; if the 15-minute polling window expires with no new review, reschedule with `/after 10m`.
+If `NO_REVIEW`: request a review (Step 6) and schedule this same prompt again with `/after 1m #copilot-loop.prompt.md`. Keep polling every minute until either a new review appears or 15 minutes have elapsed; if the 15-minute polling window expires with no new review, reschedule with `/after 10m #copilot-loop.prompt.md`.
 
 ## Step 3 — Check if the review is clean
 
@@ -135,7 +135,7 @@ gh pr edit {PR} --add-reviewer copilot-pull-request-reviewer
 
 Note: `gh pr edit --add-reviewer copilot` and `gh pr edit --add-reviewer github-copilot` do not work — use `copilot-pull-request-reviewer` exactly. Do **not** post `@copilot review` — that triggers the unrelated `copilot-swe-agent[bot]` bot.
 
-If the review is not clean, schedule the next iteration with `/after 1m` while you are still within the 15-minute polling window; otherwise schedule with `/after 10m`. Do not give a user-facing handoff.
+If the review is not clean, schedule the next iteration with `/after 1m #copilot-loop.prompt.md` while you are still within the 15-minute polling window; otherwise schedule with `/after 10m #copilot-loop.prompt.md`. Do not give a user-facing handoff.
 
 If the review is clean, do not schedule another run. Produce the final report only once, with this shape:
 
@@ -151,7 +151,7 @@ In the VS Code integrated terminal, run `copilot` to open the interactive CLI se
 /experimental on
 ```
 
-After that, run this prompt once and let the loop reschedule itself with `/after 1m` while polling for up to 15 minutes, then `/after 10m` if no new review appears.
+After that, run this prompt once and let the loop reschedule itself with `/after 1m #copilot-loop.prompt.md` while polling for up to 15 minutes, then `/after 10m #copilot-loop.prompt.md` if no new review appears.
 
 ## Repo-specific notes
 


### PR DESCRIPTION
## Context
This updates the Copilot review loop prompt so it can run fully autonomously in the GitHub Copilot CLI interactive session using `manage_schedule`, keeping rescheduling itself until the Copilot review comes back clean.

## This PR
- Rewrites the CLI loop (`.claude/commands/copilot-loop.md`) to carry poll state (PR number, iteration count, last processed review ID) forward in the scheduled prompt string rather than SQL — no external storage needed. `/copilot-loop 643` still works as the manual entry point.
- Adds `lastReviewId` tracking so the loop detects when a new review has actually arrived instead of re-processing the previous one
- Polls every 1 minute for up to 15 iterations, then falls back to 10-minute cadence, using the `iteration` counter rather than elapsed-time arithmetic
- Adds `lastProcessedReviewId` tracking to the VS Code prompt version's temp file (`.github/prompts/copilot-loop.prompt.md`) for the same reason
- Fixes elapsed-time computation in the VS Code prompt version to use portable Python instead of GNU `date -d` (unavailable on macOS)
- Review body is now printed in Step 1 so the body-based clean condition can be evaluated in both versions

## Subsequent Work
None — the VS Code prompt version remains as a reference implementation for when the `/experimental` flag becomes available.