### PR TITLE
Fix user overlay series indicators

### DIFF
--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -16,7 +16,6 @@ import type { LiveTrackerMatchSummary } from "@guilty-spark/shared/live-tracker/
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { getTeamName } from "@guilty-spark/shared/halo/team";
-import { getSeriesGroupTitleFromTeams } from "@guilty-spark/shared/individual-tracker/series-grouping";
 import type { SeriesStartedPayload } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
 import type { DatabaseService } from "../database/database";
 import type { NeatQueueConfigRow } from "../database/types/neat_queue_config";
@@ -678,7 +677,7 @@ export class NeatQueueService {
       }));
       const seriesContext: SeriesStartedPayload = {
         type: "started",
-        title: getSeriesGroupTitleFromTeams(seriesTeams) ?? title,
+        title,
         subtitle: `Queue #${request.match_number.toString()}`,
         guildIconUrl,
         teams: seriesTeams,

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -1992,7 +1992,7 @@ describe("NeatQueueService", () => {
         expect(xuids).toContain("xuid_discord_user_01");
         expect(xuids).toContain("xuid_discord_user_02");
         expect(payload).toMatchObject({
-          title: "Eagle vs Cobra",
+          title: "Test Server",
           subtitle: `Queue #${teamsCreatedRequest.match_number.toString()}`,
           guildIconUrl: null,
           teams: expect.arrayContaining<SeriesTeam>([
@@ -2038,7 +2038,7 @@ describe("NeatQueueService", () => {
         expect(xuids).toContain("xuid_discord_user_02");
       });
 
-      it("derives title from explicit team names when set", async () => {
+      it("uses guild display name for title even when explicit team names are set", async () => {
         const teamsCreatedRequest = getFakeNeatQueueData("teamsCreated");
         const team0Player = teamsCreatedRequest.teams[0]?.[0];
         const team1Player = teamsCreatedRequest.teams[1]?.[0];
@@ -2065,7 +2065,7 @@ describe("NeatQueueService", () => {
 
         expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
         const [, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], SeriesStartedPayload];
-        expect(payload.title).toBe("Eagles vs Cobras");
+        expect(payload.title).toBe("Test Server");
       });
 
       it("uses guild ID as title fallback when getGuild fails and team names are unavailable", async () => {

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -7,7 +7,7 @@ import { createElement, type CSSProperties } from "react";
 import type { MedalEntry, MedalMetadata } from "@guilty-spark/shared/halo/medals";
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
-import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import { summarizeSeriesOutcome } from "@guilty-spark/shared/halo/match-enrichment";
 import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type { TickerMatchGroup, TickerStatRow } from "../../information-ticker/information-ticker";
@@ -46,62 +46,8 @@ interface TickerFilterOptions {
   readonly medalRarityFilter: readonly number[];
 }
 
-function summarizeSeriesOutcome(
-  matches: readonly ViewerSeriesTab["matches"][number][],
-): "Win" | "Loss" | "Tie" | "DNF" | "Unknown" {
-  let wins = 0;
-  let losses = 0;
-  let ties = 0;
-  let dnf = 0;
-
-  for (const match of matches) {
-    switch (match.outcome) {
-      case "Win": {
-        wins += 1;
-        break;
-      }
-      case "Loss": {
-        losses += 1;
-        break;
-      }
-      case "Tie": {
-        ties += 1;
-        break;
-      }
-      case "DNF": {
-        dnf += 1;
-        break;
-      }
-      case "Unknown": {
-        break;
-      }
-      default: {
-        throw new UnreachableError(match.outcome);
-      }
-    }
-  }
-
-  if (wins > losses) {
-    return "Win";
-  }
-
-  if (losses > wins) {
-    return "Loss";
-  }
-
-  if (wins === 0 && losses === 0 && dnf > 0) {
-    return "DNF";
-  }
-
-  if (ties > 0) {
-    return "Tie";
-  }
-
-  return "Unknown";
-}
-
 function getSeriesOutcomeColorHex(series: ViewerSeriesTab): string | undefined {
-  const seriesOutcome = summarizeSeriesOutcome(series.matches);
+  const seriesOutcome = summarizeSeriesOutcome(series.matches.map((match) => match.outcome));
 
   if (seriesOutcome === "Win") {
     return series.matches.find((match) => match.outcome === "Win")?.colorHex;

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -7,6 +7,7 @@ import { createElement, type CSSProperties } from "react";
 import type { MedalEntry, MedalMetadata } from "@guilty-spark/shared/halo/medals";
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type { TickerMatchGroup, TickerStatRow } from "../../information-ticker/information-ticker";
@@ -43,6 +44,74 @@ interface TickerFilterOptions {
   readonly selectedSlayerStats: readonly string[];
   readonly showObjectiveStats: boolean;
   readonly medalRarityFilter: readonly number[];
+}
+
+function summarizeSeriesOutcome(
+  matches: readonly ViewerSeriesTab["matches"][number][],
+): "Win" | "Loss" | "Tie" | "DNF" | "Unknown" {
+  let wins = 0;
+  let losses = 0;
+  let ties = 0;
+  let dnf = 0;
+
+  for (const match of matches) {
+    switch (match.outcome) {
+      case "Win": {
+        wins += 1;
+        break;
+      }
+      case "Loss": {
+        losses += 1;
+        break;
+      }
+      case "Tie": {
+        ties += 1;
+        break;
+      }
+      case "DNF": {
+        dnf += 1;
+        break;
+      }
+      case "Unknown": {
+        break;
+      }
+      default: {
+        throw new UnreachableError(match.outcome);
+      }
+    }
+  }
+
+  if (wins > losses) {
+    return "Win";
+  }
+
+  if (losses > wins) {
+    return "Loss";
+  }
+
+  if (wins === 0 && losses === 0 && dnf > 0) {
+    return "DNF";
+  }
+
+  if (ties > 0) {
+    return "Tie";
+  }
+
+  return "Unknown";
+}
+
+function getSeriesOutcomeColorHex(series: ViewerSeriesTab): string | undefined {
+  const seriesOutcome = summarizeSeriesOutcome(series.matches);
+
+  if (seriesOutcome === "Win") {
+    return series.matches.find((match) => match.outcome === "Win")?.colorHex;
+  }
+
+  if (seriesOutcome === "Loss") {
+    return series.matches.find((match) => match.outcome === "Loss")?.colorHex;
+  }
+
+  return undefined;
 }
 
 export type MatchStatsState =
@@ -193,16 +262,18 @@ export class IndividualTrackerOverlayPresenter {
     let seriesIdx = -1;
     return timeline.map((item): OverlayTab => {
       if (item.type === "series") {
+        const isMatchmakingSeries = item.series.matches.every((match) => match.isMatchmaking);
+
         return {
           type: "series",
           seriesId: item.series.id,
           index: seriesIdx--,
           label: item.series.title,
           score: item.series.score,
-          teamColor: undefined,
+          teamColor: getSeriesOutcomeColorHex(item.series),
           icons: item.series.matches.map((match) => ({
             src: gameModeIconSrc(match.gameVariantCategory),
-            dimmed: false,
+            dimmed: isMatchmakingSeries && match.outcome === "Loss",
           })),
         };
       }

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -39,6 +39,7 @@ function aMatchWith(overrides: Partial<ViewerMatchTab> = {}): ViewerMatchTab {
     mapName: overrides.mapName ?? "Live Fire",
     mapBackgroundUrl: overrides.mapBackgroundUrl ?? "data:,",
     gameVariantCategory: overrides.gameVariantCategory ?? 6,
+    isMatchmaking: overrides.isMatchmaking ?? false,
     gameModeName: overrides.gameModeName ?? "Slayer",
     duration: overrides.duration ?? "10m",
     outcome: overrides.outcome ?? "Win",
@@ -137,6 +138,77 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(matchTab.type).toBe("match");
     if (matchTab.type === "match") {
       expect(matchTab.icon).toBe(gameModeIconSrc(8));
+    }
+  });
+
+  it("applies series tab color from the aggregated tracked-player outcome", () => {
+    const timeline: ViewerTimelineItem[] = [
+      {
+        type: "series",
+        series: aSeriesWith({
+          id: "series-loss",
+          isActive: false,
+          matches: [
+            aMatchWith({ matchId: "m-1", outcome: "Loss", colorHex: "#AA0011", isMatchmaking: true }),
+            aMatchWith({ matchId: "m-2", outcome: "Loss", colorHex: "#AA0011", isMatchmaking: true }),
+            aMatchWith({ matchId: "m-3", outcome: "Win", colorHex: "#00AA11", isMatchmaking: true }),
+          ],
+        }),
+      },
+    ];
+
+    const [seriesTab] = presenter.buildTabs(timeline);
+
+    expect(seriesTab.type).toBe("series");
+    if (seriesTab.type === "series") {
+      expect(seriesTab.teamColor).toBe("#AA0011");
+    }
+  });
+
+  it("dims lost icons only for matchmaking series tabs", () => {
+    const timeline: ViewerTimelineItem[] = [
+      {
+        type: "series",
+        series: aSeriesWith({
+          id: "series-matchmaking",
+          isActive: false,
+          matches: [
+            aMatchWith({ matchId: "mm-1", outcome: "Win", isMatchmaking: true }),
+            aMatchWith({ matchId: "mm-2", outcome: "Loss", isMatchmaking: true }),
+          ],
+        }),
+      },
+      {
+        type: "series",
+        series: aSeriesWith({
+          id: "series-custom",
+          isActive: false,
+          matches: [
+            aMatchWith({ matchId: "custom-1", outcome: "Loss", isMatchmaking: false }),
+            aMatchWith({ matchId: "custom-2", outcome: "Win", isMatchmaking: false }),
+          ],
+        }),
+      },
+    ];
+
+    const tabs = presenter.buildTabs(timeline);
+    const matchmakingTab = tabs.find((tab) => tab.type === "series" && tab.seriesId === "series-matchmaking");
+    const customTab = tabs.find((tab) => tab.type === "series" && tab.seriesId === "series-custom");
+
+    expect(matchmakingTab?.type).toBe("series");
+    if (matchmakingTab?.type === "series") {
+      expect(matchmakingTab.icons).toEqual([
+        { src: gameModeIconSrc(6), dimmed: false },
+        { src: gameModeIconSrc(6), dimmed: true },
+      ]);
+    }
+
+    expect(customTab?.type).toBe("series");
+    if (customTab?.type === "series") {
+      expect(customTab.icons).toEqual([
+        { src: gameModeIconSrc(6), dimmed: false },
+        { src: gameModeIconSrc(6), dimmed: false },
+      ]);
     }
   });
 

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
@@ -5,7 +5,7 @@ import { addMinutes, isValid, parseISO } from "date-fns";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import type { TrackerStatus } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
-import type { NormalizedMatchOutcome } from "@guilty-spark/shared/halo/match-enrichment";
+import { summarizeSeriesOutcome } from "@guilty-spark/shared/halo/match-enrichment";
 import { Alert } from "../../alert/alert";
 import { Button } from "../../button/button";
 import { Container } from "../../container/container";
@@ -176,54 +176,6 @@ function connectionAwareNextUpdate(
   }
 
   return nextUpdateContent(renderModel);
-}
-
-function summarizeSeriesOutcome(outcomes: readonly NormalizedMatchOutcome[]): NormalizedMatchOutcome {
-  let wins = 0;
-  let losses = 0;
-  let ties = 0;
-  let dnf = 0;
-
-  for (const outcome of outcomes) {
-    switch (outcome) {
-      case "Win": {
-        wins += 1;
-        break;
-      }
-      case "Loss": {
-        losses += 1;
-        break;
-      }
-      case "Tie": {
-        ties += 1;
-        break;
-      }
-      case "DNF": {
-        dnf += 1;
-        break;
-      }
-      case "Unknown": {
-        break;
-      }
-      default: {
-        throw new UnreachableError(outcome);
-      }
-    }
-  }
-
-  if (wins > losses) {
-    return "Win";
-  }
-  if (losses > wins) {
-    return "Loss";
-  }
-  if (wins === 0 && losses === 0 && dnf > 0) {
-    return "DNF";
-  }
-  if (ties > 0) {
-    return "Tie";
-  }
-  return "Unknown";
 }
 
 function getBackgroundAt(backgrounds: readonly string[], index: number): string {

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -13,6 +13,7 @@ export interface ViewerMatchTab {
   readonly mapName: string;
   readonly mapBackgroundUrl: string;
   readonly gameVariantCategory: number;
+  readonly isMatchmaking: boolean;
   readonly gameModeName: string;
   readonly duration: string;
   readonly outcome: NormalizedMatchOutcome;

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -110,6 +110,7 @@ function toMatchTab(summary: TrackerMatchSummary, teamHex: string, enemyHex: str
     mapName: summary.mapName,
     mapBackgroundUrl: summary.mapBackgroundUrl ?? "data:,",
     gameVariantCategory: summary.gameVariantCategory,
+    isMatchmaking: summary.isMatchmaking,
     gameModeName: getGameModeName(summary.gameVariantCategory),
     duration,
     outcome,

--- a/pages/src/components/streamer-overlay/tabs-bar.tsx
+++ b/pages/src/components/streamer-overlay/tabs-bar.tsx
@@ -8,7 +8,7 @@ interface SeriesTab {
   readonly index: number;
   readonly label: string;
   readonly score: string;
-  readonly teamColor: undefined;
+  readonly teamColor: string | undefined;
   readonly icons?: readonly { readonly src: string; readonly dimmed: boolean }[];
 }
 

--- a/shared/src/halo/match-enrichment.ts
+++ b/shared/src/halo/match-enrichment.ts
@@ -1,6 +1,7 @@
 import type { MatchStats } from "halo-infinite-api";
 import { GameVariantCategory } from "halo-infinite-api";
 import { compareAsc } from "date-fns";
+import { UnreachableError } from "../base/unreachable-error";
 import { getPlayerXuid } from "./match-stats";
 
 export type NormalizedMatchOutcome = "Win" | "Loss" | "Tie" | "DNF" | "Unknown";
@@ -57,6 +58,58 @@ export function getOutcomeColor(
     return enemyColor;
   }
   return undefined;
+}
+
+export function summarizeSeriesOutcome(outcomes: readonly NormalizedMatchOutcome[]): NormalizedMatchOutcome {
+  let wins = 0;
+  let losses = 0;
+  let ties = 0;
+  let dnf = 0;
+
+  for (const outcome of outcomes) {
+    switch (outcome) {
+      case "Win": {
+        wins += 1;
+        break;
+      }
+      case "Loss": {
+        losses += 1;
+        break;
+      }
+      case "Tie": {
+        ties += 1;
+        break;
+      }
+      case "DNF": {
+        dnf += 1;
+        break;
+      }
+      case "Unknown": {
+        break;
+      }
+      default: {
+        throw new UnreachableError(outcome);
+      }
+    }
+  }
+
+  if (wins > losses) {
+    return "Win";
+  }
+
+  if (losses > wins) {
+    return "Loss";
+  }
+
+  if (wins === 0 && losses === 0 && dnf > 0) {
+    return "DNF";
+  }
+
+  if (ties > 0) {
+    return "Tie";
+  }
+
+  return "Unknown";
 }
 
 export function buildMatchScore(matchStats: MatchStats, locale?: string): string {

--- a/shared/src/halo/tests/match-enrichment.test.ts
+++ b/shared/src/halo/tests/match-enrichment.test.ts
@@ -8,6 +8,7 @@ import {
   collapseSequentialSeriesEntries,
   getMatchOutcomeLabel,
   normalizeModeName,
+  summarizeSeriesOutcome,
 } from "../match-enrichment";
 
 describe("getMatchOutcomeLabel()", () => {
@@ -20,6 +21,28 @@ describe("getMatchOutcomeLabel()", () => {
     [99, "Unknown"],
   ])("returns %s for outcome code %s", (outcomeCode, expected) => {
     expect(getMatchOutcomeLabel(outcomeCode)).toBe(expected);
+  });
+});
+
+describe("summarizeSeriesOutcome()", () => {
+  it("returns Win when wins exceed losses", () => {
+    expect(summarizeSeriesOutcome(["Win", "Loss", "Win"])).toBe("Win");
+  });
+
+  it("returns Loss when losses exceed wins", () => {
+    expect(summarizeSeriesOutcome(["Loss", "Loss", "Win"])).toBe("Loss");
+  });
+
+  it("returns DNF when there are no wins or losses and at least one DNF", () => {
+    expect(summarizeSeriesOutcome(["Unknown", "DNF"])).toBe("DNF");
+  });
+
+  it("returns Tie when wins and losses are even and there is at least one tie", () => {
+    expect(summarizeSeriesOutcome(["Win", "Loss", "Tie"])).toBe("Tie");
+  });
+
+  it("returns Unknown when no outcome establishes a series result", () => {
+    expect(summarizeSeriesOutcome(["Unknown", "Unknown"])).toBe("Unknown");
   });
 });
 


### PR DESCRIPTION
## Context
The user-level individual tracker overlay and viewer share series data, but the overlay was still lagging behind the viewer in a few matchmaking-specific cases. Completed series tabs were staying neutral instead of reflecting the tracked player's series result, matchmaking series icons were not dimming lost games, and NeatQueue-backed series titles were still surfacing team-vs-team text instead of the Discord server identity carried with the websocket payload.

## This PR
This PR makes the user overlay series presentation line up with the user-level viewer behavior. It computes a completed-series tab color from the tracked player's aggregated series outcome, dims only lost match icons for matchmaking series tabs, threads matchmaking state into the viewer render model to support that distinction, and updates NeatQueue series context generation to use the guild display name for the tracker-facing series title while keeping the queue subtitle and guild icon intact. The overlay presenter and NeatQueue tests were expanded accordingly, and the full `npm run done` pipeline passes on the branch.

## Subsequent Work
If we want existing historical tracker entries to pick up the new guild-name title behavior retroactively, that would need a separate backfill or refresh path for already-persisted series groups.
