### PR TITLE
chore: align deployment environments with production vars

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           token: ${{ secrets.DEPLOY_TOKEN }}
           ref: ${{ github.event.workflow_run.head_sha }}
-          environment: ${{ github.event.workflow_run.head_branch == 'main' && 'api-production' || 'api-staging' }}
+          environment: ${{ github.event.workflow_run.head_branch == 'main' && 'Production' || 'api-staging' }}
           environment-url: ${{ steps.deploy.outputs.deployment-url }}
           initial-status: success
           auto-inactive: true
@@ -162,8 +162,13 @@ jobs:
             }
 
             const shouldDeactivate = (environment, index) => {
-              if (environment === "api-production" || environment === "api-staging") {
+              if (environment === "Production" || environment === "api-staging") {
                 return index > 0;
+              }
+
+              // Legacy API production naming.
+              if (environment === "api-production") {
+                return true;
               }
 
               // Legacy environments from earlier API workflow naming.

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           token: ${{ secrets.DEPLOY_TOKEN }}
           ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
-          environment: ${{ github.event_name == 'push' && 'pages-production' || format('pages-preview-pr-{0}', github.event.number) }}
+          environment: ${{ github.event_name == 'push' && 'pages-production' || 'preview' }}
           environment-url: ${{ steps.deploy-production.outputs.deployment-url || steps.preview-url.outputs.url }}
           initial-status: success
           auto-inactive: true
@@ -132,23 +132,39 @@ jobs:
       - name: Delete PR preview deployments
         uses: actions/github-script@v7
         env:
-          PREVIEW_ENVIRONMENT: ${{ format('pages-preview-pr-{0}', github.event.number) }}
+          PREVIEW_ENVIRONMENT: preview
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         with:
           github-token: ${{ secrets.DEPLOY_TOKEN }}
           script: |
             const environment = process.env.PREVIEW_ENVIRONMENT;
-            if (!environment?.startsWith("pages-preview-pr-")) {
+            if (environment !== "preview") {
               throw new Error(`Unexpected preview environment: ${environment ?? "<missing>"}`);
             }
+            const prHeadSha = process.env.PR_HEAD_SHA;
+            const prHeadRef = process.env.PR_HEAD_REF;
             const { owner, repo } = context.repo;
-            const deployments = await github.paginate(github.rest.repos.listDeployments, {
+            const allDeployments = await github.paginate(github.rest.repos.listDeployments, {
               owner,
               repo,
               environment,
               per_page: 100,
             });
 
-            core.info(`Found ${deployments.length} deployments in ${environment}`);
+            // Only delete preview deployments that belong to this PR branch/SHA.
+            const deployments = allDeployments.filter((deployment) => {
+              const deploymentRef = deployment.ref ?? "";
+              return (
+                deployment.sha === prHeadSha ||
+                deploymentRef === prHeadRef ||
+                deploymentRef === `refs/heads/${prHeadRef}`
+              );
+            });
+
+            core.info(
+              `Found ${deployments.length} matching preview deployments for ref ${prHeadRef} (${prHeadSha})`,
+            );
 
             for (const deployment of deployments) {
               try {
@@ -212,7 +228,7 @@ jobs:
               }
 
               if (environment === "preview") {
-                return true;
+                return index > 0;
               }
 
               return false;

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           token: ${{ secrets.DEPLOY_TOKEN }}
           ref: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
-          environment: ${{ github.event_name == 'push' && 'pages-production' || 'preview' }}
+          environment: ${{ github.event_name == 'push' && 'Production-Pages' || 'preview' }}
           environment-url: ${{ steps.deploy-production.outputs.deployment-url || steps.preview-url.outputs.url }}
           initial-status: success
           auto-inactive: true
@@ -214,8 +214,13 @@ jobs:
             }
 
             const shouldDeactivate = (environment, index) => {
-              if (environment === "pages-production") {
+              if (environment === "Production-Pages") {
                 return index > 0;
+              }
+
+              // Legacy Pages production naming.
+              if (environment === "pages-production") {
+                return true;
               }
 
               if (environment.startsWith("pages-preview-pr-")) {


### PR DESCRIPTION
## Context
Deployment records were recently normalized, but the environment names now need to align with production variable expectations and naming conventions used by your GitHub deployment setup.

In particular, API production should map back to `Production`, while Pages production should use `Production-Pages`, and cleanup logic should continue handling both current and legacy names safely.

## This PR
- updates [.github/workflows/deploy-api.yml](.github/workflows/deploy-api.yml) to:
  - set API production deployment environment to `Production`
  - keep non-main API deployment environment as `api-staging`
  - treat legacy `api-production` as stale during cleanup
- updates [.github/workflows/deploy-pages.yml](.github/workflows/deploy-pages.yml) to:
  - set Pages production deployment environment to `Production-Pages`
  - keep PR deployments in shared `preview`
  - treat legacy `pages-production` as stale during cleanup
- preserves existing inactivate-then-delete behavior in cleanup flows

## Subsequent Work
- merge this PR so environment naming matches your variable setup on future deployments
- optionally trigger one manual cleanup workflow run after merge to remove any leftover legacy `api-production`/`pages-production` records
