### PR TITLE
feat(overlay): add width-based tab overflow with ticker alignment

### DIFF
--- a/pages/src/components/streamer-overlay/tabs-bar.tsx
+++ b/pages/src/components/streamer-overlay/tabs-bar.tsx
@@ -94,7 +94,7 @@ export function getVisibleTabsForWidth(options: GetVisibleTabsOptions): readonly
   const activePosition = activeTabIndex == null ? undefined : tabs.findIndex((tab) => tab.index === activeTabIndex);
   const selectedPosition = tabs.findIndex((tab) => tab.index === selectedTab);
 
-  const priorityPositions = [selectedPosition, activePosition, summaryPosition].filter(
+  const priorityPositions = [activePosition, selectedPosition, summaryPosition].filter(
     (position): position is number => position != null && position >= 0,
   );
 

--- a/pages/src/components/streamer-overlay/tabs-bar.tsx
+++ b/pages/src/components/streamer-overlay/tabs-bar.tsx
@@ -1,6 +1,10 @@
-import React, { memo } from "react";
+import React, { memo, useLayoutEffect, useMemo, useRef, useState } from "react";
 import classNames from "classnames";
 import styles from "./streamer-overlay.module.css";
+
+const MIN_MATCH_TAB_WIDTH = 80;
+const MIN_SERIES_TAB_WIDTH = 100;
+const TAB_GAP_WIDTH = 4;
 
 interface SeriesTab {
   readonly type: "series";
@@ -43,6 +47,71 @@ interface TabButtonProps {
   readonly isActive: boolean;
   readonly isSelected: boolean;
   readonly onTabClick: (tabIndex: number) => void;
+}
+
+export function getOverlayTabDisplayLimit(containerWidth: number, tabs: readonly OverlayTab[]): number {
+  if (tabs.length === 0) {
+    return 0;
+  }
+
+  if (containerWidth <= 0) {
+    return 1;
+  }
+
+  let usedWidth = 0;
+  let visibleCount = 0;
+
+  for (const tab of tabs) {
+    const tabWidth = tab.type === "series" ? MIN_SERIES_TAB_WIDTH : MIN_MATCH_TAB_WIDTH;
+    const nextWidth = usedWidth + tabWidth + (visibleCount > 0 ? TAB_GAP_WIDTH : 0);
+
+    if (nextWidth > containerWidth) {
+      break;
+    }
+
+    usedWidth = nextWidth;
+    visibleCount += 1;
+  }
+
+  return Math.max(1, visibleCount);
+}
+
+interface GetVisibleTabsOptions {
+  readonly tabs: readonly OverlayTab[];
+  readonly displayLimit: number;
+  readonly activeTabIndex: number | undefined;
+  readonly selectedTab: number;
+}
+
+export function getVisibleTabsForWidth(options: GetVisibleTabsOptions): readonly OverlayTab[] {
+  const { tabs, displayLimit, activeTabIndex, selectedTab } = options;
+
+  if (tabs.length <= displayLimit) {
+    return tabs;
+  }
+
+  const summaryPosition = tabs[0]?.type === "series" ? 0 : undefined;
+  const activePosition = activeTabIndex == null ? undefined : tabs.findIndex((tab) => tab.index === activeTabIndex);
+  const selectedPosition = tabs.findIndex((tab) => tab.index === selectedTab);
+
+  const priorityPositions = [selectedPosition, activePosition, summaryPosition].filter(
+    (position): position is number => position != null && position >= 0,
+  );
+
+  if (priorityPositions.length >= displayLimit) {
+    const clampedPriorityPositions = Array.from(new Set(priorityPositions)).slice(0, displayLimit);
+    const clampedPositionSet = new Set(clampedPriorityPositions);
+
+    return tabs.filter((_tab, position) => clampedPositionSet.has(position));
+  }
+
+  const includedPositions = new Set(priorityPositions);
+
+  for (let position = tabs.length - 1; position >= 0 && includedPositions.size < displayLimit; position -= 1) {
+    includedPositions.add(position);
+  }
+
+  return tabs.filter((_tab, position) => includedPositions.has(position));
 }
 
 const TabButton = memo(({ tab, isActive, isSelected, onTabClick }: TabButtonProps): React.ReactElement => {
@@ -105,9 +174,50 @@ function OverlayTabsBarComponent({
   isPanelOpen,
   onTabClick,
 }: OverlayTabsBarProps): React.ReactElement {
+  const tabBarRef = useRef<HTMLDivElement | null>(null);
+  const [tabDisplayLimit, setTabDisplayLimit] = useState<number>(tabs.length);
+
+  useLayoutEffect(() => {
+    const tabBarNode = tabBarRef.current;
+    if (tabBarNode == null) {
+      return;
+    }
+
+    const recalculateTabDisplayLimit = (): void => {
+      const nextLimit = getOverlayTabDisplayLimit(tabBarNode.clientWidth, tabs);
+      setTabDisplayLimit((previousLimit) => (previousLimit === nextLimit ? previousLimit : nextLimit));
+    };
+
+    recalculateTabDisplayLimit();
+
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      recalculateTabDisplayLimit();
+    });
+    resizeObserver.observe(tabBarNode);
+
+    return (): void => {
+      resizeObserver.disconnect();
+    };
+  }, [tabs]);
+
+  const visibleTabs = useMemo(
+    () =>
+      getVisibleTabsForWidth({
+        tabs,
+        displayLimit: tabDisplayLimit,
+        activeTabIndex,
+        selectedTab,
+      }),
+    [activeTabIndex, selectedTab, tabDisplayLimit, tabs],
+  );
+
   return (
-    <div className={styles.tabBar}>
-      {tabs.map((tab) => {
+    <div ref={tabBarRef} className={styles.tabBar}>
+      {visibleTabs.map((tab) => {
         const tabIndex = tab.index;
         const tabKey = tab.type === "series" ? `series-${tab.seriesId}` : tab.matchId;
         const isActive = activeTabIndex === tabIndex;

--- a/pages/src/components/streamer-overlay/tabs-bar.tsx
+++ b/pages/src/components/streamer-overlay/tabs-bar.tsx
@@ -94,18 +94,19 @@ export function getVisibleTabsForWidth(options: GetVisibleTabsOptions): readonly
   const activePosition = activeTabIndex == null ? undefined : tabs.findIndex((tab) => tab.index === activeTabIndex);
   const selectedPosition = tabs.findIndex((tab) => tab.index === selectedTab);
 
-  const priorityPositions = [activePosition, selectedPosition, summaryPosition].filter(
+  const rawPriorityPositions = [activePosition, selectedPosition, summaryPosition].filter(
     (position): position is number => position != null && position >= 0,
   );
+  const uniquePriorityPositions = Array.from(new Set(rawPriorityPositions));
 
-  if (priorityPositions.length >= displayLimit) {
-    const clampedPriorityPositions = Array.from(new Set(priorityPositions)).slice(0, displayLimit);
+  if (uniquePriorityPositions.length >= displayLimit) {
+    const clampedPriorityPositions = uniquePriorityPositions.slice(0, displayLimit);
     const clampedPositionSet = new Set(clampedPriorityPositions);
 
     return tabs.filter((_tab, position) => clampedPositionSet.has(position));
   }
 
-  const includedPositions = new Set(priorityPositions);
+  const includedPositions = new Set(uniquePriorityPositions);
 
   for (let position = tabs.length - 1; position >= 0 && includedPositions.size < displayLimit; position -= 1) {
     includedPositions.add(position);

--- a/pages/src/components/streamer-overlay/tabs-bar.tsx
+++ b/pages/src/components/streamer-overlay/tabs-bar.tsx
@@ -58,11 +58,16 @@ export function getOverlayTabDisplayLimit(containerWidth: number, tabs: readonly
     return 1;
   }
 
+  // Sort widths descending so the wider series tab (if present) is counted first,
+  // keeping the limit conservative regardless of where the series tab sits in the list.
+  const tabWidths = tabs
+    .map((tab) => (tab.type === "series" ? MIN_SERIES_TAB_WIDTH : MIN_MATCH_TAB_WIDTH))
+    .sort((a, b) => b - a);
+
   let usedWidth = 0;
   let visibleCount = 0;
 
-  for (const tab of tabs) {
-    const tabWidth = tab.type === "series" ? MIN_SERIES_TAB_WIDTH : MIN_MATCH_TAB_WIDTH;
+  for (const tabWidth of tabWidths) {
     const nextWidth = usedWidth + tabWidth + (visibleCount > 0 ? TAB_GAP_WIDTH : 0);
 
     if (nextWidth > containerWidth) {
@@ -90,7 +95,7 @@ export function getVisibleTabsForWidth(options: GetVisibleTabsOptions): readonly
     return tabs;
   }
 
-  const summaryPosition = tabs[0]?.type === "series" ? 0 : undefined;
+  const summaryPosition = tabs.findIndex((tab) => tab.type === "series");
   const activePosition = activeTabIndex == null ? undefined : tabs.findIndex((tab) => tab.index === activeTabIndex);
   const selectedPosition = tabs.findIndex((tab) => tab.index === selectedTab);
 

--- a/pages/src/components/streamer-overlay/tests/tabs-bar.test.ts
+++ b/pages/src/components/streamer-overlay/tests/tabs-bar.test.ts
@@ -74,4 +74,23 @@ describe("tabs-bar width behavior", () => {
 
     expect(visibleTabs.map((tab) => tab.index)).toEqual([-1, 1, 3, 5]);
   });
+
+  it("prioritizes active ticker tab over selected tab when only one slot is available", () => {
+    const tabs: readonly OverlayTab[] = [
+      aSeriesTabWith(),
+      aMatchTabWith(0),
+      aMatchTabWith(1),
+      aMatchTabWith(2),
+      aMatchTabWith(3),
+    ];
+
+    const visibleTabs = getVisibleTabsForWidth({
+      tabs,
+      displayLimit: 1,
+      activeTabIndex: 2,
+      selectedTab: 0,
+    });
+
+    expect(visibleTabs.map((tab) => tab.index)).toEqual([2]);
+  });
 });

--- a/pages/src/components/streamer-overlay/tests/tabs-bar.test.ts
+++ b/pages/src/components/streamer-overlay/tests/tabs-bar.test.ts
@@ -75,6 +75,26 @@ describe("tabs-bar width behavior", () => {
     expect(visibleTabs.map((tab) => tab.index)).toEqual([-1, 1, 3, 5]);
   });
 
+  it("fills remaining slots when active and selected tabs are the same tab", () => {
+    const tabs: readonly OverlayTab[] = [
+      aSeriesTabWith(),
+      aMatchTabWith(0),
+      aMatchTabWith(1),
+      aMatchTabWith(2),
+      aMatchTabWith(3),
+      aMatchTabWith(4),
+    ];
+
+    const visibleTabs = getVisibleTabsForWidth({
+      tabs,
+      displayLimit: 3,
+      activeTabIndex: 2,
+      selectedTab: 2,
+    });
+
+    expect(visibleTabs.map((tab) => tab.index)).toEqual([-1, 2, 4]);
+  });
+
   it("prioritizes active ticker tab over selected tab when only one slot is available", () => {
     const tabs: readonly OverlayTab[] = [
       aSeriesTabWith(),

--- a/pages/src/components/streamer-overlay/tests/tabs-bar.test.ts
+++ b/pages/src/components/streamer-overlay/tests/tabs-bar.test.ts
@@ -34,6 +34,15 @@ describe("tabs-bar width behavior", () => {
     expect(getOverlayTabDisplayLimit(120, tabs)).toBe(1);
   });
 
+  it("accounts for series tab width when series tab is not first in the list", () => {
+    const tabs: readonly OverlayTab[] = [aMatchTabWith(0), aMatchTabWith(1), aSeriesTabWith()];
+
+    // containerWidth 168: with match-first ordering a naive walk yields limit=2 (80+84=164≤168),
+    // but the visible set would include the wider series tab (100px) causing overflow.
+    // Sorting widths descending (100 first) gives limit=1, preventing that overflow.
+    expect(getOverlayTabDisplayLimit(168, tabs)).toBe(1);
+  });
+
   it("keeps series summary and newest tabs when overflowing", () => {
     const tabs: readonly OverlayTab[] = [
       aSeriesTabWith(),
@@ -52,6 +61,25 @@ describe("tabs-bar width behavior", () => {
     });
 
     expect(visibleTabs.map((tab) => tab.index)).toEqual([-1, 2, 3, 4]);
+  });
+
+  it("keeps series summary tab when it is not first and tabs are overflowing", () => {
+    const tabs: readonly OverlayTab[] = [
+      aMatchTabWith(0),
+      aMatchTabWith(1),
+      aMatchTabWith(2),
+      aMatchTabWith(3),
+      aSeriesTabWith(),
+    ];
+
+    const visibleTabs = getVisibleTabsForWidth({
+      tabs,
+      displayLimit: 3,
+      activeTabIndex: undefined,
+      selectedTab: -99,
+    });
+
+    expect(visibleTabs.map((tab) => tab.index)).toEqual([2, 3, -1]);
   });
 
   it("preserves active and selected tabs when overflowing", () => {

--- a/pages/src/components/streamer-overlay/tests/tabs-bar.test.ts
+++ b/pages/src/components/streamer-overlay/tests/tabs-bar.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { OverlayTab } from "../tabs-bar";
+import { getOverlayTabDisplayLimit, getVisibleTabsForWidth } from "../tabs-bar";
+
+function aSeriesTabWith(overrides?: Partial<OverlayTab>): OverlayTab {
+  return {
+    type: "series",
+    seriesId: "series-1",
+    index: -1,
+    label: "Series",
+    score: "2:1",
+    teamColor: "#00AAFF",
+    ...overrides,
+  } as OverlayTab;
+}
+
+function aMatchTabWith(index: number): OverlayTab {
+  return {
+    type: "match",
+    index,
+    matchId: `match-${index.toString()}`,
+    label: `Match ${index.toString()}`,
+    score: "50:45",
+    icon: "/mode.png",
+    teamColor: "#00AAFF",
+  };
+}
+
+describe("tabs-bar width behavior", () => {
+  it("computes display limit from container width", () => {
+    const tabs: readonly OverlayTab[] = [aSeriesTabWith(), aMatchTabWith(0), aMatchTabWith(1), aMatchTabWith(2)];
+
+    expect(getOverlayTabDisplayLimit(264, tabs)).toBe(2);
+    expect(getOverlayTabDisplayLimit(120, tabs)).toBe(1);
+  });
+
+  it("keeps series summary and newest tabs when overflowing", () => {
+    const tabs: readonly OverlayTab[] = [
+      aSeriesTabWith(),
+      aMatchTabWith(0),
+      aMatchTabWith(1),
+      aMatchTabWith(2),
+      aMatchTabWith(3),
+      aMatchTabWith(4),
+    ];
+
+    const visibleTabs = getVisibleTabsForWidth({
+      tabs,
+      displayLimit: 4,
+      activeTabIndex: undefined,
+      selectedTab: -99,
+    });
+
+    expect(visibleTabs.map((tab) => tab.index)).toEqual([-1, 2, 3, 4]);
+  });
+
+  it("preserves active and selected tabs when overflowing", () => {
+    const tabs: readonly OverlayTab[] = [
+      aSeriesTabWith(),
+      aMatchTabWith(0),
+      aMatchTabWith(1),
+      aMatchTabWith(2),
+      aMatchTabWith(3),
+      aMatchTabWith(4),
+      aMatchTabWith(5),
+    ];
+
+    const visibleTabs = getVisibleTabsForWidth({
+      tabs,
+      displayLimit: 4,
+      activeTabIndex: 1,
+      selectedTab: 3,
+    });
+
+    expect(visibleTabs.map((tab) => tab.index)).toEqual([-1, 1, 3, 5]);
+  });
+});


### PR DESCRIPTION
## Context
This continues the user-level overlay tabs plan by resolving the remaining tab-overflow behavior in the shared streamer overlay tabs bar. The goal is to prevent tab overflow from exceeding available width while preserving reliable visual alignment between the active tab pointer and the information ticker.

## This PR
- adds width-based tab truncation in the shared tabs bar using rendered container width
- introduces deterministic tab visibility selection for overflow cases
- prioritizes visibility for active ticker tab, then selected tab, then series summary tab
- fills remaining visible slots from newest tabs to keep recent matches on screen
- adds focused tests for display-limit calculation and overflow visibility priority rules, including active-tab alignment under tight width constraints

## Subsequent Work
- after merge, proceed with a focused StreamerOverlay SPC refactor to move orchestration logic into presenter/store boundaries while preserving existing UI behavior
