### PR TITLE
Add follow public-route websocket regressions

### DIFF
--- a/pages/src/components/follow/follow-live-overlay/tests/follow-live-overlay-create.test.tsx
+++ b/pages/src/components/follow/follow-live-overlay/tests/follow-live-overlay-create.test.tsx
@@ -45,13 +45,15 @@ function createFollowLiveOverlayWith(
   directory: TrackerDirectory,
   options: { readonly showPreview?: boolean; readonly previewMode?: "player" | "observer" } = {},
   followLiveService = aFakeFollowLiveServiceWith({ directory }),
+  individualTrackerViewService = aFakeIndividualTrackerViewServiceWith(),
 ): {
   readonly element: React.ReactElement;
   readonly followLiveService: ReturnType<typeof aFakeFollowLiveServiceWith>;
+  readonly individualTrackerViewService: ReturnType<typeof aFakeIndividualTrackerViewServiceWith>;
 } {
   const FollowLiveOverlay = createFollowLiveOverlay({
     followLiveService,
-    individualTrackerViewService: aFakeIndividualTrackerViewServiceWith(),
+    individualTrackerViewService,
     matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     seriesMatchesService: aFakeSeriesMatchesServiceWith(),
     haloClient: aFakeHaloClientWith(),
@@ -66,6 +68,7 @@ function createFollowLiveOverlayWith(
       />
     ),
     followLiveService,
+    individualTrackerViewService,
   };
 }
 
@@ -173,5 +176,31 @@ describe("FollowLiveOverlayCreate", () => {
     await waitFor(() => {
       expect(screen.getByTestId("mock-overlay-page")).toHaveAttribute("data-instance-id", "1");
     });
+  });
+
+  it("does not call owner-only tracker view service methods in follow overlay mode", async () => {
+    const directory = aDirectoryWith({
+      trackers: [aTrackerWith({ trackerId: "tracker-3", gamertag: "Spartan Three", isLive: true, status: "active" })],
+      liveTrackerId: "tracker-3",
+    });
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith();
+    const getViewSpy = vi.spyOn(individualTrackerViewService, "getView");
+    const connectSpy = vi.spyOn(individualTrackerViewService, "connect");
+
+    render(
+      createFollowLiveOverlayWith(
+        directory,
+        { showPreview: false, previewMode: "observer" },
+        aFakeFollowLiveServiceWith({ directory }),
+        individualTrackerViewService,
+      ).element,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-overlay-page")).toBeInTheDocument();
+    });
+
+    expect(getViewSpy).not.toHaveBeenCalled();
+    expect(connectSpy).not.toHaveBeenCalled();
   });
 });

