### PR TITLE
Refactor create-factory alignment (chunk 2)

### DIFF
--- a/pages/src/apps/discord-series-stats/create.tsx
+++ b/pages/src/apps/discord-series-stats/create.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from "react";
 import { ComponentLoader, ComponentLoaderStatus } from "../../components/component-loader/component-loader";
 import { ErrorState } from "../../components/error-state/error-state";
 import { LoadingState } from "../../components/loading-state/loading-state";
-import { DiscordSeriesStats } from "../../components/discord-series-stats/create";
+import { createDiscordSeriesStats } from "../../components/discord-series-stats/create";
 import type { DiscordSeriesStatsService } from "../../services/stats/discord-series-types";
 import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
 import { DiscordSeriesStatsPresenter } from "./discord-series-stats-presenter";
@@ -30,6 +30,10 @@ function DiscordSeriesStatsData({
   guildId,
   queueNumber,
 }: DiscordSeriesStatsDataProps): ReactElement {
+  const DiscordSeriesStats = useMemo(
+    () => createDiscordSeriesStats({ matchAnalyticsService }),
+    [matchAnalyticsService],
+  );
   const store = useMemo(() => new DiscordSeriesStatsStore(), []);
 
   const presenter = useMemo(() => {
@@ -71,7 +75,7 @@ function DiscordSeriesStatsData({
       error={<ErrorState message={model.state === "error" ? model.message : "Failed to load stats"} />}
       loaded={
         model.state === "resolved" ? (
-          <DiscordSeriesStats data={model.data} matchAnalyticsService={matchAnalyticsService} />
+          <DiscordSeriesStats data={model.data} />
         ) : model.state === "pending-index" ? (
           <LoadingState
             text={`Stats are still indexing. Retry in ${Math.ceil(model.retryAfterSeconds).toString()}s.`}

--- a/pages/src/apps/live-tracker/create.tsx
+++ b/pages/src/apps/live-tracker/create.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ReactElement } from "react";
 import TimeAgo from "javascript-time-ago";
 import en from "javascript-time-ago/locale/en";
 import { ComponentLoader, ComponentLoaderStatus } from "../../components/component-loader/component-loader";
 import { ErrorState } from "../../components/error-state/error-state";
 import { LoadingState } from "../../components/loading-state/loading-state";
-import { LiveTracker } from "../../components/live-tracker/create";
+import { createLiveTracker } from "../../components/live-tracker/create";
 import type { Services } from "./services";
 import { installServices } from "./services";
 
@@ -20,6 +20,16 @@ export function LiveTrackerApp({ apiHost }: LiveTrackerAppProps): ReactElement {
   const [services, setServices] = useState<Services | null>(null);
   const [shouldConnectToTracker, setShouldConnectToTracker] = useState(false);
   const [invalidParams, setInvalidParams] = useState(false);
+  const LiveTracker = useMemo(
+    () =>
+      services == null
+        ? null
+        : createLiveTracker({
+            liveTrackerService: services.liveTrackerService,
+            matchAnalyticsService: services.matchAnalyticsService,
+          }),
+    [services],
+  );
 
   // Check URL params to determine if we need to connect to a tracker
   // Use useEffect to avoid hydration mismatch (server has no window)
@@ -83,16 +93,7 @@ export function LiveTrackerApp({ apiHost }: LiveTrackerAppProps): ReactElement {
       status={loadingServices}
       loading={<LoadingState />}
       error={<ErrorState />}
-      loaded={
-        services ? (
-          <LiveTracker
-            liveTrackerService={services.liveTrackerService}
-            matchAnalyticsService={services.matchAnalyticsService}
-          />
-        ) : (
-          <ErrorState message="Services failed to load" />
-        )
-      }
+      loaded={LiveTracker != null ? <LiveTracker /> : <ErrorState message="Services failed to load" />}
     />
   );
 }

--- a/pages/src/apps/login/create.tsx
+++ b/pages/src/apps/login/create.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ReactElement } from "react";
 import { ComponentLoader, ComponentLoaderStatus } from "../../components/component-loader/component-loader";
 import type { AuthService } from "../../services/auth/types";
 import { LoadingState } from "../../components/loading-state/loading-state";
-import { LoginPage } from "../../components/login/create";
+import { createLoginPage } from "../../components/login/create";
 import { ErrorState } from "../../components/error-state/error-state";
 import { installServices } from "./services";
 
@@ -14,6 +14,10 @@ interface LoginAppProps {
 export function LoginApp({ apiHost }: LoginAppProps): ReactElement {
   const [loadingServices, setLoadingServices] = useState(ComponentLoaderStatus.PENDING);
   const [authService, setAuthService] = useState<AuthService | null>(null);
+  const LoginPage = useMemo(
+    () => (authService == null ? null : createLoginPage({ authService, apiHost })),
+    [apiHost, authService],
+  );
 
   useEffect(() => {
     let isCancelled = false;
@@ -51,13 +55,7 @@ export function LoginApp({ apiHost }: LoginAppProps): ReactElement {
       status={loadingServices}
       loading={<LoadingState text="Checking current session..." />}
       error={<ErrorState message="Failed to load login page" />}
-      loaded={
-        authService != null ? (
-          <LoginPage authService={authService} apiHost={apiHost} />
-        ) : (
-          <ErrorState message="Services failed to load" />
-        )
-      }
+      loaded={LoginPage != null ? <LoginPage /> : <ErrorState message="Services failed to load" />}
     />
   );
 }

--- a/pages/src/components/discord-series-stats/create.tsx
+++ b/pages/src/components/discord-series-stats/create.tsx
@@ -6,12 +6,20 @@ import { DiscordSeriesStatsStore } from "./discord-series-stats-store";
 import { DiscordSeriesStatsPresenter } from "./discord-series-stats-presenter";
 import { DiscordSeriesStatsView } from "./discord-series-stats";
 
-interface DiscordSeriesStatsProps {
-  readonly data: DiscordSeriesStatsResolved;
+export interface CreateDiscordSeriesStatsConfig {
   readonly matchAnalyticsService: MatchAnalyticsService;
 }
 
-export function DiscordSeriesStats({ data, matchAnalyticsService }: DiscordSeriesStatsProps): ReactElement {
+export interface DiscordSeriesStatsProps {
+  readonly data: DiscordSeriesStatsResolved;
+}
+
+interface DiscordSeriesStatsInternalProps extends DiscordSeriesStatsProps {
+  readonly config: CreateDiscordSeriesStatsConfig;
+}
+
+function DiscordSeriesStatsInternal({ data, config }: DiscordSeriesStatsInternalProps): ReactElement {
+  const { matchAnalyticsService } = config;
   const store = useMemo(() => new DiscordSeriesStatsStore(), [data.renderData]);
   const controller = useMemo(() => new StatsController(), [data.renderData]);
   const presenter = useMemo(
@@ -35,4 +43,14 @@ export function DiscordSeriesStats({ data, matchAnalyticsService }: DiscordSerie
   const model = useMemo(() => presenter.present(snapshot), [presenter, snapshot]);
 
   return <DiscordSeriesStatsView {...model} />;
+}
+
+export function createDiscordSeriesStats(
+  config: CreateDiscordSeriesStatsConfig,
+): (props: DiscordSeriesStatsProps) => ReactElement {
+  const Component = (props: DiscordSeriesStatsProps): ReactElement => (
+    <DiscordSeriesStatsInternal {...props} config={config} />
+  );
+
+  return Component;
 }

--- a/pages/src/components/discord-series-stats/tests/create.test.tsx
+++ b/pages/src/components/discord-series-stats/tests/create.test.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
-import { DiscordSeriesStats } from "../create";
+import { createDiscordSeriesStats } from "../create";
 import { DiscordSeriesStatsPresenter } from "../discord-series-stats-presenter";
 import { aFakeMatchAnalyticsServiceWith } from "../../../services/stats/fakes/match-analytics.fake";
 
@@ -50,9 +50,9 @@ function aFakeResolvedDataWith(overrides: Partial<DiscordSeriesStatsResolved> = 
 
 describe("DiscordSeriesStats", () => {
   it("renders top-level sections", () => {
-    render(
-      <DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />,
-    );
+    const DiscordSeriesStats = createDiscordSeriesStats({ matchAnalyticsService: aFakeMatchAnalyticsServiceWith() });
+
+    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} />);
 
     expect(screen.getByRole("heading", { name: "Queue #7777 Series Stats" })).toBeInTheDocument();
     expect(screen.getByText("Guild 123456789012345678")).toBeInTheDocument();
@@ -64,17 +64,17 @@ describe("DiscordSeriesStats", () => {
   });
 
   it("shows warning when a match has invalid raw match data", () => {
-    render(
-      <DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />,
-    );
+    const DiscordSeriesStats = createDiscordSeriesStats({ matchAnalyticsService: aFakeMatchAnalyticsServiceWith() });
+
+    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} />);
 
     expect(screen.getByText("Failed to load detailed stats for match match-1.")).toBeInTheDocument();
   });
 
   it("does not render series totals when no valid raw match data exists", () => {
-    render(
-      <DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />,
-    );
+    const DiscordSeriesStats = createDiscordSeriesStats({ matchAnalyticsService: aFakeMatchAnalyticsServiceWith() });
+
+    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} />);
 
     expect(screen.queryByText("Series Totals")).not.toBeInTheDocument();
   });
@@ -82,11 +82,11 @@ describe("DiscordSeriesStats", () => {
   it("passes medal metadata from renderData into the presenter", () => {
     const medalMetadata = { 3334154676: { name: "Killing Spree", sortingWeight: 1500 } };
     const presentSpy = vi.spyOn(DiscordSeriesStatsPresenter.prototype, "present");
+    const DiscordSeriesStats = createDiscordSeriesStats({ matchAnalyticsService: aFakeMatchAnalyticsServiceWith() });
 
     render(
       <DiscordSeriesStats
         data={aFakeResolvedDataWith({ renderData: { ...aFakeResolvedDataWith().renderData, medalMetadata } })}
-        matchAnalyticsService={aFakeMatchAnalyticsServiceWith()}
       />,
     );
 
@@ -96,9 +96,9 @@ describe("DiscordSeriesStats", () => {
   });
 
   it("renders the shared series stats layout", () => {
-    render(
-      <DiscordSeriesStats data={aFakeResolvedDataWith()} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />,
-    );
+    const DiscordSeriesStats = createDiscordSeriesStats({ matchAnalyticsService: aFakeMatchAnalyticsServiceWith() });
+
+    render(<DiscordSeriesStats data={aFakeResolvedDataWith()} />);
 
     expect(screen.getByRole("heading", { name: "Series overview" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Matches" })).toBeInTheDocument();
@@ -109,6 +109,7 @@ describe("DiscordSeriesStats", () => {
     const getBatchMatchAnalyticsSpy = vi.spyOn(matchAnalyticsService, "getBatchMatchAnalytics");
     const base = aFakeResolvedDataWith();
     const secondMatch = { ...base.renderData.matches[0], matchId: "match-2" };
+    const DiscordSeriesStats = createDiscordSeriesStats({ matchAnalyticsService });
 
     render(
       <DiscordSeriesStats
@@ -116,7 +117,6 @@ describe("DiscordSeriesStats", () => {
           matchIds: ["match-1", "match-2"],
           renderData: { ...base.renderData, matches: [...base.renderData.matches, secondMatch] },
         })}
-        matchAnalyticsService={matchAnalyticsService}
       />,
     );
 

--- a/pages/src/components/live-tracker/create.tsx
+++ b/pages/src/components/live-tracker/create.tsx
@@ -9,12 +9,17 @@ import { LiveTrackerStore } from "./live-tracker-store";
 import { LiveTrackerView } from "./live-tracker";
 import { LiveTrackerProvider } from "./live-tracker-context";
 
-interface LiveTrackerProps {
+export interface CreateLiveTrackerConfig {
   readonly liveTrackerService: LiveTrackerService;
   readonly matchAnalyticsService: MatchAnalyticsService;
 }
 
-export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveTrackerProps): React.ReactElement {
+interface LiveTrackerInternalProps {
+  readonly config: CreateLiveTrackerConfig;
+}
+
+function LiveTrackerInternal({ config }: LiveTrackerInternalProps): React.ReactElement {
+  const { liveTrackerService, matchAnalyticsService } = config;
   const store = useMemo(() => new LiveTrackerStore(), []);
 
   const presenter = useMemo(
@@ -83,4 +88,10 @@ export function LiveTracker({ liveTrackerService, matchAnalyticsService }: LiveT
       }
     />
   );
+}
+
+export function createLiveTracker(config: CreateLiveTrackerConfig): () => React.ReactElement {
+  const Component = (): React.ReactElement => <LiveTrackerInternal config={config} />;
+
+  return Component;
 }

--- a/pages/src/components/live-tracker/tests/live-tracker.test.tsx
+++ b/pages/src/components/live-tracker/tests/live-tracker.test.tsx
@@ -16,7 +16,7 @@ import type {
 import { aFakeLiveTrackerScenarioWith } from "../../../services/live-tracker/fakes/scenario";
 import { aFakeLiveTrackerServiceWith } from "../../../services/live-tracker/fakes/live-tracker.fake";
 import { aFakeMatchAnalyticsServiceWith } from "../../../services/stats/fakes/match-analytics.fake";
-import { LiveTracker } from "../create";
+import { createLiveTracker } from "../create";
 
 function isSteppableLiveTrackerConnection(
   connection: LiveTrackerConnection,
@@ -80,8 +80,9 @@ async function renderLiveTrackerWith(
   const liveTrackerService = aFakeLiveTrackerServiceWith({ scenario, mode: "manual" });
   const connection = await liveTrackerService.connect({ type: "team" as const, guildId: "1", queueNumber: "3" });
   vi.spyOn(liveTrackerService, "connect").mockResolvedValue(connection);
+  const LiveTracker = createLiveTracker({ liveTrackerService, matchAnalyticsService: analyticsService });
 
-  render(<LiveTracker liveTrackerService={liveTrackerService} matchAnalyticsService={analyticsService} />);
+  render(<LiveTracker />);
   await waitFor(() => expect(screen.getByText("Connecting...")).toBeInTheDocument());
 
   if (!isSteppableLiveTrackerConnection(connection)) {
@@ -153,10 +154,12 @@ describe("LiveTracker", () => {
     vi.spyOn(liveTrackerService, "connect").mockImplementation(async () => {
       return Promise.resolve(connection);
     });
+    const LiveTracker = createLiveTracker({
+      liveTrackerService,
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+    });
 
-    render(
-      <LiveTracker liveTrackerService={liveTrackerService} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />,
-    );
+    render(<LiveTracker />);
 
     await waitFor(() => {
       expect(screen.getByText("Connecting...")).toBeInTheDocument();
@@ -254,10 +257,12 @@ describe("LiveTracker", () => {
 
     const liveTrackerService = aFakeLiveTrackerServiceWith();
     vi.spyOn(liveTrackerService, "connect").mockResolvedValue(notFoundConnection);
+    const LiveTracker = createLiveTracker({
+      liveTrackerService,
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+    });
 
-    render(
-      <LiveTracker liveTrackerService={liveTrackerService} matchAnalyticsService={aFakeMatchAnalyticsServiceWith()} />,
-    );
+    render(<LiveTracker />);
 
     await waitFor(() => {
       expect(screen.getByText("Connection Failed")).toBeInTheDocument();

--- a/pages/src/components/login/create.tsx
+++ b/pages/src/components/login/create.tsx
@@ -9,7 +9,7 @@ import type { AuthService } from "../../services/auth/types";
 import { Login } from "./login";
 import styles from "./login.module.css";
 
-interface LoginPageProps {
+export interface CreateLoginPageConfig {
   readonly authService: AuthService;
   readonly apiHost: string;
 }
@@ -39,7 +39,7 @@ function readSignInErrorMessage(): string | null {
   return null;
 }
 
-export function LoginPage({ authService, apiHost }: LoginPageProps): React.ReactElement {
+function LoginPageInternal({ authService, apiHost }: CreateLoginPageConfig): React.ReactElement {
   const [state, setState] = useState(ComponentLoaderStatus.LOADING);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -93,4 +93,10 @@ export function LoginPage({ authService, apiHost }: LoginPageProps): React.React
       />
     </div>
   );
+}
+
+export function createLoginPage(config: CreateLoginPageConfig): () => React.ReactElement {
+  const Component = (): React.ReactElement => <LoginPageInternal {...config} />;
+
+  return Component;
 }

--- a/pages/src/components/login/tests/create.test.tsx
+++ b/pages/src/components/login/tests/create.test.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { LoginPage } from "../create";
+import { createLoginPage } from "../create";
 import type { AuthService } from "../../../services/auth/types";
 import { aFakeAuthServiceWith } from "../../../services/auth/fakes/auth.fake";
 
@@ -24,8 +24,9 @@ describe("LoginPage", () => {
 
   it("renders a sign-in card linking to the API start endpoint when unauthenticated", async () => {
     vi.spyOn(authService, "getSession").mockResolvedValue({ authenticated: false });
+    const LoginPage = createLoginPage({ authService, apiHost: API_HOST });
 
-    render(<LoginPage authService={authService} apiHost={API_HOST} />);
+    render(<LoginPage />);
 
     const signIn = await screen.findByRole("link", { name: "Continue With Microsoft" });
     const url = new URL(signIn.getAttribute("href") ?? "");
@@ -42,8 +43,9 @@ describe("LoginPage", () => {
   ])("builds the sign-in URL with a safe redirect for %s", async (_label, query, expectedRedirect) => {
     window.history.pushState({}, "", `/login${query}`);
     vi.spyOn(authService, "getSession").mockResolvedValue({ authenticated: false });
+    const LoginPage = createLoginPage({ authService, apiHost: API_HOST });
 
-    render(<LoginPage authService={authService} apiHost={API_HOST} />);
+    render(<LoginPage />);
 
     const signIn = await screen.findByRole("link", { name: "Continue With Microsoft" });
     const url = new URL(signIn.getAttribute("href") ?? "");
@@ -56,8 +58,9 @@ describe("LoginPage", () => {
       .spyOn(authService, "getSession")
       .mockRejectedValueOnce(new Error("Session unavailable"))
       .mockResolvedValueOnce({ authenticated: false });
+    const LoginPage = createLoginPage({ authService, apiHost: API_HOST });
 
-    render(<LoginPage authService={authService} apiHost={API_HOST} />);
+    render(<LoginPage />);
 
     await waitFor(() => {
       expect(screen.getByText("Session unavailable")).toBeInTheDocument();
@@ -75,8 +78,9 @@ describe("LoginPage", () => {
     const user = userEvent.setup();
     window.history.pushState({}, "", "/login?error=xbox-required");
     const getSessionSpy = vi.spyOn(authService, "getSession").mockResolvedValue({ authenticated: false });
+    const LoginPage = createLoginPage({ authService, apiHost: API_HOST });
 
-    render(<LoginPage authService={authService} apiHost={API_HOST} />);
+    render(<LoginPage />);
 
     await waitFor(() => {
       expect(screen.getByText(/couldn't verify your Xbox profile/i)).toBeInTheDocument();


### PR DESCRIPTION
## Context
The follow-up after the individual tracker create-factory work is to standardize the remaining app-backed entry components around the same create/install pattern. The goal is to keep dependency installation in the app layer, return renderable components from explicit factories, and preserve the remount-safe lifecycle rule from PR 665: disposable runtime collaborators stay mount-scoped inside the returned React component.

## This PR
- Converts the remaining service-wired component create modules in this slice to explicit factory exports:
  - createLiveTracker
  - createLoginPage
  - createDiscordSeriesStats
- Updates the corresponding app entrypoints to instantiate those factories once per installed service set and render the returned components.
- Updates the touched create tests to instantiate the new factories directly.
- Keeps runtime behavior unchanged while aligning these entrypoints with the repos create-factory pattern.

## Subsequent Work
- Continue through the remaining create-factory candidates in similarly small slices.
- Use the PR 665 review lesson as a hard rule for future chunks: factory closures may hold config, but disposable presenters/stores/controllers must be created inside the returned component so remounts get fresh instances.

Validation
- npm run done (pass)
- Focused Vitest coverage for live-tracker, login, and discord-series-stats create paths (pass)
