### PR TITLE
Include credentials for individual tracker view fetch

### DIFF
--- a/pages/src/services/individual-tracker/tests/view.test.ts
+++ b/pages/src/services/individual-tracker/tests/view.test.ts
@@ -36,18 +36,15 @@ describe("RealIndividualTrackerViewService", () => {
     fetchSpy.mockRestore();
   });
 
-  it("gets the view without credentials (public route)", async () => {
+  it("gets the view with credentials", async () => {
     fetchSpy.mockResolvedValueOnce(jsonResponse({ view: FAKE_VIEW }));
 
     const result = await service.getView("tracker 1");
 
     expect(fetchSpy).toHaveBeenCalledWith(
       "https://api.example.com/api/individual-tracker/tracker%201/view",
-      expect.objectContaining({ method: "GET" }),
+      expect.objectContaining({ method: "GET", credentials: "include" }),
     );
-    const [firstCall] = fetchSpy.mock.calls;
-    const [, init] = firstCall;
-    expect(init).not.toHaveProperty("credentials");
     expect(result).toEqual({ view: FAKE_VIEW });
   });
 

--- a/pages/src/services/individual-tracker/view.ts
+++ b/pages/src/services/individual-tracker/view.ts
@@ -40,6 +40,7 @@ export class RealIndividualTrackerViewService implements IndividualTrackerViewSe
 
   public async getView(trackerId: string): Promise<TrackerViewResponse> {
     const response = await fetch(this.buildUrl(`/api/individual-tracker/${encodeURIComponent(trackerId)}/view`), {
+      credentials: "include",
       method: "GET",
     });
 


### PR DESCRIPTION
## Context
The individual tracker view route is owner-gated and requires an authenticated session cookie. Without credentials on the client fetch, owners can receive HTTP 401 for tracker view requests.

## This PR
- Adds credentials include to RealIndividualTrackerViewService.getView so session cookies are sent for /api/individual-tracker/:trackerId/view.
- Updates the corresponding view service unit test to assert credentials are included.

## Subsequent Work
- Optional: add an end-to-end browser test that verifies an authenticated owner can load a tracker view and receives 401 after session expiry.
- Optional: add explicit cookie and credential notes to auth troubleshooting docs for WebSocket handshake diagnostics.