### PR TITLE
Polish individual tracker chevron

### DIFF
--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.module.css
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.module.css
@@ -167,27 +167,32 @@
 }
 
 .entryChevron {
+  align-items: center;
   color: var(--halo-white);
-  display: inline-block;
-  font-size: 1.15rem;
-  font-weight: 700;
-  height: 1em;
-  line-height: 1;
+  display: inline-flex;
+  height: 0.875rem;
+  justify-content: center;
   margin-left: var(--space-1);
-  transition: color var(--transition-fast);
-  width: 1em;
-}
-
-.entryChevron::before {
-  content: "\02C5";
+  transition:
+    color var(--transition-fast),
+    transform var(--transition-fast);
+  width: 0.875rem;
 }
 
 .entryChevronExpanded {
   color: var(--halo-white);
+  transform: rotate(180deg);
 }
 
-.entryChevronExpanded::before {
-  content: "\02C4";
+.entryChevronIcon {
+  display: block;
+  fill: none;
+  height: 0.875rem;
+  stroke: currentcolor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.5;
+  width: 0.875rem;
 }
 
 .entryBody {

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
@@ -449,7 +449,11 @@ export function IndividualTrackerViewer({
                                 [styles.entryChevronExpanded]: isExpanded,
                               })}
                               aria-hidden="true"
-                            />
+                            >
+                              <svg viewBox="0 0 12 12" focusable="false" className={styles.entryChevronIcon}>
+                                <path d="M2.5 4.5 6 8l3.5-3.5" />
+                              </svg>
+                            </span>
                           </div>
                         }
                       />
@@ -557,7 +561,11 @@ export function IndividualTrackerViewer({
                               [styles.entryChevronExpanded]: isExpanded,
                             })}
                             aria-hidden="true"
-                          />
+                          >
+                            <svg viewBox="0 0 12 12" focusable="false" className={styles.entryChevronIcon}>
+                              <path d="M2.5 4.5 6 8l3.5-3.5" />
+                            </svg>
+                          </span>
                         </div>
                       }
                     />


### PR DESCRIPTION
## Context
We are polishing the individual tracker experience in small, reviewable steps before broader performance work. This first change focuses only on visual consistency in the tracker list interactions.

## This PR
- Replaces the tracker list expand/collapse chevron glyph with the same SVG chevron style used by the select component.
- Keeps existing behavior (expanded rotation and interaction) while aligning icon shape and stroke styling.
- Touches only viewer chevron rendering and styling.

## Subsequent Work
- Follow-up PR: update match metadata in the user view to show tracked-player KDA and damage D:T.
- Later PR (not raised yet): KV-backed Halo response caching improvements for load performance.