### PR TITLE
fix: ship enriched individual-tracker websocket payloads

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -2079,10 +2079,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     );
     try {
       const initialMessage = trackerState != null ? await this.viewMessage(trackerState) : undefined;
-      const response = this.webSocketAdapter.upgrade(
-        this.state,
-        initialMessage,
-      );
+      const response = this.webSocketAdapter.upgrade(this.state, initialMessage);
       this.logService.info(
         "IndividualTracker: WebSocket connection established",
         new Map([

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -56,6 +56,8 @@ import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { parseJsonBody } from "@guilty-spark/shared/base/request-parsing";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import {
+  DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS,
+  INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT,
   INDIVIDUAL_STATS_HIGHLIGHTS_MAX_SLOT_COUNT,
   INDIVIDUAL_STATS_HIGHLIGHTS_STAT_OPTIONS,
   type IndividualStatsHighlightOption,
@@ -140,6 +142,11 @@ function parseStatsHighlightSlots(url: URL): readonly IndividualStatsHighlightOp
   return parsedSlots.data;
 }
 
+const DEFAULT_WEBSOCKET_STATS_HIGHLIGHT_SLOTS = DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS.slice(
+  0,
+  INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT,
+);
+
 function normalizeRankTier(rankTier: string | null | undefined): string | null {
   if (rankTier == null || rankTier === "") {
     return null;
@@ -160,6 +167,8 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   private statsHighlightsCacheKey: string | undefined;
   private cachedStatsHighlights: readonly StatsHighlightItem[] | undefined;
   private cachedResolvedRosterCount: number | undefined;
+  private websocketStatsHighlightSlots: readonly IndividualStatsHighlightOption[] =
+    DEFAULT_WEBSOCKET_STATS_HIGHLIGHT_SLOTS;
 
   constructor(
     state: DurableObjectState,
@@ -304,7 +313,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         trackerState.lastUpdateTime = new Date().toISOString();
         await this.state.storage.deleteAlarm();
         await this.setState(trackerState);
-        this.broadcastViewState(trackerState);
+        await this.broadcastViewState(trackerState);
         this.closeWebSockets("Tracker idle timeout");
         await this.markRegistryStopped(trackerState);
         this.notifyUserTracker(trackerState);
@@ -335,7 +344,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       this.notifyUserTracker(trackerState);
     }
     if (shouldNotifyUserTracker) {
-      this.broadcastViewState(trackerState);
+      await this.broadcastViewState(trackerState);
     }
     await this.state.storage.setAlarm(addMilliseconds(new Date(), this.getNextAlarmInterval(trackerState)).getTime());
   }
@@ -902,7 +911,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.lastUpdateTime = new Date().toISOString();
     await this.state.storage.deleteAlarm();
     await this.setState(trackerState);
-    this.broadcastViewState(trackerState);
+    await this.broadcastViewState(trackerState);
 
     this.logService.info(
       "IndividualTracker: tracker paused",
@@ -927,7 +936,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     await this.setState(trackerState);
     const resumeAlarmDelay = this.hasPendingRecompute(trackerState) ? 0 : ALARM_INTERVAL_MS;
     await this.state.storage.setAlarm(addMilliseconds(new Date(), resumeAlarmDelay).getTime());
-    this.broadcastViewState(trackerState);
+    await this.broadcastViewState(trackerState);
 
     this.logService.info(
       "IndividualTracker: tracker resumed",
@@ -949,7 +958,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     if (trackerState != null) {
       trackerState.status = "stopped";
       trackerState.lastUpdateTime = new Date().toISOString();
-      this.broadcastViewState(trackerState);
+      await this.broadcastViewState(trackerState);
       this.closeWebSockets("Tracker stopped");
       this.logService.info(
         "IndividualTracker: tracker stopped",
@@ -1004,7 +1013,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     await this.setState(trackerState);
     this.notifyUserTracker(trackerState);
-    this.broadcastViewState(trackerState);
+    await this.broadcastViewState(trackerState);
     if (selectionChanged && !trackerState.isPaused) {
       await this.state.storage.setAlarm(Date.now());
     }
@@ -1389,7 +1398,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     await this.setState(trackerState);
     this.notifyUserTracker(trackerState);
-    this.broadcastViewState(trackerState);
+    await this.broadcastViewState(trackerState);
 
     this.logService.info(
       "IndividualTracker: series started",
@@ -1417,7 +1426,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     await this.setState(trackerState);
     this.notifyUserTracker(trackerState);
-    this.broadcastViewState(trackerState);
+    await this.broadcastViewState(trackerState);
 
     this.logService.info(
       "IndividualTracker: series ended",
@@ -1459,7 +1468,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     await this.setState(trackerState);
     this.notifyUserTracker(trackerState);
-    this.broadcastViewState(trackerState);
+    await this.broadcastViewState(trackerState);
 
     return editSeriesContract.toResponse({ success: true });
   }
@@ -1486,7 +1495,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     trackerState.lastUpdateTime = new Date().toISOString();
 
     await this.setState(trackerState);
-    this.broadcastViewState(trackerState);
+    await this.broadcastViewState(trackerState);
 
     this.logService.info(
       "IndividualTracker: series resumed",
@@ -1615,7 +1624,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     await this.setState(trackerState);
     this.notifyUserTracker(trackerState);
-    this.broadcastViewState(trackerState);
+    await this.broadcastViewState(trackerState);
     await this.state.storage.setAlarm(Date.now());
 
     return individualTrackerNudgeContract.toResponse({ success: true });
@@ -2030,8 +2039,23 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     };
   }
 
-  private viewMessage(state: IndividualTrackerInternalState): string {
-    return trackerViewMessageContract.serialize({ type: "view", view: this.toViewState(state) });
+  private async buildRealtimeViewState(state: IndividualTrackerInternalState): Promise<IndividualTrackerViewState> {
+    const statsHighlights =
+      this.websocketStatsHighlightSlots.length > 0
+        ? await this.buildStatsHighlights(state, this.websocketStatsHighlightSlots)
+        : undefined;
+    const preSeriesPlayerInfo = await this.getPreSeriesPlayerInfo(state);
+
+    return {
+      ...this.toViewState(state),
+      ...(statsHighlights != null ? { statsHighlights: [...statsHighlights] } : {}),
+      ...(preSeriesPlayerInfo != null ? { preSeriesPlayerInfo } : {}),
+    };
+  }
+
+  private async viewMessage(state: IndividualTrackerInternalState): Promise<string> {
+    const view = await this.buildRealtimeViewState(state);
+    return trackerViewMessageContract.serialize({ type: "view", view });
   }
 
   private async handleWebSocket(request: Request): Promise<Response> {
@@ -2041,6 +2065,11 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
 
     const trackerState = await this.getState();
+    const url = new URL(request.url);
+    const requestedStatsHighlightSlots = parseStatsHighlightSlots(url);
+    this.websocketStatsHighlightSlots =
+      requestedStatsHighlightSlots.length > 0 ? requestedStatsHighlightSlots : DEFAULT_WEBSOCKET_STATS_HIGHLIGHT_SLOTS;
+
     this.logService.info(
       "IndividualTracker: WebSocket connection requested",
       new Map([
@@ -2049,9 +2078,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       ]),
     );
     try {
+      const initialMessage = trackerState != null ? await this.viewMessage(trackerState) : undefined;
       const response = this.webSocketAdapter.upgrade(
         this.state,
-        trackerState != null ? this.viewMessage(trackerState) : undefined,
+        initialMessage,
       );
       this.logService.info(
         "IndividualTracker: WebSocket connection established",
@@ -2089,8 +2119,12 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     this.logService.warn(error, new Map([["context", "IndividualTracker: WebSocket error"]]));
   }
 
-  private broadcastViewState(state: IndividualTrackerInternalState): void {
-    this.webSocketAdapter.broadcast(this.state, this.viewMessage(state));
+  private async broadcastViewState(state: IndividualTrackerInternalState): Promise<void> {
+    try {
+      this.webSocketAdapter.broadcast(this.state, await this.viewMessage(state));
+    } catch (error: unknown) {
+      this.logService.warn(error, new Map([["context", "IndividualTracker: failed to broadcast view state"]]));
+    }
   }
 
   private closeWebSockets(reason: string): void {

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -2043,12 +2043,12 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     const statsHighlights =
       this.websocketStatsHighlightSlots.length > 0
         ? await this.buildStatsHighlights(state, this.websocketStatsHighlightSlots)
-        : undefined;
+        : [];
     const preSeriesPlayerInfo = await this.getPreSeriesPlayerInfo(state);
 
     return {
       ...this.toViewState(state),
-      ...(statsHighlights != null ? { statsHighlights: [...statsHighlights] } : {}),
+      statsHighlights: [...statsHighlights],
       ...(preSeriesPlayerInfo != null ? { preSeriesPlayerInfo } : {}),
     };
   }
@@ -2067,8 +2067,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     const trackerState = await this.getState();
     const url = new URL(request.url);
     const requestedStatsHighlightSlots = parseStatsHighlightSlots(url);
-    this.websocketStatsHighlightSlots =
-      requestedStatsHighlightSlots.length > 0 ? requestedStatsHighlightSlots : DEFAULT_WEBSOCKET_STATS_HIGHLIGHT_SLOTS;
+    this.websocketStatsHighlightSlots = url.searchParams.has("statsHighlightSlots")
+      ? requestedStatsHighlightSlots
+      : DEFAULT_WEBSOCKET_STATS_HIGHLIGHT_SLOTS;
 
     this.logService.info(
       "IndividualTracker: WebSocket connection requested",

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -2066,10 +2066,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     const trackerState = await this.getState();
     const url = new URL(request.url);
-    const requestedStatsHighlightSlots = parseStatsHighlightSlots(url);
-    this.websocketStatsHighlightSlots = url.searchParams.has("statsHighlightSlots")
-      ? requestedStatsHighlightSlots
-      : DEFAULT_WEBSOCKET_STATS_HIGHLIGHT_SLOTS;
+    if (url.searchParams.has("statsHighlightSlots")) {
+      this.websocketStatsHighlightSlots = parseStatsHighlightSlots(url);
+    }
 
     this.logService.info(
       "IndividualTracker: WebSocket connection requested",

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1685,6 +1685,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
   private async getPreSeriesPlayerInfo(
     state: IndividualTrackerInternalState,
+    persist = true,
   ): Promise<PreSeriesPlayerInfo | undefined> {
     const cacheKey = this.getPreSeriesPlayerInfoCacheKey(state);
     if (state.preSeriesPlayerInfoLatestMatchId === cacheKey) {
@@ -1692,6 +1693,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
 
     const preSeriesPlayerInfo = await this.buildPreSeriesPlayerInfo(state);
+    if (!persist) {
+      return preSeriesPlayerInfo;
+    }
+
     if (preSeriesPlayerInfo !== undefined) {
       state.preSeriesPlayerInfo = preSeriesPlayerInfo;
     } else {
@@ -2044,7 +2049,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       this.websocketStatsHighlightSlots.length > 0
         ? await this.buildStatsHighlights(state, this.websocketStatsHighlightSlots)
         : [];
-    const preSeriesPlayerInfo = await this.getPreSeriesPlayerInfo(state);
+    const preSeriesPlayerInfo = await this.getPreSeriesPlayerInfo(state, false);
 
     return {
       ...this.toViewState(state),

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2385,6 +2385,50 @@ describe("IndividualTrackerDO", () => {
       expect(secondMessage.view.statsHighlights).toEqual([]);
     });
 
+    it("does not persist pre-series profile updates during websocket view generation", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          trackerId: "t1",
+          gamertag: "Tag1",
+          status: "active",
+          xuid: "tracked-xuid",
+          lastSeenMatchId: "m2",
+          preSeriesPlayerInfoLatestMatchId: "m1",
+          preSeriesPlayerInfo: {
+            currentRank: 1200,
+            currentRankTier: "Gold",
+            currentRankSubTier: 1,
+            currentRankMeasurementMatchesRemaining: null,
+            currentRankInitialMeasurementMatches: null,
+            allTimePeakRank: 1250,
+            esra: 1200,
+            lastRankedGamePlayed: "2024-11-25T10:00:00.000Z",
+          },
+          matchIds: ["m1"],
+          selectedMatchIds: ["m1"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m1",
+              startTime: "s",
+              endTime: "e",
+              mapAssetId: "map",
+              mapVersionId: "map-v",
+              mapName: "Streets",
+              modeAssetId: "mode",
+              gameVariantCategory: 6,
+              outcome: "Win",
+              score: "50:42",
+            }),
+          },
+        }),
+      );
+      storagePutSpy.mockClear();
+
+      await individualTrackerDO.fetch(wsRequest());
+
+      expect(storagePutSpy).not.toHaveBeenCalled();
+    });
+
     it("does not send an initial message when no state exists", async () => {
       storageGetSpy.mockResolvedValue(null);
 

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2347,6 +2347,44 @@ describe("IndividualTrackerDO", () => {
       expect(parsed.view.statsHighlights).toEqual([]);
     });
 
+    it("does not overwrite configured stats highlight slots when websocket query is absent", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          trackerId: "t1",
+          gamertag: "Tag1",
+          status: "active",
+          matchIds: ["m1"],
+          selectedMatchIds: ["m1"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m1",
+              startTime: "s",
+              endTime: "e",
+              mapAssetId: "map",
+              mapVersionId: "map-v",
+              mapName: "Streets",
+              modeAssetId: "mode",
+              gameVariantCategory: 6,
+              outcome: "Win",
+              score: "50:42",
+            }),
+          },
+        }),
+      );
+
+      await individualTrackerDO.fetch(wsRequest("?statsHighlightSlots=%5B%5D"));
+      await individualTrackerDO.fetch(wsRequest());
+
+      const firstMessage = trackerViewMessageContract.parse(
+        Preconditions.checkExists(webSocketAdapter.initialMessages[0]),
+      );
+      const secondMessage = trackerViewMessageContract.parse(
+        Preconditions.checkExists(webSocketAdapter.initialMessages[1]),
+      );
+      expect(firstMessage.view.statsHighlights).toEqual([]);
+      expect(secondMessage.view.statsHighlights).toEqual([]);
+    });
+
     it("does not send an initial message when no state exists", async () => {
       storageGetSpy.mockResolvedValue(null);
 

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2232,8 +2232,8 @@ describe("IndividualTrackerDO", () => {
       individualTrackerDO = new IndividualTrackerDO(mockState, env, () => services, webSocketAdapter);
     });
 
-    const wsRequest = (): Request =>
-      new Request("http://do/websocket", { method: "GET", headers: { Upgrade: "websocket" } });
+    const wsRequest = (query = ""): Request =>
+      new Request(`http://do/websocket${query}`, { method: "GET", headers: { Upgrade: "websocket" } });
 
     it("returns 426 when the Upgrade header is missing", async () => {
       const response = await individualTrackerDO.fetch(new Request("http://do/websocket", { method: "GET" }));
@@ -2282,6 +2282,69 @@ describe("IndividualTrackerDO", () => {
       expect(parsed.view.trackerId).toBe("t1");
       expect(parsed.view.status).toBe("active");
       expect(parsed.view.matches).toHaveLength(1);
+    });
+
+    it("uses default stats highlight slots when websocket query is absent", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          trackerId: "t1",
+          gamertag: "Tag1",
+          status: "active",
+          matchIds: ["m1"],
+          selectedMatchIds: ["m1"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m1",
+              startTime: "s",
+              endTime: "e",
+              mapAssetId: "map",
+              mapVersionId: "map-v",
+              mapName: "Streets",
+              modeAssetId: "mode",
+              gameVariantCategory: 6,
+              outcome: "Win",
+              score: "50:42",
+            }),
+          },
+        }),
+      );
+
+      await individualTrackerDO.fetch(wsRequest());
+
+      const parsed = trackerViewMessageContract.parse(Preconditions.checkExists(webSocketAdapter.initialMessages[0]));
+      expect(parsed.view.statsHighlights).toBeDefined();
+      expect(parsed.view.statsHighlights?.length).toBeGreaterThan(0);
+    });
+
+    it("keeps statsHighlights as an empty array when statsHighlightSlots is explicitly empty", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          trackerId: "t1",
+          gamertag: "Tag1",
+          status: "active",
+          matchIds: ["m1"],
+          selectedMatchIds: ["m1"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m1",
+              startTime: "s",
+              endTime: "e",
+              mapAssetId: "map",
+              mapVersionId: "map-v",
+              mapName: "Streets",
+              modeAssetId: "mode",
+              gameVariantCategory: 6,
+              outcome: "Win",
+              score: "50:42",
+            }),
+          },
+        }),
+      );
+
+      await individualTrackerDO.fetch(wsRequest("?statsHighlightSlots=%5B%5D"));
+
+      const parsed = trackerViewMessageContract.parse(Preconditions.checkExists(webSocketAdapter.initialMessages[0]));
+      expect(parsed.view.statsHighlights).toEqual([]);
     });
 
     it("does not send an initial message when no state exists", async () => {

--- a/api/routes/individual-tracker/view.ts
+++ b/api/routes/individual-tracker/view.ts
@@ -41,7 +41,7 @@ export const trackerViewRoutesRegisterHandler: RoutesRegisterHandler = (router, 
 
   router.get("/api/individual-tracker/:trackerId/ws", async (request, env: Env) => {
     const services = installServices({ env });
-    const { databaseService, logService } = services;
+    const { databaseService, individualTrackerService, logService } = services;
 
     try {
       const parsedParams = parsePathParams(request.params, trackerParamsSchema, "Invalid tracker id");
@@ -59,11 +59,17 @@ export const trackerViewRoutesRegisterHandler: RoutesRegisterHandler = (router, 
         return errorContract.toResponse({ error: "Tracker not found" }, { status: 404, noStore: true });
       }
 
+      const streamerSettings = await individualTrackerService.getSettingsForView(row.UserId);
+      const statsHighlightSlots =
+        streamerSettings.visibleSections?.statsHighlightSlots ??
+        DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS.slice(0, INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT);
+
       const doId = env.INDIVIDUAL_TRACKER_DO.idFromName(`${row.UserId}:${trackerId}`);
       const stub = env.INDIVIDUAL_TRACKER_DO.get(doId);
 
       const forwardedUrl = new URL(request.url);
       forwardedUrl.pathname = "/websocket";
+      forwardedUrl.searchParams.set("statsHighlightSlots", JSON.stringify(statsHighlightSlots));
 
       return await stub.fetch(new Request(forwardedUrl.toString(), { headers: request.headers }));
     } catch (error) {

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -204,13 +204,13 @@ describe("useIndividualTrackerViewer", () => {
     });
 
     act(() => {
-      individualTrackerViewService.lastConnection?.emitView(
-        aFakeTrackerViewStateWith({
+      individualTrackerViewService.lastConnection?.emitView({
+        ...aFakeTrackerLiveViewWith({
           trackerId: "tracker-1",
           status: "active",
-          statsHighlights: [{ label: "KDA", value: "3.4" }],
         }),
-      );
+        statsHighlights: [{ label: "KDA", value: "3.4" }],
+      });
     });
 
     await waitFor(() => {

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -219,6 +219,48 @@ describe("useIndividualTrackerViewer", () => {
     });
   });
 
+  it("clears stats highlights when websocket payload omits them", async () => {
+    const firstView = aFakeTrackerViewStateWith({
+      trackerId: "tracker-1",
+      status: "active",
+      statsHighlights: [{ label: "KDA", value: "2.1" }],
+    });
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({ view: firstView });
+    const getViewSpy = vi.spyOn(individualTrackerViewService, "getView");
+    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+
+    const { result } = renderHook(() =>
+      useIndividualTrackerViewer({
+        individualTrackerViewService,
+        matchAnalyticsService,
+        seriesMatchesService,
+        haloClient,
+        trackerId: "tracker-1",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.snapshot.status).toBe(ComponentLoaderStatus.LOADED);
+      expect(result.current.model.renderModel?.statsHighlights?.[0]?.value).toBe("2.1");
+      expect(individualTrackerViewService.lastConnection).not.toBeNull();
+    });
+
+    act(() => {
+      individualTrackerViewService.lastConnection?.emitView(
+        aFakeTrackerLiveViewWith({
+          trackerId: "tracker-1",
+          status: "active",
+          matches: [aFakeTrackerMatchSummaryWith({ matchId: "match-2" })],
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(getViewSpy).toHaveBeenCalledTimes(1);
+      expect(result.current.model.renderModel?.statsHighlights).toBeUndefined();
+    });
+  });
+
   it("preserves server streamer settings when websocket payload omits streamerSettings", async () => {
     const serverSettings: StreamerViewSettings = {
       styleFlags: {

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -153,7 +153,7 @@ describe("useIndividualTrackerViewer", () => {
     expect(getMatchStatsSpy).not.toHaveBeenCalled();
   });
 
-  it("treats the public viewer path as connected after the initial view loads", async () => {
+  it("connects the public viewer path after the initial view loads", async () => {
     const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
       view: aFakeTrackerViewStateWith({ trackerId: "tracker-1", status: "active" }),
     });
@@ -172,10 +172,105 @@ describe("useIndividualTrackerViewer", () => {
 
     await waitFor(() => {
       expect(result.current.snapshot.status).toBe(ComponentLoaderStatus.LOADED);
-      expect(result.current.snapshot.connectionStatus).toBe("connected");
     });
 
-    expect(connectSpy).not.toHaveBeenCalled();
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates stats highlights directly from websocket payloads", async () => {
+    const firstView = aFakeTrackerViewStateWith({
+      trackerId: "tracker-1",
+      status: "active",
+      statsHighlights: [{ label: "KDA", value: "2.1" }],
+    });
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({ view: firstView });
+    const getViewSpy = vi.spyOn(individualTrackerViewService, "getView");
+    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+
+    const { result } = renderHook(() =>
+      useIndividualTrackerViewer({
+        individualTrackerViewService,
+        matchAnalyticsService,
+        seriesMatchesService,
+        haloClient,
+        trackerId: "tracker-1",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.snapshot.status).toBe(ComponentLoaderStatus.LOADED);
+      expect(result.current.model.renderModel?.statsHighlights?.[0]?.value).toBe("2.1");
+      expect(individualTrackerViewService.lastConnection).not.toBeNull();
+    });
+
+    act(() => {
+      individualTrackerViewService.lastConnection?.emitView(
+        aFakeTrackerViewStateWith({
+          trackerId: "tracker-1",
+          status: "active",
+          statsHighlights: [{ label: "KDA", value: "3.4" }],
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(getViewSpy).toHaveBeenCalledTimes(1);
+      expect(result.current.model.renderModel?.statsHighlights?.[0]?.value).toBe("3.4");
+    });
+  });
+
+  it("preserves server streamer settings when websocket payload omits streamerSettings", async () => {
+    const serverSettings: StreamerViewSettings = {
+      styleFlags: {
+        colorMode: "observer",
+      },
+    };
+    const localSettings: StreamerViewSettings = {
+      styleFlags: {
+        colorMode: "player",
+      },
+    };
+    const firstView = {
+      ...aFakeTrackerViewStateWith({
+        trackerId: "tracker-1",
+        status: "active",
+      }),
+      streamerSettings: serverSettings,
+    };
+    const websocketViewWithoutSettings = aFakeTrackerLiveViewWith({
+      trackerId: "tracker-1",
+      status: "active",
+      matches: [aFakeTrackerMatchSummaryWith({ matchId: "match-2" })],
+    });
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({ view: firstView });
+    const getViewSpy = vi.spyOn(individualTrackerViewService, "getView");
+    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+
+    const { result } = renderHook(() =>
+      useIndividualTrackerViewer({
+        individualTrackerViewService,
+        matchAnalyticsService,
+        seriesMatchesService,
+        haloClient,
+        trackerId: "tracker-1",
+        streamerSettings: localSettings,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.snapshot.status).toBe(ComponentLoaderStatus.LOADED);
+      expect(result.current.model.streamerSettings?.styleFlags?.colorMode).toBe("observer");
+      expect(individualTrackerViewService.lastConnection).not.toBeNull();
+    });
+
+    act(() => {
+      individualTrackerViewService.lastConnection?.emitView(websocketViewWithoutSettings);
+    });
+
+    await waitFor(() => {
+      expect(getViewSpy).toHaveBeenCalledTimes(1);
+      expect(result.current.model.streamerSettings?.styleFlags?.colorMode).toBe("observer");
+    });
   });
 
   it("loads long series in a single request when a series entry expands", async () => {

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -527,13 +527,6 @@ export class IndividualTrackerViewerPresenter {
     this.statusSubscription?.unsubscribe();
     this.connection?.disconnect();
 
-    // Only establish individual-tracker WS connection in managed context (when individualTrackerService is available).
-    // Public pages (follow viewer) should not connect to per-tracker endpoints.
-    if (this.config.individualTrackerService == null) {
-      this.config.store.setConnectionStatus("connected");
-      return;
-    }
-
     const connection = this.config.individualTrackerViewService.connect(this.config.trackerId);
     this.connection = connection;
     this.viewSubscription = connection.subscribe((view) => {

--- a/pages/src/components/individual-tracker/viewer/viewer-store.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-store.ts
@@ -75,11 +75,15 @@ export class IndividualTrackerViewerStore {
   public setView(view: TrackerLiveMessageView): void {
     const isLive = this.snapshot.view?.isLive ?? false;
     const streamerSettings = this.snapshot.view?.streamerSettings;
-    const statsHighlights = view.statsHighlights ?? this.snapshot.view?.statsHighlights;
-    const preSeriesPlayerInfo = view.preSeriesPlayerInfo ?? this.snapshot.view?.preSeriesPlayerInfo;
     this.update({
       status: ComponentLoaderStatus.LOADED,
-      view: { ...view, isLive, streamerSettings, statsHighlights, preSeriesPlayerInfo },
+      view: {
+        ...view,
+        isLive,
+        streamerSettings,
+        statsHighlights: view.statsHighlights,
+        preSeriesPlayerInfo: view.preSeriesPlayerInfo,
+      },
     });
   }
 

--- a/pages/src/components/individual-tracker/viewer/viewer-store.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-store.ts
@@ -1,4 +1,4 @@
-import type { TrackerLiveView, TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import type { TrackerLiveMessageView, TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { TrackerViewConnectionStatus } from "../../../services/individual-tracker/view-types";
 import type { MatchStatsData } from "../../../controllers/stats/types";
 import type { KillMatrixPivotData } from "../../../controllers/stats/kill-matrix/types";
@@ -72,11 +72,11 @@ export class IndividualTrackerViewerStore {
     this.update({ status: ComponentLoaderStatus.ERROR, errorMessage });
   }
 
-  public setView(view: TrackerLiveView): void {
+  public setView(view: TrackerLiveMessageView): void {
     const isLive = this.snapshot.view?.isLive ?? false;
     const streamerSettings = this.snapshot.view?.streamerSettings;
-    const statsHighlights = this.snapshot.view?.statsHighlights;
-    const preSeriesPlayerInfo = this.snapshot.view?.preSeriesPlayerInfo;
+    const statsHighlights = view.statsHighlights ?? this.snapshot.view?.statsHighlights;
+    const preSeriesPlayerInfo = view.preSeriesPlayerInfo ?? this.snapshot.view?.preSeriesPlayerInfo;
     this.update({
       status: ComponentLoaderStatus.LOADED,
       view: { ...view, isLive, streamerSettings, statsHighlights, preSeriesPlayerInfo },

--- a/pages/src/services/individual-tracker/fakes/view.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/view.fake.ts
@@ -1,5 +1,6 @@
 import type {
   StatsHighlightItem,
+  TrackerLiveMessageView,
   TrackerLiveView,
   TrackerMatchSummary,
   TrackerSeriesGroup,
@@ -143,7 +144,7 @@ class FakeTrackerViewConnection implements TrackerViewConnection {
     }
   }
 
-  public emitView(view: TrackerLiveView): void {
+  public emitView(view: TrackerLiveMessageView): void {
     for (const listener of this.listeners) {
       listener(view);
     }

--- a/pages/src/services/individual-tracker/view-types.ts
+++ b/pages/src/services/individual-tracker/view-types.ts
@@ -1,6 +1,6 @@
-import type { TrackerLiveView, TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import type { TrackerLiveMessageView, TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
 
-export type TrackerViewListener = (view: TrackerLiveView) => void;
+export type TrackerViewListener = (view: TrackerLiveMessageView) => void;
 
 export type TrackerViewConnectionStatus =
   | "connecting"

--- a/pages/src/services/individual-tracker/view-types.ts
+++ b/pages/src/services/individual-tracker/view-types.ts
@@ -1,4 +1,7 @@
-import type { TrackerLiveMessageView, TrackerViewResponse } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import type {
+  TrackerLiveMessageView,
+  TrackerViewResponse,
+} from "@guilty-spark/shared/contracts/individual-tracker/view";
 
 export type TrackerViewListener = (view: TrackerLiveMessageView) => void;
 

--- a/shared/src/contracts/individual-tracker/tests/view.test.ts
+++ b/shared/src/contracts/individual-tracker/tests/view.test.ts
@@ -186,6 +186,7 @@ describe("trackerViewMessageSchema", () => {
       lastMatchDiscoveredAt: "2024-11-26T11:55:00.000Z",
       hasActiveSeries: false,
       hasRecentCompletedSeries: false,
+      statsHighlights: [{ label: "KDA", value: "3.0" }],
     },
   };
 
@@ -193,8 +194,29 @@ describe("trackerViewMessageSchema", () => {
     expect(trackerViewMessageSchema.parse(validMessage)).toEqual(validMessage);
   });
 
-  it("does not include isLive in the live-view payload", () => {
+  it("does not include isLive in the websocket live-view payload", () => {
     expect("isLive" in validMessage.view).toBe(false);
+  });
+
+  it("accepts preSeriesPlayerInfo in websocket payload", () => {
+    const result = trackerViewMessageSchema.safeParse({
+      ...validMessage,
+      view: {
+        ...validMessage.view,
+        preSeriesPlayerInfo: {
+          currentRank: 1500,
+          currentRankTier: "Diamond",
+          currentRankSubTier: 2,
+          currentRankMeasurementMatchesRemaining: null,
+          currentRankInitialMeasurementMatches: null,
+          allTimePeakRank: 1610,
+          esra: 1488,
+          lastRankedGamePlayed: "2024-11-26T10:00:00.000Z",
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
   });
 
   it("rejects a message with the wrong type literal", () => {

--- a/shared/src/contracts/individual-tracker/view.ts
+++ b/shared/src/contracts/individual-tracker/view.ts
@@ -109,9 +109,15 @@ export type TrackerViewState = z.infer<typeof trackerViewStateSchema>;
 export const trackerViewContract = defineContract(z.object({ view: trackerViewStateSchema }));
 export type TrackerViewResponse = z.infer<typeof trackerViewContract.schema>;
 
+export const trackerLiveMessageViewSchema = trackerLiveViewSchema.extend({
+  statsHighlights: z.array(statsHighlightItemSchema).optional(),
+  preSeriesPlayerInfo: preSeriesPlayerInfoSchema.optional(),
+});
+export type TrackerLiveMessageView = z.infer<typeof trackerLiveMessageViewSchema>;
+
 export const trackerViewMessageSchema = z.object({
   type: z.literal("view"),
-  view: trackerLiveViewSchema,
+  view: trackerLiveMessageViewSchema,
 });
 export type TrackerViewMessage = z.infer<typeof trackerViewMessageSchema>;
 


### PR DESCRIPTION
## Context
The previous PR #645 fixed public/follow viewer staleness by opening websocket subscriptions, but it relied on a per-message `getView` hydration pass to refresh enriched fields (`statsHighlights`, `preSeriesPlayerInfo`).

This PR moves to the intended architecture: websocket pushes contain everything the viewer needs to render, so the frontend can apply updates directly without follow-up HTTP requests.

It also keeps an important historical note from PR #609 in mind: we previously had a managed-only websocket gate with `setConnectionStatus("connected")` for public viewers. That was removed because it masked connection state while preventing public/follow viewers from subscribing to live per-tracker updates, which was the core cause of stale list/component rendering.

## This PR
- updates shared individual-tracker websocket contracts so `view` messages can include enriched realtime fields (including `statsHighlights` and `preSeriesPlayerInfo`)
- updates `IndividualTrackerDO` websocket message generation to emit enriched payloads directly
- forwards configured stats-highlight slots from the websocket route to the DO websocket endpoint so realtime payloads align with viewer settings/defaults
- removes frontend per-message `getView` hydration logic from the individual tracker viewer presenter
- keeps public/follow viewer websocket subscription active (no forced synthetic "connected" state)
- updates viewer/store/service typing and fakes to consume enriched websocket payloads
- updates regression tests across shared contracts, DO websocket behavior, view connection, and viewer hook behavior

## Subsequent Work
- after this PR merges, follow with a dedicated hardening PR that enforces architectural boundary separation:
  - owner-only access for individual-tracker HTTP/WebSocket endpoints
  - public viewer/overlay consumption from user-level public directory HTTP/WebSocket endpoints only
- monitor websocket payload size and broadcast frequency in production to ensure expected performance
- if needed later, optimize enriched field computation cadence in DO while preserving the websocket-first rendering model
