### PR TITLE
Fix overlay ticker crash when showing only my stats

### DIFF
--- a/pages/src/components/information-ticker/information-ticker.tsx
+++ b/pages/src/components/information-ticker/information-ticker.tsx
@@ -37,15 +37,36 @@ const InformationTickerComponent = function InformationTicker({
   onScrollComplete,
 }: InformationTickerProps): React.ReactElement {
   const [currentRowIndex, setCurrentRowIndex] = React.useState(0);
+  const { rows } = currentMatchGroup;
+  const hasRows = rows.length > 0;
+  const safeRowIndex = hasRows ? Math.min(currentRowIndex, rows.length - 1) : 0;
 
   // Reset to first row when match group changes
   useEffect(() => {
     setCurrentRowIndex(0);
   }, [currentMatchGroup]);
 
+  useEffect(() => {
+    if (!hasRows) {
+      if (currentRowIndex !== 0) {
+        setCurrentRowIndex(0);
+      }
+      return;
+    }
+
+    if (currentRowIndex >= rows.length) {
+      setCurrentRowIndex(rows.length - 1);
+    }
+  }, [currentRowIndex, hasRows, rows.length]);
+
   const handleRowScrollComplete = (): void => {
+    if (!hasRows) {
+      onScrollComplete();
+      return;
+    }
+
     // Move to next row or complete the cycle
-    if (currentRowIndex < currentMatchGroup.rows.length - 1) {
+    if (safeRowIndex < rows.length - 1) {
       setCurrentRowIndex(currentRowIndex + 1);
     } else {
       // All rows complete, notify parent
@@ -54,7 +75,11 @@ const InformationTickerComponent = function InformationTicker({
     }
   };
 
-  const currentRow = currentMatchGroup.rows[currentRowIndex];
+  if (!hasRows) {
+    return <div className={styles.ticker} />;
+  }
+
+  const currentRow = rows[safeRowIndex];
   const teamColor = teamColors[currentRow.teamId];
 
   return (

--- a/pages/src/components/information-ticker/tests/information-ticker.test.tsx
+++ b/pages/src/components/information-ticker/tests/information-ticker.test.tsx
@@ -383,4 +383,12 @@ describe("InformationTicker", () => {
     const rowElement = container.querySelector("[style*='--row-color']");
     expect(rowElement).toBeInTheDocument();
   });
+
+  it("does not crash when current match group has no rows", () => {
+    const matchGroup = aFakeTickerMatchGroupWith({ rows: [] });
+
+    expect(() => {
+      render(<InformationTicker currentMatchGroup={matchGroup} teamColors={teamColors} onScrollComplete={vi.fn()} />);
+    }).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Context
Toggling "show only my stats" while the overlay ticker was active could temporarily produce a match group with zero rows, causing the ticker renderer to access teamId on an undefined row and crash.

## This PR
- Adds an empty-row guard in InformationTicker so transient zero-row states do not crash rendering.
- Normalizes row index handling when row counts change during live updates.
- Adds a focused regression test proving InformationTicker does not throw when current match group rows are empty.

## Subsequent Work
- Optional: add an integration test that toggles "show only my stats" live while the overlay is rendering and verifies the ticker remains stable.
- Optional: add lightweight runtime telemetry for overlay render guard paths to quantify how often transient empty-row states occur.