--- a/pages/src/components/follow/follow-live-viewer/tests/follow-live-viewer-create.test.tsx
+++ b/pages/src/components/follow/follow-live-viewer/tests/follow-live-viewer-create.test.tsx
@@ -51,10 +51,15 @@ vi.mock("../../../individual-tracker/viewer/create", () => ({
 function createFollowLiveViewerWith(
   directory: TrackerDirectory,
   followLiveService = aFakeFollowLiveServiceWith({ directory }),
-): { readonly element: React.ReactElement; readonly followLiveService: ReturnType<typeof aFakeFollowLiveServiceWith> } {
+  individualTrackerViewService = aFakeIndividualTrackerViewServiceWith(),
+): {
+  readonly element: React.ReactElement;
+  readonly followLiveService: ReturnType<typeof aFakeFollowLiveServiceWith>;
+  readonly individualTrackerViewService: ReturnType<typeof aFakeIndividualTrackerViewServiceWith>;
+} {
   const FollowLiveViewer = createFollowLiveViewer({
     followLiveService,
-    individualTrackerViewService: aFakeIndividualTrackerViewServiceWith(),
+    individualTrackerViewService,
     matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     seriesMatchesService: aFakeSeriesMatchesServiceWith(),
     haloClient: aFakeHaloClientWith(),
@@ -63,6 +68,7 @@ function createFollowLiveViewerWith(
   return {
     element: <FollowLiveViewer gamertag="Spartan One" />,
     followLiveService,
+    individualTrackerViewService,
   };
 }
 
@@ -238,6 +244,66 @@ describe("FollowLiveViewerCreate", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("mock-connection-status-override")).toHaveTextContent("connecting");
+    });
+  });
+
+  it("does not call owner-only tracker view service methods in follow viewer mode", async () => {
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith();
+    const getViewSpy = vi.spyOn(individualTrackerViewService, "getView");
+    const connectSpy = vi.spyOn(individualTrackerViewService, "connect");
+
+    render(createFollowLiveViewerWith(aDirectoryWith(), aFakeFollowLiveServiceWith({ directory: aDirectoryWith() }), individualTrackerViewService).element);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-viewer")).toBeInTheDocument();
+    });
+
+    expect(getViewSpy).not.toHaveBeenCalled();
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+
+  it("recovers after websocket error and resumes updates from later directory pushes", async () => {
+    const initialDirectory: TrackerDirectory = aDirectoryWith({
+      trackers: [
+        aTrackerWith({ trackerId: "tracker-1", gamertag: "Spartan One", isLive: true, status: "active" }),
+        aTrackerWith({ trackerId: "tracker-2", gamertag: "Spartan Two", isLive: false, status: "active" }),
+      ],
+      liveTrackerId: "tracker-1",
+    });
+    const { element, followLiveService } = createFollowLiveViewerWith(initialDirectory);
+
+    render(element);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-external-view-tracker-id")).toHaveTextContent("tracker-1");
+      expect(screen.getByTestId("mock-connection-status-override")).toHaveTextContent("none");
+    });
+
+    act(() => {
+      followLiveService.lastConnection?.emitStatus("error");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-connection-status-override")).toHaveTextContent("error");
+    });
+
+    const resumedDirectory: TrackerDirectory = {
+      ...initialDirectory,
+      trackers: [
+        { ...initialDirectory.trackers[0], isLive: false },
+        { ...initialDirectory.trackers[1], isLive: true },
+      ],
+      liveTrackerId: "tracker-2",
+    };
+
+    act(() => {
+      followLiveService.lastConnection?.emitStatus("connected");
+      followLiveService.lastConnection?.emitDirectory(resumedDirectory);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-connection-status-override")).toHaveTextContent("none");
+      expect(screen.getByTestId("mock-external-view-tracker-id")).toHaveTextContent("tracker-2");
     });
   });
 });

--- a/pages/src/components/follow/follow-live-viewer/tests/follow-live-viewer-create.test.tsx
+++ b/pages/src/components/follow/follow-live-viewer/tests/follow-live-viewer-create.test.tsx
@@ -252,7 +252,13 @@ describe("FollowLiveViewerCreate", () => {
     const getViewSpy = vi.spyOn(individualTrackerViewService, "getView");
     const connectSpy = vi.spyOn(individualTrackerViewService, "connect");
 
-    render(createFollowLiveViewerWith(aDirectoryWith(), aFakeFollowLiveServiceWith({ directory: aDirectoryWith() }), individualTrackerViewService).element);
+    render(
+      createFollowLiveViewerWith(
+        aDirectoryWith(),
+        aFakeFollowLiveServiceWith({ directory: aDirectoryWith() }),
+        individualTrackerViewService,
+      ).element,
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId("mock-viewer")).toBeInTheDocument();


### PR DESCRIPTION
## Context
The follow live viewer and overlay are intended to be public-facing surfaces that consume only public user-level follow routes, while still updating live as directory websocket events arrive.

## This PR
- Adds regression coverage for follow viewer to verify owner-only tracker view service methods are not called in follow mode.
- Adds regression coverage for follow overlay to verify owner-only tracker view service methods are not called in follow mode.
- Adds websocket recovery coverage in follow viewer to verify status transitions (including error) still allow subsequent directory pushes to update the selected live tracker.

## Subsequent Work
- Optional: add equivalent reconnect-path regression assertions at the service-layer websocket connection tests.
- Optional: add a lightweight route-level integration test that asserts follow endpoints remain unauthenticated and return only directory payloads.