### PR TITLE
Refactor individual tracker create factories (chunk 1)

### DIFF
--- a/pages/src/apps/individual-tracker-manager/create.tsx
+++ b/pages/src/apps/individual-tracker-manager/create.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ReactElement } from "react";
 import { ComponentLoader, ComponentLoaderStatus } from "../../components/component-loader/component-loader";
 import { ErrorState } from "../../components/error-state/error-state";
 import { LoadingState } from "../../components/loading-state/loading-state";
-import { IndividualTrackerManagerPage } from "../../components/individual-tracker-manager/create";
+import { createIndividualTrackerManagerPage } from "../../components/individual-tracker-manager/create";
 import type { Services } from "./services";
 import { installServices } from "./services";
 
@@ -14,6 +14,18 @@ interface IndividualTrackerManagerAppProps {
 export function IndividualTrackerManagerApp({ apiHost }: IndividualTrackerManagerAppProps): ReactElement {
   const [state, setState] = useState(ComponentLoaderStatus.PENDING);
   const [services, setServices] = useState<Services | null>(null);
+  const IndividualTrackerManagerPage = useMemo(
+    () =>
+      services == null
+        ? null
+        : createIndividualTrackerManagerPage({
+            authService: services.authService,
+            individualTrackerService: services.individualTrackerService,
+            settingsService: services.settingsService,
+            individualTrackerViewService: services.individualTrackerViewService,
+          }),
+    [services],
+  );
 
   useEffect(() => {
     let isCancelled = false;
@@ -50,13 +62,8 @@ export function IndividualTrackerManagerApp({ apiHost }: IndividualTrackerManage
       loading={<LoadingState text="Loading tracker manager..." />}
       error={<ErrorState message="Failed to load tracker manager" />}
       loaded={
-        services ? (
-          <IndividualTrackerManagerPage
-            authService={services.authService}
-            individualTrackerService={services.individualTrackerService}
-            settingsService={services.settingsService}
-            individualTrackerViewService={services.individualTrackerViewService}
-          />
+        IndividualTrackerManagerPage != null ? (
+          <IndividualTrackerManagerPage />
         ) : (
           <ErrorState message="Services failed to load" />
         )

--- a/pages/src/apps/individual-tracker-overlay/create.tsx
+++ b/pages/src/apps/individual-tracker-overlay/create.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ReactElement } from "react";
 import { ComponentLoader, ComponentLoaderStatus } from "../../components/component-loader/component-loader";
 import { ErrorState } from "../../components/error-state/error-state";
 import { LoadingState } from "../../components/loading-state/loading-state";
-import { IndividualTrackerOverlayPage } from "../../components/individual-tracker/overlay/create";
+import { createIndividualTrackerOverlayPage } from "../../components/individual-tracker/overlay/create";
 import type { Services } from "../individual-tracker-viewer/services";
 import { installServices } from "../individual-tracker-viewer/services";
 
@@ -15,6 +15,18 @@ interface IndividualTrackerOverlayAppProps {
 export function IndividualTrackerOverlayApp({ apiHost, trackerId }: IndividualTrackerOverlayAppProps): ReactElement {
   const [state, setState] = useState(ComponentLoaderStatus.PENDING);
   const [services, setServices] = useState<Services | null>(null);
+  const IndividualTrackerOverlayPage = useMemo(
+    () =>
+      services == null
+        ? null
+        : createIndividualTrackerOverlayPage({
+            individualTrackerViewService: services.individualTrackerViewService,
+            matchAnalyticsService: services.matchAnalyticsService,
+            seriesMatchesService: services.seriesMatchesService,
+            haloClient: services.haloClient,
+          }),
+    [services],
+  );
 
   useEffect(() => {
     if (trackerId === "") {
@@ -59,14 +71,8 @@ export function IndividualTrackerOverlayApp({ apiHost, trackerId }: IndividualTr
       loading={<LoadingState text="Loading tracker..." />}
       error={<ErrorState message="Failed to load tracker" />}
       loaded={
-        services ? (
-          <IndividualTrackerOverlayPage
-            individualTrackerViewService={services.individualTrackerViewService}
-            matchAnalyticsService={services.matchAnalyticsService}
-            seriesMatchesService={services.seriesMatchesService}
-            haloClient={services.haloClient}
-            trackerId={trackerId}
-          />
+        IndividualTrackerOverlayPage != null ? (
+          <IndividualTrackerOverlayPage trackerId={trackerId} />
         ) : (
           <ErrorState message="Services failed to load" />
         )

--- a/pages/src/apps/individual-tracker-viewer/create.tsx
+++ b/pages/src/apps/individual-tracker-viewer/create.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ReactElement } from "react";
 import TimeAgo from "javascript-time-ago";
 import en from "javascript-time-ago/locale/en";
 import { ComponentLoader, ComponentLoaderStatus } from "../../components/component-loader/component-loader";
 import { ErrorState } from "../../components/error-state/error-state";
 import { LoadingState } from "../../components/loading-state/loading-state";
-import { IndividualTrackerViewerPage } from "../../components/individual-tracker/viewer/create";
+import { createIndividualTrackerViewerPage } from "../../components/individual-tracker/viewer/create";
 import type { Services } from "./services";
 import { installServices } from "./services";
 
@@ -25,6 +25,19 @@ function redirectToLogin(): void {
 export function IndividualTrackerViewerApp({ apiHost, trackerId }: IndividualTrackerViewerAppProps): ReactElement {
   const [state, setState] = useState(ComponentLoaderStatus.PENDING);
   const [services, setServices] = useState<Services | null>(null);
+  const IndividualTrackerViewerPage = useMemo(
+    () =>
+      services == null
+        ? null
+        : createIndividualTrackerViewerPage({
+            individualTrackerService: services.individualTrackerService,
+            individualTrackerViewService: services.individualTrackerViewService,
+            matchAnalyticsService: services.matchAnalyticsService,
+            seriesMatchesService: services.seriesMatchesService,
+            haloClient: services.haloClient,
+          }),
+    [services],
+  );
 
   useEffect(() => {
     if (trackerId === "") {
@@ -76,16 +89,8 @@ export function IndividualTrackerViewerApp({ apiHost, trackerId }: IndividualTra
       loading={<LoadingState text="Checking current session..." />}
       error={<ErrorState message="Failed to load tracker" />}
       loaded={
-        services ? (
-          <IndividualTrackerViewerPage
-            individualTrackerService={services.individualTrackerService}
-            individualTrackerViewService={services.individualTrackerViewService}
-            matchAnalyticsService={services.matchAnalyticsService}
-            seriesMatchesService={services.seriesMatchesService}
-            haloClient={services.haloClient}
-            trackerId={trackerId}
-            pageTitleVariant="tracker"
-          />
+        IndividualTrackerViewerPage != null ? (
+          <IndividualTrackerViewerPage trackerId={trackerId} pageTitleVariant="tracker" />
         ) : (
           <ErrorState message="Services failed to load" />
         )

--- a/pages/src/components/follow/follow-live-overlay/follow-live-overlay.tsx
+++ b/pages/src/components/follow/follow-live-overlay/follow-live-overlay.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import type { HaloInfiniteClient } from "halo-infinite-api";
+import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { ComponentLoaderStatus } from "../../component-loader/component-loader";
 import { ComponentLoader } from "../../component-loader/component-loader";
 import { ErrorState } from "../../error-state/error-state";
 import { LoadingState } from "../../loading-state/loading-state";
-import { IndividualTrackerOverlayPage } from "../../individual-tracker/overlay/create";
+import { createIndividualTrackerOverlayPage } from "../../individual-tracker/overlay/create";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { SeriesMatchesService } from "../../../services/stats/series-matches-types";
@@ -12,7 +13,7 @@ import type { SeriesMatchesService } from "../../../services/stats/series-matche
 export interface FollowLiveOverlayProps {
   readonly loadStatus: ComponentLoaderStatus;
   readonly liveTrackerId: string | null;
-  readonly liveTrackerView: Parameters<typeof IndividualTrackerOverlayPage>[0]["externalView"];
+  readonly liveTrackerView: TrackerViewState | undefined;
   readonly individualTrackerViewService: IndividualTrackerViewService;
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
@@ -34,14 +35,21 @@ export function FollowLiveOverlay({
   previewMode = "observer",
   onRetry,
 }: FollowLiveOverlayProps): React.ReactElement {
+  const IndividualTrackerOverlayPage = React.useMemo(
+    () =>
+      createIndividualTrackerOverlayPage({
+        individualTrackerViewService,
+        matchAnalyticsService,
+        seriesMatchesService,
+        haloClient,
+      }),
+    [haloClient, individualTrackerViewService, matchAnalyticsService, seriesMatchesService],
+  );
+
   const loadedState =
     liveTrackerId != null ? (
       <IndividualTrackerOverlayPage
         key={liveTrackerId}
-        individualTrackerViewService={individualTrackerViewService}
-        matchAnalyticsService={matchAnalyticsService}
-        seriesMatchesService={seriesMatchesService}
-        haloClient={haloClient}
         trackerId={liveTrackerId}
         externalView={liveTrackerView}
         showPreview={showPreview}

--- a/pages/src/components/follow/follow-live-overlay/tests/follow-live-overlay-create.test.tsx
+++ b/pages/src/components/follow/follow-live-overlay/tests/follow-live-overlay-create.test.tsx
@@ -16,28 +16,30 @@ import { createFollowLiveOverlay } from "../create";
 let mockOverlayInstanceCount = 0;
 
 vi.mock("../../../individual-tracker/overlay/create", () => ({
-  IndividualTrackerOverlayPage: ({
-    trackerId,
-    externalView,
-    showPreview,
-    previewMode,
-  }: {
-    trackerId: string;
-    externalView?: TrackerViewState;
-    showPreview?: boolean;
-    previewMode?: "player" | "observer";
-  }): React.ReactElement => {
-    const [instanceId] = React.useState(() => {
-      mockOverlayInstanceCount += 1;
-      return mockOverlayInstanceCount;
-    });
+  createIndividualTrackerOverlayPage: () => {
+    return function MockIndividualTrackerOverlayPage({
+      trackerId,
+      externalView,
+      showPreview,
+      previewMode,
+    }: {
+      trackerId: string;
+      externalView?: TrackerViewState;
+      showPreview?: boolean;
+      previewMode?: "player" | "observer";
+    }): React.ReactElement {
+      const [instanceId] = React.useState(() => {
+        mockOverlayInstanceCount += 1;
+        return mockOverlayInstanceCount;
+      });
 
-    return (
-      <div data-testid="mock-overlay-page" data-instance-id={instanceId.toString()}>
-        {`${trackerId}:${String(showPreview)}:${previewMode ?? "observer"}`}
-        <span data-testid="mock-overlay-external-view-tracker-id">{externalView?.trackerId ?? "none"}</span>
-      </div>
-    );
+      return (
+        <div data-testid="mock-overlay-page" data-instance-id={instanceId.toString()}>
+          {`${trackerId}:${String(showPreview)}:${previewMode ?? "observer"}`}
+          <span data-testid="mock-overlay-external-view-tracker-id">{externalView?.trackerId ?? "none"}</span>
+        </div>
+      );
+    };
   },
 }));
 

--- a/pages/src/components/follow/follow-live-viewer/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer/follow-live-viewer.tsx
@@ -6,7 +6,7 @@ import type { ComponentLoaderStatus } from "../../component-loader/component-loa
 import { ComponentLoader } from "../../component-loader/component-loader";
 import { ErrorState } from "../../error-state/error-state";
 import { LoadingState } from "../../loading-state/loading-state";
-import { IndividualTrackerViewerPage } from "../../individual-tracker/viewer/create";
+import { createIndividualTrackerViewerPage } from "../../individual-tracker/viewer/create";
 import type {
   IndividualTrackerViewService,
   TrackerViewConnectionStatus,
@@ -50,14 +50,21 @@ export function FollowLiveViewer({
   onSelectTracker,
   onRetry,
 }: FollowLiveViewerProps): React.ReactElement {
+  const IndividualTrackerViewerPage = React.useMemo(
+    () =>
+      createIndividualTrackerViewerPage({
+        individualTrackerViewService,
+        matchAnalyticsService,
+        seriesMatchesService,
+        haloClient,
+      }),
+    [haloClient, individualTrackerViewService, matchAnalyticsService, seriesMatchesService],
+  );
+
   const loadedState =
     resolvedSelectedTrackerId != null ? (
       <IndividualTrackerViewerPage
         key={resolvedSelectedTrackerId}
-        individualTrackerViewService={individualTrackerViewService}
-        matchAnalyticsService={matchAnalyticsService}
-        seriesMatchesService={seriesMatchesService}
-        haloClient={haloClient}
         trackerId={resolvedSelectedTrackerId}
         streamerSettings={selectedTrackerStreamerSettings}
         externalView={selectedTrackerView}

--- a/pages/src/components/follow/follow-live-viewer/tests/follow-live-viewer-create.test.tsx
+++ b/pages/src/components/follow/follow-live-viewer/tests/follow-live-viewer-create.test.tsx
@@ -16,35 +16,37 @@ import { createFollowLiveViewer } from "../create";
 let mockViewerInstanceCount = 0;
 
 vi.mock("../../../individual-tracker/viewer/create", () => ({
-  IndividualTrackerViewerPage: ({
-    trackerId,
-    streamerSettings,
-    externalView,
-    connectionStatusOverride,
-  }: {
-    trackerId: string;
-    streamerSettings?: TrackerDirectory["streamerSettings"];
-    externalView?: TrackerViewState;
-    connectionStatusOverride?: string;
-  }): React.ReactElement => {
-    const [instanceId] = React.useState(() => {
-      mockViewerInstanceCount += 1;
-      return mockViewerInstanceCount;
-    });
+  createIndividualTrackerViewerPage: () => {
+    return function MockIndividualTrackerViewerPage({
+      trackerId,
+      streamerSettings,
+      externalView,
+      connectionStatusOverride,
+    }: {
+      trackerId: string;
+      streamerSettings?: TrackerDirectory["streamerSettings"];
+      externalView?: TrackerViewState;
+      connectionStatusOverride?: string;
+    }): React.ReactElement {
+      const [instanceId] = React.useState(() => {
+        mockViewerInstanceCount += 1;
+        return mockViewerInstanceCount;
+      });
 
-    return (
-      <div data-testid="mock-viewer" data-instance-id={instanceId.toString()}>
-        {trackerId}
-        <span data-testid="mock-streamer-settings">
-          {streamerSettings?.styleFlags?.matchmakingMyStatsOnly === true ? "true" : "false"}
-        </span>
-        <span data-testid="mock-external-view-tracker-id">{externalView?.trackerId ?? "none"}</span>
-        <span data-testid="mock-external-view-streamer-settings">
-          {externalView?.streamerSettings?.styleFlags?.matchmakingMyStatsOnly === true ? "true" : "false"}
-        </span>
-        <span data-testid="mock-connection-status-override">{connectionStatusOverride ?? "none"}</span>
-      </div>
-    );
+      return (
+        <div data-testid="mock-viewer" data-instance-id={instanceId.toString()}>
+          {trackerId}
+          <span data-testid="mock-streamer-settings">
+            {streamerSettings?.styleFlags?.matchmakingMyStatsOnly === true ? "true" : "false"}
+          </span>
+          <span data-testid="mock-external-view-tracker-id">{externalView?.trackerId ?? "none"}</span>
+          <span data-testid="mock-external-view-streamer-settings">
+            {externalView?.streamerSettings?.styleFlags?.matchmakingMyStatsOnly === true ? "true" : "false"}
+          </span>
+          <span data-testid="mock-connection-status-override">{connectionStatusOverride ?? "none"}</span>
+        </div>
+      );
+    };
   },
 }));
 

--- a/pages/src/components/individual-tracker-manager/create.tsx
+++ b/pages/src/components/individual-tracker-manager/create.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useSyncExternalStore } from "react";
+import React, { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
 import type { AuthService } from "../../services/auth/types";
 import type { IndividualTrackerSettingsService } from "../../services/individual-tracker/settings-types";
 import type { IndividualTrackerService } from "../../services/individual-tracker/types";
@@ -169,27 +169,33 @@ export function createIndividualTrackerManagerPage(
     confirmDelete: (message): boolean => window.confirm(message),
   });
 
-  const store = new IndividualTrackerStore();
-  const settingsStore = new StreamerSettingsStore();
-  const settingsPresenter = new StreamerSettingsPresenter({
-    settingsService: config.settingsService,
-    store: settingsStore,
-  });
-  const presenter = new IndividualTrackerPresenter({
-    authService: config.authService,
-    settingsService: config.settingsService,
-    store,
-    liveTrackersController,
-  });
+  const Component = (): React.ReactElement => {
+    const store = useMemo(() => new IndividualTrackerStore(), []);
+    const settingsStore = useMemo(() => new StreamerSettingsStore(), []);
+    const settingsPresenter = useMemo(
+      () => new StreamerSettingsPresenter({ settingsService: config.settingsService, store: settingsStore }),
+      [settingsStore],
+    );
+    const presenter = useMemo(
+      () =>
+        new IndividualTrackerPresenter({
+          authService: config.authService,
+          settingsService: config.settingsService,
+          store,
+          liveTrackersController,
+        }),
+      [store],
+    );
 
-  const Component = (): React.ReactElement => (
-    <IndividualTrackerManagerPageInternal
-      presenter={presenter}
-      settingsPresenter={settingsPresenter}
-      settingsStore={settingsStore}
-      LiveTrackersComponent={LiveTrackersComponent}
-    />
-  );
+    return (
+      <IndividualTrackerManagerPageInternal
+        presenter={presenter}
+        settingsPresenter={settingsPresenter}
+        settingsStore={settingsStore}
+        LiveTrackersComponent={LiveTrackersComponent}
+      />
+    );
+  };
 
   return Component;
 }

--- a/pages/src/components/individual-tracker-manager/create.tsx
+++ b/pages/src/components/individual-tracker-manager/create.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
+import React, { useCallback, useEffect, useSyncExternalStore } from "react";
 import type { AuthService } from "../../services/auth/types";
 import type { IndividualTrackerSettingsService } from "../../services/individual-tracker/settings-types";
 import type { IndividualTrackerService } from "../../services/individual-tracker/types";
@@ -12,50 +12,26 @@ import { StreamerSettingsPresenter } from "./streamer-settings/streamer-settings
 import { StreamerSettingsSectionView } from "./streamer-settings/streamer-settings";
 import { StreamerSettingsStore } from "./streamer-settings/streamer-settings-store";
 
-interface IndividualTrackerManagerPageProps {
+export interface CreateIndividualTrackerManagerPageConfig {
   readonly authService: AuthService;
   readonly individualTrackerService: IndividualTrackerService;
   readonly settingsService: IndividualTrackerSettingsService;
   readonly individualTrackerViewService: IndividualTrackerViewService;
 }
 
-export function IndividualTrackerManagerPage({
-  authService,
-  individualTrackerService,
-  settingsService,
-  individualTrackerViewService,
-}: IndividualTrackerManagerPageProps): React.ReactElement {
-  const { controller: liveTrackersController, Component: LiveTrackersComponent } = useMemo(
-    () =>
-      createLiveTrackersSection({
-        individualTrackerService,
-        individualTrackerViewService,
-        navigateTo: (url): void => {
-          window.location.assign(url);
-        },
-        confirmDelete: (message): boolean => window.confirm(message),
-      }),
-    [individualTrackerService, individualTrackerViewService],
-  );
+interface IndividualTrackerManagerPageInternalProps {
+  readonly presenter: IndividualTrackerPresenter;
+  readonly settingsPresenter: StreamerSettingsPresenter;
+  readonly settingsStore: StreamerSettingsStore;
+  readonly LiveTrackersComponent: () => React.ReactElement;
+}
 
-  const store = useMemo(() => new IndividualTrackerStore(), []);
-  const settingsStore = useMemo(() => new StreamerSettingsStore(), []);
-  const settingsPresenter = useMemo(
-    () => new StreamerSettingsPresenter({ settingsService, store: settingsStore }),
-    [settingsService, settingsStore],
-  );
-
-  const presenter = useMemo(
-    () =>
-      new IndividualTrackerPresenter({
-        authService,
-        settingsService,
-        store,
-        liveTrackersController,
-      }),
-    [authService, settingsService, store, liveTrackersController],
-  );
-
+function IndividualTrackerManagerPageInternal({
+  presenter,
+  settingsPresenter,
+  settingsStore,
+  LiveTrackersComponent,
+}: IndividualTrackerManagerPageInternalProps): React.ReactElement {
   useEffect(() => {
     presenter.start();
     return (): void => {
@@ -179,4 +155,41 @@ export function IndividualTrackerManagerPage({
       }
     />
   );
+}
+
+export function createIndividualTrackerManagerPage(
+  config: CreateIndividualTrackerManagerPageConfig,
+): () => React.ReactElement {
+  const { controller: liveTrackersController, Component: LiveTrackersComponent } = createLiveTrackersSection({
+    individualTrackerService: config.individualTrackerService,
+    individualTrackerViewService: config.individualTrackerViewService,
+    navigateTo: (url): void => {
+      window.location.assign(url);
+    },
+    confirmDelete: (message): boolean => window.confirm(message),
+  });
+
+  const store = new IndividualTrackerStore();
+  const settingsStore = new StreamerSettingsStore();
+  const settingsPresenter = new StreamerSettingsPresenter({
+    settingsService: config.settingsService,
+    store: settingsStore,
+  });
+  const presenter = new IndividualTrackerPresenter({
+    authService: config.authService,
+    settingsService: config.settingsService,
+    store,
+    liveTrackersController,
+  });
+
+  const Component = (): React.ReactElement => (
+    <IndividualTrackerManagerPageInternal
+      presenter={presenter}
+      settingsPresenter={settingsPresenter}
+      settingsStore={settingsStore}
+      LiveTrackersComponent={LiveTrackersComponent}
+    />
+  );
+
+  return Component;
 }

--- a/pages/src/components/individual-tracker-manager/create.tsx
+++ b/pages/src/components/individual-tracker-manager/create.tsx
@@ -160,18 +160,23 @@ function IndividualTrackerManagerPageInternal({
 export function createIndividualTrackerManagerPage(
   config: CreateIndividualTrackerManagerPageConfig,
 ): () => React.ReactElement {
-  const { controller: liveTrackersController, Component: LiveTrackersComponent } = createLiveTrackersSection({
-    individualTrackerService: config.individualTrackerService,
-    individualTrackerViewService: config.individualTrackerViewService,
-    navigateTo: (url): void => {
-      window.location.assign(url);
-    },
-    confirmDelete: (message): boolean => window.confirm(message),
-  });
-
   const Component = (): React.ReactElement => {
     const store = useMemo(() => new IndividualTrackerStore(), []);
     const settingsStore = useMemo(() => new StreamerSettingsStore(), []);
+
+    const { controller: liveTrackersController, Component: LiveTrackersComponent } = useMemo(
+      () =>
+        createLiveTrackersSection({
+          individualTrackerService: config.individualTrackerService,
+          individualTrackerViewService: config.individualTrackerViewService,
+          navigateTo: (url): void => {
+            window.location.assign(url);
+          },
+          confirmDelete: (message): boolean => window.confirm(message),
+        }),
+      [],
+    );
+
     const settingsPresenter = useMemo(
       () => new StreamerSettingsPresenter({ settingsService: config.settingsService, store: settingsStore }),
       [settingsStore],
@@ -184,7 +189,7 @@ export function createIndividualTrackerManagerPage(
           store,
           liveTrackersController,
         }),
-      [store],
+      [store, liveTrackersController],
     );
 
     return (

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -13,38 +13,36 @@ import { IndividualTrackerOverlayPresenter } from "./individual-tracker-overlay-
 import { OverlayPagePresenter } from "./overlay-page-presenter";
 import { OverlayPageStore } from "./overlay-page-store";
 
-interface IndividualTrackerOverlayPageProps {
+export interface CreateIndividualTrackerOverlayPageConfig {
   readonly individualTrackerViewService: IndividualTrackerViewService;
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
   readonly haloClient: HaloInfiniteClient;
+}
+
+export interface IndividualTrackerOverlayPageProps {
   readonly trackerId: string;
   readonly externalView?: TrackerViewState;
   readonly showPreview?: boolean;
   readonly previewMode?: "player" | "observer";
 }
 
-export function IndividualTrackerOverlayPage({
-  individualTrackerViewService,
-  matchAnalyticsService,
-  seriesMatchesService,
-  haloClient,
+interface IndividualTrackerOverlayPageInternalProps extends IndividualTrackerOverlayPageProps {
+  readonly config: CreateIndividualTrackerOverlayPageConfig;
+  readonly presenter: OverlayPagePresenter;
+  readonly store: OverlayPageStore;
+}
+
+function IndividualTrackerOverlayPageInternal({
+  config,
+  presenter,
+  store,
   trackerId,
   externalView,
   showPreview = false,
   previewMode = "observer",
-}: IndividualTrackerOverlayPageProps): React.ReactElement {
-  const store = useMemo(() => new OverlayPageStore(), [trackerId]);
-
-  const presenter = useMemo(
-    () =>
-      new OverlayPagePresenter({
-        store,
-        haloClient,
-        matchAnalyticsService,
-      }),
-    [haloClient, matchAnalyticsService, store],
-  );
+}: IndividualTrackerOverlayPageInternalProps): React.ReactElement {
+  const { individualTrackerViewService, matchAnalyticsService, seriesMatchesService, haloClient } = config;
 
   const { snapshot, model, onRetry, onToggleEntry } = useIndividualTrackerViewer({
     individualTrackerViewService,
@@ -56,11 +54,14 @@ export function IndividualTrackerOverlayPage({
   });
 
   useEffect(() => {
-    presenter.reset();
     return (): void => {
       presenter.dispose();
     };
   }, [presenter]);
+
+  useEffect(() => {
+    presenter.reset();
+  }, [presenter, trackerId]);
 
   useEffect(() => {
     if (model.renderModel == null) {
@@ -171,4 +172,21 @@ export function IndividualTrackerOverlayPage({
       }
     />
   );
+}
+
+export function createIndividualTrackerOverlayPage(
+  config: CreateIndividualTrackerOverlayPageConfig,
+): (props: IndividualTrackerOverlayPageProps) => React.ReactElement {
+  const store = new OverlayPageStore();
+  const presenter = new OverlayPagePresenter({
+    store,
+    haloClient: config.haloClient,
+    matchAnalyticsService: config.matchAnalyticsService,
+  });
+
+  const Component = (props: IndividualTrackerOverlayPageProps): React.ReactElement => (
+    <IndividualTrackerOverlayPageInternal {...props} config={config} presenter={presenter} store={store} />
+  );
+
+  return Component;
 }

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -29,20 +29,26 @@ export interface IndividualTrackerOverlayPageProps {
 
 interface IndividualTrackerOverlayPageInternalProps extends IndividualTrackerOverlayPageProps {
   readonly config: CreateIndividualTrackerOverlayPageConfig;
-  readonly presenter: OverlayPagePresenter;
-  readonly store: OverlayPageStore;
 }
 
 function IndividualTrackerOverlayPageInternal({
   config,
-  presenter,
-  store,
   trackerId,
   externalView,
   showPreview = false,
   previewMode = "observer",
 }: IndividualTrackerOverlayPageInternalProps): React.ReactElement {
   const { individualTrackerViewService, matchAnalyticsService, seriesMatchesService, haloClient } = config;
+  const store = useMemo(() => new OverlayPageStore(), []);
+  const presenter = useMemo(
+    () =>
+      new OverlayPagePresenter({
+        store,
+        haloClient,
+        matchAnalyticsService,
+      }),
+    [haloClient, matchAnalyticsService, store],
+  );
 
   const { snapshot, model, onRetry, onToggleEntry } = useIndividualTrackerViewer({
     individualTrackerViewService,
@@ -177,15 +183,8 @@ function IndividualTrackerOverlayPageInternal({
 export function createIndividualTrackerOverlayPage(
   config: CreateIndividualTrackerOverlayPageConfig,
 ): (props: IndividualTrackerOverlayPageProps) => React.ReactElement {
-  const store = new OverlayPageStore();
-  const presenter = new OverlayPagePresenter({
-    store,
-    haloClient: config.haloClient,
-    matchAnalyticsService: config.matchAnalyticsService,
-  });
-
   const Component = (props: IndividualTrackerOverlayPageProps): React.ReactElement => (
-    <IndividualTrackerOverlayPageInternal {...props} config={config} presenter={presenter} store={store} />
+    <IndividualTrackerOverlayPageInternal {...props} config={config} />
   );
 
   return Component;

--- a/pages/src/components/individual-tracker/overlay/tests/create.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/create.test.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../../../services/individual-tracker/fakes/view.fake";
 import { aFakeMatchAnalyticsServiceWith } from "../../../../services/stats/fakes/match-analytics.fake";
 import { aFakeSeriesMatchesServiceWith } from "../../../../services/stats/fakes/series-matches.fake";
-import { IndividualTrackerOverlayPage } from "../create";
+import { createIndividualTrackerOverlayPage } from "../create";
 
 vi.mock("../individual-tracker-overlay", () => ({
   IndividualTrackerOverlay: (props: {
@@ -83,16 +83,14 @@ describe("IndividualTrackerOverlayPage", () => {
 
     const matchAnalyticsService = aFakeMatchAnalyticsServiceWith();
     const getBatchMatchAnalytics = vi.spyOn(matchAnalyticsService, "getBatchMatchAnalytics");
+    const IndividualTrackerOverlayPage = createIndividualTrackerOverlayPage({
+      individualTrackerViewService,
+      matchAnalyticsService,
+      seriesMatchesService: aFakeSeriesMatchesServiceWith(),
+      haloClient,
+    });
 
-    render(
-      <IndividualTrackerOverlayPage
-        individualTrackerViewService={individualTrackerViewService}
-        matchAnalyticsService={matchAnalyticsService}
-        seriesMatchesService={aFakeSeriesMatchesServiceWith()}
-        haloClient={haloClient}
-        trackerId="tracker-1"
-      />,
-    );
+    render(<IndividualTrackerOverlayPage trackerId="tracker-1" />);
 
     await waitFor(() => {
       expect(screen.getByText("select")).toBeInTheDocument();
@@ -132,16 +130,14 @@ describe("IndividualTrackerOverlayPage", () => {
     const haloClient = aFakeHaloClientWith({
       getMatchStats: vi.fn(async () => Promise.reject(new Error("boom"))),
     });
+    const IndividualTrackerOverlayPage = createIndividualTrackerOverlayPage({
+      individualTrackerViewService,
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+      seriesMatchesService: aFakeSeriesMatchesServiceWith(),
+      haloClient,
+    });
 
-    render(
-      <IndividualTrackerOverlayPage
-        individualTrackerViewService={individualTrackerViewService}
-        matchAnalyticsService={aFakeMatchAnalyticsServiceWith()}
-        seriesMatchesService={aFakeSeriesMatchesServiceWith()}
-        haloClient={haloClient}
-        trackerId="tracker-1"
-      />,
-    );
+    render(<IndividualTrackerOverlayPage trackerId="tracker-1" />);
 
     await waitFor(() => {
       expect(screen.getByText("select")).toBeInTheDocument();
@@ -170,16 +166,14 @@ describe("IndividualTrackerOverlayPage", () => {
         Promise.resolve(aFakeMatchStatsWith({ MatchId: "match-1" })),
     );
     const haloClient = aFakeHaloClientWith({ getMatchStats });
+    const IndividualTrackerOverlayPage = createIndividualTrackerOverlayPage({
+      individualTrackerViewService,
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+      seriesMatchesService: aFakeSeriesMatchesServiceWith(),
+      haloClient,
+    });
 
-    const { rerender } = render(
-      <IndividualTrackerOverlayPage
-        individualTrackerViewService={individualTrackerViewService}
-        matchAnalyticsService={aFakeMatchAnalyticsServiceWith()}
-        seriesMatchesService={aFakeSeriesMatchesServiceWith()}
-        haloClient={haloClient}
-        trackerId="tracker-1"
-      />,
-    );
+    const { rerender } = render(<IndividualTrackerOverlayPage trackerId="tracker-1" />);
 
     await waitFor(() => {
       expect(screen.getByText("select")).toBeInTheDocument();
@@ -192,15 +186,7 @@ describe("IndividualTrackerOverlayPage", () => {
       expect(screen.getByTestId("panel-state")).toHaveTextContent("loaded");
     });
 
-    rerender(
-      <IndividualTrackerOverlayPage
-        individualTrackerViewService={individualTrackerViewService}
-        matchAnalyticsService={aFakeMatchAnalyticsServiceWith()}
-        seriesMatchesService={aFakeSeriesMatchesServiceWith()}
-        haloClient={haloClient}
-        trackerId="tracker-2"
-      />,
-    );
+    rerender(<IndividualTrackerOverlayPage trackerId="tracker-2" />);
 
     await waitFor(() => {
       expect(screen.getByText("select")).toBeInTheDocument();

--- a/pages/src/components/individual-tracker/overlay/tests/create.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/create.test.tsx
@@ -201,4 +201,51 @@ describe("IndividualTrackerOverlayPage", () => {
 
     expect(getMatchStats).toHaveBeenCalledTimes(2);
   });
+
+  it("loads match stats after remounting the created component", async () => {
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
+      view: aFakeTrackerViewStateWith({
+        trackerId: "tracker-1",
+        status: "active",
+        matches: [aFakeTrackerMatchSummaryWith({ matchId: "match-1" })],
+      }),
+    });
+    const getMatchStats = vi.fn(
+      async (): Promise<ReturnType<typeof aFakeMatchStatsWith>> =>
+        Promise.resolve(aFakeMatchStatsWith({ MatchId: "match-1" })),
+    );
+    const haloClient = aFakeHaloClientWith({ getMatchStats });
+    const IndividualTrackerOverlayPage = createIndividualTrackerOverlayPage({
+      individualTrackerViewService,
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+      seriesMatchesService: aFakeSeriesMatchesServiceWith(),
+      haloClient,
+    });
+
+    const { rerender } = render(<IndividualTrackerOverlayPage key="first" trackerId="tracker-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("select")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("select"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("panel-state")).toHaveTextContent("loaded");
+    });
+
+    rerender(<IndividualTrackerOverlayPage key="second" trackerId="tracker-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("select")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("select"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("panel-state")).toHaveTextContent("loaded");
+    });
+
+    expect(getMatchStats).toHaveBeenCalledTimes(2);
+  });
 });

--- a/pages/src/components/individual-tracker/viewer/create.tsx
+++ b/pages/src/components/individual-tracker/viewer/create.tsx
@@ -15,12 +15,15 @@ import type { SeriesMatchesService } from "../../../services/stats/series-matche
 import { IndividualTrackerViewer } from "./individual-tracker-viewer";
 import { useIndividualTrackerViewer } from "./use-individual-tracker-viewer";
 
-interface IndividualTrackerViewerPageProps {
-  readonly individualTrackerService?: IndividualTrackerService;
+export interface CreateIndividualTrackerViewerPageConfig {
   readonly individualTrackerViewService: IndividualTrackerViewService;
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
   readonly haloClient: HaloInfiniteClient;
+  readonly individualTrackerService?: IndividualTrackerService;
+}
+
+export interface IndividualTrackerViewerPageProps {
   readonly trackerId: string;
   readonly streamerSettings?: StreamerViewSettings;
   readonly externalView?: TrackerViewState;
@@ -28,18 +31,25 @@ interface IndividualTrackerViewerPageProps {
   readonly pageTitleVariant?: "tracker";
 }
 
-export function IndividualTrackerViewerPage({
-  individualTrackerService,
-  individualTrackerViewService,
-  matchAnalyticsService,
-  seriesMatchesService,
-  haloClient,
+interface IndividualTrackerViewerPageInternalProps extends IndividualTrackerViewerPageProps {
+  readonly config: CreateIndividualTrackerViewerPageConfig;
+}
+
+function IndividualTrackerViewerPageInternal({
+  config,
   trackerId,
   streamerSettings,
   externalView,
   connectionStatusOverride,
   pageTitleVariant,
-}: IndividualTrackerViewerPageProps): React.ReactElement {
+}: IndividualTrackerViewerPageInternalProps): React.ReactElement {
+  const {
+    individualTrackerService,
+    individualTrackerViewService,
+    matchAnalyticsService,
+    seriesMatchesService,
+    haloClient,
+  } = config;
   const canManage = individualTrackerService != null;
 
   const { snapshot, model, onToggleEntry, onRefresh, onRetry } = useIndividualTrackerViewer({
@@ -96,4 +106,14 @@ export function IndividualTrackerViewerPage({
       }
     />
   );
+}
+
+export function createIndividualTrackerViewerPage(
+  config: CreateIndividualTrackerViewerPageConfig,
+): (props: IndividualTrackerViewerPageProps) => React.ReactElement {
+  const Component = (props: IndividualTrackerViewerPageProps): React.ReactElement => (
+    <IndividualTrackerViewerPageInternal {...props} config={config} />
+  );
+
+  return Component;
 }


### PR DESCRIPTION
## Context
The repo-wide follow-up after merged overlay/tabs work is to standardize page entry wiring around the create-factory install pattern. This keeps stateful collaborators stable, makes dependency injection explicit, and aligns app entrypoints with existing create conventions used in other sections.

## This PR
- Refactors chunk-1 targets to explicit create factories:
  - createIndividualTrackerOverlayPage
  - createIndividualTrackerViewerPage
  - createIndividualTrackerManagerPage
- Updates app entrypoints to instantiate these factories once per installed service set and render the returned components.
- Updates follow live overlay/viewer consumers to use the new create exports.
- Updates overlay and follow create tests/mocks to target the new factory exports while preserving behavior.
- Preserves runtime behavior (including tracker-id reset semantics and follow-mode constraints) while aligning dependency wiring.

## Subsequent Work
- Continue chunked create-factory alignment across the next planned component groups.
- Keep each chunk behavior-preserving with focused tests and full npm run done validation before publish.

Validation
- npm run done (pass)
- Focused vitest suites for overlay/follow create paths (pass)
