### PR TITLE
Refine user-level overlay tab behavior

### DIFF
--- a/pages/src/components/individual-tracker-manager/create.tsx
+++ b/pages/src/components/individual-tracker-manager/create.tsx
@@ -122,6 +122,8 @@ export function IndividualTrackerManagerPage({
           observerEnemyColor={settingsSnapshot.observerEnemyColor}
           displaySettings={settingsSnapshot.displaySettings}
           tickerSettings={settingsSnapshot.tickerSettings}
+          inSeriesShowSeriesTab={settingsSnapshot.inSeriesShowSeriesTab}
+          matchmakingShowSummaryTab={settingsSnapshot.matchmakingShowSummaryTab}
           inSeriesShowTicker={settingsSnapshot.inSeriesShowTicker}
           matchmakingShowTicker={settingsSnapshot.matchmakingShowTicker}
           matchmakingShowStatsHighlights={settingsSnapshot.matchmakingShowStatsHighlights}
@@ -144,6 +146,12 @@ export function IndividualTrackerManagerPage({
           }}
           onTickerSettingsChange={(updates): void => {
             settingsPresenter.setTickerSettings(updates);
+          }}
+          onInSeriesShowSeriesTabChange={(enabled): void => {
+            settingsPresenter.setInSeriesShowSeriesTab(enabled);
+          }}
+          onMatchmakingShowSummaryTabChange={(enabled): void => {
+            settingsPresenter.setMatchmakingShowSummaryTab(enabled);
           }}
           onInSeriesShowTickerChange={(enabled): void => {
             settingsPresenter.setInSeriesShowTicker(enabled);

--- a/pages/src/components/individual-tracker-manager/streamer-settings/create.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/create.tsx
@@ -45,6 +45,8 @@ export function StreamerSettingsSection({
       observerEnemyColor={snapshot.observerEnemyColor}
       displaySettings={snapshot.displaySettings}
       tickerSettings={snapshot.tickerSettings}
+      inSeriesShowSeriesTab={snapshot.inSeriesShowSeriesTab}
+      matchmakingShowSummaryTab={snapshot.matchmakingShowSummaryTab}
       inSeriesShowTicker={snapshot.inSeriesShowTicker}
       matchmakingShowTicker={snapshot.matchmakingShowTicker}
       matchmakingShowStatsHighlights={snapshot.matchmakingShowStatsHighlights}
@@ -67,6 +69,12 @@ export function StreamerSettingsSection({
       }}
       onTickerSettingsChange={(updates): void => {
         presenter.setTickerSettings(updates);
+      }}
+      onInSeriesShowSeriesTabChange={(enabled): void => {
+        presenter.setInSeriesShowSeriesTab(enabled);
+      }}
+      onMatchmakingShowSummaryTabChange={(enabled): void => {
+        presenter.setMatchmakingShowSummaryTab(enabled);
       }}
       onInSeriesShowTickerChange={(enabled): void => {
         presenter.setInSeriesShowTicker(enabled);

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-presenter.ts
@@ -67,6 +67,8 @@ function settingsToSnapshot(
       showObjectiveStats: styleFlags.showObjectiveStats ?? snapshot.tickerSettings.showObjectiveStats,
       medalRarityFilter: styleFlags.medalRarityFilter ?? snapshot.tickerSettings.medalRarityFilter,
     },
+    inSeriesShowSeriesTab: styleFlags.inSeriesShowSeriesTab ?? snapshot.inSeriesShowSeriesTab,
+    matchmakingShowSummaryTab: styleFlags.matchmakingShowSummaryTab ?? snapshot.matchmakingShowSummaryTab,
     inSeriesShowTicker: styleFlags.inSeriesShowTicker ?? visibleSections.showTicker ?? snapshot.inSeriesShowTicker,
     matchmakingShowTicker:
       styleFlags.matchmakingShowTicker ?? visibleSections.showTicker ?? snapshot.matchmakingShowTicker,
@@ -107,6 +109,8 @@ function snapshotToSettings(snapshot: StreamerSettingsSnapshot): StreamerViewSet
       selectedSlayerStats: [...snapshot.tickerSettings.selectedSlayerStats],
       showObjectiveStats: snapshot.tickerSettings.showObjectiveStats,
       medalRarityFilter: [...snapshot.tickerSettings.medalRarityFilter],
+      inSeriesShowSeriesTab: snapshot.inSeriesShowSeriesTab,
+      matchmakingShowSummaryTab: snapshot.matchmakingShowSummaryTab,
       inSeriesShowTicker: snapshot.inSeriesShowTicker,
       matchmakingShowTicker: snapshot.matchmakingShowTicker,
       matchmakingShowStatsHighlights: snapshot.matchmakingShowStatsHighlights,
@@ -207,6 +211,24 @@ export class StreamerSettingsPresenter {
     }
     const current = this.config.store.getSnapshot().tickerSettings;
     this.config.store.setTickerSettings({ ...current, ...updates });
+    this.scheduleSave();
+  }
+
+  public setInSeriesShowSeriesTab(enabled: boolean): void {
+    if (this.isDisposed) {
+      return;
+    }
+
+    this.config.store.batchUpdate({ inSeriesShowSeriesTab: enabled });
+    this.scheduleSave();
+  }
+
+  public setMatchmakingShowSummaryTab(enabled: boolean): void {
+    if (this.isDisposed) {
+      return;
+    }
+
+    this.config.store.batchUpdate({ matchmakingShowSummaryTab: enabled });
     this.scheduleSave();
   }
 

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-store.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-store.ts
@@ -19,6 +19,8 @@ export interface StreamerSettingsSnapshot {
   readonly observerEnemyColor: string;
   readonly displaySettings: DisplaySettings;
   readonly tickerSettings: TickerSettings;
+  readonly inSeriesShowSeriesTab: boolean;
+  readonly matchmakingShowSummaryTab: boolean;
   readonly inSeriesShowTicker: boolean;
   readonly matchmakingShowTicker: boolean;
   readonly matchmakingShowStatsHighlights: boolean;
@@ -74,6 +76,8 @@ export class StreamerSettingsStore {
       observerEnemyColor: "cerulean",
       displaySettings: DEFAULT_DISPLAY_SETTINGS,
       tickerSettings: DEFAULT_TICKER_SETTINGS,
+      inSeriesShowSeriesTab: true,
+      matchmakingShowSummaryTab: true,
       inSeriesShowTicker: true,
       matchmakingShowTicker: true,
       matchmakingShowStatsHighlights: true,

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -57,6 +57,8 @@ export interface StreamerSettingsSectionViewProps {
   readonly observerEnemyColor: string;
   readonly displaySettings: DisplaySettings;
   readonly tickerSettings: TickerSettings;
+  readonly inSeriesShowSeriesTab: boolean;
+  readonly matchmakingShowSummaryTab: boolean;
   readonly inSeriesShowTicker: boolean;
   readonly matchmakingShowTicker: boolean;
   readonly matchmakingShowStatsHighlights: boolean;
@@ -70,6 +72,8 @@ export interface StreamerSettingsSectionViewProps {
   readonly onObserverColorsChange: (teamColor: string, enemyColor: string) => void;
   readonly onDisplaySettingsChange: (updates: Partial<DisplaySettings>) => void;
   readonly onTickerSettingsChange: (updates: Partial<TickerSettings>) => void;
+  readonly onInSeriesShowSeriesTabChange: (enabled: boolean) => void;
+  readonly onMatchmakingShowSummaryTabChange: (enabled: boolean) => void;
   readonly onInSeriesShowTickerChange: (enabled: boolean) => void;
   readonly onMatchmakingShowTickerChange: (enabled: boolean) => void;
   readonly onMatchmakingShowStatsHighlightsChange: (enabled: boolean) => void;
@@ -87,6 +91,8 @@ export function StreamerSettingsSectionView({
   observerEnemyColor,
   displaySettings,
   tickerSettings,
+  inSeriesShowSeriesTab,
+  matchmakingShowSummaryTab,
   inSeriesShowTicker,
   matchmakingShowTicker,
   matchmakingShowStatsHighlights,
@@ -100,6 +106,8 @@ export function StreamerSettingsSectionView({
   onObserverColorsChange,
   onDisplaySettingsChange,
   onTickerSettingsChange,
+  onInSeriesShowSeriesTabChange,
+  onMatchmakingShowSummaryTabChange,
   onInSeriesShowTickerChange,
   onMatchmakingShowTickerChange,
   onMatchmakingShowStatsHighlightsChange,
@@ -433,6 +441,14 @@ export function StreamerSettingsSectionView({
           </p>
         </div>
         <Checkbox
+          checked={inSeriesShowSeriesTab}
+          onChange={(checked): void => {
+            onInSeriesShowSeriesTabChange(checked);
+          }}
+          label="Show series score tab"
+          description="Show a first tab that opens the overall series stats panel when a series is active."
+        />
+        <Checkbox
           checked={tickerSettings.showPreSeriesInfo}
           onChange={(checked): void => {
             onTickerSettingsChange({ showPreSeriesInfo: checked });
@@ -479,6 +495,14 @@ export function StreamerSettingsSectionView({
             Matchmaking top-section stats depend on Stats Highlights and this overlay visibility toggle.
           </p>
         </div>
+        <Checkbox
+          checked={matchmakingShowSummaryTab}
+          onChange={(checked): void => {
+            onMatchmakingShowSummaryTabChange(checked);
+          }}
+          label="Show summary tab"
+          description="Show a first tab that opens a compact matchmaking summary when no series is active."
+        />
         <Checkbox
           checked={matchmakingShowStatsHighlights}
           onChange={(checked): void => {

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -501,7 +501,7 @@ export function StreamerSettingsSectionView({
             onMatchmakingShowSummaryTabChange(checked);
           }}
           label="Show summary tab"
-          description="Show a first tab that opens a compact matchmaking summary when no series is active."
+          description="Show matchmaking summary/series tabs when no active series is in progress."
         />
         <Checkbox
           checked={matchmakingShowStatsHighlights}

--- a/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings-presenter.test.ts
@@ -82,6 +82,8 @@ describe("StreamerSettingsPresenter", () => {
           visibleSections: { showTicker: false, showTabs: false },
           styleFlags: {
             showPreSeriesInfo: false,
+            inSeriesShowSeriesTab: false,
+            matchmakingShowSummaryTab: false,
             inSeriesShowTicker: false,
             matchmakingShowTicker: true,
             matchmakingShowStatsHighlights: false,
@@ -95,6 +97,8 @@ describe("StreamerSettingsPresenter", () => {
       expect(store.getSnapshot().tickerSettings.showTicker).toBe(false);
       expect(store.getSnapshot().tickerSettings.showTabs).toBe(false);
       expect(store.getSnapshot().tickerSettings.showPreSeriesInfo).toBe(false);
+      expect(store.getSnapshot().inSeriesShowSeriesTab).toBe(false);
+      expect(store.getSnapshot().matchmakingShowSummaryTab).toBe(false);
       expect(store.getSnapshot().inSeriesShowTicker).toBe(false);
       expect(store.getSnapshot().matchmakingShowTicker).toBe(true);
       expect(store.getSnapshot().matchmakingShowStatsHighlights).toBe(false);
@@ -266,6 +270,44 @@ describe("StreamerSettingsPresenter", () => {
 
       expect(store.getSnapshot().tickerSettings.showTicker).toBe(false);
       expect(store.getSnapshot().tickerSettings.showTabs).toBe(true);
+    });
+  });
+
+  describe("setInSeriesShowSeriesTab", () => {
+    it("updates inSeriesShowSeriesTab in the store and schedules a save", async () => {
+      const { store, presenter, settingsService } = aHarness();
+      const updateSpy: MockInstance<typeof settingsService.updateSettings> = vi.spyOn(
+        settingsService,
+        "updateSettings",
+      );
+
+      presenter.setInSeriesShowSeriesTab(false);
+
+      expect(store.getSnapshot().inSeriesShowSeriesTab).toBe(false);
+
+      await vi.runAllTimersAsync();
+
+      const [[saved]] = updateSpy.mock.calls;
+      expect(saved.styleFlags?.inSeriesShowSeriesTab).toBe(false);
+    });
+  });
+
+  describe("setMatchmakingShowSummaryTab", () => {
+    it("updates matchmakingShowSummaryTab in the store and schedules a save", async () => {
+      const { store, presenter, settingsService } = aHarness();
+      const updateSpy: MockInstance<typeof settingsService.updateSettings> = vi.spyOn(
+        settingsService,
+        "updateSettings",
+      );
+
+      presenter.setMatchmakingShowSummaryTab(false);
+
+      expect(store.getSnapshot().matchmakingShowSummaryTab).toBe(false);
+
+      await vi.runAllTimersAsync();
+
+      const [[saved]] = updateSpy.mock.calls;
+      expect(saved.styleFlags?.matchmakingShowSummaryTab).toBe(false);
     });
   });
 

--- a/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
@@ -65,6 +65,8 @@ function aFakeProps(overrides?: Partial<StreamerSettingsSectionViewProps>): Stre
     observerEnemyColor: "cerulean",
     displaySettings: DEFAULT_DISPLAY_SETTINGS,
     tickerSettings: DEFAULT_TICKER_SETTINGS,
+    inSeriesShowSeriesTab: true,
+    matchmakingShowSummaryTab: true,
     inSeriesShowTicker: true,
     matchmakingShowTicker: true,
     matchmakingShowStatsHighlights: true,
@@ -78,6 +80,8 @@ function aFakeProps(overrides?: Partial<StreamerSettingsSectionViewProps>): Stre
     onObserverColorsChange: (): void => undefined,
     onDisplaySettingsChange: (): void => undefined,
     onTickerSettingsChange: (): void => undefined,
+    onInSeriesShowSeriesTabChange: (): void => undefined,
+    onMatchmakingShowSummaryTabChange: (): void => undefined,
     onInSeriesShowTickerChange: (): void => undefined,
     onMatchmakingShowTickerChange: (): void => undefined,
     onMatchmakingShowStatsHighlightsChange: (): void => undefined,
@@ -240,6 +244,18 @@ describe("StreamerSettingsSectionView", () => {
       expect(screen.getByTestId("ticker-settings-section")).toBeInTheDocument();
     });
 
+    it("renders the series tab toggle in the in-series section", () => {
+      render(<StreamerSettingsSectionView {...aFakeProps()} />);
+
+      expect(screen.getByRole("checkbox", { name: /show series score tab/i })).toBeInTheDocument();
+    });
+
+    it("renders the summary tab toggle in the matchmaking section", () => {
+      render(<StreamerSettingsSectionView {...aFakeProps()} />);
+
+      expect(screen.getByRole("checkbox", { name: /show summary tab/i })).toBeInTheDocument();
+    });
+
     it("renders font size sliders for all sections", () => {
       render(<StreamerSettingsSectionView {...aFakeProps()} />);
 
@@ -318,6 +334,28 @@ describe("StreamerSettingsSectionView", () => {
       render(<StreamerSettingsSectionView {...aFakeProps({ onInSeriesShowTickerChange: onChange })} />);
 
       await user.click(screen.getByRole("checkbox", { name: /in series\s*show information ticker/i }));
+
+      expect(onChange).toHaveBeenCalledWith(false);
+    });
+
+    it("calls onInSeriesShowSeriesTabChange when the series tab toggle is clicked", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn<(enabled: boolean) => void>();
+
+      render(<StreamerSettingsSectionView {...aFakeProps({ onInSeriesShowSeriesTabChange: onChange })} />);
+
+      await user.click(screen.getByRole("checkbox", { name: /show series score tab/i }));
+
+      expect(onChange).toHaveBeenCalledWith(false);
+    });
+
+    it("calls onMatchmakingShowSummaryTabChange when the summary tab toggle is clicked", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn<(enabled: boolean) => void>();
+
+      render(<StreamerSettingsSectionView {...aFakeProps({ onMatchmakingShowSummaryTabChange: onChange })} />);
+
+      await user.click(screen.getByRole("checkbox", { name: /show summary tab/i }));
 
       expect(onChange).toHaveBeenCalledWith(false);
     });

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -146,9 +146,7 @@ export function IndividualTrackerOverlayPage({
             isPanelOpen={isPanelOpen}
             matchesLength={model.renderModel.accumulated.total}
             matchStatsPanelState={overlayModel.matchStatsPanelState}
-            seriesStatsPanelState={
-              selectedSeriesEntryState?.kind === "series" ? selectedSeriesEntryState.state : null
-            }
+            seriesStatsPanelState={selectedSeriesEntryState?.kind === "series" ? selectedSeriesEntryState.state : null}
             selectedMatchId={overlayModel.selectedMatchId}
             selectedSeriesId={overlayModel.selectedSeriesId}
             showPreview={showPreview}

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -46,7 +46,7 @@ export function IndividualTrackerOverlayPage({
     [haloClient, matchAnalyticsService, store],
   );
 
-  const { snapshot, model, onRetry } = useIndividualTrackerViewer({
+  const { snapshot, model, onRetry, onToggleEntry } = useIndividualTrackerViewer({
     individualTrackerViewService,
     matchAnalyticsService,
     seriesMatchesService,
@@ -90,6 +90,13 @@ export function IndividualTrackerOverlayPage({
 
   const overlayModel = useMemo(() => presenter.present(overlaySnapshot), [overlaySnapshot, presenter]);
   const overlayPresenter = useMemo(() => new IndividualTrackerOverlayPresenter(), []);
+  const selectedSeriesEntryState = useMemo(() => {
+    if (overlayModel.selectedSeriesId == null) {
+      return null;
+    }
+
+    return model.entryStates.get(`series:${overlayModel.selectedSeriesId}`) ?? null;
+  }, [model.entryStates, overlayModel.selectedSeriesId]);
   const overlayViewModel = useMemo(
     () =>
       model.renderModel != null
@@ -98,6 +105,7 @@ export function IndividualTrackerOverlayPage({
             streamerSettings: model.streamerSettings,
             matchStatsByMatchId: overlaySnapshot.matchStatsByMatchId,
             selectedMatchId: overlayModel.selectedMatchId,
+            selectedSeriesId: overlayModel.selectedSeriesId,
           })
         : null,
     [
@@ -105,12 +113,25 @@ export function IndividualTrackerOverlayPage({
       model.streamerSettings,
       overlaySnapshot.matchStatsByMatchId,
       overlayModel.selectedMatchId,
+      overlayModel.selectedSeriesId,
       overlayPresenter,
     ],
   );
   const isPanelOpen = useMemo(
-    () => overlayPresenter.isPanelOpen(overlayModel.selectedMatchId, overlayModel.matchStatsState),
-    [overlayModel.matchStatsState, overlayModel.selectedMatchId, overlayPresenter],
+    () =>
+      overlayPresenter.isPanelOpen(
+        overlayModel.selectedMatchId,
+        overlayModel.matchStatsState,
+        overlayModel.selectedSeriesId,
+        selectedSeriesEntryState?.state ?? null,
+      ),
+    [
+      overlayModel.matchStatsState,
+      overlayModel.selectedMatchId,
+      overlayModel.selectedSeriesId,
+      overlayPresenter,
+      selectedSeriesEntryState,
+    ],
   );
 
   return (
@@ -125,11 +146,18 @@ export function IndividualTrackerOverlayPage({
             isPanelOpen={isPanelOpen}
             matchesLength={model.renderModel.accumulated.total}
             matchStatsPanelState={overlayModel.matchStatsPanelState}
+            seriesStatsPanelState={
+              selectedSeriesEntryState?.kind === "series" ? selectedSeriesEntryState.state : null
+            }
             selectedMatchId={overlayModel.selectedMatchId}
+            selectedSeriesId={overlayModel.selectedSeriesId}
             showPreview={showPreview}
             previewMode={previewMode}
             onSelectMatch={(matchId): void => {
               presenter.selectMatch(matchId);
+            }}
+            onSelectSeries={(seriesId): void => {
+              presenter.selectSeriesAndToggleIfAvailable(model.renderModel?.timeline ?? null, seriesId, onToggleEntry);
             }}
             onDeselect={(): void => {
               presenter.deselect();

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -97,6 +97,10 @@ export function IndividualTrackerOverlayPage({
 
     return model.entryStates.get(`series:${overlayModel.selectedSeriesId}`) ?? null;
   }, [model.entryStates, overlayModel.selectedSeriesId]);
+  const selectedSeriesPanelState = useMemo(
+    () => (selectedSeriesEntryState?.kind === "series" ? selectedSeriesEntryState.state : null),
+    [selectedSeriesEntryState],
+  );
   const overlayViewModel = useMemo(
     () =>
       model.renderModel != null
@@ -123,14 +127,14 @@ export function IndividualTrackerOverlayPage({
         overlayModel.selectedMatchId,
         overlayModel.matchStatsState,
         overlayModel.selectedSeriesId,
-        selectedSeriesEntryState?.state ?? null,
+        selectedSeriesPanelState,
       ),
     [
       overlayModel.matchStatsState,
       overlayModel.selectedMatchId,
       overlayModel.selectedSeriesId,
       overlayPresenter,
-      selectedSeriesEntryState,
+      selectedSeriesPanelState,
     ],
   );
 
@@ -146,7 +150,7 @@ export function IndividualTrackerOverlayPage({
             isPanelOpen={isPanelOpen}
             matchesLength={model.renderModel.accumulated.total}
             matchStatsPanelState={overlayModel.matchStatsPanelState}
-            seriesStatsPanelState={selectedSeriesEntryState?.kind === "series" ? selectedSeriesEntryState.state : null}
+            seriesStatsPanelState={selectedSeriesPanelState}
             selectedMatchId={overlayModel.selectedMatchId}
             selectedSeriesId={overlayModel.selectedSeriesId}
             showPreview={showPreview}

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -149,6 +149,7 @@ interface BuildOverlayViewModelOptions {
   readonly streamerSettings: StreamerViewSettings | undefined;
   readonly matchStatsByMatchId: ReadonlyMap<string, MatchStatsState>;
   readonly selectedMatchId: string | null;
+  readonly selectedSeriesId?: string | null;
 }
 
 interface IndividualTrackerOverlayPresenterConfig {
@@ -178,30 +179,40 @@ export class IndividualTrackerOverlayPresenter {
   ): readonly OverlayTab[] {
     const activeSeries = activeSeriesOverride ?? this.getActiveSeries(timeline);
     if (activeSeries != null) {
+      const seriesTab: OverlayTab = {
+        type: "series",
+        seriesId: activeSeries.id,
+        index: -1,
+        label: activeSeries.matches.length === 0 ? "Series score" : activeSeries.title,
+        score: activeSeries.score,
+        teamColor: getSeriesOutcomeColorHex(activeSeries),
+        icons:
+          activeSeries.matches.length > 0
+            ? activeSeries.matches.map((match) => ({
+                src: gameModeIconSrc(match.gameVariantCategory),
+                dimmed: false,
+              }))
+            : undefined,
+      };
+
       if (activeSeries.matches.length === 0) {
-        return [
-          {
-            type: "series",
-            seriesId: activeSeries.id,
-            index: -1,
-            label: "Series score",
-            score: activeSeries.score,
-            teamColor: undefined,
-          },
-        ];
+        return [seriesTab];
       }
 
-      return activeSeries.matches.map(
-        (match, index): OverlayTab => ({
-          type: "match",
-          index,
-          matchId: match.matchId,
-          label: match.mapName,
-          score: match.score,
-          icon: gameModeIconSrc(match.gameVariantCategory),
-          teamColor: match.colorHex,
-        }),
-      );
+      return [
+        seriesTab,
+        ...activeSeries.matches.map(
+          (match, index): OverlayTab => ({
+            type: "match",
+            index,
+            matchId: match.matchId,
+            label: match.mapName,
+            score: match.score,
+            icon: gameModeIconSrc(match.gameVariantCategory),
+            teamColor: match.colorHex,
+          }),
+        ),
+      ];
     }
 
     let matchIdx = 0;
@@ -235,8 +246,17 @@ export class IndividualTrackerOverlayPresenter {
     });
   }
 
-  public isPanelOpen(selectedMatchId: string | null, matchStatsState: MatchStatsState | null): boolean {
-    return selectedMatchId != null && (matchStatsState?.status === "loaded" || matchStatsState?.status === "error");
+  public isPanelOpen(
+    selectedMatchId: string | null,
+    matchStatsState: MatchStatsState | null,
+    selectedSeriesId: string | null,
+    seriesEntryState: { readonly status: string } | null,
+  ): boolean {
+    if (selectedMatchId != null && (matchStatsState?.status === "loaded" || matchStatsState?.status === "error")) {
+      return true;
+    }
+
+    return selectedSeriesId != null && seriesEntryState != null;
   }
 
   public buildPreSeriesTickerGroup(options: {

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -152,6 +152,11 @@ interface BuildOverlayViewModelOptions {
   readonly selectedSeriesId?: string | null;
 }
 
+interface BuildTabsOptions {
+  readonly includeInSeriesSummaryTab: boolean;
+  readonly includeMatchmakingSummaryTab: boolean;
+}
+
 interface IndividualTrackerOverlayPresenterConfig {
   readonly defaultTeamColors?: readonly [TeamColor, TeamColor];
 }
@@ -176,9 +181,29 @@ export class IndividualTrackerOverlayPresenter {
   public buildTabs(
     timeline: readonly ViewerTimelineItem[],
     activeSeriesOverride: ViewerSeriesTab | null = null,
+    options: BuildTabsOptions = {
+      includeInSeriesSummaryTab: true,
+      includeMatchmakingSummaryTab: true,
+    },
   ): readonly OverlayTab[] {
     const activeSeries = activeSeriesOverride ?? this.getActiveSeries(timeline);
     if (activeSeries != null) {
+      const matchTabs = activeSeries.matches.map(
+        (match, index): OverlayTab => ({
+          type: "match",
+          index,
+          matchId: match.matchId,
+          label: match.mapName,
+          score: match.score,
+          icon: gameModeIconSrc(match.gameVariantCategory),
+          teamColor: match.colorHex,
+        }),
+      );
+
+      if (!options.includeInSeriesSummaryTab) {
+        return matchTabs;
+      }
+
       const seriesTab: OverlayTab = {
         type: "series",
         seriesId: activeSeries.id,
@@ -199,50 +224,46 @@ export class IndividualTrackerOverlayPresenter {
         return [seriesTab];
       }
 
-      return [
-        seriesTab,
-        ...activeSeries.matches.map(
-          (match, index): OverlayTab => ({
-            type: "match",
-            index,
-            matchId: match.matchId,
-            label: match.mapName,
-            score: match.score,
-            icon: gameModeIconSrc(match.gameVariantCategory),
-            teamColor: match.colorHex,
-          }),
-        ),
-      ];
+      return [seriesTab, ...matchTabs];
     }
 
     let matchIdx = 0;
     let seriesIdx = -1;
-    return timeline.map((item): OverlayTab => {
+    return timeline.flatMap((item): readonly OverlayTab[] => {
       if (item.type === "series") {
+        if (!options.includeMatchmakingSummaryTab) {
+          return [];
+        }
+
         const isMatchmakingSeries = item.series.matches.every((match) => match.isMatchmaking);
 
-        return {
-          type: "series",
-          seriesId: item.series.id,
-          index: seriesIdx--,
-          label: item.series.title,
-          score: item.series.score,
-          teamColor: getSeriesOutcomeColorHex(item.series),
-          icons: item.series.matches.map((match) => ({
-            src: gameModeIconSrc(match.gameVariantCategory),
-            dimmed: isMatchmakingSeries && match.outcome === "Loss",
-          })),
-        };
+        return [
+          {
+            type: "series",
+            seriesId: item.series.id,
+            index: seriesIdx--,
+            label: item.series.title,
+            score: item.series.score,
+            teamColor: getSeriesOutcomeColorHex(item.series),
+            icons: item.series.matches.map((match) => ({
+              src: gameModeIconSrc(match.gameVariantCategory),
+              dimmed: isMatchmakingSeries && match.outcome === "Loss",
+            })),
+          },
+        ];
       }
-      return {
-        type: "match",
-        index: matchIdx++,
-        matchId: item.match.matchId,
-        label: item.match.mapName,
-        score: item.match.score,
-        icon: gameModeIconSrc(item.match.gameVariantCategory),
-        teamColor: item.match.colorHex,
-      };
+
+      return [
+        {
+          type: "match",
+          index: matchIdx++,
+          matchId: item.match.matchId,
+          label: item.match.mapName,
+          score: item.match.score,
+          icon: gameModeIconSrc(item.match.gameVariantCategory),
+          teamColor: item.match.colorHex,
+        },
+      ];
     });
   }
 
@@ -430,7 +451,10 @@ export class IndividualTrackerOverlayPresenter {
     const activeSeries = this.getOverlayActiveSeries(renderModel);
     const teamColors = this.getTeamColors(renderModel, activeSeries);
     const showTicker = this.getShowTicker(streamerSettings, activeSeries, displaySettings.showTicker);
-    const tabs = this.buildTabs(renderModel.timeline, activeSeries);
+    const tabs = this.buildTabs(renderModel.timeline, activeSeries, {
+      includeInSeriesSummaryTab: streamerSettings?.styleFlags?.inSeriesShowSeriesTab ?? true,
+      includeMatchmakingSummaryTab: streamerSettings?.styleFlags?.matchmakingShowSummaryTab ?? true,
+    });
     const loadedTickerGroups = this.buildTickerGroups(options.matchStatsByMatchId, tabs, {
       trackedGamertag: renderModel.gamertag,
       includeOnlyTrackedPlayer: this.getIncludeOnlyTrackedPlayer(streamerSettings, activeSeries),
@@ -459,7 +483,7 @@ export class IndividualTrackerOverlayPresenter {
       teamColors,
       tabs,
       tickerMatchGroups,
-      showTabs: displaySettings.showTabs && this.getShowTabs(renderModel),
+      showTabs: displaySettings.showTabs && tabs.length > 0,
       showTicker,
       showPreSeriesInfo: tickerMatchGroups.length > 0 && activeSeries?.matches.length === 0,
       fontSizeStyles,
@@ -749,9 +773,5 @@ export class IndividualTrackerOverlayPresenter {
       ...row,
       teamColorIndex: row.teamId === trackedPlayerTeamId ? 0 : 1,
     }));
-  }
-
-  private getShowTabs(renderModel: IndividualTrackerViewerRenderModel): boolean {
-    return renderModel.timeline.length > 0 || renderModel.hasActiveSeries;
   }
 }

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -14,7 +14,12 @@ import type { TickerMatchGroup, TickerStatRow } from "../../information-ticker/i
 import { createMatchStatsFormatter } from "../../../controllers/stats/create";
 import type { MatchStatsValues } from "../../../controllers/stats/types";
 import type { OverlayTab } from "../../streamer-overlay/tabs-bar";
-import type { IndividualTrackerViewerRenderModel, ViewerSeriesTab, ViewerTimelineItem } from "../viewer/types";
+import type {
+  IndividualTrackerViewerRenderModel,
+  SeriesDetailsState,
+  ViewerSeriesTab,
+  ViewerTimelineItem,
+} from "../viewer/types";
 import { gameModeIconSrc } from "../game-mode-icon";
 import { RankIcon } from "../../icons/rank-icon";
 import { ALL_SLAYER_STATS, DEFAULT_TICKER_SETTINGS } from "../../live-tracker/settings/types";
@@ -271,7 +276,7 @@ export class IndividualTrackerOverlayPresenter {
     selectedMatchId: string | null,
     matchStatsState: MatchStatsState | null,
     selectedSeriesId: string | null,
-    seriesEntryState: { readonly status: string } | null,
+    seriesEntryState: SeriesDetailsState | null,
   ): boolean {
     if (selectedMatchId != null && (matchStatsState?.status === "loaded" || matchStatsState?.status === "error")) {
       return true;

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -85,7 +85,11 @@ export function IndividualTrackerOverlay({
   const handleTabClick = useCallback(
     (tabIndex: number): void => {
       const selectedTab = viewModel.tabs.find((currentTab) => currentTab.index === tabIndex);
-      if (selectedTab?.type === "series") {
+      if (selectedTab == null) {
+        return;
+      }
+
+      if (selectedTab.type === "series") {
         if (selectedTab.seriesId === selectedSeriesId) {
           onDeselect();
         } else {
@@ -94,13 +98,10 @@ export function IndividualTrackerOverlay({
         return;
       }
 
-      const selectedMatchTab = viewModel.tabs.find((t) => t.type === "match" && t.index === tabIndex);
-      if (selectedMatchTab?.type === "match") {
-        if (selectedMatchTab.matchId === selectedMatchId) {
-          onDeselect();
-        } else {
-          onSelectMatch(selectedMatchTab.matchId);
-        }
+      if (selectedTab.matchId === selectedMatchId) {
+        onDeselect();
+      } else {
+        onSelectMatch(selectedTab.matchId);
       }
     },
     [onDeselect, onSelectMatch, onSelectSeries, selectedMatchId, selectedSeriesId, viewModel.tabs],

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -1,8 +1,12 @@
 import React, { useCallback, useMemo } from "react";
+import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { StreamerOverlay } from "../../streamer-overlay/streamer-overlay";
 import { TopSection } from "../../streamer-overlay/top-section";
 import { StatsPanel } from "../viewer/stats-panel";
-import type { MatchDetailsState } from "../viewer/types";
+import { SeriesStatsView } from "../../series-stats/series-stats";
+import { Alert } from "../../alert/alert";
+import { LoadingState } from "../../loading-state/loading-state";
+import type { MatchDetailsState, SeriesDetailsState } from "../viewer/types";
 import { OverlayStatsHighlights } from "./overlay-stats-highlights";
 import type { IndividualTrackerOverlayViewModel } from "./types";
 import styles from "./individual-tracker-overlay.module.css";
@@ -12,10 +16,13 @@ interface IndividualTrackerOverlayProps {
   readonly isPanelOpen: boolean;
   readonly matchesLength: number;
   readonly matchStatsPanelState: MatchDetailsState | null;
+  readonly seriesStatsPanelState: SeriesDetailsState | null;
   readonly selectedMatchId: string | null;
+  readonly selectedSeriesId: string | null;
   readonly showPreview?: boolean;
   readonly previewMode?: "player" | "observer";
   readonly onSelectMatch: (matchId: string) => void;
+  readonly onSelectSeries: (seriesId: string) => void;
   readonly onDeselect: () => void;
 }
 
@@ -24,10 +31,13 @@ export function IndividualTrackerOverlay({
   isPanelOpen,
   matchesLength,
   matchStatsPanelState,
+  seriesStatsPanelState,
   selectedMatchId,
+  selectedSeriesId,
   showPreview = false,
   previewMode = "observer",
   onSelectMatch,
+  onSelectSeries,
   onDeselect,
 }: IndividualTrackerOverlayProps): React.ReactElement {
   const topSection = useMemo(() => {
@@ -74,27 +84,61 @@ export function IndividualTrackerOverlay({
 
   const handleTabClick = useCallback(
     (tabIndex: number): void => {
-      if (tabIndex < 0) {
-        onDeselect();
-        return;
-      }
-      const tab = viewModel.tabs.find((t) => t.type === "match" && t.index === tabIndex);
-      if (tab?.type === "match") {
-        if (tab.matchId === selectedMatchId) {
+      const selectedTab = viewModel.tabs.find((currentTab) => currentTab.index === tabIndex);
+      if (selectedTab?.type === "series") {
+        if (selectedTab.seriesId === selectedSeriesId) {
           onDeselect();
         } else {
-          onSelectMatch(tab.matchId);
+          onSelectSeries(selectedTab.seriesId);
+        }
+        return;
+      }
+
+      const selectedMatchTab = viewModel.tabs.find((t) => t.type === "match" && t.index === tabIndex);
+      if (selectedMatchTab?.type === "match") {
+        if (selectedMatchTab.matchId === selectedMatchId) {
+          onDeselect();
+        } else {
+          onSelectMatch(selectedMatchTab.matchId);
         }
       }
     },
-    [onDeselect, onSelectMatch, selectedMatchId, viewModel.tabs],
+    [onDeselect, onSelectMatch, onSelectSeries, selectedMatchId, selectedSeriesId, viewModel.tabs],
   );
 
-  const hasPanelContent = useCallback((): boolean => false, []);
+  const hasPanelContent = useCallback(
+    (tabIndex: number): boolean => viewModel.tabs.some((tab) => tab.index === tabIndex),
+    [viewModel.tabs],
+  );
 
   const renderPanelContent = useCallback(
-    (): React.ReactElement | null => <StatsPanel state={matchStatsPanelState} />,
-    [matchStatsPanelState],
+    (tabIndex: number): React.ReactElement | null => {
+      const selectedTab = viewModel.tabs.find((currentTab) => currentTab.index === tabIndex);
+
+      if (selectedTab?.type === "series") {
+        if (seriesStatsPanelState == null) {
+          return null;
+        }
+
+        switch (seriesStatsPanelState.status) {
+          case "loading": {
+            return <LoadingState text="Loading series stats..." />;
+          }
+          case "error": {
+            return <Alert variant="error">{seriesStatsPanelState.message}</Alert>;
+          }
+          case "loaded": {
+            return <SeriesStatsView {...seriesStatsPanelState.viewModel} noGutter={true} />;
+          }
+          default: {
+            throw new UnreachableError(seriesStatsPanelState);
+          }
+        }
+      }
+
+      return <StatsPanel state={matchStatsPanelState} />;
+    },
+    [matchStatsPanelState, seriesStatsPanelState, viewModel.tabs],
   );
 
   return (

--- a/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
@@ -83,7 +83,6 @@ export class OverlayPagePresenter {
 
   public deselect(): void {
     this.config.store.setSelectedMatchId(null);
-    this.config.store.setSelectedSeriesId(null);
   }
 
   public present(snapshot: OverlayPageSnapshot): OverlayPageViewModel {

--- a/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
@@ -6,7 +6,7 @@ import { StatsController } from "../../../controllers/stats/stats-controller";
 import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPlayer } from "../../../controllers/stats/kill-matrix/types";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
-import type { MatchDetailsState } from "../viewer/types";
+import type { MatchDetailsState, ViewerTimelineItem } from "../viewer/types";
 import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
 import type { OverlayPageSnapshot, OverlayPageStore } from "./overlay-page-store";
 
@@ -18,6 +18,7 @@ interface OverlayPagePresenterConfig {
 
 export interface OverlayPageViewModel {
   readonly selectedMatchId: string | null;
+  readonly selectedSeriesId: string | null;
   readonly matchStatsState: MatchStatsState | null;
   readonly matchStatsPanelState: MatchDetailsState | null;
 }
@@ -64,8 +65,25 @@ export class OverlayPagePresenter {
     void this.loadMatchStatsAsync(matchId);
   }
 
+  public selectSeriesAndToggleIfAvailable(
+    timeline: readonly ViewerTimelineItem[] | null,
+    seriesId: string,
+    onToggleEntry: (item: ViewerTimelineItem) => void,
+  ): void {
+    this.config.store.setSelectedSeriesId(seriesId);
+    if (timeline == null) {
+      return;
+    }
+
+    const timelineItem = this.findSeriesInTimeline(timeline, seriesId);
+    if (timelineItem != null) {
+      onToggleEntry(timelineItem);
+    }
+  }
+
   public deselect(): void {
     this.config.store.setSelectedMatchId(null);
+    this.config.store.setSelectedSeriesId(null);
   }
 
   public present(snapshot: OverlayPageSnapshot): OverlayPageViewModel {
@@ -74,6 +92,7 @@ export class OverlayPagePresenter {
 
     return {
       selectedMatchId: snapshot.selectedMatchId,
+      selectedSeriesId: snapshot.selectedSeriesId,
       matchStatsState,
       matchStatsPanelState: this.toMatchStatsPanelState(snapshot.selectedMatchId, matchStatsState),
     };
@@ -178,5 +197,15 @@ export class OverlayPagePresenter {
           ? KillMatrixFormatter.transpose(killMatrixRows, orderedPlayers)
           : EMPTY_KILL_MATRIX_PIVOT_DATA,
     };
+  }
+
+  private findSeriesInTimeline(timeline: readonly ViewerTimelineItem[], seriesId: string): ViewerTimelineItem | null {
+    for (const item of timeline) {
+      if (item.type === "series" && item.series.id === seriesId) {
+        return item;
+      }
+    }
+
+    return null;
   }
 }

--- a/pages/src/components/individual-tracker/overlay/overlay-page-store.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-store.ts
@@ -2,12 +2,14 @@ import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
 
 export interface OverlayPageSnapshot {
   readonly selectedMatchId: string | null;
+  readonly selectedSeriesId: string | null;
   readonly matchStatsByMatchId: ReadonlyMap<string, MatchStatsState>;
 }
 
 export class OverlayPageStore {
   private snapshot: OverlayPageSnapshot = {
     selectedMatchId: null,
+    selectedSeriesId: null,
     matchStatsByMatchId: new Map(),
   };
 
@@ -27,12 +29,17 @@ export class OverlayPageStore {
   public reset(): void {
     this.update({
       selectedMatchId: null,
+      selectedSeriesId: null,
       matchStatsByMatchId: new Map(),
     });
   }
 
   public setSelectedMatchId(selectedMatchId: string | null): void {
-    this.update({ selectedMatchId });
+    this.update({ selectedMatchId, selectedSeriesId: null });
+  }
+
+  public setSelectedSeriesId(selectedSeriesId: string | null): void {
+    this.update({ selectedMatchId: null, selectedSeriesId });
   }
 
   public setMatchStatsState(matchId: string, state: MatchStatsState): void {

--- a/pages/src/components/individual-tracker/overlay/tests/create.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/create.test.tsx
@@ -21,8 +21,11 @@ vi.mock("../individual-tracker-overlay", () => ({
     isPanelOpen: boolean;
     matchesLength: number;
     selectedMatchId: string | null;
+    selectedSeriesId: string | null;
     matchStatsPanelState: { status: string } | null;
+    seriesStatsPanelState: { status: string } | null;
     onSelectMatch: (matchId: string) => void;
+    onSelectSeries: (seriesId: string) => void;
     onDeselect: () => void;
   }): React.ReactElement => {
     return (
@@ -31,6 +34,7 @@ vi.mock("../individual-tracker-overlay", () => ({
         <div data-testid="panel-open">{props.isPanelOpen ? "yes" : "no"}</div>
         <div data-testid="matches-length">{props.matchesLength.toString()}</div>
         <div data-testid="selected-match">{props.selectedMatchId ?? "none"}</div>
+        <div data-testid="selected-series">{props.selectedSeriesId ?? "none"}</div>
         <div data-testid="panel-state">{props.matchStatsPanelState?.status ?? "none"}</div>
         <button
           type="button"

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -95,6 +95,7 @@ describe("individual-tracker-overlay-presenter", () => {
         aMatchWith({ matchId: "b", gameVariantCategory: 8 }),
       ],
     });
+
     const timeline: ViewerTimelineItem[] = [
       { type: "series", series: aSeriesWith({ id: "series-old", isActive: false }) },
       { type: "series", series: activeSeries },
@@ -114,6 +115,38 @@ describe("individual-tracker-overlay-presenter", () => {
     ]);
   });
 
+  it("omits the in-series summary tab when inSeriesShowSeriesTab is disabled", () => {
+    const activeSeries = aSeriesWith({
+      id: "series-active",
+      isActive: true,
+      matches: [
+        aMatchWith({ matchId: "a", gameVariantCategory: 6 }),
+        aMatchWith({ matchId: "b", gameVariantCategory: 8 }),
+      ],
+    });
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        hasActiveSeries: true,
+        activeSeriesContext: {
+          title: "Series",
+          subtitle: "Bo3",
+          teams: [],
+        },
+        timeline: [{ type: "series", series: activeSeries }],
+      }),
+      streamerSettings: {
+        styleFlags: {
+          inSeriesShowSeriesTab: false,
+        },
+      } satisfies StreamerViewSettings,
+      matchStatsByMatchId: new Map(),
+      selectedMatchId: null,
+    });
+
+    expect(model.tabs.map((tab) => (tab.type === "match" ? tab.matchId : tab.seriesId))).toEqual(["a", "b"]);
+    expect(model.tabs.every((tab) => tab.type === "match")).toBe(true);
+  });
+
   it("builds series-consolidated tabs with per-match mode icons when no active series", () => {
     const completedSeries = aSeriesWith({
       id: "series-complete",
@@ -123,6 +156,7 @@ describe("individual-tracker-overlay-presenter", () => {
         aMatchWith({ matchId: "s2", gameVariantCategory: 7 }),
       ],
     });
+
     const timeline: ViewerTimelineItem[] = [
       { type: "series", series: completedSeries },
       { type: "match", match: aMatchWith({ matchId: "solo", gameVariantCategory: 8 }) },
@@ -144,6 +178,30 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(matchTab.type).toBe("match");
     if (matchTab.type === "match") {
       expect(matchTab.icon).toBe(gameModeIconSrc(8));
+    }
+  });
+
+  it("omits matchmaking summary tabs when matchmakingShowSummaryTab is disabled", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        timeline: [
+          { type: "series", series: aSeriesWith({ id: "series-complete", isActive: false }) },
+          { type: "match", match: aMatchWith({ matchId: "solo", gameVariantCategory: 8 }) },
+        ],
+      }),
+      streamerSettings: {
+        styleFlags: {
+          matchmakingShowSummaryTab: false,
+        },
+      } satisfies StreamerViewSettings,
+      matchStatsByMatchId: new Map(),
+      selectedMatchId: null,
+    });
+
+    expect(model.tabs).toHaveLength(1);
+    expect(model.tabs[0]?.type).toBe("match");
+    if (model.tabs[0]?.type === "match") {
+      expect(model.tabs[0].matchId).toBe("solo");
     }
   });
 

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -86,7 +86,7 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(activeSeries?.id).toBe("series-active");
   });
 
-  it("builds only active series match tabs when active series exists", () => {
+  it("builds a first series tab before active-series match tabs", () => {
     const activeSeries = aSeriesWith({
       id: "series-active",
       isActive: true,
@@ -103,9 +103,15 @@ describe("individual-tracker-overlay-presenter", () => {
 
     const tabs = presenter.buildTabs(timeline);
 
-    expect(tabs).toHaveLength(2);
-    expect(tabs.every((tab) => tab.type === "match")).toBe(true);
-    expect(tabs.map((tab) => (tab.type === "match" ? tab.matchId : "series"))).toEqual(["a", "b"]);
+    expect(tabs).toHaveLength(3);
+    expect(tabs[0]?.type).toBe("series");
+    expect(tabs[1]?.type).toBe("match");
+    expect(tabs[2]?.type).toBe("match");
+    expect(tabs.map((tab) => (tab.type === "series" ? tab.seriesId : tab.matchId))).toEqual([
+      "series-active",
+      "a",
+      "b",
+    ]);
   });
 
   it("builds series-consolidated tabs with per-match mode icons when no active series", () => {

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -34,8 +34,11 @@ function aPropsWith(options?: {
   streamerSettings?: StreamerViewSettings;
   matchStatsState?: MatchStatsState;
   matchStatsPanelState?: React.ComponentProps<typeof IndividualTrackerOverlay>["matchStatsPanelState"];
+  seriesStatsPanelState?: React.ComponentProps<typeof IndividualTrackerOverlay>["seriesStatsPanelState"];
   selectedMatchId?: string | null;
+  selectedSeriesId?: string | null;
   onSelectMatch?: (matchId: string) => void;
+  onSelectSeries?: (seriesId: string) => void;
   onDeselect?: () => void;
 }): React.ComponentProps<typeof IndividualTrackerOverlay> {
   const presenter = new IndividualTrackerOverlayPresenter();
@@ -53,11 +56,19 @@ function aPropsWith(options?: {
       matchStatsByMatchId,
       selectedMatchId,
     }),
-    isPanelOpen: presenter.isPanelOpen(selectedMatchId, matchStatsState),
+    isPanelOpen: presenter.isPanelOpen(
+      selectedMatchId,
+      matchStatsState,
+      options?.selectedSeriesId ?? null,
+      options?.seriesStatsPanelState ?? null,
+    ),
     matchesLength: renderModel.accumulated.total,
     matchStatsPanelState: options?.matchStatsPanelState ?? null,
+    seriesStatsPanelState: options?.seriesStatsPanelState ?? null,
     selectedMatchId,
+    selectedSeriesId: options?.selectedSeriesId ?? null,
     onSelectMatch: options?.onSelectMatch ?? ((): void => undefined),
+    onSelectSeries: options?.onSelectSeries ?? ((): void => undefined),
     onDeselect: options?.onDeselect ?? ((): void => undefined),
   };
 }

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
@@ -161,4 +161,27 @@ describe("OverlayPagePresenter", () => {
     expect(store.getSnapshot().selectedSeriesId).toBe("series-1");
     expect(onToggleEntry).toHaveBeenCalledOnce();
   });
+
+  it("clears selection with a single store notification", () => {
+    const store = new OverlayPageStore();
+    const presenter = new OverlayPagePresenter({
+      store,
+      haloClient: aFakeHaloClientWith({
+        getMatchStats: vi.fn(async () => Promise.resolve(aFakeMatchStatsWith())),
+      }),
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+    });
+    const listener = vi.fn<() => void>();
+    const unsubscribe = store.subscribe(listener);
+
+    presenter.selectSeriesAndToggleIfAvailable(null, "series-1", vi.fn<(item: ViewerTimelineItem) => void>());
+    listener.mockClear();
+
+    presenter.deselect();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(store.getSnapshot().selectedMatchId).toBeNull();
+    expect(store.getSnapshot().selectedSeriesId).toBeNull();
+    unsubscribe();
+  });
 });

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
@@ -3,6 +3,7 @@ import { waitFor } from "@testing-library/react";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 import { aFakeHaloClientWith } from "../../../../services/fakes/halo-client.fake";
 import { aFakeMatchAnalyticsServiceWith } from "../../../../services/stats/fakes/match-analytics.fake";
+import type { ViewerTimelineItem } from "../../viewer/types";
 import { OverlayPagePresenter } from "../overlay-page-presenter";
 import { OverlayPageStore } from "../overlay-page-store";
 
@@ -123,5 +124,41 @@ describe("OverlayPagePresenter", () => {
 
     presenter.preloadMatchStats(["match-1", "match-2"]);
     expect(getMatchStats).toHaveBeenCalledTimes(3);
+  });
+
+  it("selects a series and toggles the matching timeline item when present", () => {
+    const store = new OverlayPageStore();
+    const presenter = new OverlayPagePresenter({
+      store,
+      haloClient: aFakeHaloClientWith({
+        getMatchStats: vi.fn(async () => Promise.resolve(aFakeMatchStatsWith())),
+      }),
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+    });
+    const timeline: readonly ViewerTimelineItem[] = [
+      {
+        type: "series",
+        series: {
+          id: "series-1",
+          title: "Series 1",
+          subtitle: "Best of 1",
+          isActive: true,
+          teams: [],
+          matchBackgroundUrls: [],
+          score: "1:0",
+          duration: "10m",
+          startTime: "2026-01-01T00:00:00.000Z",
+          endTime: "2026-01-01T00:10:00.000Z",
+          matches: [],
+          colorHex: undefined,
+        },
+      },
+    ];
+    const onToggleEntry = vi.fn<(item: ViewerTimelineItem) => void>();
+
+    presenter.selectSeriesAndToggleIfAvailable(timeline, "series-1", onToggleEntry);
+
+    expect(store.getSnapshot().selectedSeriesId).toBe("series-1");
+    expect(onToggleEntry).toHaveBeenCalledOnce();
   });
 });

--- a/shared/src/individual-tracker/streamer-view-settings.ts
+++ b/shared/src/individual-tracker/streamer-view-settings.ts
@@ -137,6 +137,8 @@ export const streamerViewStyleFlagsSchema = z.object({
   enemyColor: z.string().optional(),
   observerColorOverrides: streamerViewObserverColorOverridesSchema.optional(),
   showPreSeriesInfo: z.boolean().optional(),
+  inSeriesShowSeriesTab: z.boolean().optional(),
+  matchmakingShowSummaryTab: z.boolean().optional(),
   selectedSlayerStats: z.array(z.string()).optional(),
   showObjectiveStats: z.boolean().optional(),
   medalRarityFilter: z.array(z.number()).optional(),


### PR DESCRIPTION
## Context
This change brings the user-level individual tracker overlay closer to the live tracker behavior. It restores the series-first tab pattern in active series mode, adds lightweight matchmaking-first tab support behind separate streamer toggles, and wires the overlay state through presenter-owned selection flow.
## This PR
- Restore the series-first tab path in the overlay and keep panel state handling exhaustive.
- Add separate streamer settings for the series-first and matchmaking summary tab behaviors, defaulted on.
- Route series selection through the presenter and reuse the viewer hook's series entry state for panel loading.
- Update the overlay and streamer-settings tests to cover the new behavior.
## Subsequent Work
- Align the top-team rendering in the overlay with the live tracker overlay behavior.
- Preserve the live tracker-style auto-scrolling player presentation instead of a static vertical list.
- Keep the existing fade interval between team names and player names when a team name is present.
- Evaluate whether tab overflow needs width-based truncation or a simpler cap in a follow-up.