### PR TITLE
feat(individual-tracker): wire team-name toggle from streamer settings

### DIFF
--- a/pages/src/components/individual-tracker-manager/create.tsx
+++ b/pages/src/components/individual-tracker-manager/create.tsx
@@ -124,6 +124,7 @@ export function IndividualTrackerManagerPage({
           tickerSettings={settingsSnapshot.tickerSettings}
           inSeriesShowSeriesTab={settingsSnapshot.inSeriesShowSeriesTab}
           matchmakingShowSummaryTab={settingsSnapshot.matchmakingShowSummaryTab}
+          disableTeamPlayerNames={settingsSnapshot.disableTeamPlayerNames}
           inSeriesShowTicker={settingsSnapshot.inSeriesShowTicker}
           matchmakingShowTicker={settingsSnapshot.matchmakingShowTicker}
           matchmakingShowStatsHighlights={settingsSnapshot.matchmakingShowStatsHighlights}
@@ -152,6 +153,9 @@ export function IndividualTrackerManagerPage({
           }}
           onMatchmakingShowSummaryTabChange={(enabled): void => {
             settingsPresenter.setMatchmakingShowSummaryTab(enabled);
+          }}
+          onDisableTeamPlayerNamesChange={(enabled): void => {
+            settingsPresenter.setDisableTeamPlayerNames(enabled);
           }}
           onInSeriesShowTickerChange={(enabled): void => {
             settingsPresenter.setInSeriesShowTicker(enabled);

--- a/pages/src/components/individual-tracker-manager/streamer-settings/create.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/create.tsx
@@ -47,6 +47,7 @@ export function StreamerSettingsSection({
       tickerSettings={snapshot.tickerSettings}
       inSeriesShowSeriesTab={snapshot.inSeriesShowSeriesTab}
       matchmakingShowSummaryTab={snapshot.matchmakingShowSummaryTab}
+      disableTeamPlayerNames={snapshot.disableTeamPlayerNames}
       inSeriesShowTicker={snapshot.inSeriesShowTicker}
       matchmakingShowTicker={snapshot.matchmakingShowTicker}
       matchmakingShowStatsHighlights={snapshot.matchmakingShowStatsHighlights}
@@ -75,6 +76,9 @@ export function StreamerSettingsSection({
       }}
       onMatchmakingShowSummaryTabChange={(enabled): void => {
         presenter.setMatchmakingShowSummaryTab(enabled);
+      }}
+      onDisableTeamPlayerNamesChange={(enabled): void => {
+        presenter.setDisableTeamPlayerNames(enabled);
       }}
       onInSeriesShowTickerChange={(enabled): void => {
         presenter.setInSeriesShowTicker(enabled);

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-presenter.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-presenter.ts
@@ -69,6 +69,7 @@ function settingsToSnapshot(
     },
     inSeriesShowSeriesTab: styleFlags.inSeriesShowSeriesTab ?? snapshot.inSeriesShowSeriesTab,
     matchmakingShowSummaryTab: styleFlags.matchmakingShowSummaryTab ?? snapshot.matchmakingShowSummaryTab,
+    disableTeamPlayerNames: styleFlags.disableTeamPlayerNames ?? snapshot.disableTeamPlayerNames,
     inSeriesShowTicker: styleFlags.inSeriesShowTicker ?? visibleSections.showTicker ?? snapshot.inSeriesShowTicker,
     matchmakingShowTicker:
       styleFlags.matchmakingShowTicker ?? visibleSections.showTicker ?? snapshot.matchmakingShowTicker,
@@ -111,6 +112,7 @@ function snapshotToSettings(snapshot: StreamerSettingsSnapshot): StreamerViewSet
       medalRarityFilter: [...snapshot.tickerSettings.medalRarityFilter],
       inSeriesShowSeriesTab: snapshot.inSeriesShowSeriesTab,
       matchmakingShowSummaryTab: snapshot.matchmakingShowSummaryTab,
+      disableTeamPlayerNames: snapshot.disableTeamPlayerNames,
       inSeriesShowTicker: snapshot.inSeriesShowTicker,
       matchmakingShowTicker: snapshot.matchmakingShowTicker,
       matchmakingShowStatsHighlights: snapshot.matchmakingShowStatsHighlights,
@@ -229,6 +231,15 @@ export class StreamerSettingsPresenter {
     }
 
     this.config.store.batchUpdate({ matchmakingShowSummaryTab: enabled });
+    this.scheduleSave();
+  }
+
+  public setDisableTeamPlayerNames(enabled: boolean): void {
+    if (this.isDisposed) {
+      return;
+    }
+
+    this.config.store.batchUpdate({ disableTeamPlayerNames: enabled });
     this.scheduleSave();
   }
 

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-store.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-store.ts
@@ -21,6 +21,7 @@ export interface StreamerSettingsSnapshot {
   readonly tickerSettings: TickerSettings;
   readonly inSeriesShowSeriesTab: boolean;
   readonly matchmakingShowSummaryTab: boolean;
+  readonly disableTeamPlayerNames: boolean;
   readonly inSeriesShowTicker: boolean;
   readonly matchmakingShowTicker: boolean;
   readonly matchmakingShowStatsHighlights: boolean;
@@ -78,6 +79,7 @@ export class StreamerSettingsStore {
       tickerSettings: DEFAULT_TICKER_SETTINGS,
       inSeriesShowSeriesTab: true,
       matchmakingShowSummaryTab: true,
+      disableTeamPlayerNames: false,
       inSeriesShowTicker: true,
       matchmakingShowTicker: true,
       matchmakingShowStatsHighlights: true,

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -59,6 +59,7 @@ export interface StreamerSettingsSectionViewProps {
   readonly tickerSettings: TickerSettings;
   readonly inSeriesShowSeriesTab: boolean;
   readonly matchmakingShowSummaryTab: boolean;
+  readonly disableTeamPlayerNames: boolean;
   readonly inSeriesShowTicker: boolean;
   readonly matchmakingShowTicker: boolean;
   readonly matchmakingShowStatsHighlights: boolean;
@@ -74,6 +75,7 @@ export interface StreamerSettingsSectionViewProps {
   readonly onTickerSettingsChange: (updates: Partial<TickerSettings>) => void;
   readonly onInSeriesShowSeriesTabChange: (enabled: boolean) => void;
   readonly onMatchmakingShowSummaryTabChange: (enabled: boolean) => void;
+  readonly onDisableTeamPlayerNamesChange: (enabled: boolean) => void;
   readonly onInSeriesShowTickerChange: (enabled: boolean) => void;
   readonly onMatchmakingShowTickerChange: (enabled: boolean) => void;
   readonly onMatchmakingShowStatsHighlightsChange: (enabled: boolean) => void;
@@ -93,6 +95,7 @@ export function StreamerSettingsSectionView({
   tickerSettings,
   inSeriesShowSeriesTab,
   matchmakingShowSummaryTab,
+  disableTeamPlayerNames,
   inSeriesShowTicker,
   matchmakingShowTicker,
   matchmakingShowStatsHighlights,
@@ -108,6 +111,7 @@ export function StreamerSettingsSectionView({
   onTickerSettingsChange,
   onInSeriesShowSeriesTabChange,
   onMatchmakingShowSummaryTabChange,
+  onDisableTeamPlayerNamesChange,
   onInSeriesShowTickerChange,
   onMatchmakingShowTickerChange,
   onMatchmakingShowStatsHighlightsChange,
@@ -431,6 +435,14 @@ export function StreamerSettingsSectionView({
           </p>
         </div>
         <DisplaySettingsSection settings={displaySettings} onChange={onDisplaySettingsChange} />
+        <Checkbox
+          checked={disableTeamPlayerNames}
+          onChange={(checked): void => {
+            onDisableTeamPlayerNamesChange(checked);
+          }}
+          label="Disable toggling to player names"
+          description="Show only team names in the top section instead of fading to player names."
+        />
 
         <hr className={styles.sectionDivider} />
 

--- a/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings-presenter.test.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings-presenter.test.ts
@@ -84,6 +84,7 @@ describe("StreamerSettingsPresenter", () => {
             showPreSeriesInfo: false,
             inSeriesShowSeriesTab: false,
             matchmakingShowSummaryTab: false,
+            disableTeamPlayerNames: true,
             inSeriesShowTicker: false,
             matchmakingShowTicker: true,
             matchmakingShowStatsHighlights: false,
@@ -99,6 +100,7 @@ describe("StreamerSettingsPresenter", () => {
       expect(store.getSnapshot().tickerSettings.showPreSeriesInfo).toBe(false);
       expect(store.getSnapshot().inSeriesShowSeriesTab).toBe(false);
       expect(store.getSnapshot().matchmakingShowSummaryTab).toBe(false);
+      expect(store.getSnapshot().disableTeamPlayerNames).toBe(true);
       expect(store.getSnapshot().inSeriesShowTicker).toBe(false);
       expect(store.getSnapshot().matchmakingShowTicker).toBe(true);
       expect(store.getSnapshot().matchmakingShowStatsHighlights).toBe(false);
@@ -308,6 +310,25 @@ describe("StreamerSettingsPresenter", () => {
 
       const [[saved]] = updateSpy.mock.calls;
       expect(saved.styleFlags?.matchmakingShowSummaryTab).toBe(false);
+    });
+  });
+
+  describe("setDisableTeamPlayerNames", () => {
+    it("updates disableTeamPlayerNames in the store and schedules a save", async () => {
+      const { store, presenter, settingsService } = aHarness();
+      const updateSpy: MockInstance<typeof settingsService.updateSettings> = vi.spyOn(
+        settingsService,
+        "updateSettings",
+      );
+
+      presenter.setDisableTeamPlayerNames(true);
+
+      expect(store.getSnapshot().disableTeamPlayerNames).toBe(true);
+
+      await vi.runAllTimersAsync();
+
+      const [[saved]] = updateSpy.mock.calls;
+      expect(saved.styleFlags?.disableTeamPlayerNames).toBe(true);
     });
   });
 

--- a/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
@@ -67,6 +67,7 @@ function aFakeProps(overrides?: Partial<StreamerSettingsSectionViewProps>): Stre
     tickerSettings: DEFAULT_TICKER_SETTINGS,
     inSeriesShowSeriesTab: true,
     matchmakingShowSummaryTab: true,
+    disableTeamPlayerNames: false,
     inSeriesShowTicker: true,
     matchmakingShowTicker: true,
     matchmakingShowStatsHighlights: true,
@@ -82,6 +83,7 @@ function aFakeProps(overrides?: Partial<StreamerSettingsSectionViewProps>): Stre
     onTickerSettingsChange: (): void => undefined,
     onInSeriesShowSeriesTabChange: (): void => undefined,
     onMatchmakingShowSummaryTabChange: (): void => undefined,
+    onDisableTeamPlayerNamesChange: (): void => undefined,
     onInSeriesShowTickerChange: (): void => undefined,
     onMatchmakingShowTickerChange: (): void => undefined,
     onMatchmakingShowStatsHighlightsChange: (): void => undefined,
@@ -256,6 +258,12 @@ describe("StreamerSettingsSectionView", () => {
       expect(screen.getByRole("checkbox", { name: /show summary tab/i })).toBeInTheDocument();
     });
 
+    it("renders the disable team player names toggle in the in-series top section", () => {
+      render(<StreamerSettingsSectionView {...aFakeProps()} />);
+
+      expect(screen.getByRole("checkbox", { name: /disable toggling to player names/i })).toBeInTheDocument();
+    });
+
     it("renders font size sliders for all sections", () => {
       render(<StreamerSettingsSectionView {...aFakeProps()} />);
 
@@ -358,6 +366,17 @@ describe("StreamerSettingsSectionView", () => {
       await user.click(screen.getByRole("checkbox", { name: /show summary tab/i }));
 
       expect(onChange).toHaveBeenCalledWith(false);
+    });
+
+    it("calls onDisableTeamPlayerNamesChange when the top-section toggle is clicked", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn<(enabled: boolean) => void>();
+
+      render(<StreamerSettingsSectionView {...aFakeProps({ onDisableTeamPlayerNamesChange: onChange })} />);
+
+      await user.click(screen.getByRole("checkbox", { name: /disable toggling to player names/i }));
+
+      expect(onChange).toHaveBeenCalledWith(true);
     });
 
     it("calls onMatchmakingShowTickerChange when the matchmaking ticker toggle is clicked", async () => {

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -483,7 +483,8 @@ export class IndividualTrackerOverlayPresenter {
 
     return {
       pinTopSection: activeSeries != null,
-      topSection: activeSeries != null ? this.getTopSectionModel(activeSeries, displaySettings) : null,
+      topSection:
+        activeSeries != null ? this.getTopSectionModel(activeSeries, displaySettings, streamerSettings) : null,
       statsHighlights: this.getMatchmakingStatsHighlights(streamerSettings, activeSeries, renderModel.statsHighlights),
       teamColors,
       tabs,
@@ -537,7 +538,11 @@ export class IndividualTrackerOverlayPresenter {
     };
   }
 
-  private getTopSectionModel(activeSeries: ViewerSeriesTab, settings: OverlayDisplaySettings): OverlayTopSectionModel {
+  private getTopSectionModel(
+    activeSeries: ViewerSeriesTab,
+    settings: OverlayDisplaySettings,
+    streamerSettings: StreamerViewSettings | undefined,
+  ): OverlayTopSectionModel {
     const teamLeft = activeSeries.teams.find((team) => team.id === 0);
     const teamRight = activeSeries.teams.find((team) => team.id === 1);
     const showTeamDetails = settings.showTeamDetails && teamLeft != null && teamRight != null;
@@ -548,6 +553,7 @@ export class IndividualTrackerOverlayPresenter {
       showScore: settings.showScore,
       seriesScore: activeSeries.score,
       showTeamDetails,
+      disableTeamPlayerNames: streamerSettings?.styleFlags?.disableTeamPlayerNames === true,
       teamLeft: showTeamDetails ? getTeamDetailsModel(teamLeft, settings) : null,
       teamRight: showTeamDetails ? getTeamDetailsModel(teamRight, settings) : null,
     };

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from "react";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { StreamerOverlay } from "../../streamer-overlay/streamer-overlay";
 import { TopSection } from "../../streamer-overlay/top-section";
+import { TeamDetailsContent } from "../../streamer-overlay/team-details-content";
 import { StatsPanel } from "../viewer/stats-panel";
 import { SeriesStatsView } from "../../series-stats/series-stats";
 import { Alert } from "../../alert/alert";
@@ -53,22 +54,32 @@ export function IndividualTrackerOverlay({
           teamColors={viewModel.teamColors}
           teamLeft={
             viewModel.topSection.teamLeft != null ? (
-              <>
-                <div>{viewModel.topSection.teamLeft.name}</div>
-                {viewModel.topSection.teamLeft.players.map((player) => (
-                  <div key={`left-${player.key}`}>{player.label}</div>
-                ))}
-              </>
+              <TeamDetailsContent
+                team={{
+                  players: viewModel.topSection.teamLeft.players.map((player) => ({
+                    id: player.key,
+                    displayName: player.label,
+                  })),
+                }}
+                teamName={viewModel.topSection.teamLeft.name}
+                disableTeamPlayerNames={viewModel.topSection.disableTeamPlayerNames}
+                renderPlayerNameContent={(_playerId, displayName): React.ReactElement => <>{displayName}</>}
+              />
             ) : null
           }
           teamRight={
             viewModel.topSection.teamRight != null ? (
-              <>
-                <div>{viewModel.topSection.teamRight.name}</div>
-                {viewModel.topSection.teamRight.players.map((player) => (
-                  <div key={`right-${player.key}`}>{player.label}</div>
-                ))}
-              </>
+              <TeamDetailsContent
+                team={{
+                  players: viewModel.topSection.teamRight.players.map((player) => ({
+                    id: player.key,
+                    displayName: player.label,
+                  })),
+                }}
+                teamName={viewModel.topSection.teamRight.name}
+                disableTeamPlayerNames={viewModel.topSection.disableTeamPlayerNames}
+                renderPlayerNameContent={(_playerId, displayName): React.ReactElement => <>{displayName}</>}
+              />
             ) : null
           }
         />

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -583,6 +583,58 @@ describe("individual-tracker-overlay-presenter", () => {
     ]);
   });
 
+  it("sets disableTeamPlayerNames in top section when style flag is enabled", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        timeline: [
+          {
+            type: "series",
+            series: aSeriesWith({
+              isActive: true,
+              teams: [
+                { id: 0, name: "Alpha", players: [{ discordName: "AlphaDiscord", gamertag: "AlphaTag" }] },
+                { id: 1, name: "Beta", players: [{ discordName: "BetaDiscord", gamertag: "BetaTag" }] },
+              ],
+            }),
+          },
+        ],
+      }),
+      streamerSettings: {
+        styleFlags: {
+          disableTeamPlayerNames: true,
+        },
+      },
+      matchStatsByMatchId: new Map(),
+      selectedMatchId: null,
+    });
+
+    expect(model.topSection?.disableTeamPlayerNames).toBe(true);
+  });
+
+  it("defaults disableTeamPlayerNames to false in top section", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        timeline: [
+          {
+            type: "series",
+            series: aSeriesWith({
+              isActive: true,
+              teams: [
+                { id: 0, name: "Alpha", players: [{ discordName: "AlphaDiscord", gamertag: "AlphaTag" }] },
+                { id: 1, name: "Beta", players: [{ discordName: "BetaDiscord", gamertag: "BetaTag" }] },
+              ],
+            }),
+          },
+        ],
+      }),
+      streamerSettings: undefined,
+      matchStatsByMatchId: new Map(),
+      selectedMatchId: null,
+    });
+
+    expect(model.topSection?.disableTeamPlayerNames).toBe(false);
+  });
+
   it("shows matchmaking stats highlights by default when provided by viewer settings", () => {
     const model = presenter.present({
       renderModel: aRenderModelWith({

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -224,8 +224,8 @@ describe("IndividualTrackerOverlay", () => {
     );
 
     expect(screen.getByText("Alpha")).toBeInTheDocument();
-    expect(screen.getByText("Gamertag Name")).toBeInTheDocument();
-    expect(screen.getByText("Xbox Only")).toBeInTheDocument();
+    expect(screen.getByText(/Gamertag Name/)).toBeInTheDocument();
+    expect(screen.getByText(/Xbox Only/)).toBeInTheDocument();
     expect(screen.getByText("Beta")).toBeInTheDocument();
     expect(screen.getByText("Unknown")).toBeInTheDocument();
   });
@@ -484,6 +484,57 @@ describe("IndividualTrackerOverlay", () => {
       visibleSections: {
         showDiscordNames: false,
         showXboxNames: false,
+      },
+    };
+
+    render(<IndividualTrackerOverlay {...aPropsWith({ renderModel, streamerSettings })} />);
+
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+    expect(screen.queryByText("DiscordAlpha")).not.toBeInTheDocument();
+    expect(screen.queryByText("XboxAlpha")).not.toBeInTheDocument();
+    expect(screen.queryByText("DiscordBeta")).not.toBeInTheDocument();
+    expect(screen.queryByText("XboxBeta")).not.toBeInTheDocument();
+  });
+
+  it("shows only team names when disableTeamPlayerNames is enabled", () => {
+    const renderModel = aRenderModel({
+      matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" }), aFakeTrackerMatchSummaryWith({ matchId: "m-2" })],
+      series: [
+        aFakeTrackerSeriesGroupWith({
+          id: "series-1",
+          title: "Alpha vs Beta",
+          subtitle: "Bo3",
+          matchIds: ["m-1", "m-2"],
+          score: "1:0",
+        }),
+      ],
+      hasActiveSeries: true,
+      activeSeriesContext: {
+        title: "Alpha vs Beta",
+        subtitle: "Bo3",
+        teams: [
+          {
+            id: 0,
+            name: "Alpha",
+            players: [{ discordId: null, discordName: "DiscordAlpha", gamertag: "XboxAlpha", xboxId: null }],
+          },
+          {
+            id: 1,
+            name: "Beta",
+            players: [{ discordId: null, discordName: "DiscordBeta", gamertag: "XboxBeta", xboxId: null }],
+          },
+        ],
+      },
+    });
+
+    const streamerSettings: StreamerViewSettings = {
+      visibleSections: {
+        showDiscordNames: true,
+        showXboxNames: true,
+      },
+      styleFlags: {
+        disableTeamPlayerNames: true,
       },
     };
 

--- a/pages/src/components/individual-tracker/overlay/types.ts
+++ b/pages/src/components/individual-tracker/overlay/types.ts
@@ -32,6 +32,7 @@ export interface OverlayTopSectionModel {
   readonly showScore: boolean;
   readonly seriesScore: string;
   readonly showTeamDetails: boolean;
+  readonly disableTeamPlayerNames: boolean;
   readonly teamLeft: OverlayTeamDetailsModel | null;
   readonly teamRight: OverlayTeamDetailsModel | null;
 }

--- a/shared/src/individual-tracker/streamer-view-settings.ts
+++ b/shared/src/individual-tracker/streamer-view-settings.ts
@@ -139,6 +139,7 @@ export const streamerViewStyleFlagsSchema = z.object({
   showPreSeriesInfo: z.boolean().optional(),
   inSeriesShowSeriesTab: z.boolean().optional(),
   matchmakingShowSummaryTab: z.boolean().optional(),
+  disableTeamPlayerNames: z.boolean().optional(),
   selectedSlayerStats: z.array(z.string()).optional(),
   showObjectiveStats: z.boolean().optional(),
   medalRarityFilter: z.array(z.number()).optional(),


### PR DESCRIPTION
## Context
We are continuing the user-level individual tracker overlay parity work so streamer top-section behavior matches the live tracker experience where appropriate. This slice focuses on ensuring team-name/player-name presentation behavior is controlled by persisted streamer settings instead of hardcoded overlay values.

## This PR
- adds `disableTeamPlayerNames` to the individual tracker streamer settings contract and wires it through load/save presenter/store paths
- adds a streamer settings UI toggle for the in-series top section (`Disable toggling to player names`)
- threads the setting through manager `create.tsx` wiring into the overlay presenter/view model
- updates the individual tracker overlay top section to pass the setting into `TeamDetailsContent` for both teams
- adds/updates tests across:
  - streamer settings presenter
  - streamer settings view interactions
  - individual overlay presenter
  - individual overlay render behavior

Validation:
- `npx vitest run pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings-presenter.test.ts pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx`
- `npm run typecheck:pages`

## Subsequent Work
- resolve remaining top-section settings parity for `showServerIcon` in individual tracker overlay:
  - either hide/remove it from individual-tracker streamer settings surfaces
  - or add icon data to individual-tracker view model and wire `showServerIcon` end-to-end
