### PR TITLE
Unify trailing slash handling and branded error pages

### DIFF
--- a/pages/src/pages/404.astro
+++ b/pages/src/pages/404.astro
@@ -1,0 +1,23 @@
+---
+import Layout from "../layouts/layout.astro";
+import Button from "../components/button/button.astro";
+import ErrorState from "../components/error-state/error-state.astro";
+import styles from "./_styles/error-page.module.css";
+
+const pageTitle = "404 - Resource Not Found | Guilty Spark";
+const pageDescription = "The requested resource was not found in this sector.";
+---
+
+<Layout title={pageTitle} description={pageDescription}>
+  <section class={styles.section}>
+    <div class={styles.content}>
+      <ErrorState
+        title="Resource Not Found"
+        message="The page or endpoint you requested does not exist. Verify the URL and try again."
+      />
+      <div class={styles.actions}>
+        <Button href="/" variant="secondary">Return to Command Center</Button>
+      </div>
+    </div>
+  </section>
+</Layout>

--- a/pages/src/pages/500.astro
+++ b/pages/src/pages/500.astro
@@ -1,0 +1,31 @@
+---
+import Layout from "../layouts/layout.astro";
+import Button from "../components/button/button.astro";
+import ErrorState from "../components/error-state/error-state.astro";
+import styles from "./_styles/error-page.module.css";
+
+interface Props {
+  readonly error: unknown;
+}
+
+const { error } = Astro.props;
+
+const pageTitle = "500 - System Fault | Guilty Spark";
+const pageDescription = "An unexpected internal fault interrupted rendering.";
+
+const userMessage =
+  error instanceof Error
+    ? "An internal operation failed while processing your request. Please retry shortly."
+    : "An unexpected internal error occurred while processing your request. Please retry shortly.";
+---
+
+<Layout title={pageTitle} description={pageDescription}>
+  <section class={styles.section}>
+    <div class={styles.content}>
+      <ErrorState title="System Fault" message={userMessage} />
+      <div class={styles.actions}>
+        <Button href="/" variant="secondary">Return to Command Center</Button>
+      </div>
+    </div>
+  </section>
+</Layout>

--- a/pages/src/pages/_styles/error-page.module.css
+++ b/pages/src/pages/_styles/error-page.module.css
@@ -1,0 +1,24 @@
+.section {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  min-height: calc(100vh - 220px);
+  padding: var(--space-10) var(--gutter-mobile);
+}
+
+.content {
+  width: min(680px, 100%);
+}
+
+.actions {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--space-2);
+}
+
+@media (--desktop-viewport) {
+  .section {
+    min-height: calc(100vh - 250px);
+  }
+}

--- a/pages/wrangler.jsonc
+++ b/pages/wrangler.jsonc
@@ -1,11 +1,15 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "guilty-spark-web",
-  // `main` and `assets` are intentionally omitted: the @astrojs/cloudflare adapter
-  // generates them (dist/server/entry.mjs + the dist/client assets dir bound to ASSETS)
-  // into dist/server/wrangler.json and redirects wrangler to that config on deploy.
+  // `main` is intentionally omitted: the @astrojs/cloudflare adapter generates it
+  // (dist/server/entry.mjs) and redirects wrangler to dist/server/wrangler.json on deploy.
+  // We still set asset routing behavior here so Cloudflare canonicalizes HTML URLs
+  // without trailing slashes, matching Astro's trailingSlash: "never" setting.
   "compatibility_date": "2026-05-15",
   "compatibility_flags": ["global_fetch_strictly_public"],
+  "assets": {
+    "html_handling": "drop-trailing-slash",
+  },
   // The @astrojs/cloudflare adapter enables Astro KV sessions and binds them to "SESSION".
   // Declaring the existing namespace by id stops Wrangler from re-provisioning it on every deploy.
   "kv_namespaces": [

--- a/pages/wrangler.jsonc
+++ b/pages/wrangler.jsonc
@@ -9,6 +9,7 @@
   "compatibility_flags": ["global_fetch_strictly_public"],
   "assets": {
     "html_handling": "drop-trailing-slash",
+    "not_found_handling": "404-page",
   },
   // The @astrojs/cloudflare adapter enables Astro KV sessions and binds them to "SESSION".
   // Declaring the existing namespace by id stops Wrangler from re-provisioning it on every deploy.


### PR DESCRIPTION
## Context
This update aligns URL canonicalization and error handling for the Pages app so user-facing behavior is consistent between Astro and Cloudflare. It also ensures 404 and 500 responses match the existing Guilty Spark visual language rather than default platform pages.

## This PR
- Configure Cloudflare Pages assets routing to canonicalize HTML routes without trailing slashes.
- Configure Cloudflare assets not-found handling to use a project 404 page.
- Add custom Astro 404 and 500 pages using the existing shared error-state visual component.
- Ensure both error pages include a centered call-to-action back to the home experience using the shared button component.

## Subsequent Work
- Deploy Pages and verify production responses for:
  - valid route with accidental trailing slash -> canonical non-slash URL
  - unknown route -> custom branded 404
  - runtime render fault in SSR path -> custom branded 500