### PR TITLE
fix(pages): revert conflicting asset routing config causing 404s

### DIFF
--- a/pages/wrangler.jsonc
+++ b/pages/wrangler.jsonc
@@ -1,16 +1,11 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "guilty-spark-web",
-  // `main` is intentionally omitted: the @astrojs/cloudflare adapter generates it
-  // (dist/server/entry.mjs) and redirects wrangler to dist/server/wrangler.json on deploy.
-  // We still set asset routing behavior here so Cloudflare canonicalizes HTML URLs
-  // without trailing slashes, matching Astro's trailingSlash: "never" setting.
+  // `main` and `assets` are intentionally omitted: the @astrojs/cloudflare adapter
+  // generates them (dist/server/entry.mjs + the dist/client assets dir bound to ASSETS)
+  // into dist/server/wrangler.json and redirects wrangler to that config on deploy.
   "compatibility_date": "2026-05-15",
   "compatibility_flags": ["global_fetch_strictly_public"],
-  "assets": {
-    "html_handling": "drop-trailing-slash",
-    "not_found_handling": "404-page",
-  },
   // The @astrojs/cloudflare adapter enables Astro KV sessions and binds them to "SESSION".
   // Declaring the existing namespace by id stops Wrangler from re-provisioning it on every deploy.
   "kv_namespaces": [


### PR DESCRIPTION
## Context

Production was returning HTTP 404 for dynamic SSR pages:
- User view (`/u/[gamertag]`)
- User overlay (`/u/[gamertag]/overlay`)
- Individual tracker view (`/individual-tracker/[trackerId]`)
- Individual tracker overlay (`/individual-tracker/[trackerId]/overlay`)

The backend API was working correctly, but requests to these pages were failing at the Cloudflare edge level before reaching the Astro SSR handler.

## This PR

Reverts the explicit `assets` configuration added in commit 1ef6b66 (`Unify trailing slash handling and branded error pages`).

**Why this fixes it:**

The @astrojs/cloudflare adapter is designed to omit `assets` from the base `wrangler.jsonc` and generate it in `dist/server/wrangler.json` with SSR-aware routing. When an explicit `assets` section with `not_found_handling: 404-page` was added to the base config:

1. Wrangler doesn't deep-merge config objects—it takes the first definition
2. The explicit `404-page` routing rule is applied at the Cloudflare edge (before the Worker)
3. Requests to non-existent static paths (like `/u/gamertag`) immediately return 404
4. The generated adapter config (which would pass these to the SSR handler) never takes effect

Removing the explicit `assets` section lets the adapter's generated config fully control routing, properly passing dynamic requests to the Astro SSR entry point.

**Testing:**
- ✓ Build passes (`npm run build:pages`)
- ✓ Typecheck passes
- ✓ Generated `dist/server/wrangler.json` has correct SSR asset binding