### PR TITLE
Create-factory alignment chunk 4 for manager and match-history sections

### DIFF
--- a/pages/src/components/individual-tracker-manager/create.tsx
+++ b/pages/src/components/individual-tracker-manager/create.tsx
@@ -7,7 +7,7 @@ import { IndividualTrackerPresenter } from "./individual-tracker-presenter";
 import { IndividualTrackerStore } from "./individual-tracker-store";
 import { IndividualTrackerShell } from "./individual-tracker";
 import { createLiveTrackersSection } from "./live-trackers/create";
-import { StatsHighlightsSection } from "./stats-highlights/create";
+import { createStatsHighlightsSection } from "./stats-highlights/create";
 import { StreamerSettingsPresenter } from "./streamer-settings/streamer-settings-presenter";
 import { StreamerSettingsSectionView } from "./streamer-settings/streamer-settings";
 import { StreamerSettingsStore } from "./streamer-settings/streamer-settings-store";
@@ -24,6 +24,7 @@ interface IndividualTrackerManagerPageInternalProps {
   readonly settingsPresenter: StreamerSettingsPresenter;
   readonly settingsStore: StreamerSettingsStore;
   readonly LiveTrackersComponent: () => React.ReactElement;
+  readonly StatsHighlightsSection: ReturnType<typeof createStatsHighlightsSection>;
 }
 
 function IndividualTrackerManagerPageInternal({
@@ -31,6 +32,7 @@ function IndividualTrackerManagerPageInternal({
   settingsPresenter,
   settingsStore,
   LiveTrackersComponent,
+  StatsHighlightsSection,
 }: IndividualTrackerManagerPageInternalProps): React.ReactElement {
   useEffect(() => {
     presenter.start();
@@ -163,6 +165,7 @@ export function createIndividualTrackerManagerPage(
   const Component = (): React.ReactElement => {
     const store = useMemo(() => new IndividualTrackerStore(), []);
     const settingsStore = useMemo(() => new StreamerSettingsStore(), []);
+    const StatsHighlightsSection = useMemo(() => createStatsHighlightsSection(), []);
 
     const { controller: liveTrackersController, Component: LiveTrackersComponent } = useMemo(
       () =>
@@ -198,6 +201,7 @@ export function createIndividualTrackerManagerPage(
         settingsPresenter={settingsPresenter}
         settingsStore={settingsStore}
         LiveTrackersComponent={LiveTrackersComponent}
+        StatsHighlightsSection={StatsHighlightsSection}
       />
     );
   };

--- a/pages/src/components/individual-tracker-manager/stats-highlights/create.tsx
+++ b/pages/src/components/individual-tracker-manager/stats-highlights/create.tsx
@@ -4,7 +4,7 @@ import { StatsHighlightsSectionStore } from "./stats-highlights-store";
 import { StatsHighlightsSectionView } from "./stats-highlights";
 import type { StatsHighlightsSectionProps } from "./types";
 
-export function StatsHighlightsSection({
+function StatsHighlightsSectionInternal({
   statsHighlightSlots,
   saveStatus,
   saveErrorMessage,
@@ -56,4 +56,12 @@ export function StatsHighlightsSection({
       }}
     />
   );
+}
+
+export function createStatsHighlightsSection(): (props: StatsHighlightsSectionProps) => React.ReactElement {
+  const Component = (props: StatsHighlightsSectionProps): React.ReactElement => (
+    <StatsHighlightsSectionInternal {...props} />
+  );
+
+  return Component;
 }

--- a/pages/src/components/individual-tracker-manager/stats-highlights/tests/stats-highlights.test.tsx
+++ b/pages/src/components/individual-tracker-manager/stats-highlights/tests/stats-highlights.test.tsx
@@ -1,14 +1,12 @@
 import "@testing-library/jest-dom/vitest";
 
-import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { StatsHighlightsSection } from "../create";
+import { createStatsHighlightsSection } from "../create";
+import type { StatsHighlightsSectionProps } from "../types";
 
-function aFakeProps(
-  overrides: Partial<React.ComponentProps<typeof StatsHighlightsSection>> = {},
-): React.ComponentProps<typeof StatsHighlightsSection> {
+function aFakeProps(overrides: Partial<StatsHighlightsSectionProps> = {}): StatsHighlightsSectionProps {
   return {
     statsHighlightSlots: [],
     saveStatus: "idle",
@@ -24,6 +22,8 @@ describe("StatsHighlightsSectionView", () => {
   });
 
   it("shows the section as disabled when no stats highlights slots are configured", () => {
+    const StatsHighlightsSection = createStatsHighlightsSection();
+
     render(<StatsHighlightsSection {...aFakeProps()} />);
 
     expect(screen.getByRole("checkbox", { name: /show stats highlights/i })).not.toBeChecked();
@@ -32,6 +32,7 @@ describe("StatsHighlightsSectionView", () => {
   });
 
   it("enables stats highlights with the default six-slot layout", async () => {
+    const StatsHighlightsSection = createStatsHighlightsSection();
     const user = userEvent.setup();
     const onStatsHighlightSlotsChange = vi.fn<(statsHighlightSlots: readonly string[]) => void>();
 
@@ -50,6 +51,7 @@ describe("StatsHighlightsSectionView", () => {
   });
 
   it("extends the slot list up to eight configured highlights", async () => {
+    const StatsHighlightsSection = createStatsHighlightsSection();
     const user = userEvent.setup();
     const onStatsHighlightSlotsChange = vi.fn<(statsHighlightSlots: readonly string[]) => void>();
 
@@ -84,6 +86,7 @@ describe("StatsHighlightsSectionView", () => {
   });
 
   it("updates an individual highlight slot", async () => {
+    const StatsHighlightsSection = createStatsHighlightsSection();
     const user = userEvent.setup();
     const onStatsHighlightSlotsChange = vi.fn<(statsHighlightSlots: readonly string[]) => void>();
 
@@ -102,6 +105,8 @@ describe("StatsHighlightsSectionView", () => {
   });
 
   it("groups stat options into individual, compacted, and profile sections", () => {
+    const StatsHighlightsSection = createStatsHighlightsSection();
+
     const { container } = render(
       <StatsHighlightsSection
         {...aFakeProps({

--- a/pages/src/components/individual-tracker-manager/streamer-settings/create.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/create.tsx
@@ -5,17 +5,25 @@ import { StreamerSettingsPresenter } from "./streamer-settings-presenter";
 import { StreamerSettingsStore } from "./streamer-settings-store";
 import { StreamerSettingsSectionView } from "./streamer-settings";
 
-interface StreamerSettingsSectionProps {
-  readonly settings: StreamerViewSettings;
+export interface CreateStreamerSettingsSectionConfig {
   readonly settingsService: IndividualTrackerSettingsService;
+}
+
+export interface StreamerSettingsSectionProps {
+  readonly settings: StreamerViewSettings;
   readonly gamertag: string | null;
 }
 
-export function StreamerSettingsSection({
+interface StreamerSettingsSectionInternalProps extends StreamerSettingsSectionProps {
+  readonly config: CreateStreamerSettingsSectionConfig;
+}
+
+function StreamerSettingsSectionInternal({
+  config,
   settings,
-  settingsService,
   gamertag,
-}: StreamerSettingsSectionProps): React.ReactElement {
+}: StreamerSettingsSectionInternalProps): React.ReactElement {
+  const { settingsService } = config;
   const store = useMemo(() => new StreamerSettingsStore(), []);
   const presenter = useMemo(() => new StreamerSettingsPresenter({ settingsService, store }), [settingsService, store]);
 
@@ -100,4 +108,14 @@ export function StreamerSettingsSection({
       }}
     />
   );
+}
+
+export function createStreamerSettingsSection(
+  config: CreateStreamerSettingsSectionConfig,
+): (props: StreamerSettingsSectionProps) => React.ReactElement {
+  const Component = (props: StreamerSettingsSectionProps): React.ReactElement => (
+    <StreamerSettingsSectionInternal {...props} config={config} />
+  );
+
+  return Component;
 }

--- a/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.tsx
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.tsx
@@ -6,7 +6,7 @@ import { Button } from "../../button/button";
 import { Checkbox } from "../../checkbox/checkbox";
 import { Dialog } from "../../dialog/dialog";
 import { Input } from "../../input/input";
-import { MatchHistorySection } from "../../match-history/create";
+import { createMatchHistorySection } from "../../match-history/create";
 import { TrackerSummary } from "../../individual-tracker-manager/tracker-summary/tracker-summary";
 import styles from "./add-tracker-dialog.module.css";
 
@@ -67,6 +67,8 @@ export function AddTrackerDialog({
   onSeriesGroupSubtitleChange,
   onStartTracker,
 }: AddTrackerDialogProps): React.ReactElement | null {
+  const MatchHistorySection = React.useMemo(() => createMatchHistorySection(), []);
+
   return (
     <Dialog
       open={open}

--- a/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog.tsx
+++ b/pages/src/components/individual-tracker/game-selection-dialog/game-selection-dialog.tsx
@@ -6,7 +6,7 @@ import { Button } from "../../button/button";
 import { Checkbox } from "../../checkbox/checkbox";
 import { Dialog } from "../../dialog/dialog";
 import { LoadingState } from "../../loading-state/loading-state";
-import { MatchHistorySection } from "../../match-history/create";
+import { createMatchHistorySection } from "../../match-history/create";
 import styles from "./game-selection-dialog.module.css";
 
 export interface GameSelectionDialogProps {
@@ -58,6 +58,8 @@ export function GameSelectionDialog({
   onHideShortGamesChange,
   onLoadMore,
 }: GameSelectionDialogProps): React.ReactElement | null {
+  const MatchHistorySection = React.useMemo(() => createMatchHistorySection(), []);
+
   if (!isOpen) {
     return null;
   }

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.tsx
@@ -3,7 +3,7 @@ import { Button } from "../../button/button";
 import { Dialog } from "../../dialog/dialog";
 import { Input } from "../../input/input";
 import { Alert } from "../../alert/alert";
-import { MatchHistorySection } from "../../match-history/create";
+import { createMatchHistorySection } from "../../match-history/create";
 import type { ManualSeriesDialogSnapshot, ManualSeriesTeamSnapshot } from "./manual-series-dialog-store";
 import styles from "./manual-series-dialog.module.css";
 
@@ -99,6 +99,8 @@ export function ManualSeriesDialog({
   onBackfillMatchToggle,
   onStartSeries,
 }: ManualSeriesDialogProps): React.ReactElement | null {
+  const MatchHistorySection = React.useMemo(() => createMatchHistorySection(), []);
+
   if (!isOpen) {
     return null;
   }

--- a/pages/src/components/match-history/create.tsx
+++ b/pages/src/components/match-history/create.tsx
@@ -5,7 +5,7 @@ import { MatchHistoryPresenter } from "./match-history-presenter";
 import { MatchHistoryStore } from "./match-history-store";
 import { MatchHistory } from "./match-history";
 
-interface MatchHistorySectionProps {
+export interface MatchHistorySectionProps {
   readonly entries: readonly TrackerMatchHistoryEntry[] | null;
   readonly loadingCount?: number;
   readonly showGroupings?: boolean;
@@ -26,7 +26,7 @@ interface MatchHistorySectionProps {
   readonly onSeriesGroupSubtitleChange?: (groupIndex: number, value: string | null) => void;
 }
 
-export function MatchHistorySection({
+function MatchHistorySectionInternal({
   entries,
   loadingCount,
   showGroupings = false,
@@ -83,4 +83,10 @@ export function MatchHistorySection({
       model={model}
     />
   );
+}
+
+export function createMatchHistorySection(): (props: MatchHistorySectionProps) => React.JSX.Element {
+  const Component = (props: MatchHistorySectionProps): React.JSX.Element => <MatchHistorySectionInternal {...props} />;
+
+  return Component;
 }

--- a/pages/src/components/match-history/create.tsx
+++ b/pages/src/components/match-history/create.tsx
@@ -85,8 +85,8 @@ function MatchHistorySectionInternal({
   );
 }
 
-export function createMatchHistorySection(): (props: MatchHistorySectionProps) => React.JSX.Element {
-  const Component = (props: MatchHistorySectionProps): React.JSX.Element => <MatchHistorySectionInternal {...props} />;
+export function createMatchHistorySection(): (props: MatchHistorySectionProps) => React.ReactElement {
+  const Component = (props: MatchHistorySectionProps): React.ReactElement => <MatchHistorySectionInternal {...props} />;
 
   return Component;
 }

--- a/pages/src/components/match-history/tests/match-history.test.tsx
+++ b/pages/src/components/match-history/tests/match-history.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { TrackerMatchHistoryEntry } from "../../../services/individual-tracker/types";
 import { MatchHistory } from "../match-history";
-import { MatchHistorySection } from "../create";
+import { createMatchHistorySection } from "../create";
 import { HALO_TEAM_COLORS } from "../../team-colors/team-colors";
 import type { MatchHistoryModel } from "../match-history-presenter";
 
@@ -40,6 +40,7 @@ function aMatchWith(
 
 describe("MatchHistorySection", () => {
   it("calls add-to-above for a custom single match with a custom match above", () => {
+    const MatchHistorySection = createMatchHistorySection();
     const onAddToAboveGroup = vi.fn<(matchId: string) => void>();
 
     render(
@@ -56,6 +57,8 @@ describe("MatchHistorySection", () => {
   });
 
   it("hides add controls for a matchmaking match", () => {
+    const MatchHistorySection = createMatchHistorySection();
+
     render(<MatchHistorySection entries={[aMatchWith("m1", "matchmaking", "Slayer")]} allowManualGrouping={true} />);
 
     expect(screen.queryByTitle("Add to group above")).not.toBeInTheDocument();
@@ -64,6 +67,8 @@ describe("MatchHistorySection", () => {
   });
 
   it("renders only break controls for grouped matches without eligible adjacent groupable matches", () => {
+    const MatchHistorySection = createMatchHistorySection();
+
     render(
       <MatchHistorySection
         entries={[
@@ -83,6 +88,8 @@ describe("MatchHistorySection", () => {
   });
 
   it("renders Load more button when hasMore is true", () => {
+    const MatchHistorySection = createMatchHistorySection();
+
     render(
       <MatchHistorySection
         entries={[aMatchWith("m1", "custom", "Slayer")]}
@@ -95,6 +102,8 @@ describe("MatchHistorySection", () => {
   });
 
   it("does not render Load more button when hasMore is false", () => {
+    const MatchHistorySection = createMatchHistorySection();
+
     render(<MatchHistorySection entries={[aMatchWith("m1", "custom", "Slayer")]} hasMore={false} />);
 
     expect(screen.queryByRole("button", { name: "Load more" })).not.toBeInTheDocument();
@@ -117,6 +126,7 @@ describe("MatchHistorySection", () => {
   });
 
   it("calls onLoadMore when Load more button is clicked", () => {
+    const MatchHistorySection = createMatchHistorySection();
     const onLoadMore = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
 
     render(
@@ -129,6 +139,8 @@ describe("MatchHistorySection", () => {
   });
 
   it("rotates series colors by visible series order", () => {
+    const MatchHistorySection = createMatchHistorySection();
+
     const { container } = render(
       <MatchHistorySection
         entries={[


### PR DESCRIPTION
## Context
The create-factory alignment follow-up is being delivered in bounded chunks after the user-level overlay work. Chunk 1, chunk 2, and chunk 3 are merged, and chunk 4 continues the remaining manager subsection and utility create entrypoint alignment.

## This PR
This PR delivers chunk 4 by converting remaining create entrypoints to factory exports and updating direct consumers to instantiate returned components.

- Converted create entrypoints to factory exports:
  - `createStreamerSettingsSection`
  - `createStatsHighlightsSection`
  - `createMatchHistorySection`
- Updated consumers to use factory-returned components:
  - manager page now instantiates stats-highlights section through `createStatsHighlightsSection`
  - add-tracker, game-selection, and manual-series dialogs now instantiate match-history section through `createMatchHistorySection`
- Updated focused tests to construct migrated factory sections.
- Validation:
  - Focused Vitest run for touched manager/dialog/match-history surfaces: `55/55` passing.
  - Full `npm run done` passing.

## Subsequent Work
- Run Copilot review loop for this PR and apply any lifecycle/remount hardening if findings are raised.
- If review is clean, merge this chunk and reconcile the plan to confirm whether any create entrypoint alignment remains.
