### PR TITLE
Add KV-backed Halo response cache in resilient fetch

### DIFF
--- a/api/services/halo/resilient-fetch.ts
+++ b/api/services/halo/resilient-fetch.ts
@@ -396,7 +396,8 @@ export function createResilientFetch({
 
   return async function resilientFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-    const cacheInit: RequestInit = init ?? (input instanceof Request ? { method: input.method } : {});
+    const cacheInit: RequestInit =
+      input instanceof Request ? { ...init, method: init?.method ?? input.method } : { ...init };
     const kvCachedResponse = await getKvCachedResponse(url, cacheInit);
     if (kvCachedResponse != null) {
       return kvCachedResponse;

--- a/api/services/halo/resilient-fetch.ts
+++ b/api/services/halo/resilient-fetch.ts
@@ -95,7 +95,7 @@ function isGetRequest(init?: RequestInit): boolean {
 function isHaloWaypointUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.hostname.endsWith("halowaypoint.com");
+    return parsed.hostname === "halowaypoint.com" || parsed.hostname.endsWith(".halowaypoint.com");
   } catch {
     return false;
   }
@@ -212,19 +212,36 @@ export function createResilientFetch({
     }
 
     const cacheKey = buildResponseCacheKey(url);
-    const cached = await env.APP_DATA.get<KvCachedResponse>(cacheKey, "json");
-    if (cached == null) {
+    try {
+      const cached = await env.APP_DATA.get<KvCachedResponse>(cacheKey, "json");
+      if (cached == null) {
+        return null;
+      }
+
+      const headers = new Headers(cached.headers);
+      headers.set("x-gs-kv-cache", "HIT");
+      logService.debug(`KV cache HIT for ${url}`);
+      return new Response(cached.body, { status: cached.status, headers });
+    } catch {
       return null;
     }
+  }
 
-    const headers = new Headers(cached.headers);
-    headers.set("x-gs-kv-cache", "HIT");
-    logService.debug(`KV cache HIT for ${url}`);
-    return new Response(cached.body, { status: cached.status, headers });
+  function isCacheControlPrivateOrNoStore(headers: Headers): boolean {
+    const cacheControl = headers.get("cache-control");
+    if (cacheControl == null) {
+      return false;
+    }
+    const lower = cacheControl.toLowerCase();
+    return lower.includes("no-store") || lower.includes("private");
   }
 
   async function maybeCacheResponseInKv(url: string, init: RequestInit | undefined, response: Response): Promise<void> {
     if (!isKvResponseCacheableRequest(url, init) || response.status !== 200) {
+      return;
+    }
+
+    if (isCacheControlPrivateOrNoStore(response.headers)) {
       return;
     }
 
@@ -233,18 +250,22 @@ export function createResilientFetch({
       return;
     }
 
-    const cacheKey = buildResponseCacheKey(url);
-    const cloned = response.clone();
-    const body = await cloned.text();
-    const ttlSeconds = resolveResponseCacheTtlSeconds(url, cloned.headers);
-    const payload: KvCachedResponse = {
-      status: cloned.status,
-      headers: Array.from(cloned.headers.entries()),
-      body,
-    };
+    try {
+      const cacheKey = buildResponseCacheKey(url);
+      const cloned = response.clone();
+      const body = await cloned.text();
+      const ttlSeconds = resolveResponseCacheTtlSeconds(url, cloned.headers);
+      const payload: KvCachedResponse = {
+        status: cloned.status,
+        headers: Array.from(cloned.headers.entries()),
+        body,
+      };
 
-    await env.APP_DATA.put(cacheKey, JSON.stringify(payload), { expirationTtl: ttlSeconds });
-    logService.debug(`KV cache store for ${url}`, new Map([["ttlSeconds", ttlSeconds.toString()]]));
+      await env.APP_DATA.put(cacheKey, JSON.stringify(payload), { expirationTtl: ttlSeconds });
+      logService.debug(`KV cache store for ${url}`, new Map([["ttlSeconds", ttlSeconds.toString()]]));
+    } catch {
+      // KV write failure is best-effort; do not fail the request
+    }
   }
 
   function scheduleKvWrite(key: string, data: string, ttlSeconds: number): void {
@@ -375,7 +396,8 @@ export function createResilientFetch({
 
   return async function resilientFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-    const kvCachedResponse = await getKvCachedResponse(url, init);
+    const cacheInit: RequestInit = init ?? (input instanceof Request ? { method: input.method } : {});
+    const kvCachedResponse = await getKvCachedResponse(url, cacheInit);
     if (kvCachedResponse != null) {
       return kvCachedResponse;
     }
@@ -384,7 +406,7 @@ export function createResilientFetch({
 
     if (useProxy) {
       const proxiedResponse = await fetchViaProxy(input, init);
-      await maybeCacheResponseInKv(url, init, proxiedResponse);
+      await maybeCacheResponseInKv(url, cacheInit, proxiedResponse);
       return proxiedResponse;
     }
 
@@ -449,7 +471,7 @@ export function createResilientFetch({
 
     try {
       const response = await fetchWithRetry();
-      await maybeCacheResponseInKv(url, init, response);
+      await maybeCacheResponseInKv(url, cacheInit, response);
       return response;
     } catch (error) {
       logService.error(error, new Map([["url", url]]));

--- a/api/services/halo/resilient-fetch.ts
+++ b/api/services/halo/resilient-fetch.ts
@@ -22,6 +22,12 @@ interface DebounceEntry {
   data: string;
 }
 
+interface KvCachedResponse {
+  status: number;
+  headers: [string, string][];
+  body: string;
+}
+
 function isValidUrl(url: string): boolean {
   try {
     new URL(url);
@@ -81,6 +87,75 @@ function transformUrlForProxy(originalUrl: string, proxyBaseUrl: string): string
   return `${proxyBase}${pathWithDomain}`;
 }
 
+function isGetRequest(init?: RequestInit): boolean {
+  const method = init?.method ?? "GET";
+  return method.toUpperCase() === "GET";
+}
+
+function isHaloWaypointUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.endsWith("halowaypoint.com");
+  } catch {
+    return false;
+  }
+}
+
+function parseCacheControlMaxAgeSeconds(headers: Headers): number | null {
+  const cacheControl = headers.get("cache-control");
+  if (cacheControl == null) {
+    return null;
+  }
+
+  const match = /max-age=(\d+)/i.exec(cacheControl);
+  if (match == null) {
+    return null;
+  }
+
+  const [, maxAgeValue] = match;
+  if (maxAgeValue == null) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(maxAgeValue, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function resolveResponseCacheTtlSeconds(url: string, headers: Headers): number {
+  const fromHeaders = parseCacheControlMaxAgeSeconds(headers);
+  if (fromHeaders != null) {
+    return Math.min(Math.max(fromHeaders, 30), 604800);
+  }
+
+  try {
+    const parsed = new URL(url);
+    const path = parsed.pathname.toLowerCase();
+    if (path.includes("/matches/") || path.includes("/metadata")) {
+      return 604800;
+    }
+    if (path.includes("/players/") && path.includes("/matches")) {
+      return 60;
+    }
+    if (path.includes("/players/") && path.includes("servicerecord")) {
+      return 60;
+    }
+    if (path.includes("/playlist") || path.includes("/csr")) {
+      return 86400;
+    }
+    if (path.includes("/users")) {
+      return 3600;
+    }
+  } catch {
+    // Malformed URL should be effectively impossible here; use safe default.
+  }
+
+  return 3600;
+}
+
 export function createResilientFetch({
   env,
   logService,
@@ -95,6 +170,7 @@ export function createResilientFetch({
 
   const circuitBreakerKey = kvKeyNamespace != null ? `${kvKeyNamespace}:circuit_breaker` : KV_KEYS.CIRCUIT_BREAKER;
   const errorWindowKey = kvKeyNamespace != null ? `${kvKeyNamespace}:errors` : KV_KEYS.ERROR_WINDOW;
+  const responseCacheKeyPrefix = kvKeyNamespace != null ? `${kvKeyNamespace}:responses` : "halo:responses";
 
   const kvDebounceMap = new Map<string, DebounceEntry>();
 
@@ -120,6 +196,55 @@ export function createResilientFetch({
         ]),
       );
     }
+  }
+
+  function buildResponseCacheKey(url: string): string {
+    return `${responseCacheKeyPrefix}:${url}`;
+  }
+
+  function isKvResponseCacheableRequest(url: string, init?: RequestInit): boolean {
+    return isGetRequest(init) && isHaloWaypointUrl(url);
+  }
+
+  async function getKvCachedResponse(url: string, init?: RequestInit): Promise<Response | null> {
+    if (!isKvResponseCacheableRequest(url, init)) {
+      return null;
+    }
+
+    const cacheKey = buildResponseCacheKey(url);
+    const cached = await env.APP_DATA.get<KvCachedResponse>(cacheKey, "json");
+    if (cached == null) {
+      return null;
+    }
+
+    const headers = new Headers(cached.headers);
+    headers.set("x-gs-kv-cache", "HIT");
+    logService.debug(`KV cache HIT for ${url}`);
+    return new Response(cached.body, { status: cached.status, headers });
+  }
+
+  async function maybeCacheResponseInKv(url: string, init: RequestInit | undefined, response: Response): Promise<void> {
+    if (!isKvResponseCacheableRequest(url, init) || response.status !== 200) {
+      return;
+    }
+
+    const contentType = response.headers.get("content-type") ?? "";
+    if (!contentType.toLowerCase().includes("application/json")) {
+      return;
+    }
+
+    const cacheKey = buildResponseCacheKey(url);
+    const cloned = response.clone();
+    const body = await cloned.text();
+    const ttlSeconds = resolveResponseCacheTtlSeconds(url, cloned.headers);
+    const payload: KvCachedResponse = {
+      status: cloned.status,
+      headers: Array.from(cloned.headers.entries()),
+      body,
+    };
+
+    await env.APP_DATA.put(cacheKey, JSON.stringify(payload), { expirationTtl: ttlSeconds });
+    logService.debug(`KV cache store for ${url}`, new Map([["ttlSeconds", ttlSeconds.toString()]]));
   }
 
   function scheduleKvWrite(key: string, data: string, ttlSeconds: number): void {
@@ -250,10 +375,17 @@ export function createResilientFetch({
 
   return async function resilientFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const kvCachedResponse = await getKvCachedResponse(url, init);
+    if (kvCachedResponse != null) {
+      return kvCachedResponse;
+    }
+
     const useProxy = await shouldUseProxy();
 
     if (useProxy) {
-      return fetchViaProxy(input, init);
+      const proxiedResponse = await fetchViaProxy(input, init);
+      await maybeCacheResponseInKv(url, init, proxiedResponse);
+      return proxiedResponse;
     }
 
     function getRetryAfterMs(response: Response): number {
@@ -316,7 +448,9 @@ export function createResilientFetch({
     }
 
     try {
-      return await fetchWithRetry();
+      const response = await fetchWithRetry();
+      await maybeCacheResponseInKv(url, init, response);
+      return response;
     } catch (error) {
       logService.error(error, new Map([["url", url]]));
       throw error;

--- a/api/services/halo/tests/resilient-fetch.test.ts
+++ b/api/services/halo/tests/resilient-fetch.test.ts
@@ -1023,5 +1023,30 @@ describe("createResilientFetch", () => {
         expect.anything(),
       );
     });
+
+    it("skips KV caching when input is a Request with non-GET method and init supplies only headers", async () => {
+      kvGetSpy.mockResolvedValue(null);
+      fetchSpy.mockResolvedValue(
+        aFakeResponseWith({
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "",
+      });
+
+      const request = new Request("https://halostats.svc.halowaypoint.com/test", { method: "POST" });
+      await resilientFetch(request, { headers: { "x-custom": "value" } });
+
+      expect(kvPutSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("halo:responses:"),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
   });
 });

--- a/api/services/halo/tests/resilient-fetch.test.ts
+++ b/api/services/halo/tests/resilient-fetch.test.ts
@@ -874,4 +874,154 @@ describe("createResilientFetch", () => {
       expect(logServiceDebugSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe("KV caching safety", () => {
+    it("does not cache responses from non-halowaypoint domains resembling halowaypoint.com", async () => {
+      kvGetSpy.mockResolvedValue(null);
+      fetchSpy.mockResolvedValue(
+        aFakeResponseWith({
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "",
+      });
+
+      await resilientFetch("https://evilhalowaypoint.com/test");
+
+      expect(kvPutSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("evilhalowaypoint.com"),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns null from getKvCachedResponse when KV throws instead of propagating error", async () => {
+      kvGetSpy.mockImplementation(async (key) => {
+        if (String(key).startsWith("halo:responses:")) {
+          throw new Error("KV unavailable");
+        }
+        return Promise.resolve(null);
+      });
+      fetchSpy.mockResolvedValue(
+        aFakeResponseWith({
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "",
+      });
+
+      const response = await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      expect(response.status).toBe(200);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not reject when KV put fails during cache store", async () => {
+      kvGetSpy.mockResolvedValue(null);
+      kvPutSpy.mockImplementation(async (key) => {
+        if (String(key).startsWith("halo:responses:")) {
+          return Promise.reject(new Error("KV write failure"));
+        }
+        return Promise.resolve();
+      });
+      fetchSpy.mockResolvedValue(
+        aFakeResponseWith({
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "",
+      });
+
+      await expect(resilientFetch("https://halostats.svc.halowaypoint.com/test")).resolves.toBeDefined();
+    });
+
+    it("skips KV caching when response has cache-control: no-store", async () => {
+      kvGetSpy.mockResolvedValue(null);
+      fetchSpy.mockResolvedValue(
+        aFakeResponseWith({
+          status: 200,
+          headers: { "content-type": "application/json", "cache-control": "no-store" },
+        }),
+      );
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      expect(kvPutSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("halo:responses:"),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it("skips KV caching when response has cache-control: private", async () => {
+      kvGetSpy.mockResolvedValue(null);
+      fetchSpy.mockResolvedValue(
+        aFakeResponseWith({
+          status: 200,
+          headers: { "content-type": "application/json", "cache-control": "private, max-age=3600" },
+        }),
+      );
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      expect(kvPutSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("halo:responses:"),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it("skips KV caching when input is a Request object with a non-GET method", async () => {
+      kvGetSpy.mockResolvedValue(null);
+      fetchSpy.mockResolvedValue(
+        aFakeResponseWith({
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "",
+      });
+
+      const request = new Request("https://halostats.svc.halowaypoint.com/test", { method: "POST" });
+      await resilientFetch(request);
+
+      expect(kvPutSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("halo:responses:"),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
 });

--- a/api/services/halo/tests/resilient-fetch.test.ts
+++ b/api/services/halo/tests/resilient-fetch.test.ts
@@ -73,6 +73,55 @@ describe("createResilientFetch", () => {
       expect(kvGetSpy).toHaveBeenCalledWith(KV_KEYS.PROXY_ENABLED);
       expect(kvGetSpy).not.toHaveBeenCalledWith(KV_KEYS.CIRCUIT_BREAKER, "json");
     });
+
+    it("serves a cached Halo Waypoint response from KV before hitting network", async () => {
+      kvGetSpy.mockImplementation(async (key) => {
+        if (key === "halo:responses:https://halostats.svc.halowaypoint.com/test") {
+          return Promise.resolve({
+            status: 200,
+            headers: [["content-type", "application/json"]],
+            body: JSON.stringify({ source: "kv" }),
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "",
+      });
+
+      const response = await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(await response.json()).toEqual({ source: "kv" });
+      expect(response.headers.get("x-gs-kv-cache")).toBe("HIT");
+    });
+
+    it("stores successful Halo Waypoint JSON responses into KV", async () => {
+      kvGetSpy.mockResolvedValue(null);
+      fetchSpy.mockResolvedValue(
+        aFakeResponseWith({
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const resilientFetch = createResilientFetch({
+        env,
+        logService,
+        proxyUrl: "",
+      });
+
+      await resilientFetch("https://halostats.svc.halowaypoint.com/test");
+
+      expect(kvPutSpy).toHaveBeenCalledWith(
+        "halo:responses:https://halostats.svc.halowaypoint.com/test",
+        expect.any(String),
+        expect.objectContaining({ expirationTtl: expect.any(Number) as number }),
+      );
+    });
   });
 
   describe("master toggle", () => {


### PR DESCRIPTION
## Context
This branch adds a targeted performance optimization for Halo Infinite API traffic used by the individual tracker path. With the recent metadata refresh merged, we can now isolate and land the remaining cache work as a focused change. The goal is to reduce repeated upstream calls for read-heavy Halo Waypoint GET endpoints while keeping request behavior predictable.

## This PR
- adds a KV-backed response cache inside `createResilientFetch` for cache-eligible requests (Halo Waypoint + GET)
- implements read-through behavior: return cached response from KV before making network/proxy requests
- implements write-through behavior: cache successful `200` JSON responses after fetch/proxy completion
- stores full replayable payload (`status`, `headers`, `body`) so callers get a normal `Response`
- applies TTL selection using `cache-control: max-age` when present, with safe bounds, and path-based fallbacks otherwise
- scopes cache keys under `halo:responses:` (or namespaced prefix when `kvKeyNamespace` is set)
- adds coverage in resilient-fetch tests for KV hit short-circuit and KV store behavior

## Subsequent Work
- validate hit rate and latency deltas in production logs/metrics after deployment
- tune per-endpoint fallback TTLs based on observed staleness tolerance and request frequency
- consider selective invalidation/versioning strategy if any endpoint payload shape begins changing frequently
