### PR TITLE
IndividualTrackerViewService: fix path post url change

### DIFF
--- a/pages/src/services/individual-tracker/tests/view.test.ts
+++ b/pages/src/services/individual-tracker/tests/view.test.ts
@@ -42,7 +42,7 @@ describe("RealIndividualTrackerViewService", () => {
     const result = await service.getView("tracker 1");
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      "https://api.example.com/api/individual-tracker/tracker%201/view",
+      "https://api.example.com/api/individual-tracker/tracker%201",
       expect.objectContaining({ method: "GET" }),
     );
     const [firstCall] = fetchSpy.mock.calls;

--- a/pages/src/services/individual-tracker/view.ts
+++ b/pages/src/services/individual-tracker/view.ts
@@ -39,7 +39,7 @@ export class RealIndividualTrackerViewService implements IndividualTrackerViewSe
   }
 
   public async getView(trackerId: string): Promise<TrackerViewResponse> {
-    const response = await fetch(this.buildUrl(`/api/individual-tracker/${encodeURIComponent(trackerId)}/view`), {
+    const response = await fetch(this.buildUrl(`/api/individual-tracker/${encodeURIComponent(trackerId)}`), {
       method: "GET",
     });
 


### PR DESCRIPTION
## Context
The public user-level viewer route was simplified from /u/<gamertag>/view to /u/<gamertag>. That route shift required all consumers and tests that build or call the individual tracker public view endpoint to stay aligned so local and CI behavior match.

## This PR
- Fixes the individual tracker view service test expectation to match the updated endpoint path.
- Ensures the changed-files test gate (npm run test:changed) picks up and runs related tests successfully.
- Includes verification that npm run done passes end-to-end on this branch after the fix.

## Subsequent Work
- Remove the temporary backend compatibility alias for /u/:gamertag/view once you are ready to fully drop legacy clients.
- Keep route-helper and service tests as the first checks when changing any public route shape again.
