### PR TITLE
fix: restore live viewer updates and highlight hydration

### DIFF
--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -153,7 +153,7 @@ describe("useIndividualTrackerViewer", () => {
     expect(getMatchStatsSpy).not.toHaveBeenCalled();
   });
 
-  it("treats the public viewer path as connected after the initial view loads", async () => {
+  it("connects the public viewer path after the initial view loads", async () => {
     const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
       view: aFakeTrackerViewStateWith({ trackerId: "tracker-1", status: "active" }),
     });
@@ -172,10 +172,62 @@ describe("useIndividualTrackerViewer", () => {
 
     await waitFor(() => {
       expect(result.current.snapshot.status).toBe(ComponentLoaderStatus.LOADED);
-      expect(result.current.snapshot.connectionStatus).toBe("connected");
     });
 
-    expect(connectSpy).not.toHaveBeenCalled();
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("hydrates stats highlights after websocket updates", async () => {
+    const firstView = aFakeTrackerViewStateWith({
+      trackerId: "tracker-1",
+      status: "active",
+      statsHighlights: [{ label: "KDA", value: "2.1" }],
+    });
+    const secondView = aFakeTrackerViewStateWith({
+      trackerId: "tracker-1",
+      status: "active",
+      statsHighlights: [{ label: "KDA", value: "3.4" }],
+    });
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({ view: firstView });
+    const getViewSpy = vi
+      .spyOn(individualTrackerViewService, "getView")
+      .mockResolvedValueOnce({ view: firstView })
+      .mockResolvedValueOnce({ view: secondView });
+    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+
+    const { result } = renderHook(() =>
+      useIndividualTrackerViewer({
+        individualTrackerViewService,
+        matchAnalyticsService,
+        seriesMatchesService,
+        haloClient,
+        trackerId: "tracker-1",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.snapshot.status).toBe(ComponentLoaderStatus.LOADED);
+      expect(result.current.model.renderModel?.statsHighlights?.[0]?.value).toBe("2.1");
+      expect(individualTrackerViewService.lastConnection).not.toBeNull();
+    });
+
+    act(() => {
+      individualTrackerViewService.lastConnection?.emitView(
+        aFakeTrackerLiveViewWith({
+          trackerId: "tracker-1",
+          status: "active",
+          matches: [
+            aFakeTrackerMatchSummaryWith({ matchId: "match-1" }),
+            aFakeTrackerMatchSummaryWith({ matchId: "match-2" }),
+          ],
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(getViewSpy).toHaveBeenCalledTimes(2);
+      expect(result.current.model.renderModel?.statsHighlights?.[0]?.value).toBe("3.4");
+    });
   });
 
   it("loads long series in a single request when a series entry expands", async () => {

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -230,6 +230,131 @@ describe("useIndividualTrackerViewer", () => {
     });
   });
 
+  it("does not enqueue another hydration request after dispose", async () => {
+    const firstView = aFakeTrackerViewStateWith({
+      trackerId: "tracker-1",
+      status: "active",
+      statsHighlights: [{ label: "KDA", value: "2.1" }],
+    });
+    const hydratedView = aFakeTrackerViewStateWith({
+      trackerId: "tracker-1",
+      status: "active",
+      statsHighlights: [{ label: "KDA", value: "3.4" }],
+    });
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({ view: firstView });
+    let resolveHydration:
+      | ((value: { readonly view: ReturnType<typeof aFakeTrackerViewStateWith> }) => void)
+      | undefined;
+    const hydrationPromise = new Promise<{ readonly view: ReturnType<typeof aFakeTrackerViewStateWith> }>((resolve) => {
+      resolveHydration = resolve;
+    });
+    const getViewSpy = vi
+      .spyOn(individualTrackerViewService, "getView")
+      .mockResolvedValueOnce({ view: firstView })
+      .mockImplementationOnce(async () => hydrationPromise)
+      .mockImplementation(async () => Promise.reject(new Error("Hydration should not run after dispose")));
+    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+
+    const { result, unmount } = renderHook(() =>
+      useIndividualTrackerViewer({
+        individualTrackerViewService,
+        matchAnalyticsService,
+        seriesMatchesService,
+        haloClient,
+        trackerId: "tracker-1",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.snapshot.status).toBe(ComponentLoaderStatus.LOADED);
+      expect(individualTrackerViewService.lastConnection).not.toBeNull();
+    });
+
+    act(() => {
+      individualTrackerViewService.lastConnection?.emitView(
+        aFakeTrackerLiveViewWith({ trackerId: "tracker-1", status: "active" }),
+      );
+      individualTrackerViewService.lastConnection?.emitView(
+        aFakeTrackerLiveViewWith({ trackerId: "tracker-1", status: "active" }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(getViewSpy).toHaveBeenCalledTimes(2);
+    });
+
+    unmount();
+
+    expect(resolveHydration).toBeDefined();
+    await act(async () => {
+      resolveHydration?.({ view: hydratedView });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(getViewSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("preserves server streamer settings when hydration omits streamerSettings", async () => {
+    const serverSettings: StreamerViewSettings = {
+      styleFlags: {
+        colorMode: "observer",
+      },
+    };
+    const localSettings: StreamerViewSettings = {
+      styleFlags: {
+        colorMode: "player",
+      },
+    };
+    const firstView = {
+      ...aFakeTrackerViewStateWith({
+        trackerId: "tracker-1",
+        status: "active",
+      }),
+      streamerSettings: serverSettings,
+    };
+    const hydratedViewWithoutSettings = aFakeTrackerViewStateWith({
+      trackerId: "tracker-1",
+      status: "active",
+      statsHighlights: [{ label: "KDA", value: "3.4" }],
+    });
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({ view: firstView });
+    const getViewSpy = vi
+      .spyOn(individualTrackerViewService, "getView")
+      .mockResolvedValueOnce({ view: firstView })
+      .mockResolvedValueOnce({ view: hydratedViewWithoutSettings });
+    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+
+    const { result } = renderHook(() =>
+      useIndividualTrackerViewer({
+        individualTrackerViewService,
+        matchAnalyticsService,
+        seriesMatchesService,
+        haloClient,
+        trackerId: "tracker-1",
+        streamerSettings: localSettings,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.snapshot.status).toBe(ComponentLoaderStatus.LOADED);
+      expect(result.current.model.streamerSettings?.styleFlags?.colorMode).toBe("observer");
+      expect(individualTrackerViewService.lastConnection).not.toBeNull();
+    });
+
+    act(() => {
+      individualTrackerViewService.lastConnection?.emitView(
+        aFakeTrackerLiveViewWith({ trackerId: "tracker-1", status: "active" }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(getViewSpy).toHaveBeenCalledTimes(2);
+      expect(result.current.model.streamerSettings?.styleFlags?.colorMode).toBe("observer");
+    });
+  });
+
   it("loads long series in a single request when a series entry expands", async () => {
     const matchIds = Array.from({ length: 13 }, (_, index) => `m-${(index + 1).toString()}`);
     const matches = matchIds.map((matchId) => aFakeTrackerMatchSummaryWith({ matchId }));

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -220,6 +220,8 @@ export class IndividualTrackerViewerPresenter {
   private viewSubscription: TrackerViewSubscription | null = null;
   private statusSubscription: TrackerViewSubscription | null = null;
   private awaitingRefresh = false;
+  private isHydratingEnrichedView = false;
+  private hydrateQueued = false;
   private streamerSettings: StreamerViewSettings | undefined;
   private streamerSettingsKey = "null";
   private hasServerStreamerSettings = false;
@@ -522,17 +524,57 @@ export class IndividualTrackerViewerPresenter {
     }
   }
 
+  private queueEnrichedViewHydration(): void {
+    if (this.isHydratingEnrichedView) {
+      this.hydrateQueued = true;
+      return;
+    }
+
+    void this.hydrateEnrichedViewAsync();
+  }
+
+  private async hydrateEnrichedViewAsync(): Promise<void> {
+    this.isHydratingEnrichedView = true;
+    try {
+      const response = await this.config.individualTrackerViewService.getView(this.config.trackerId);
+      if (this.isDisposed) {
+        return;
+      }
+
+      this.hasServerStreamerSettings = response.view.streamerSettings !== undefined;
+
+      const snapshot = this.config.store.getSnapshot();
+      if (snapshot.view == null) {
+        return;
+      }
+
+      const streamerSettings =
+        response.view.streamerSettings === undefined && this.streamerSettings !== undefined && !this.hasServerStreamerSettings
+          ? this.streamerSettings
+          : response.view.streamerSettings;
+
+      this.config.store.setLoaded({
+        ...snapshot.view,
+        isLive: response.view.isLive,
+        streamerSettings,
+        statsHighlights: response.view.statsHighlights,
+        preSeriesPlayerInfo: response.view.preSeriesPlayerInfo,
+      });
+    } catch {
+      // Hydration failures should not interrupt live timeline updates.
+    } finally {
+      this.isHydratingEnrichedView = false;
+      if (this.hydrateQueued) {
+        this.hydrateQueued = false;
+        void this.hydrateEnrichedViewAsync();
+      }
+    }
+  }
+
   private openConnection(): void {
     this.viewSubscription?.unsubscribe();
     this.statusSubscription?.unsubscribe();
     this.connection?.disconnect();
-
-    // Only establish individual-tracker WS connection in managed context (when individualTrackerService is available).
-    // Public pages (follow viewer) should not connect to per-tracker endpoints.
-    if (this.config.individualTrackerService == null) {
-      this.config.store.setConnectionStatus("connected");
-      return;
-    }
 
     const connection = this.config.individualTrackerViewService.connect(this.config.trackerId);
     this.connection = connection;
@@ -545,6 +587,8 @@ export class IndividualTrackerViewerPresenter {
         this.awaitingRefresh = false;
         this.config.store.setRefreshState(false);
       }
+
+      this.queueEnrichedViewHydration();
     });
     this.statusSubscription = connection.subscribeStatus((status) => {
       if (this.isDisposed) {

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -475,6 +475,7 @@ export class IndividualTrackerViewerPresenter {
   public dispose(): void {
     this.isDisposed = true;
     this.awaitingRefresh = false;
+    this.hydrateQueued = false;
     this.viewSubscription?.unsubscribe();
     this.viewSubscription = null;
     this.statusSubscription?.unsubscribe();
@@ -525,6 +526,10 @@ export class IndividualTrackerViewerPresenter {
   }
 
   private queueEnrichedViewHydration(): void {
+    if (this.isDisposed) {
+      return;
+    }
+
     if (this.isHydratingEnrichedView) {
       this.hydrateQueued = true;
       return;
@@ -541,19 +546,19 @@ export class IndividualTrackerViewerPresenter {
         return;
       }
 
-      this.hasServerStreamerSettings = response.view.streamerSettings !== undefined;
-
       const snapshot = this.config.store.getSnapshot();
       if (snapshot.view == null) {
         return;
       }
+
+      this.hasServerStreamerSettings ||= response.view.streamerSettings !== undefined;
 
       const streamerSettings =
         response.view.streamerSettings === undefined &&
         this.streamerSettings !== undefined &&
         !this.hasServerStreamerSettings
           ? this.streamerSettings
-          : response.view.streamerSettings;
+          : (response.view.streamerSettings ?? snapshot.view.streamerSettings);
 
       this.config.store.setLoaded({
         ...snapshot.view,
@@ -566,7 +571,7 @@ export class IndividualTrackerViewerPresenter {
       // Hydration failures should not interrupt live timeline updates.
     } finally {
       this.isHydratingEnrichedView = false;
-      if (this.hydrateQueued) {
+      if (this.hydrateQueued && !this.isDisposed) {
         this.hydrateQueued = false;
         void this.hydrateEnrichedViewAsync();
       }

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -549,7 +549,9 @@ export class IndividualTrackerViewerPresenter {
       }
 
       const streamerSettings =
-        response.view.streamerSettings === undefined && this.streamerSettings !== undefined && !this.hasServerStreamerSettings
+        response.view.streamerSettings === undefined &&
+        this.streamerSettings !== undefined &&
+        !this.hasServerStreamerSettings
           ? this.streamerSettings
           : response.view.streamerSettings;
 


### PR DESCRIPTION
## Context
The frontend was receiving live tracker websocket updates, but two viewer surfaces were not reflecting those updates correctly.

In public/follow contexts, the individual tracker viewer path did not establish the tracker websocket connection, so new matches did not propagate into the rendered list/components. Separately, stats highlights were enriched fields loaded from the view endpoint and remained stale after live websocket messages.

## This PR
- updates [pages/src/components/individual-tracker/viewer/viewer-presenter.ts](pages/src/components/individual-tracker/viewer/viewer-presenter.ts) to:
  - always establish the tracker websocket connection in viewer contexts (including public/follow)
  - keep immediate live timeline updates from websocket messages
  - enqueue a guarded enriched-view hydration after websocket updates so `statsHighlights` and `preSeriesPlayerInfo` stay current
  - preserve existing managed-only refresh behavior for explicit refresh actions
- updates [pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts](pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts) to:
  - assert the public viewer path connects
  - add regression coverage for stats highlight hydration after websocket updates

## Subsequent Work
- monitor follow viewer and overlay behavior in production for hydration frequency and tune if needed
- if future load patterns require it, consider expanding websocket payloads to include enriched fields and remove hydrate follow-up calls
