### PR TITLE
Create-factory alignment chunk 3 for individual-tracker dialogs

### DIFF
--- a/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
+++ b/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useSyncExternalStore } from "react";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
-import { AddTrackerDialogSection } from "../../individual-tracker/add-tracker-dialog/create";
-import { GameSelectionDialogSection } from "../../individual-tracker/game-selection-dialog/create";
-import { ManualSeriesDialogSection } from "../../individual-tracker/manual-series-dialog/create";
+import { createAddTrackerDialogSection } from "../../individual-tracker/add-tracker-dialog/create";
+import { createGameSelectionDialogSection } from "../../individual-tracker/game-selection-dialog/create";
+import { createManualSeriesDialogSection } from "../../individual-tracker/manual-series-dialog/create";
 import { LiveTrackersPresenter } from "./live-trackers-presenter";
 import { LiveTrackersStore } from "./live-trackers-store";
 import type { LiveTrackersController, LiveTrackersSectionController } from "./types";
@@ -20,6 +20,29 @@ function LiveTrackersSectionInternal({
   individualTrackerService,
   individualTrackerViewService,
 }: LiveTrackersSectionInternalProps): React.ReactElement {
+  const AddTrackerDialogSection = React.useMemo(
+    () =>
+      createAddTrackerDialogSection({
+        individualTrackerService,
+      }),
+    [individualTrackerService],
+  );
+  const GameSelectionDialogSection = React.useMemo(
+    () =>
+      createGameSelectionDialogSection({
+        individualTrackerService,
+      }),
+    [individualTrackerService],
+  );
+  const ManualSeriesDialogSection = React.useMemo(
+    () =>
+      createManualSeriesDialogSection({
+        individualTrackerService,
+        viewService: individualTrackerViewService,
+      }),
+    [individualTrackerService, individualTrackerViewService],
+  );
+
   useEffect(() => {
     controller.start();
     return (): void => {
@@ -52,7 +75,6 @@ function LiveTrackersSectionInternal({
               controller.closeAddDialog();
               void controller.refresh();
             }}
-            individualTrackerService={individualTrackerService}
           />
           {snapshot.gameSelectionDialogState != null && (
             <GameSelectionDialogSection
@@ -72,7 +94,6 @@ function LiveTrackersSectionInternal({
                 controller.closeGameSelectionDialog();
                 void controller.refresh();
               }}
-              individualTrackerService={individualTrackerService}
             />
           )}
           {snapshot.manualSeriesDialogState != null && (
@@ -92,8 +113,6 @@ function LiveTrackersSectionInternal({
                 void controller.refresh();
               }}
               initialData={snapshot.manualSeriesDialogState.initialData}
-              individualTrackerService={individualTrackerService}
-              viewService={individualTrackerViewService}
             />
           )}
         </>

--- a/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
+++ b/pages/src/components/individual-tracker-manager/live-trackers/create.tsx
@@ -38,7 +38,7 @@ function LiveTrackersSectionInternal({
     () =>
       createManualSeriesDialogSection({
         individualTrackerService,
-        viewService: individualTrackerViewService,
+        individualTrackerViewService,
       }),
     [individualTrackerService, individualTrackerViewService],
   );

--- a/pages/src/components/individual-tracker/add-tracker-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/create.tsx
@@ -4,23 +4,41 @@ import { AddTrackerDialogPresenter } from "./add-tracker-dialog-presenter";
 import { AddTrackerDialogStore } from "./add-tracker-dialog-store";
 import { AddTrackerDialog } from "./add-tracker-dialog";
 
-interface AddTrackerDialogSectionProps {
-  readonly isOpen: boolean;
-  readonly onClose: () => void;
-  readonly onTrackerStarted: () => void;
+export interface CreateAddTrackerDialogSectionConfig {
   readonly individualTrackerService: IndividualTrackerService;
 }
 
-export function AddTrackerDialogSection({
+export interface AddTrackerDialogSectionProps {
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onTrackerStarted: () => void;
+}
+
+interface AddTrackerDialogSectionInternalProps extends AddTrackerDialogSectionProps {
+  readonly config: CreateAddTrackerDialogSectionConfig;
+}
+
+function AddTrackerDialogSectionInternal({
+  config,
   isOpen,
   onClose,
   onTrackerStarted,
-  individualTrackerService,
-}: AddTrackerDialogSectionProps): React.ReactElement {
+}: AddTrackerDialogSectionInternalProps): React.ReactElement {
+  const onTrackerStartedRef = React.useRef(onTrackerStarted);
+  onTrackerStartedRef.current = onTrackerStarted;
+
+  const { individualTrackerService } = config;
   const store = useMemo(() => new AddTrackerDialogStore(), []);
   const presenter = useMemo(
-    () => new AddTrackerDialogPresenter({ store, individualTrackerService, onTrackerStarted }),
-    [store, individualTrackerService, onTrackerStarted],
+    () =>
+      new AddTrackerDialogPresenter({
+        store,
+        individualTrackerService,
+        onTrackerStarted: (): void => {
+          onTrackerStartedRef.current();
+        },
+      }),
+    [store, individualTrackerService],
   );
 
   useEffect(() => {
@@ -97,4 +115,14 @@ export function AddTrackerDialogSection({
       }}
     />
   );
+}
+
+export function createAddTrackerDialogSection(
+  config: CreateAddTrackerDialogSectionConfig,
+): (props: AddTrackerDialogSectionProps) => React.ReactElement {
+  const Component = (props: AddTrackerDialogSectionProps): React.ReactElement => (
+    <AddTrackerDialogSectionInternal {...props} config={config} />
+  );
+
+  return Component;
 }

--- a/pages/src/components/individual-tracker/game-selection-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/game-selection-dialog/create.tsx
@@ -5,6 +5,10 @@ import { GameSelectionDialogPresenter } from "./game-selection-dialog-presenter"
 import { GameSelectionDialogStore } from "./game-selection-dialog-store";
 import { GameSelectionDialog } from "./game-selection-dialog";
 
+export interface CreateGameSelectionDialogSectionConfig {
+  readonly individualTrackerService: IndividualTrackerService;
+}
+
 export interface GameSelectionDialogSectionProps {
   readonly isOpen: boolean;
   readonly trackerId: string;
@@ -17,10 +21,14 @@ export interface GameSelectionDialogSectionProps {
   readonly hasActiveSeriesWarning?: boolean;
   readonly onClose: () => void;
   readonly onSynced: () => void;
-  readonly individualTrackerService: IndividualTrackerService;
 }
 
-export function GameSelectionDialogSection({
+interface GameSelectionDialogSectionInternalProps extends GameSelectionDialogSectionProps {
+  readonly config: CreateGameSelectionDialogSectionConfig;
+}
+
+function GameSelectionDialogSectionInternal({
+  config,
   isOpen,
   trackerId,
   trackerLabel,
@@ -32,10 +40,11 @@ export function GameSelectionDialogSection({
   hasActiveSeriesWarning,
   onClose,
   onSynced,
-  individualTrackerService,
-}: GameSelectionDialogSectionProps): React.ReactElement | null {
+}: GameSelectionDialogSectionInternalProps): React.ReactElement | null {
   const onSyncedRef = useRef(onSynced);
   onSyncedRef.current = onSynced;
+
+  const { individualTrackerService } = config;
 
   const store = useMemo(() => new GameSelectionDialogStore(), []);
 
@@ -134,4 +143,14 @@ export function GameSelectionDialogSection({
       }}
     />
   );
+}
+
+export function createGameSelectionDialogSection(
+  config: CreateGameSelectionDialogSectionConfig,
+): (props: GameSelectionDialogSectionProps) => React.ReactElement | null {
+  const Component = (props: GameSelectionDialogSectionProps): React.ReactElement | null => (
+    <GameSelectionDialogSectionInternal {...props} config={config} />
+  );
+
+  return Component;
 }

--- a/pages/src/components/individual-tracker/game-selection-dialog/tests/game-selection-dialog.test.tsx
+++ b/pages/src/components/individual-tracker/game-selection-dialog/tests/game-selection-dialog.test.tsx
@@ -2,12 +2,9 @@ import "@testing-library/jest-dom/vitest";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import type {
-  IndividualTrackerService,
-  TrackerMatchHistoryResponse,
-} from "../../../../services/individual-tracker/types";
+import type { TrackerMatchHistoryResponse } from "../../../../services/individual-tracker/types";
 import { FakeIndividualTrackerService } from "../../../../services/individual-tracker/fakes/individual-tracker.fake";
-import { GameSelectionDialogSection } from "../create";
+import { createGameSelectionDialogSection } from "../create";
 
 afterEach(() => {
   cleanup();
@@ -55,6 +52,9 @@ describe("GameSelectionDialogSection", () => {
           /* keep pending */
         }),
     );
+    const GameSelectionDialogSection = createGameSelectionDialogSection({
+      individualTrackerService: service,
+    });
 
     render(
       <GameSelectionDialogSection
@@ -67,7 +67,6 @@ describe("GameSelectionDialogSection", () => {
         initialSeriesGroups={[]}
         onClose={vi.fn()}
         onSynced={vi.fn()}
-        individualTrackerService={service as IndividualTrackerService}
       />,
     );
 
@@ -79,6 +78,9 @@ describe("GameSelectionDialogSection", () => {
   it("shows error alert and hides match list when getMatchHistory fails", async () => {
     const service = new FakeIndividualTrackerService();
     vi.spyOn(service, "getMatchHistory").mockRejectedValue(new Error("Network error"));
+    const GameSelectionDialogSection = createGameSelectionDialogSection({
+      individualTrackerService: service,
+    });
 
     render(
       <GameSelectionDialogSection
@@ -91,7 +93,6 @@ describe("GameSelectionDialogSection", () => {
         initialSeriesGroups={[]}
         onClose={vi.fn()}
         onSynced={vi.fn()}
-        individualTrackerService={service as IndividualTrackerService}
       />,
     );
 
@@ -105,6 +106,9 @@ describe("GameSelectionDialogSection", () => {
   it("loads and displays matches when opened", async () => {
     const service = new FakeIndividualTrackerService();
     vi.spyOn(service, "getMatchHistory").mockResolvedValue(aResponse({ matches: [aMatch("m1"), aMatch("m2")] }));
+    const GameSelectionDialogSection = createGameSelectionDialogSection({
+      individualTrackerService: service,
+    });
 
     render(
       <GameSelectionDialogSection
@@ -117,7 +121,6 @@ describe("GameSelectionDialogSection", () => {
         initialSeriesGroups={[]}
         onClose={vi.fn()}
         onSynced={vi.fn()}
-        individualTrackerService={service as IndividualTrackerService}
       />,
     );
 
@@ -176,6 +179,9 @@ describe("GameSelectionDialogSection", () => {
         ],
       }),
     );
+    const GameSelectionDialogSection = createGameSelectionDialogSection({
+      individualTrackerService: service,
+    });
 
     render(
       <GameSelectionDialogSection
@@ -188,7 +194,6 @@ describe("GameSelectionDialogSection", () => {
         initialSeriesGroups={[]}
         onClose={vi.fn()}
         onSynced={vi.fn()}
-        individualTrackerService={service as IndividualTrackerService}
       />,
     );
 
@@ -207,6 +212,9 @@ describe("GameSelectionDialogSection", () => {
     vi.spyOn(service, "getMatchHistory").mockResolvedValue(aResponse({ matches: [aMatch("m1")] }));
     const syncSpy = vi.spyOn(service, "syncMatchesToTracker").mockResolvedValue(undefined);
     const onSynced = vi.fn();
+    const GameSelectionDialogSection = createGameSelectionDialogSection({
+      individualTrackerService: service,
+    });
 
     render(
       <GameSelectionDialogSection
@@ -219,7 +227,6 @@ describe("GameSelectionDialogSection", () => {
         initialSeriesGroups={[]}
         onClose={vi.fn()}
         onSynced={onSynced}
-        individualTrackerService={service as IndividualTrackerService}
       />,
     );
 
@@ -246,6 +253,9 @@ describe("GameSelectionDialogSection", () => {
     const syncSpy = vi.spyOn(service, "syncMatchesToTracker").mockResolvedValue(undefined);
     const onSynced = vi.fn();
     const onClose = vi.fn();
+    const GameSelectionDialogSection = createGameSelectionDialogSection({
+      individualTrackerService: service,
+    });
 
     render(
       <GameSelectionDialogSection
@@ -258,7 +268,6 @@ describe("GameSelectionDialogSection", () => {
         initialSeriesGroups={[]}
         onClose={onClose}
         onSynced={onSynced}
-        individualTrackerService={service as IndividualTrackerService}
       />,
     );
 

--- a/pages/src/components/individual-tracker/manual-series-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/create.tsx
@@ -6,33 +6,41 @@ import { ManualSeriesDialogStore } from "./manual-series-dialog-store";
 import type { SeriesInitialData } from "./manual-series-dialog-store";
 import { ManualSeriesDialog } from "./manual-series-dialog";
 
-interface ManualSeriesDialogSectionProps {
+export interface CreateManualSeriesDialogSectionConfig {
+  readonly individualTrackerService: IndividualTrackerService;
+  readonly viewService: IndividualTrackerViewService;
+}
+
+export interface ManualSeriesDialogSectionProps {
   readonly trackerId: string;
   readonly trackerLabel: string;
   readonly isOpen: boolean;
   readonly onClose: () => void;
   readonly onSeriesStarted: () => void;
-  readonly individualTrackerService: IndividualTrackerService;
-  readonly viewService: IndividualTrackerViewService;
   readonly initialData?: SeriesInitialData;
   readonly onSeriesEdited?: () => void;
 }
 
-export function ManualSeriesDialogSection({
+interface ManualSeriesDialogSectionInternalProps extends ManualSeriesDialogSectionProps {
+  readonly config: CreateManualSeriesDialogSectionConfig;
+}
+
+function ManualSeriesDialogSectionInternal({
+  config,
   trackerId,
   trackerLabel,
   isOpen,
   onClose,
   onSeriesStarted,
-  individualTrackerService,
-  viewService,
   initialData,
   onSeriesEdited,
-}: ManualSeriesDialogSectionProps): React.ReactElement | null {
+}: ManualSeriesDialogSectionInternalProps): React.ReactElement | null {
   const onSeriesStartedRef = useRef(onSeriesStarted);
   onSeriesStartedRef.current = onSeriesStarted;
   const onSeriesEditedRef = useRef(onSeriesEdited);
   onSeriesEditedRef.current = onSeriesEdited;
+
+  const { individualTrackerService, viewService } = config;
 
   const store = useMemo(() => new ManualSeriesDialogStore(initialData), []);
   const presenter = useMemo(
@@ -109,4 +117,14 @@ export function ManualSeriesDialogSection({
       onStartSeries={handleSubmit}
     />
   );
+}
+
+export function createManualSeriesDialogSection(
+  config: CreateManualSeriesDialogSectionConfig,
+): (props: ManualSeriesDialogSectionProps) => React.ReactElement | null {
+  const Component = (props: ManualSeriesDialogSectionProps): React.ReactElement | null => (
+    <ManualSeriesDialogSectionInternal {...props} config={config} />
+  );
+
+  return Component;
 }

--- a/pages/src/components/individual-tracker/manual-series-dialog/create.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/create.tsx
@@ -8,7 +8,7 @@ import { ManualSeriesDialog } from "./manual-series-dialog";
 
 export interface CreateManualSeriesDialogSectionConfig {
   readonly individualTrackerService: IndividualTrackerService;
-  readonly viewService: IndividualTrackerViewService;
+  readonly individualTrackerViewService: IndividualTrackerViewService;
 }
 
 export interface ManualSeriesDialogSectionProps {
@@ -40,7 +40,7 @@ function ManualSeriesDialogSectionInternal({
   const onSeriesEditedRef = useRef(onSeriesEdited);
   onSeriesEditedRef.current = onSeriesEdited;
 
-  const { individualTrackerService, viewService } = config;
+  const { individualTrackerService, individualTrackerViewService } = config;
 
   const store = useMemo(() => new ManualSeriesDialogStore(initialData), []);
   const presenter = useMemo(
@@ -49,7 +49,7 @@ function ManualSeriesDialogSectionInternal({
         trackerId,
         store,
         individualTrackerService,
-        individualTrackerViewService: viewService,
+        individualTrackerViewService,
         onSeriesStarted: (): void => {
           onSeriesStartedRef.current();
         },
@@ -57,7 +57,7 @@ function ManualSeriesDialogSectionInternal({
           onSeriesEditedRef.current?.();
         },
       }),
-    [trackerId, store, individualTrackerService, viewService],
+    [trackerId, store, individualTrackerService, individualTrackerViewService],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Context
The user-level overlay tabs migration is being delivered in bounded chunks that align Pages create modules with the create-factory pattern. Chunk 1 and chunk 2 are already merged, including lifecycle hardening from Copilot review feedback that disposable collaborators must be created at mount scope rather than factory scope.

## This PR
This PR delivers chunk 3 by converting the individual tracker dialog create modules to create-factory exports and updating the manager live-trackers composition to consume the returned components.

- Converts dialog create modules to factory exports:
  - `createAddTrackerDialogSection`
  - `createGameSelectionDialogSection`
  - `createManualSeriesDialogSection`
- Keeps presenter/store instances mount-scoped inside each returned component.
- Updates live-trackers composition to instantiate dialog section components via `useMemo` and stop passing previously inlined service props.
- Updates game-selection dialog section tests to construct the section through the new factory.
- Validation:
  - Focused Vitest run for chunk-3 surfaces: 42/42 passing.
  - `npm run typecheck:pages` passing.
  - Full `npm run done` passing.

## Subsequent Work
- Continue to chunk 4, limited to the remaining nearest-neighbor create-factory alignment entry points.
- Keep Copilot review loop expectations from PR #665 applied (especially remount/lifecycle safety and targeted regression coverage).
