### PR TITLE
Enable Dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,3 +78,12 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,3 +87,6 @@ updates:
       all:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Context
Dependabot in this repository currently updates npm dependencies across workspace manifests, but it does not yet track GitHub Actions versions used in workflow files. Adding actions updates reduces supply-chain drift and keeps CI workflow dependencies patched.

## This PR
- adds a new Dependabot update entry for the github-actions ecosystem
- targets the repository root so workflow action versions are scanned and updated
- runs on a weekly schedule to match the existing cadence
- groups all actions updates under a single all group for manageable PR volume

## Subsequent Work
- optionally split actions updates into separate groups (for example, official vs third-party actions) if review volume grows
- optionally pin schedule day/time to align with your normal dependency triage window
