### PR TITLE
Public view/API view: update route to remove `/view`

### DIFF
--- a/api/routes/user-tracker/follow.ts
+++ b/api/routes/user-tracker/follow.ts
@@ -15,7 +15,7 @@ function getUserTrackerStub(env: Env, userId: string): DurableObjectStub<UserTra
 }
 
 export const userTrackerFollowRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
-  router.get("/u/:gamertag/view", async (request, env: Env) => {
+  router.get("/u/:gamertag", async (request, env: Env) => {
     const services = installServices({ env });
     const { databaseService, logService } = services;
 

--- a/api/routes/user-tracker/tests/follow.test.ts
+++ b/api/routes/user-tracker/tests/follow.test.ts
@@ -50,7 +50,7 @@ describe("/u/:gamertag follow routes", () => {
     vi.unstubAllGlobals();
   });
 
-  describe("GET /u/:gamertag/view", () => {
+  describe("GET /u/:gamertag", () => {
     it("returns 404 when gamertag is not found", async () => {
       const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
         const services = installFakeServicesWith({ env });
@@ -59,7 +59,7 @@ describe("/u/:gamertag follow routes", () => {
       });
       userTrackerRoutesRegisterHandler(router, localInstallServices);
 
-      const res = (await router.fetch(getRequest("/u/UnknownTag/view"), env)) as Response;
+      const res = (await router.fetch(getRequest("/u/UnknownTag"), env)) as Response;
 
       expect(res.status).toBe(404);
     });
@@ -101,7 +101,7 @@ describe("/u/:gamertag follow routes", () => {
       });
       userTrackerRoutesRegisterHandler(router, localInstallServices);
 
-      const res = (await router.fetch(getRequest("/u/KnownTag/view"), localEnv)) as Response;
+      const res = (await router.fetch(getRequest("/u/KnownTag"), localEnv)) as Response;
 
       expect(res.status).toBe(200);
       await expect(res.json<TrackerDirectoryResponse>()).resolves.toEqual({
@@ -140,7 +140,7 @@ describe("/u/:gamertag follow routes", () => {
       });
       userTrackerRoutesRegisterHandler(router, localInstallServices);
 
-      const res = (await router.fetch(getRequest("/u/EmptyTag/view"), localEnv)) as Response;
+      const res = (await router.fetch(getRequest("/u/EmptyTag"), localEnv)) as Response;
 
       expect(res.status).toBe(200);
       await expect(res.json<TrackerDirectoryResponse>()).resolves.toEqual({ trackers: [], liveTrackerId: null });

--- a/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
@@ -99,7 +99,7 @@ describe("StreamerSettingsSectionView", () => {
       vi.stubGlobal("location", { origin: "https://example.com" });
       render(<StreamerSettingsSectionView {...aFakeProps({ gamertag: "gamertag-abc" })} />);
 
-      expect(screen.getByText(/\/u\/gamertag-abc\/view/)).toBeInTheDocument();
+      expect(screen.getByText("https://example.com/u/gamertag-abc")).toBeInTheDocument();
       expect(screen.getByText(/\/u\/gamertag-abc\/overlay/)).toBeInTheDocument();
 
       vi.unstubAllGlobals();
@@ -122,7 +122,7 @@ describe("StreamerSettingsSectionView", () => {
       const copyButtons = screen.getAllByRole("button", { name: "Copy" });
       await user.click(copyButtons[0]);
 
-      expect(writeText).toHaveBeenCalledWith(expect.stringContaining("/u/gamertag-abc/view"));
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining("/u/gamertag-abc"));
 
       vi.unstubAllGlobals();
     });

--- a/pages/src/components/individual-tracker/routes.ts
+++ b/pages/src/components/individual-tracker/routes.ts
@@ -23,7 +23,7 @@ export function buildIndividualTrackerTrackerViewPath(trackerId: string): string
 }
 
 export function buildIndividualTrackerPublicViewPath(gamertag: string): string {
-  return `/u/${encodeURIComponent(gamertag)}/view`;
+  return `/u/${encodeURIComponent(gamertag)}`;
 }
 
 export function buildIndividualTrackerPublicOverlayPath(gamertag: string): string {

--- a/pages/src/components/individual-tracker/tests/routes.test.ts
+++ b/pages/src/components/individual-tracker/tests/routes.test.ts
@@ -30,12 +30,12 @@ describe("buildIndividualTrackerTrackerViewPath", () => {
 });
 
 describe("buildIndividualTrackerPublicViewPath", () => {
-  it("returns the /u/<gamertag>/view path", () => {
-    expect(buildIndividualTrackerPublicViewPath("SpartanOne")).toBe("/u/SpartanOne/view");
+  it("returns the /u/<gamertag> path", () => {
+    expect(buildIndividualTrackerPublicViewPath("SpartanOne")).toBe("/u/SpartanOne");
   });
 
   it("percent-encodes special characters in the gamertag", () => {
-    expect(buildIndividualTrackerPublicViewPath("Spartan One")).toBe("/u/Spartan%20One/view");
+    expect(buildIndividualTrackerPublicViewPath("Spartan One")).toBe("/u/Spartan%20One");
   });
 });
 

--- a/pages/src/pages/u/[gamertag].astro
+++ b/pages/src/pages/u/[gamertag].astro
@@ -1,8 +1,8 @@
 ---
 export const prerender = false;
-import Layout from "../../../layouts/layout.astro";
-import { API_HOST } from "../../../constants";
-import { FollowLiveApp } from "../../../apps/follow-live/create";
+import Layout from "../../layouts/layout.astro";
+import { API_HOST } from "../../constants";
+import { FollowLiveApp } from "../../apps/follow-live/create";
 const { gamertag } = Astro.params;
 ---
 

--- a/pages/src/services/follow/follow.ts
+++ b/pages/src/services/follow/follow.ts
@@ -39,7 +39,7 @@ export class RealFollowLiveService implements FollowLiveService {
   }
 
   public async getDirectory(gamertag: string): Promise<TrackerDirectory> {
-    const response = await fetch(this.buildUrl(`/u/${encodeURIComponent(gamertag)}/view`), {
+    const response = await fetch(this.buildUrl(`/u/${encodeURIComponent(gamertag)}`), {
       method: "GET",
     });
 

--- a/pages/src/services/follow/tests/follow.test.ts
+++ b/pages/src/services/follow/tests/follow.test.ts
@@ -40,7 +40,7 @@ function directoryMessageData(directory: TrackerDirectory): string {
 }
 
 describe("RealFollowLiveService.getDirectory", () => {
-  it("fetches /u/<gamertag>/view with no credentials and returns the parsed directory", async () => {
+  it("fetches /u/<gamertag> with no credentials and returns the parsed directory", async () => {
     const service = new RealFollowLiveService({ apiHost: "https://api.example.com" });
     const directory = aFakeDirectory();
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
@@ -52,7 +52,7 @@ describe("RealFollowLiveService.getDirectory", () => {
 
     const result = await service.getDirectory("SomeTag");
 
-    expect(fetchSpy).toHaveBeenCalledWith("https://api.example.com/u/SomeTag/view", { method: "GET" });
+    expect(fetchSpy).toHaveBeenCalledWith("https://api.example.com/u/SomeTag", { method: "GET" });
     expect(result).toEqual(directory);
     fetchSpy.mockRestore();
   });


### PR DESCRIPTION
## Context

Just to make things a little nicer, removing the `/view` part of the path for the public route and public API route.