### PR TITLE
chore: deployment lifecycle cleanup

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -95,23 +95,13 @@ jobs:
           SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
           TOKEN_ENCRYPTION_SECRET: ${{ secrets.TOKEN_ENCRYPTION_SECRET }}
 
-      - name: Resolve deployment URL
-        id: deployment-url
-        env:
-          WRANGLER_OUTPUT: ${{ steps.deploy.outputs.command-output }}
-        run: |
-          url=$(printf '%s' "$WRANGLER_OUTPUT" \
-            | grep -oE 'https://[a-z0-9.-]+\.workers\.dev' \
-            | head -1)
-          echo "url=$url" >> "$GITHUB_OUTPUT"
-
       - name: Update GitHub deployment
         id: update_deployment
         uses: chrnorm/deployment-action@v2
         with:
           token: ${{ secrets.DEPLOY_TOKEN }}
           environment: ${{ github.event.workflow_run.head_branch == 'main' && 'api-production' || 'api-staging' }}
-          environment-url: ${{ steps.deployment-url.outputs.url }}
+          environment-url: ${{ steps.deploy.outputs.deployment-url }}
           initial-status: success
           auto-inactive: true
           transient-environment: ${{ github.event.workflow_run.head_branch != 'main' }}

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -100,6 +100,7 @@ jobs:
         uses: chrnorm/deployment-action@v2
         with:
           token: ${{ secrets.DEPLOY_TOKEN }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           environment: ${{ github.event.workflow_run.head_branch == 'main' && 'api-production' || 'api-staging' }}
           environment-url: ${{ steps.deploy.outputs.deployment-url }}
           initial-status: success

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,5 +1,9 @@
 name: Deploy API
 
+permissions:
+  contents: read
+  deployments: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -7,6 +11,11 @@ on:
         description: "Debug the event payload"
         required: false
         type: boolean
+      cleanup_old_deployments:
+        description: "Delete stale API deployments, including legacy Staging"
+        required: false
+        type: boolean
+        default: false
   workflow_run:
     workflows: [Typecheck]
     types: [completed]
@@ -86,6 +95,27 @@ jobs:
           SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
           TOKEN_ENCRYPTION_SECRET: ${{ secrets.TOKEN_ENCRYPTION_SECRET }}
 
+      - name: Resolve deployment URL
+        id: deployment-url
+        env:
+          WRANGLER_OUTPUT: ${{ steps.deploy.outputs.command-output }}
+        run: |
+          url=$(printf '%s' "$WRANGLER_OUTPUT" \
+            | grep -oE 'https://[a-z0-9.-]+\.workers\.dev' \
+            | head -1)
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Update GitHub deployment
+        id: update_deployment
+        uses: chrnorm/deployment-action@v2
+        with:
+          token: ${{ secrets.DEPLOY_TOKEN }}
+          environment: ${{ github.event.workflow_run.head_branch == 'main' && 'api-production' || 'api-staging' }}
+          environment-url: ${{ steps.deployment-url.outputs.url }}
+          initial-status: success
+          auto-inactive: true
+          transient-environment: ${{ github.event.workflow_run.head_branch != 'main' }}
+
       - name: Set output directories
         run: |
           echo "WRANGLER_BUILD_DIR=api/.wrangler/build" >> $GITHUB_ENV
@@ -116,3 +146,81 @@ jobs:
     steps:
       - run: echo 'The triggering workflow failed'
       - run: exit 1
+
+  cleanup-old-deployments:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && inputs.cleanup_old_deployments == true
+    steps:
+      - name: Delete stale API deployments
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DEPLOY_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const deployments = await github.paginate(github.rest.repos.listDeployments, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const byEnvironment = new Map();
+            for (const deployment of deployments) {
+              const list = byEnvironment.get(deployment.environment) ?? [];
+              list.push(deployment);
+              byEnvironment.set(deployment.environment, list);
+            }
+
+            const shouldDeactivate = (environment, index) => {
+              if (environment === "api-production" || environment === "api-staging") {
+                return index > 0;
+              }
+
+              // Legacy environments from earlier API workflow naming.
+              if (environment === "staging") {
+                return index > 0;
+              }
+
+              // Older legacy environment name.
+              if (environment === "Staging") {
+                return true;
+              }
+
+              return false;
+            };
+
+            let deletedCount = 0;
+
+            for (const [environment, envDeployments] of byEnvironment.entries()) {
+              envDeployments.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
+
+              for (let index = 0; index < envDeployments.length; index += 1) {
+                const deployment = envDeployments[index];
+                if (!shouldDeactivate(environment, index)) {
+                  continue;
+                }
+
+                try {
+                  await github.rest.repos.createDeploymentStatus({
+                    owner,
+                    repo,
+                    deployment_id: deployment.id,
+                    state: "inactive",
+                    description: "Stale deployment cleanup",
+                    auto_inactive: false,
+                  });
+
+                  await github.rest.repos.deleteDeployment({
+                    owner,
+                    repo,
+                    deployment_id: deployment.id,
+                  });
+
+                  deletedCount += 1;
+                } catch (error) {
+                  const message = error instanceof Error ? error.message : String(error);
+                  core.warning(`Failed to delete deployment ${deployment.id}: ${message}`);
+                }
+              }
+            }
+
+            core.notice(`Deleted ${deletedCount} stale API deployments.`);

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -177,7 +177,7 @@ jobs:
 
               // Legacy environments from earlier API workflow naming.
               if (environment === "staging") {
-                return index > 0;
+                return true;
               }
 
               // Older legacy environment name.

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Set up Node.js

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -137,6 +137,9 @@ jobs:
           github-token: ${{ secrets.DEPLOY_TOKEN }}
           script: |
             const environment = process.env.PREVIEW_ENVIRONMENT;
+            if (!environment?.startsWith("pages-preview-pr-")) {
+              throw new Error(`Unexpected preview environment: ${environment ?? "<missing>"}`);
+            }
             const { owner, repo } = context.repo;
             const deployments = await github.paginate(github.rest.repos.listDeployments, {
               owner,

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,16 +1,33 @@
 name: Deploy Pages
 
+permissions:
+  contents: read
+  deployments: write
+
 on:
+  workflow_dispatch:
+    inputs:
+      cleanup_old_deployments:
+        description: "Delete stale Pages preview deployments"
+        required: false
+        type: boolean
+        default: false
   push:
     branches:
       - main
   pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
     branches:
       - main
 
 jobs:
   deploy:
     name: Deploy
+    if: github.event_name == 'push' || (github.event_name == 'pull_request_target' && github.event.action != 'closed')
     runs-on: ubuntu-latest
 
     steps:
@@ -98,8 +115,138 @@ jobs:
         id: update_deployment
         uses: chrnorm/deployment-action@v2
         with:
-          token: "${{ secrets.DEPLOY_TOKEN }}"
-          environment: ${{ github.event_name == 'push' && 'production' || 'preview' }}
+          token: ${{ secrets.DEPLOY_TOKEN }}
+          environment: ${{ github.event_name == 'push' && 'pages-production' || format('pages-preview-pr-{0}', github.event.number) }}
           environment-url: ${{ steps.deploy-production.outputs.deployment-url || steps.preview-url.outputs.url }}
           initial-status: success
+          auto-inactive: true
           transient-environment: ${{ github.event_name != 'push' }}
+
+  close-preview-deployment:
+    name: Close preview deployment
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Delete PR preview deployments
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_ENVIRONMENT: ${{ format('pages-preview-pr-{0}', github.event.number) }}
+        with:
+          github-token: ${{ secrets.DEPLOY_TOKEN }}
+          script: |
+            const environment = process.env.PREVIEW_ENVIRONMENT;
+            const { owner, repo } = context.repo;
+            const deployments = await github.paginate(github.rest.repos.listDeployments, {
+              owner,
+              repo,
+              environment,
+              per_page: 100,
+            });
+
+            core.info(`Found ${deployments.length} deployments in ${environment}`);
+
+            for (const deployment of deployments) {
+              try {
+                await github.rest.repos.createDeploymentStatus({
+                  owner,
+                  repo,
+                  deployment_id: deployment.id,
+                  state: "inactive",
+                  description: "PR closed",
+                  auto_inactive: false,
+                });
+
+                await github.rest.repos.deleteDeployment({
+                  owner,
+                  repo,
+                  deployment_id: deployment.id,
+                });
+              } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                core.warning(`Failed to delete deployment ${deployment.id}: ${message}`);
+              }
+            }
+
+  cleanup-old-deployments:
+    name: Cleanup stale deployments
+    if: github.event_name == 'workflow_dispatch' && inputs.cleanup_old_deployments == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Delete stale preview deployments
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DEPLOY_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const deployments = await github.paginate(github.rest.repos.listDeployments, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const byEnvironment = new Map();
+            for (const deployment of deployments) {
+              const list = byEnvironment.get(deployment.environment) ?? [];
+              list.push(deployment);
+              byEnvironment.set(deployment.environment, list);
+            }
+
+            const shouldDeactivate = (environment, index) => {
+              if (environment === "pages-production") {
+                return index > 0;
+              }
+
+              if (environment.startsWith("pages-preview-pr-")) {
+                return true;
+              }
+
+              // Legacy environments from the previous workflow naming.
+              if (environment === "production") {
+                return index > 0;
+              }
+
+              if (environment === "preview") {
+                return true;
+              }
+
+              return false;
+            };
+
+            let deletedCount = 0;
+
+            for (const [environment, envDeployments] of byEnvironment.entries()) {
+              envDeployments.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
+
+              for (let index = 0; index < envDeployments.length; index += 1) {
+                const deployment = envDeployments[index];
+                if (!shouldDeactivate(environment, index)) {
+                  continue;
+                }
+
+                try {
+                  await github.rest.repos.createDeploymentStatus({
+                    owner,
+                    repo,
+                    deployment_id: deployment.id,
+                    state: "inactive",
+                    description: "Stale deployment cleanup",
+                    auto_inactive: false,
+                  });
+
+                  await github.rest.repos.deleteDeployment({
+                    owner,
+                    repo,
+                    deployment_id: deployment.id,
+                  });
+
+                  deletedCount += 1;
+                } catch (error) {
+                  const message = error instanceof Error ? error.message : String(error);
+                  core.warning(`Failed to delete deployment ${deployment.id}: ${message}`);
+                }
+              }
+            }
+
+            core.notice(`Deleted ${deletedCount} stale deployments.`);

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -204,7 +204,7 @@ jobs:
 
               // Legacy environments from the previous workflow naming.
               if (environment === "production") {
-                return index > 0;
+                return true;
               }
 
               if (environment === "preview") {

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -199,7 +199,7 @@ jobs:
               }
 
               if (environment.startsWith("pages-preview-pr-")) {
-                return true;
+                return index > 0;
               }
 
               // Legacy environments from the previous workflow naming.

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Delete stale preview deployments
+      - name: Delete stale Pages deployments
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       cleanup_old_deployments:
-        description: "Delete stale Pages preview deployments"
+        description: "Delete stale Pages deployments (preview, legacy, and old production)"
         required: false
         type: boolean
         default: false
@@ -116,6 +116,7 @@ jobs:
         uses: chrnorm/deployment-action@v2
         with:
           token: ${{ secrets.DEPLOY_TOKEN }}
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
           environment: ${{ github.event_name == 'push' && 'pages-production' || format('pages-preview-pr-{0}', github.event.number) }}
           environment-url: ${{ steps.deploy-production.outputs.deployment-url || steps.preview-url.outputs.url }}
           initial-status: success


### PR DESCRIPTION
## Context
The repository had accumulated a large number of stale deployment records from preview and historical environment naming, making Deployments difficult to trust as a current signal.

This change tightens lifecycle behavior so deployment records better reflect what is actually active, with explicit handling for preview lifecycle events and compatibility with the dedicated deployment token/account setup.

## This PR
- updates the Pages deployment workflow to:
  - scope preview deployments per PR environment name
  - auto-inactivate superseded deployments on new deployment events
  - handle PR close by inactivating and deleting preview deployments for that PR
  - provide workflow-dispatch cleanup logic to delete stale preview/legacy records
- updates the API deployment workflow to:
  - publish deployment records under explicit API environment names
  - auto-inactivate superseded deployments
  - provide workflow-dispatch cleanup logic that also removes legacy `Staging` records
- keeps deployment status updates using the deployment token secret (third-party deployment account path)

## Subsequent Work
- merge this PR so the lifecycle behavior becomes authoritative on main
- optionally run one manual workflow-dispatch cleanup after merge to reconcile any newly-created legacy records during transition
