### PR TITLE
refactor(streamer-overlay): extract SPC orchestration and create factory

### DIFF
--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from "react";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
-import { StreamerOverlayCreate } from "../../streamer-overlay/create";
+import { createStreamerOverlaySection } from "../../streamer-overlay/create";
 import { TopSection } from "../../streamer-overlay/top-section";
 import { TeamDetailsContent } from "../../streamer-overlay/team-details-content";
 import { StatsPanel } from "../viewer/stats-panel";
@@ -41,6 +41,8 @@ export function IndividualTrackerOverlay({
   onSelectSeries,
   onDeselect,
 }: IndividualTrackerOverlayProps): React.ReactElement {
+  const StreamerOverlaySection = useMemo(() => createStreamerOverlaySection(), []);
+
   const topSection = useMemo(() => {
     if (viewModel.topSection != null) {
       return (
@@ -163,7 +165,7 @@ export function IndividualTrackerOverlay({
         } as React.CSSProperties
       }
     >
-      <StreamerOverlayCreate
+      <StreamerOverlaySection
         topSection={topSection}
         pinTopSection={viewModel.pinTopSection}
         teamColors={viewModel.teamColors}

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from "react";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
-import { StreamerOverlay } from "../../streamer-overlay/streamer-overlay";
+import { StreamerOverlayCreate } from "../../streamer-overlay/create";
 import { TopSection } from "../../streamer-overlay/top-section";
 import { TeamDetailsContent } from "../../streamer-overlay/team-details-content";
 import { StatsPanel } from "../viewer/stats-panel";
@@ -163,7 +163,7 @@ export function IndividualTrackerOverlay({
         } as React.CSSProperties
       }
     >
-      <StreamerOverlay
+      <StreamerOverlayCreate
         topSection={topSection}
         pinTopSection={viewModel.pinTopSection}
         teamColors={viewModel.teamColors}

--- a/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
@@ -21,7 +21,7 @@ import {
 import type { LiveTrackerNeatQueueStateRenderModel } from "../types";
 import { TopSection } from "../../streamer-overlay/top-section";
 import { TeamDetailsContent } from "../../streamer-overlay/team-details-content";
-import { StreamerOverlayCreate as SharedStreamerOverlay } from "../../streamer-overlay/create";
+import { createStreamerOverlaySection } from "../../streamer-overlay/create";
 import type { OverlayTab } from "../../streamer-overlay/tabs-bar";
 import { StatsPanelContent } from "./stats-panel";
 import styles from "./streamer-overlay.module.css";
@@ -70,6 +70,8 @@ function NeatQueueStreamerOverlay({
   settings,
   settingsUi,
 }: NeatQueueStreamerOverlayProps): React.ReactElement {
+  const SharedStreamerOverlay = useMemo(() => createStreamerOverlaySection(), []);
+
   const allMatchStats = useAllMatchStats();
   const seriesStats = useSeriesStats();
   const allMatchKillMatrix = useAllMatchKillMatrix();

--- a/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
@@ -21,7 +21,7 @@ import {
 import type { LiveTrackerNeatQueueStateRenderModel } from "../types";
 import { TopSection } from "../../streamer-overlay/top-section";
 import { TeamDetailsContent } from "../../streamer-overlay/team-details-content";
-import { StreamerOverlay as SharedStreamerOverlay } from "../../streamer-overlay/streamer-overlay";
+import { StreamerOverlayCreate as SharedStreamerOverlay } from "../../streamer-overlay/create";
 import type { OverlayTab } from "../../streamer-overlay/tabs-bar";
 import { StatsPanelContent } from "./stats-panel";
 import styles from "./streamer-overlay.module.css";

--- a/pages/src/components/streamer-overlay/create.tsx
+++ b/pages/src/components/streamer-overlay/create.tsx
@@ -1,0 +1,121 @@
+import React, { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
+import type { TeamColor } from "../team-colors/team-colors";
+import type { TickerMatchGroup } from "../information-ticker/information-ticker";
+import type { OverlayTab } from "./tabs-bar";
+import { StreamerOverlayPresenter } from "./streamer-overlay-presenter";
+import { StreamerOverlayStore } from "./streamer-overlay-store";
+import { StreamerOverlay } from "./streamer-overlay";
+
+export interface StreamerOverlayProps {
+  readonly topSection: React.ReactNode;
+  readonly pinTopSection?: boolean;
+  readonly teamColors: TeamColor[];
+  readonly tabs: readonly OverlayTab[];
+  readonly tickerMatchGroups: readonly TickerMatchGroup[];
+  readonly showTabs: boolean;
+  readonly showTicker: boolean;
+  readonly matchesLength: number;
+  readonly showPreview: boolean;
+  readonly previewMode: "player" | "observer";
+  readonly fontSizeStyles: React.CSSProperties;
+  readonly settingsUi: React.ReactNode;
+  readonly hasPanelContent: (tabIndex: number) => boolean;
+  readonly renderPanelContent: (tabIndex: number) => React.ReactElement | null;
+  readonly panelOpen?: boolean;
+  readonly onTabClick?: (tabIndex: number) => void;
+  readonly onClosePanel?: () => void;
+}
+
+export function StreamerOverlayCreate({
+  topSection,
+  pinTopSection = false,
+  teamColors,
+  tabs,
+  tickerMatchGroups,
+  showTabs,
+  showTicker,
+  matchesLength,
+  showPreview,
+  previewMode,
+  fontSizeStyles,
+  settingsUi,
+  hasPanelContent,
+  renderPanelContent,
+  panelOpen,
+  onTabClick,
+  onClosePanel,
+}: StreamerOverlayProps): React.ReactElement {
+  const store = useMemo(() => new StreamerOverlayStore(), []);
+  const presenter = useMemo(() => new StreamerOverlayPresenter({ store }), [store]);
+  const subscribe = useCallback((listener: () => void) => store.subscribe(listener), [store]);
+  const getSnapshot = useCallback(() => store.getSnapshot(), [store]);
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  const handleScrollComplete = useCallback((): void => {
+    presenter.onScrollComplete(tickerMatchGroups);
+  }, [presenter, tickerMatchGroups]);
+
+  useEffect(() => {
+    presenter.syncCurrentMatchIndex(tickerMatchGroups);
+  }, [presenter, tickerMatchGroups]);
+
+  useEffect(() => {
+    presenter.syncLatestMatch({
+      showTicker,
+      matchesLength,
+      tickerMatchGroups,
+    });
+  }, [matchesLength, presenter, showTicker, tickerMatchGroups]);
+
+  const handleTabClick = useCallback(
+    (tabIndex: number): void => {
+      presenter.handleTabClick({
+        tabIndex,
+        hasPanelContent,
+        onTabClick,
+        panelOpen,
+      });
+    },
+    [hasPanelContent, onTabClick, panelOpen, presenter],
+  );
+
+  const handleClosePanel = useCallback((): void => {
+    presenter.handleClosePanel(onClosePanel);
+  }, [onClosePanel, presenter]);
+
+  const viewModel = useMemo(
+    () =>
+      presenter.present(snapshot, {
+        showTicker,
+        tickerMatchGroups,
+        panelOpen,
+        renderPanelContent,
+      }),
+    [panelOpen, presenter, renderPanelContent, showTicker, snapshot, tickerMatchGroups],
+  );
+
+  return (
+    <StreamerOverlay
+      topSection={topSection}
+      pinTopSection={pinTopSection}
+      teamColors={teamColors}
+      tabs={tabs}
+      showTabs={showTabs}
+      showTicker={showTicker}
+      showPreview={showPreview}
+      previewMode={previewMode}
+      fontSizeStyles={fontSizeStyles}
+      settingsUi={settingsUi}
+      currentMatchGroup={viewModel.currentMatchGroup}
+      activeTabIndex={viewModel.activeTabIndex}
+      selectedTab={viewModel.selectedTab}
+      isPanelOpen={viewModel.isPanelOpen}
+      panelContent={viewModel.panelContent}
+      onTabClick={handleTabClick}
+      onScrollComplete={handleScrollComplete}
+      onClosePanel={handleClosePanel}
+    />
+  );
+}
+
+export const StreamerOverlaySection = StreamerOverlayCreate;

--- a/pages/src/components/streamer-overlay/create.tsx
+++ b/pages/src/components/streamer-overlay/create.tsx
@@ -26,7 +26,12 @@ export interface StreamerOverlayProps {
   readonly onClosePanel?: () => void;
 }
 
-export function StreamerOverlayCreate({
+interface StreamerOverlaySectionInternalProps extends StreamerOverlayProps {
+  readonly store: StreamerOverlayStore;
+  readonly presenter: StreamerOverlayPresenter;
+}
+
+function StreamerOverlaySectionInternal({
   topSection,
   pinTopSection = false,
   teamColors,
@@ -44,9 +49,9 @@ export function StreamerOverlayCreate({
   panelOpen,
   onTabClick,
   onClosePanel,
-}: StreamerOverlayProps): React.ReactElement {
-  const store = useMemo(() => new StreamerOverlayStore(), []);
-  const presenter = useMemo(() => new StreamerOverlayPresenter({ store }), [store]);
+  store,
+  presenter,
+}: StreamerOverlaySectionInternalProps): React.ReactElement {
   const subscribe = useCallback((listener: () => void) => store.subscribe(listener), [store]);
   const getSnapshot = useCallback(() => store.getSnapshot(), [store]);
   const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
@@ -118,4 +123,13 @@ export function StreamerOverlayCreate({
   );
 }
 
-export const StreamerOverlaySection = StreamerOverlayCreate;
+export function createStreamerOverlaySection(): (props: StreamerOverlayProps) => React.ReactElement {
+  const store = new StreamerOverlayStore();
+  const presenter = new StreamerOverlayPresenter({ store });
+
+  const Component = (props: StreamerOverlayProps): React.ReactElement => (
+    <StreamerOverlaySectionInternal {...props} store={store} presenter={presenter} />
+  );
+
+  return Component;
+}

--- a/pages/src/components/streamer-overlay/streamer-overlay-presenter.ts
+++ b/pages/src/components/streamer-overlay/streamer-overlay-presenter.ts
@@ -1,0 +1,134 @@
+import type React from "react";
+import type { TickerMatchGroup } from "../information-ticker/information-ticker";
+import type { StreamerOverlaySnapshot, StreamerOverlayStore } from "./streamer-overlay-store";
+
+interface StreamerOverlayPresenterConfig {
+  readonly store: StreamerOverlayStore;
+}
+
+interface HandleTabClickOptions {
+  readonly tabIndex: number;
+  readonly hasPanelContent: (tabIndex: number) => boolean;
+  readonly onTabClick?: (tabIndex: number) => void;
+  readonly panelOpen: boolean | undefined;
+}
+
+interface SyncLatestMatchOptions {
+  readonly showTicker: boolean;
+  readonly matchesLength: number;
+  readonly tickerMatchGroups: readonly TickerMatchGroup[];
+}
+
+interface PresentOptions {
+  readonly showTicker: boolean;
+  readonly tickerMatchGroups: readonly TickerMatchGroup[];
+  readonly panelOpen: boolean | undefined;
+  readonly renderPanelContent: (tabIndex: number) => React.ReactElement | null;
+}
+
+export interface StreamerOverlayViewModel {
+  readonly selectedTab: number;
+  readonly isPanelOpen: boolean;
+  readonly currentMatchGroup: TickerMatchGroup | undefined;
+  readonly activeTabIndex: number | undefined;
+  readonly panelContent: React.ReactElement | null;
+}
+
+export class StreamerOverlayPresenter {
+  private readonly config: StreamerOverlayPresenterConfig;
+
+  public constructor(config: StreamerOverlayPresenterConfig) {
+    this.config = config;
+  }
+
+  public onScrollComplete(tickerMatchGroups: readonly TickerMatchGroup[]): void {
+    if (tickerMatchGroups.length === 0) {
+      return;
+    }
+
+    const snapshot = this.config.store.getSnapshot();
+    const nextMatchIndex = (snapshot.currentMatchIndex + 1) % tickerMatchGroups.length;
+    this.config.store.setCurrentMatchIndex(nextMatchIndex);
+  }
+
+  public syncCurrentMatchIndex(tickerMatchGroups: readonly TickerMatchGroup[]): void {
+    const snapshot = this.config.store.getSnapshot();
+
+    if (tickerMatchGroups.length === 0) {
+      if (snapshot.currentMatchIndex !== 0) {
+        this.config.store.setCurrentMatchIndex(0);
+      }
+      return;
+    }
+
+    if (snapshot.currentMatchIndex < tickerMatchGroups.length) {
+      return;
+    }
+
+    this.config.store.setCurrentMatchIndex(0);
+  }
+
+  public syncLatestMatch(options: SyncLatestMatchOptions): void {
+    if (!options.showTicker) {
+      return;
+    }
+
+    const snapshot = this.config.store.getSnapshot();
+    const currentMatchCount = options.matchesLength;
+
+    let nextCurrentMatchIndex = snapshot.currentMatchIndex;
+
+    if (currentMatchCount > snapshot.previousMatchCount && snapshot.previousMatchCount > 0) {
+      const latestMatchIndex = options.tickerMatchGroups.findIndex(
+        (group) => group.matchIndex === currentMatchCount - 1,
+      );
+      if (latestMatchIndex !== -1) {
+        nextCurrentMatchIndex = latestMatchIndex;
+      }
+    }
+
+    this.config.store.batchUpdate({
+      currentMatchIndex: nextCurrentMatchIndex,
+      previousMatchCount: currentMatchCount,
+    });
+  }
+
+  public handleTabClick(options: HandleTabClickOptions): void {
+    const snapshot = this.config.store.getSnapshot();
+    options.onTabClick?.(options.tabIndex);
+
+    if (!options.hasPanelContent(options.tabIndex)) {
+      this.config.store.setSelectedTab(options.tabIndex);
+      return;
+    }
+
+    const isPanelOpen = options.panelOpen ?? snapshot.internalIsPanelOpen;
+    const openPanel = snapshot.selectedTab === options.tabIndex ? !isPanelOpen : true;
+
+    this.config.store.batchUpdate({
+      selectedTab: options.tabIndex,
+      internalIsPanelOpen: openPanel,
+    });
+  }
+
+  public handleClosePanel(onClosePanel?: () => void): void {
+    this.config.store.setInternalIsPanelOpen(false);
+    onClosePanel?.();
+  }
+
+  public present(snapshot: StreamerOverlaySnapshot, options: PresentOptions): StreamerOverlayViewModel {
+    const hasTickerGroups = options.tickerMatchGroups.length > 0;
+    const currentMatchGroup = hasTickerGroups
+      ? options.tickerMatchGroups[snapshot.currentMatchIndex % options.tickerMatchGroups.length]
+      : undefined;
+    const activeTabIndex = options.showTicker && currentMatchGroup != null ? currentMatchGroup.matchIndex : undefined;
+
+    return {
+      selectedTab: snapshot.selectedTab,
+      isPanelOpen: options.panelOpen ?? snapshot.internalIsPanelOpen,
+      currentMatchGroup,
+      activeTabIndex,
+      panelContent: options.renderPanelContent(snapshot.selectedTab),
+    };
+  }
+}

--- a/pages/src/components/streamer-overlay/streamer-overlay-store.ts
+++ b/pages/src/components/streamer-overlay/streamer-overlay-store.ts
@@ -1,0 +1,55 @@
+export interface StreamerOverlaySnapshot {
+  readonly selectedTab: number;
+  readonly internalIsPanelOpen: boolean;
+  readonly currentMatchIndex: number;
+  readonly previousMatchCount: number;
+}
+
+export class StreamerOverlayStore {
+  private snapshot: StreamerOverlaySnapshot = {
+    selectedTab: -1,
+    internalIsPanelOpen: false,
+    currentMatchIndex: 0,
+    previousMatchCount: 0,
+  };
+
+  private readonly subscribers = new Set<() => void>();
+
+  public subscribe(listener: () => void): () => void {
+    this.subscribers.add(listener);
+    return (): void => {
+      this.subscribers.delete(listener);
+    };
+  }
+
+  public getSnapshot(): StreamerOverlaySnapshot {
+    return this.snapshot;
+  }
+
+  public setSelectedTab(selectedTab: number): void {
+    this.update({ selectedTab });
+  }
+
+  public setInternalIsPanelOpen(internalIsPanelOpen: boolean): void {
+    this.update({ internalIsPanelOpen });
+  }
+
+  public setCurrentMatchIndex(currentMatchIndex: number): void {
+    this.update({ currentMatchIndex });
+  }
+
+  public setPreviousMatchCount(previousMatchCount: number): void {
+    this.update({ previousMatchCount });
+  }
+
+  public batchUpdate(partial: Partial<StreamerOverlaySnapshot>): void {
+    this.update(partial);
+  }
+
+  private update(partial: Partial<StreamerOverlaySnapshot>): void {
+    this.snapshot = { ...this.snapshot, ...partial };
+    for (const subscriber of this.subscribers) {
+      subscriber();
+    }
+  }
+}

--- a/pages/src/components/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/streamer-overlay/streamer-overlay.tsx
@@ -1,10 +1,12 @@
-import React, { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import classNames from "classnames";
 import type { TeamColor } from "../team-colors/team-colors";
 import type { TickerMatchGroup } from "../information-ticker/information-ticker";
 import type { OverlayTab } from "./tabs-bar";
 import { BottomSection } from "./bottom-section";
 import { StatsPanel } from "./stats-panel/stats-panel";
+import { StreamerOverlayPresenter } from "./streamer-overlay-presenter";
+import { StreamerOverlayStore } from "./streamer-overlay-store";
 import styles from "./streamer-overlay.module.css";
 
 export interface StreamerOverlayProps {
@@ -46,74 +48,54 @@ export function StreamerOverlay({
   onTabClick,
   onClosePanel,
 }: StreamerOverlayProps): React.ReactElement {
-  const [selectedTab, setSelectedTab] = useState(-1); // -1 = series, 0+ = match index
-  const [internalIsPanelOpen, setInternalIsPanelOpen] = useState(false);
-  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
-  const [previousMatchCount, setPreviousMatchCount] = useState(0);
+  const store = useMemo(() => new StreamerOverlayStore(), []);
+  const presenter = useMemo(() => new StreamerOverlayPresenter({ store }), [store]);
+  const subscribe = useCallback((listener: () => void) => store.subscribe(listener), [store]);
+  const getSnapshot = useCallback(() => store.getSnapshot(), [store]);
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   const nodeRef = useRef<HTMLDivElement>(null);
 
-  const isPanelOpen = panelOpen ?? internalIsPanelOpen;
-
-  const handleScrollComplete = (): void => {
-    if (tickerMatchGroups.length === 0) {
-      return;
-    }
-
-    setCurrentMatchIndex((prevIndex) => (prevIndex + 1) % tickerMatchGroups.length);
-  };
+  const handleScrollComplete = useCallback((): void => {
+    presenter.onScrollComplete(tickerMatchGroups);
+  }, [presenter, tickerMatchGroups]);
 
   useEffect(() => {
-    if (currentMatchIndex < tickerMatchGroups.length) {
-      return;
-    }
-
-    setCurrentMatchIndex(0);
-  }, [currentMatchIndex, tickerMatchGroups.length]);
+    presenter.syncCurrentMatchIndex(tickerMatchGroups);
+  }, [presenter, tickerMatchGroups]);
 
   useEffect(() => {
-    if (!showTicker) {
-      return;
-    }
-
-    const currentMatchCount = matchesLength;
-
-    if (currentMatchCount > previousMatchCount && previousMatchCount > 0) {
-      const latestMatchIndex = tickerMatchGroups.findIndex((group) => group.matchIndex === currentMatchCount - 1);
-      if (latestMatchIndex !== -1) {
-        setCurrentMatchIndex(latestMatchIndex);
-      }
-    }
-
-    setPreviousMatchCount(currentMatchCount);
-  }, [matchesLength, showTicker, tickerMatchGroups, previousMatchCount]);
+    presenter.syncLatestMatch({
+      showTicker,
+      matchesLength,
+      tickerMatchGroups,
+    });
+  }, [matchesLength, presenter, showTicker, tickerMatchGroups]);
 
   const handleTabClick = useCallback(
     (tabIndex: number): void => {
-      onTabClick?.(tabIndex);
-      setSelectedTab(tabIndex);
-      if (!hasPanelContent(tabIndex)) {
-        return;
-      }
-
-      const openPanel = selectedTab === tabIndex ? !isPanelOpen : true;
-      setInternalIsPanelOpen(openPanel);
+      presenter.handleTabClick({
+        tabIndex,
+        hasPanelContent,
+        onTabClick,
+        panelOpen,
+      });
     },
-    [hasPanelContent, isPanelOpen, onTabClick, selectedTab],
+    [hasPanelContent, onTabClick, panelOpen, presenter],
   );
 
   const handleClosePanel = useCallback((): void => {
-    setInternalIsPanelOpen(false);
-    onClosePanel?.();
-  }, [onClosePanel]);
+    presenter.handleClosePanel(onClosePanel);
+  }, [onClosePanel, presenter]);
 
-  const hasTickerGroups = tickerMatchGroups.length > 0;
-  const currentMatchGroup = hasTickerGroups
-    ? tickerMatchGroups[currentMatchIndex % tickerMatchGroups.length]
-    : undefined;
-  const activeTabIndex = showTicker && hasTickerGroups ? currentMatchGroup?.matchIndex : undefined;
-  const panelContent = useMemo<React.ReactElement | null>(
-    () => renderPanelContent(selectedTab),
-    [renderPanelContent, selectedTab],
+  const viewModel = useMemo(
+    () =>
+      presenter.present(snapshot, {
+        showTicker,
+        tickerMatchGroups,
+        panelOpen,
+        renderPanelContent,
+      }),
+    [panelOpen, presenter, renderPanelContent, showTicker, snapshot, tickerMatchGroups],
   );
 
   return (
@@ -131,21 +113,21 @@ export function StreamerOverlay({
       <BottomSection
         showTabs={showTabs}
         showTicker={showTicker}
-        currentMatchGroup={currentMatchGroup}
+        currentMatchGroup={viewModel.currentMatchGroup}
         teamColors={teamColors}
         tabs={tabs}
-        activeTabIndex={activeTabIndex}
-        selectedTab={selectedTab}
-        isPanelOpen={isPanelOpen}
+        activeTabIndex={viewModel.activeTabIndex}
+        selectedTab={viewModel.selectedTab}
+        isPanelOpen={viewModel.isPanelOpen}
         onTabClick={handleTabClick}
         onScrollComplete={handleScrollComplete}
       />
 
       <StatsPanel
-        isPanelOpen={isPanelOpen}
+        isPanelOpen={viewModel.isPanelOpen}
         nodeRef={nodeRef}
         onClosePanel={handleClosePanel}
-        panelContent={panelContent}
+        panelContent={viewModel.panelContent}
       />
     </div>
   );

--- a/pages/src/components/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/streamer-overlay/streamer-overlay.tsx
@@ -1,32 +1,31 @@
-import React, { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import React, { useRef } from "react";
 import classNames from "classnames";
 import type { TeamColor } from "../team-colors/team-colors";
 import type { TickerMatchGroup } from "../information-ticker/information-ticker";
 import type { OverlayTab } from "./tabs-bar";
 import { BottomSection } from "./bottom-section";
 import { StatsPanel } from "./stats-panel/stats-panel";
-import { StreamerOverlayPresenter } from "./streamer-overlay-presenter";
-import { StreamerOverlayStore } from "./streamer-overlay-store";
 import styles from "./streamer-overlay.module.css";
 
-export interface StreamerOverlayProps {
+export interface StreamerOverlayComponentProps {
   readonly topSection: React.ReactNode;
   readonly pinTopSection?: boolean;
   readonly teamColors: TeamColor[];
   readonly tabs: readonly OverlayTab[];
-  readonly tickerMatchGroups: readonly TickerMatchGroup[];
   readonly showTabs: boolean;
   readonly showTicker: boolean;
-  readonly matchesLength: number;
   readonly showPreview: boolean;
   readonly previewMode: "player" | "observer";
   readonly fontSizeStyles: React.CSSProperties;
   readonly settingsUi: React.ReactNode;
-  readonly hasPanelContent: (tabIndex: number) => boolean;
-  readonly renderPanelContent: (tabIndex: number) => React.ReactElement | null;
-  readonly panelOpen?: boolean;
-  readonly onTabClick?: (tabIndex: number) => void;
-  readonly onClosePanel?: () => void;
+  readonly currentMatchGroup: TickerMatchGroup | undefined;
+  readonly activeTabIndex: number | undefined;
+  readonly selectedTab: number;
+  readonly isPanelOpen: boolean;
+  readonly panelContent: React.ReactElement | null;
+  readonly onTabClick: (tabIndex: number) => void;
+  readonly onScrollComplete: () => void;
+  readonly onClosePanel: () => void;
 }
 
 export function StreamerOverlay({
@@ -34,69 +33,22 @@ export function StreamerOverlay({
   pinTopSection = false,
   teamColors,
   tabs,
-  tickerMatchGroups,
   showTabs,
   showTicker,
-  matchesLength,
   showPreview,
   previewMode,
   fontSizeStyles,
   settingsUi,
-  hasPanelContent,
-  renderPanelContent,
-  panelOpen,
+  currentMatchGroup,
+  activeTabIndex,
+  selectedTab,
+  isPanelOpen,
+  panelContent,
   onTabClick,
+  onScrollComplete,
   onClosePanel,
-}: StreamerOverlayProps): React.ReactElement {
-  const store = useMemo(() => new StreamerOverlayStore(), []);
-  const presenter = useMemo(() => new StreamerOverlayPresenter({ store }), [store]);
-  const subscribe = useCallback((listener: () => void) => store.subscribe(listener), [store]);
-  const getSnapshot = useCallback(() => store.getSnapshot(), [store]);
-  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}: StreamerOverlayComponentProps): React.ReactElement {
   const nodeRef = useRef<HTMLDivElement>(null);
-
-  const handleScrollComplete = useCallback((): void => {
-    presenter.onScrollComplete(tickerMatchGroups);
-  }, [presenter, tickerMatchGroups]);
-
-  useEffect(() => {
-    presenter.syncCurrentMatchIndex(tickerMatchGroups);
-  }, [presenter, tickerMatchGroups]);
-
-  useEffect(() => {
-    presenter.syncLatestMatch({
-      showTicker,
-      matchesLength,
-      tickerMatchGroups,
-    });
-  }, [matchesLength, presenter, showTicker, tickerMatchGroups]);
-
-  const handleTabClick = useCallback(
-    (tabIndex: number): void => {
-      presenter.handleTabClick({
-        tabIndex,
-        hasPanelContent,
-        onTabClick,
-        panelOpen,
-      });
-    },
-    [hasPanelContent, onTabClick, panelOpen, presenter],
-  );
-
-  const handleClosePanel = useCallback((): void => {
-    presenter.handleClosePanel(onClosePanel);
-  }, [onClosePanel, presenter]);
-
-  const viewModel = useMemo(
-    () =>
-      presenter.present(snapshot, {
-        showTicker,
-        tickerMatchGroups,
-        panelOpen,
-        renderPanelContent,
-      }),
-    [panelOpen, presenter, renderPanelContent, showTicker, snapshot, tickerMatchGroups],
-  );
 
   return (
     <div
@@ -113,22 +65,17 @@ export function StreamerOverlay({
       <BottomSection
         showTabs={showTabs}
         showTicker={showTicker}
-        currentMatchGroup={viewModel.currentMatchGroup}
+        currentMatchGroup={currentMatchGroup}
         teamColors={teamColors}
         tabs={tabs}
-        activeTabIndex={viewModel.activeTabIndex}
-        selectedTab={viewModel.selectedTab}
-        isPanelOpen={viewModel.isPanelOpen}
-        onTabClick={handleTabClick}
-        onScrollComplete={handleScrollComplete}
+        activeTabIndex={activeTabIndex}
+        selectedTab={selectedTab}
+        isPanelOpen={isPanelOpen}
+        onTabClick={onTabClick}
+        onScrollComplete={onScrollComplete}
       />
 
-      <StatsPanel
-        isPanelOpen={viewModel.isPanelOpen}
-        nodeRef={nodeRef}
-        onClosePanel={handleClosePanel}
-        panelContent={viewModel.panelContent}
-      />
+      <StatsPanel isPanelOpen={isPanelOpen} nodeRef={nodeRef} onClosePanel={onClosePanel} panelContent={panelContent} />
     </div>
   );
 }

--- a/pages/src/components/streamer-overlay/tests/streamer-overlay-presenter.test.tsx
+++ b/pages/src/components/streamer-overlay/tests/streamer-overlay-presenter.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import type { TickerMatchGroup } from "../../information-ticker/information-ticker";
+import { StreamerOverlayPresenter } from "../streamer-overlay-presenter";
+import { StreamerOverlayStore } from "../streamer-overlay-store";
+
+function aTickerMatchGroupWith(matchIndex: number): TickerMatchGroup {
+  return {
+    matchIndex,
+    label: `Match ${matchIndex.toString()}`,
+    rows: [],
+  };
+}
+
+describe("StreamerOverlayPresenter", () => {
+  it("toggles internal panel state when clicking the same tab with panel content", () => {
+    const store = new StreamerOverlayStore();
+    const presenter = new StreamerOverlayPresenter({ store });
+
+    presenter.handleTabClick({
+      tabIndex: 2,
+      hasPanelContent: () => true,
+      panelOpen: undefined,
+    });
+
+    expect(store.getSnapshot().selectedTab).toBe(2);
+    expect(store.getSnapshot().internalIsPanelOpen).toBe(true);
+
+    presenter.handleTabClick({
+      tabIndex: 2,
+      hasPanelContent: () => true,
+      panelOpen: undefined,
+    });
+
+    expect(store.getSnapshot().internalIsPanelOpen).toBe(false);
+  });
+
+  it("moves ticker index to latest match when match count increases", () => {
+    const store = new StreamerOverlayStore();
+    const presenter = new StreamerOverlayPresenter({ store });
+    const tickerMatchGroups: readonly TickerMatchGroup[] = [
+      aTickerMatchGroupWith(0),
+      aTickerMatchGroupWith(1),
+      aTickerMatchGroupWith(2),
+    ];
+
+    store.setPreviousMatchCount(2);
+    store.setCurrentMatchIndex(0);
+
+    presenter.syncLatestMatch({
+      showTicker: true,
+      matchesLength: 3,
+      tickerMatchGroups,
+    });
+
+    expect(store.getSnapshot().currentMatchIndex).toBe(2);
+    expect(store.getSnapshot().previousMatchCount).toBe(3);
+  });
+
+  it("resets current ticker index when it is out of range", () => {
+    const store = new StreamerOverlayStore();
+    const presenter = new StreamerOverlayPresenter({ store });
+
+    store.setCurrentMatchIndex(3);
+
+    presenter.syncCurrentMatchIndex([aTickerMatchGroupWith(0)]);
+
+    expect(store.getSnapshot().currentMatchIndex).toBe(0);
+  });
+
+  it("derives active tab and panel state in present", () => {
+    const store = new StreamerOverlayStore();
+    const presenter = new StreamerOverlayPresenter({ store });
+
+    store.setSelectedTab(5);
+    store.setCurrentMatchIndex(0);
+
+    const viewModel = presenter.present(store.getSnapshot(), {
+      showTicker: true,
+      tickerMatchGroups: [aTickerMatchGroupWith(7)],
+      panelOpen: true,
+      renderPanelContent: (tabIndex): React.ReactElement => <div>{tabIndex.toString()}</div>,
+    });
+
+    expect(viewModel.selectedTab).toBe(5);
+    expect(viewModel.isPanelOpen).toBe(true);
+    expect(viewModel.activeTabIndex).toBe(7);
+    expect(viewModel.currentMatchGroup?.matchIndex).toBe(7);
+    expect(viewModel.panelContent).not.toBeNull();
+  });
+});

--- a/pages/src/components/streamer-overlay/tests/streamer-overlay.test.tsx
+++ b/pages/src/components/streamer-overlay/tests/streamer-overlay.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 
 import React from "react";
-import { describe, expect, it, vi, afterEach } from "vitest";
+import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type { OverlayTab } from "../tabs-bar";
@@ -17,7 +17,11 @@ afterEach(() => {
 });
 
 describe("StreamerOverlay", () => {
-  const StreamerOverlaySection = createStreamerOverlaySection();
+  let StreamerOverlaySection: ReturnType<typeof createStreamerOverlaySection>;
+
+  beforeEach(() => {
+    StreamerOverlaySection = createStreamerOverlaySection();
+  });
 
   const teamColors: TeamColor[] = [
     { id: "eagle", name: "Eagle", hex: "#0066CC" },

--- a/pages/src/components/streamer-overlay/tests/streamer-overlay.test.tsx
+++ b/pages/src/components/streamer-overlay/tests/streamer-overlay.test.tsx
@@ -6,7 +6,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type { OverlayTab } from "../tabs-bar";
 import type { TickerMatchGroup } from "../../information-ticker/information-ticker";
-import { StreamerOverlayCreate, type StreamerOverlayProps } from "../create";
+import { createStreamerOverlaySection, type StreamerOverlayProps } from "../create";
 
 vi.mock("../../information-ticker/information-ticker", () => ({
   InformationTicker: (): React.ReactNode => <div data-testid="information-ticker">Information Ticker</div>,
@@ -17,6 +17,8 @@ afterEach(() => {
 });
 
 describe("StreamerOverlay", () => {
+  const StreamerOverlaySection = createStreamerOverlaySection();
+
   const teamColors: TeamColor[] = [
     { id: "eagle", name: "Eagle", hex: "#0066CC" },
     { id: "cobra", name: "Cobra", hex: "#CC0000" },
@@ -66,20 +68,20 @@ describe("StreamerOverlay", () => {
   };
 
   it("renders settings and top section", () => {
-    render(<StreamerOverlayCreate {...defaultProps} />);
+    render(<StreamerOverlaySection {...defaultProps} />);
 
     expect(screen.getByText("Settings UI")).toBeInTheDocument();
     expect(screen.getByText("Top Section")).toBeInTheDocument();
   });
 
   it("renders information ticker when enabled", () => {
-    render(<StreamerOverlayCreate {...defaultProps} />);
+    render(<StreamerOverlaySection {...defaultProps} />);
 
     expect(screen.getByTestId("information-ticker")).toBeInTheDocument();
   });
 
   it("opens panel when tab is clicked", () => {
-    render(<StreamerOverlayCreate {...defaultProps} />);
+    render(<StreamerOverlaySection {...defaultProps} />);
 
     fireEvent.click(screen.getByRole("button", { name: /series score/i }));
 
@@ -87,7 +89,7 @@ describe("StreamerOverlay", () => {
   });
 
   it("hides bottom section when tabs and ticker are disabled", () => {
-    render(<StreamerOverlayCreate {...defaultProps} showTabs={false} showTicker={false} />);
+    render(<StreamerOverlaySection {...defaultProps} showTabs={false} showTicker={false} />);
 
     expect(screen.queryByRole("button", { name: /series score/i })).not.toBeInTheDocument();
     expect(screen.queryByTestId("information-ticker")).not.toBeInTheDocument();

--- a/pages/src/components/streamer-overlay/tests/streamer-overlay.test.tsx
+++ b/pages/src/components/streamer-overlay/tests/streamer-overlay.test.tsx
@@ -6,7 +6,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type { OverlayTab } from "../tabs-bar";
 import type { TickerMatchGroup } from "../../information-ticker/information-ticker";
-import { StreamerOverlay, type StreamerOverlayProps } from "../streamer-overlay";
+import { StreamerOverlayCreate, type StreamerOverlayProps } from "../create";
 
 vi.mock("../../information-ticker/information-ticker", () => ({
   InformationTicker: (): React.ReactNode => <div data-testid="information-ticker">Information Ticker</div>,
@@ -66,20 +66,20 @@ describe("StreamerOverlay", () => {
   };
 
   it("renders settings and top section", () => {
-    render(<StreamerOverlay {...defaultProps} />);
+    render(<StreamerOverlayCreate {...defaultProps} />);
 
     expect(screen.getByText("Settings UI")).toBeInTheDocument();
     expect(screen.getByText("Top Section")).toBeInTheDocument();
   });
 
   it("renders information ticker when enabled", () => {
-    render(<StreamerOverlay {...defaultProps} />);
+    render(<StreamerOverlayCreate {...defaultProps} />);
 
     expect(screen.getByTestId("information-ticker")).toBeInTheDocument();
   });
 
   it("opens panel when tab is clicked", () => {
-    render(<StreamerOverlay {...defaultProps} />);
+    render(<StreamerOverlayCreate {...defaultProps} />);
 
     fireEvent.click(screen.getByRole("button", { name: /series score/i }));
 
@@ -87,7 +87,7 @@ describe("StreamerOverlay", () => {
   });
 
   it("hides bottom section when tabs and ticker are disabled", () => {
-    render(<StreamerOverlay {...defaultProps} showTabs={false} showTicker={false} />);
+    render(<StreamerOverlayCreate {...defaultProps} showTabs={false} showTicker={false} />);
 
     expect(screen.queryByRole("button", { name: /series score/i })).not.toBeInTheDocument();
     expect(screen.queryByTestId("information-ticker")).not.toBeInTheDocument();


### PR DESCRIPTION
## Context
After tab-overflow and ticker-alignment changes in PR #663, the next planned step was to align StreamerOverlay with the repository SPC/factory conventions so state orchestration is no longer embedded in the render component. This keeps behavior stable while making future overlay changes easier to reason about and test.

## This PR
- extracts StreamerOverlay orchestration into dedicated store/presenter modules:
  - `streamer-overlay-store.ts`
  - `streamer-overlay-presenter.ts`
- converts `streamer-overlay.tsx` into a render-focused component that consumes derived view props and callbacks
- introduces create-factory wiring in `streamer-overlay/create.tsx` that:
  - accepts dependencies/props at render time
  - keeps store/presenter instances stable
  - returns a renderable component via `createStreamerOverlaySection()`
- updates consumers to use the factory pattern:
  - individual tracker overlay
  - live tracker shared overlay usage
- adds presenter-focused tests and updates integration tests to target the factory entrypoint
- validates behavior with full `npm run done` and focused overlay test coverage

## Subsequent Work
- run a follow-up pass to align remaining `create.tsx` modules across the repo to the same install-sequence factory pattern (create dependencies once, return renderable Component)
