### PR TITLE
Centralize Discord series stats retrieval/cache and force overview cache hydration

### DIFF
--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -28,11 +28,13 @@ import { SeriesPlayersEmbed } from "../../embeds/stats/series-players-embed";
 import { SeriesOverviewEmbed } from "../../embeds/stats/series-overview-embed";
 import type { SeriesOverviewEmbedOutput } from "../../embeds/stats/series-overview-embed";
 import { SeriesTeamsEmbed } from "../../embeds/stats/series-teams-embed";
+import {
+  buildDiscordSeriesRenderDataFromMatches,
+} from "../../services/discord/discord-series-stats";
 import type { GuildConfigRow } from "../../services/database/types/guild_config";
 import { StatsReturnType } from "../../services/database/types/guild_config";
 import { EndUserError } from "../../base/end-user-error";
 import { create } from "../../embeds/stats/create";
-import type { JsonAny } from "../../services/log/types";
 
 export enum InteractionButton {
   Retry = "btn_stats_retry",
@@ -244,6 +246,8 @@ export class StatsCommand extends BaseCommand {
         components: seriesEmbed.components,
       });
 
+      await this.cacheDiscordSeriesStats(guildId, queueData.queue, series);
+
       const message = await discordService.getMessageFromInteractionToken(interaction.token);
       const messageChannel = await discordService.getChannel(message.channel_id);
       const thread = [ChannelType.PublicThread, ChannelType.PrivateThread, ChannelType.AnnouncementThread].includes(
@@ -259,10 +263,7 @@ export class StatsCommand extends BaseCommand {
       await this.postSeriesEmbedsToThread(thread.id, series, guildConfig, locale);
       await this.postGameStatsOrButton(thread.id, series, guildConfig, locale);
 
-      await Promise.all([
-        haloService.updateDiscordAssociations(),
-        this.warmDiscordSeriesStatsRoute(guildId, queueData.queue),
-      ]);
+      await haloService.updateDiscordAssociations();
     } catch (error) {
       if (error instanceof EndUserError && computedQueue != null && endDateTime != null) {
         error.appendData({
@@ -363,13 +364,12 @@ export class StatsCommand extends BaseCommand {
           components: seriesEmbed.components,
         });
 
+        await this.cacheDiscordSeriesStats(guildId, queueData.queue, series);
+
         await this.postSeriesEmbedsToThread(threadChannelId, series, guildConfig, locale);
         await this.postGameStatsOrButton(threadChannelId, series, guildConfig, locale);
 
-        await Promise.all([
-          haloService.updateDiscordAssociations(),
-          this.warmDiscordSeriesStatsRoute(guildId, queueData.queue),
-        ]);
+        await haloService.updateDiscordAssociations();
       }
     } catch (error) {
       if (error instanceof EndUserError) {
@@ -668,30 +668,32 @@ export class StatsCommand extends BaseCommand {
     });
   }
 
-  private async warmDiscordSeriesStatsRoute(guildId: string, queueNumber: number): Promise<void> {
-    const { logService } = this.services;
-    const url = `${this.env.HOST_URL}/api/stats/discord/${guildId}/${queueNumber.toString()}`;
+  private async cacheDiscordSeriesStats(guildId: string, queueNumber: number, series: MatchStats[]): Promise<void> {
+    const { discordService, haloService, logService } = this.services;
 
     try {
-      const response = await fetch(url, { method: "GET" });
-      if (response.ok) {
-        return;
-      }
+      const renderData = await buildDiscordSeriesRenderDataFromMatches({
+        discordService,
+        logService,
+        haloService,
+        guildId,
+        queueNumber,
+        matches: series,
+      });
 
-      logService.warn(
-        `Discord series stats warm request returned non-OK status: ${response.status.toString()}`,
-        new Map<string, JsonAny>([
-          ["guildId", guildId],
-          ["queueNumber", queueNumber],
-          ["status", response.status],
-        ]),
-      );
+      await discordService.cacheResolvedDiscordSeriesStats({
+        guildId,
+        queueNumber,
+        matchIds: series.map((match) => match.MatchId),
+        renderData,
+      });
     } catch (error) {
       logService.warn(
         error,
-        new Map<string, JsonAny>([
+        new Map([
           ["guildId", guildId],
-          ["queueNumber", queueNumber],
+          ["queueNumber", queueNumber.toString()],
+          ["context", "Failed to cache discord series stats directly"],
         ]),
       );
     }

--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -28,9 +28,7 @@ import { SeriesPlayersEmbed } from "../../embeds/stats/series-players-embed";
 import { SeriesOverviewEmbed } from "../../embeds/stats/series-overview-embed";
 import type { SeriesOverviewEmbedOutput } from "../../embeds/stats/series-overview-embed";
 import { SeriesTeamsEmbed } from "../../embeds/stats/series-teams-embed";
-import {
-  buildDiscordSeriesRenderDataFromMatches,
-} from "../../services/discord/discord-series-stats";
+import { buildDiscordSeriesRenderDataFromMatches } from "../../services/discord/discord-series-stats";
 import type { GuildConfigRow } from "../../services/database/types/guild_config";
 import { StatsReturnType } from "../../services/database/types/guild_config";
 import { EndUserError } from "../../base/end-user-error";

--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -691,7 +691,7 @@ export class StatsCommand extends BaseCommand {
         new Map([
           ["guildId", guildId],
           ["queueNumber", queueNumber.toString()],
-          ["context", "Failed to cache discord series stats directly"],
+          ["reason", "Failed to cache discord series stats directly"],
         ]),
       );
     }

--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -682,7 +682,7 @@ export class StatsCommand extends BaseCommand {
       await discordService.cacheResolvedDiscordSeriesStats({
         guildId,
         queueNumber,
-        matchIds: series.map((match) => match.MatchId),
+        matchIds: renderData.matches.map((match) => match.matchId),
         renderData,
       });
     } catch (error) {

--- a/api/commands/stats/tests/stats.test.ts
+++ b/api/commands/stats/tests/stats.test.ts
@@ -39,7 +39,10 @@ import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import { aFakeGuildConfigRow } from "../../../services/database/fakes/database.fake";
 import { EndUserError } from "../../../base/end-user-error";
 import type { MatchPlayer } from "../../../services/halo/types";
-import { getDiscordSeriesStatsCacheKey } from "../../../services/discord/discord-series-stats";
+import {
+  DISCORD_SERIES_STATS_RESOLVED_CACHE_TTL_SECONDS,
+  getDiscordSeriesStatsCacheKey,
+} from "../../../services/discord/discord-series-stats";
 
 const applicationCommandInteractionStatsNeatQueue: APIApplicationCommandInteraction = {
   ...fakeBaseAPIApplicationCommandInteraction,
@@ -381,7 +384,7 @@ describe("StatsCommand", () => {
         expect(appDataPutSpy).toHaveBeenCalledWith(
           getDiscordSeriesStatsCacheKey("fake-guild-id", 777),
           expect.any(String),
-          expect.objectContaining({ expirationTtl: 60 * 60 * 24 }),
+          expect.objectContaining({ expirationTtl: DISCORD_SERIES_STATS_RESOLVED_CACHE_TTL_SECONDS }),
         );
       });
 
@@ -688,7 +691,7 @@ describe("StatsCommand", () => {
           expect(appDataPutSpy).toHaveBeenCalledWith(
             getDiscordSeriesStatsCacheKey("fake-guild-id", 777),
             expect.any(String),
-            expect.objectContaining({ expirationTtl: 60 * 60 * 24 }),
+            expect.objectContaining({ expirationTtl: DISCORD_SERIES_STATS_RESOLVED_CACHE_TTL_SECONDS }),
           );
         });
 

--- a/api/commands/stats/tests/stats.test.ts
+++ b/api/commands/stats/tests/stats.test.ts
@@ -39,6 +39,7 @@ import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import { aFakeGuildConfigRow } from "../../../services/database/fakes/database.fake";
 import { EndUserError } from "../../../base/end-user-error";
 import type { MatchPlayer } from "../../../services/halo/types";
+import { getDiscordSeriesStatsCacheKey } from "../../../services/discord/discord-series-stats";
 
 const applicationCommandInteractionStatsNeatQueue: APIApplicationCommandInteraction = {
   ...fakeBaseAPIApplicationCommandInteraction,
@@ -117,15 +118,15 @@ describe("StatsCommand", () => {
   let statsCommand: StatsCommand;
   let services: Services;
   let env: Env;
-  let fetchSpy: MockInstance<typeof globalThis.fetch>;
+  let appDataPutSpy: MockInstance<typeof env.APP_DATA.put>;
   let updateDeferredReplySpy: MockInstance<typeof services.discordService.updateDeferredReply>;
   let updateDeferredReplyWithErrorSpy: MockInstance<typeof services.discordService.updateDeferredReplyWithError>;
 
   beforeEach(() => {
-    services = installFakeServicesWith();
     env = aFakeEnvWith();
+    services = installFakeServicesWith({ env });
     statsCommand = new StatsCommand(services, env);
-    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
+    appDataPutSpy = vi.spyOn(env.APP_DATA, "put").mockResolvedValue();
 
     updateDeferredReplySpy = vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue(apiMessage);
     updateDeferredReplyWithErrorSpy = vi
@@ -374,12 +375,14 @@ describe("StatsCommand", () => {
         expect(updateDiscordAssociationsSpy).toHaveBeenCalledWith();
       });
 
-      it("warms the discord series stats route after posting embeds", async () => {
+      it("caches resolved discord series stats after posting embeds", async () => {
         await jobToComplete?.();
 
-        expect(fetchSpy).toHaveBeenCalledWith("http://localhost:8787/api/stats/discord/fake-guild-id/777", {
-          method: "GET",
-        });
+        expect(appDataPutSpy).toHaveBeenCalledWith(
+          getDiscordSeriesStatsCacheKey("fake-guild-id", 777),
+          expect.any(String),
+          expect.objectContaining({ expirationTtl: 60 * 60 * 24 }),
+        );
       });
 
       it("calls discordService.updateDeferredReplyWithError with an error when an error is thrown", async () => {
@@ -677,14 +680,16 @@ describe("StatsCommand", () => {
           expect(updateDiscordAssociationsSpy).toHaveBeenCalled();
         });
 
-        it("warms the discord series stats route after posting embeds", async () => {
+        it("caches resolved discord series stats after posting embeds", async () => {
           getMessagesSpy.mockResolvedValue([threadFirstMessage]);
 
           await jobToComplete?.();
 
-          expect(fetchSpy).toHaveBeenCalledWith("http://localhost:8787/api/stats/discord/fake-guild-id/777", {
-            method: "GET",
-          });
+          expect(appDataPutSpy).toHaveBeenCalledWith(
+            getDiscordSeriesStatsCacheKey("fake-guild-id", 777),
+            expect.any(String),
+            expect.objectContaining({ expirationTtl: 60 * 60 * 24 }),
+          );
         });
 
         it("appends previous error data when new error occurs", async () => {

--- a/api/routes/stats/discord-series.ts
+++ b/api/routes/stats/discord-series.ts
@@ -1,42 +1,21 @@
-import type { APIEmbed, APIMessage } from "discord-api-types/v10";
-import { EmbedType, MessageSearchAuthorType, MessageSearchSortMode } from "discord-api-types/v10";
-import type { MatchStats } from "halo-infinite-api";
 import { parsePathParams } from "@guilty-spark/shared/base/request-parsing";
-import { Preconditions } from "@guilty-spark/shared/base/preconditions";
-import { getReadableDuration } from "@guilty-spark/shared/halo/duration";
-import { getTeamName } from "@guilty-spark/shared/halo/team";
-import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
-import { getMedalMetadataFromMatches } from "@guilty-spark/shared/halo/medals";
 import {
   discordSeriesStatsContract,
   discordSeriesStatsParamsSchema,
   type DiscordSeriesStats,
   type DiscordSeriesStatsForbidden,
-  type DiscordSeriesStatsNotFound,
-  type DiscordSeriesStatsPending,
   type DiscordSeriesStatsResolved,
 } from "@guilty-spark/shared/contracts/stats/discord-series";
 import { errorContract } from "@guilty-spark/shared/contracts/error";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
-import { DiscordError } from "../../services/discord/discord-error";
-import type { DiscordService } from "../../services/discord/discord";
-import { EmbedColors } from "../../embeds/colors";
+import type { DiscordSeriesLookupResult, DiscordService } from "../../services/discord/discord";
+import {
+  buildDiscordSeriesRenderDataFromMatches,
+  DISCORD_SERIES_STATS_RESOLVED_CACHE_CONTROL_HEADER,
+} from "../../services/discord/discord-series-stats";
 import type { RoutesRegisterHandler } from "../base/types";
 import type { HaloService } from "../../services/halo/halo";
 import type { LogService } from "../../services/log/types";
-
-const DEFAULT_PENDING_RETRY_SECONDS = 2;
-const PENDING_CACHE_TTL_SECONDS = 60 * 5;
-const RESOLVED_CACHE_TTL_SECONDS = 60 * 60 * 24;
-const NOT_FOUND_CACHE_TTL_SECONDS = 60 * 5;
-const RESOLVED_STALE_WHILE_REVALIDATE_SECONDS = 60 * 5;
-const RESOLVED_CACHE_CONTROL_HEADER = `public, s-maxage=${RESOLVED_CACHE_TTL_SECONDS.toString()}, stale-while-revalidate=${RESOLVED_STALE_WHILE_REVALIDATE_SECONDS.toString()}`;
-
-const MATCH_ID_REGEX = /https:\/\/halodatahive\.com\/Infinite\/Match\/([a-zA-Z0-9-]+)/g;
-
-function getCacheKey(guildId: string, queueNumber: number): string {
-  return `stats:discord:series:${guildId}:${queueNumber.toString()}`;
-}
 
 function getResponseOptions(response: DiscordSeriesStats): {
   status: number;
@@ -45,7 +24,7 @@ function getResponseOptions(response: DiscordSeriesStats): {
 } {
   switch (response.status) {
     case "resolved": {
-      return { status: 200, headers: { "Cache-Control": RESOLVED_CACHE_CONTROL_HEADER } };
+      return { status: 200, headers: { "Cache-Control": DISCORD_SERIES_STATS_RESOLVED_CACHE_CONTROL_HEADER } };
     }
     case "pending-index": {
       return {
@@ -66,213 +45,9 @@ function getResponseOptions(response: DiscordSeriesStats): {
   }
 }
 
-function getOverviewEmbed(message: APIMessage, queueNumber: number): APIEmbed | null {
-  for (const embed of message.embeds) {
-    if (embed.type !== EmbedType.Rich) {
-      continue;
-    }
-    if (embed.color !== EmbedColors.INFO) {
-      continue;
-    }
-    const match = embed.title?.match(/^Series stats for queue #(\d+)\b/);
-    if (match?.[1] !== queueNumber.toString()) {
-      continue;
-    }
-
-    return embed;
-  }
-
-  return null;
-}
-
-function extractMatchIdsFromEmbeds(embeds: readonly APIEmbed[]): string[] {
-  const matchIds = new Set<string>();
-
-  for (const embed of embeds) {
-    const gameFieldValue = embed.fields?.find((field) => field.name === "Game")?.value;
-    if (gameFieldValue == null) {
-      continue;
-    }
-
-    const matches = gameFieldValue.matchAll(MATCH_ID_REGEX);
-    for (const match of matches) {
-      const [, matchId] = match;
-      if (matchId != null) {
-        matchIds.add(matchId);
-      }
-    }
-  }
-
-  return [...matchIds];
-}
-
-function sanitizeRetryAfterSeconds(retryAfterValue: unknown): number {
-  if (typeof retryAfterValue !== "number") {
-    return DEFAULT_PENDING_RETRY_SECONDS;
-  }
-
-  if (!Number.isFinite(retryAfterValue) || retryAfterValue <= 0) {
-    return DEFAULT_PENDING_RETRY_SECONDS;
-  }
-
-  return retryAfterValue;
-}
-
-type DiscordSeriesLookupResult =
-  | {
-      status: "resolved";
-      guildId: string;
-      queueNumber: number;
-      matchIds: string[];
-    }
-  | DiscordSeriesStatsPending
-  | DiscordSeriesStatsNotFound;
-
-function getForbiddenResponseData(guildId: string, queueNumber: number): DiscordSeriesStatsForbidden {
-  return {
-    status: "forbidden",
-    guildId,
-    queueNumber,
-    reason: "Missing Discord permissions or message content access",
-  };
-}
-
-async function cachePendingResponse({
-  env,
-  cacheKey,
-  guildId,
-  queueNumber,
-  retryAfterSeconds,
-}: {
-  env: Env;
-  cacheKey: string;
-  guildId: string;
-  queueNumber: number;
-  retryAfterSeconds: number;
-}): Promise<DiscordSeriesStatsPending> {
-  const pendingResponse: DiscordSeriesStatsPending = {
-    status: "pending-index",
-    guildId,
-    queueNumber,
-    retryAfterSeconds,
-  };
-
-  await env.APP_DATA.put(cacheKey, JSON.stringify(pendingResponse), {
-    expirationTtl: PENDING_CACHE_TTL_SECONDS,
-  });
-
-  return pendingResponse;
-}
-
-async function cacheLookupResultWhenNeeded({
-  env,
-  cacheKey,
-  lookupResult,
-}: {
-  env: Env;
-  cacheKey: string;
-  lookupResult: DiscordSeriesLookupResult;
-}): Promise<void> {
-  if (lookupResult.status === "pending-index") {
-    await env.APP_DATA.put(cacheKey, JSON.stringify(lookupResult), { expirationTtl: PENDING_CACHE_TTL_SECONDS });
-  }
-
-  if (lookupResult.status === "not-found") {
-    await env.APP_DATA.put(cacheKey, JSON.stringify(lookupResult), {
-      expirationTtl: NOT_FOUND_CACHE_TTL_SECONDS,
-    });
-  }
-}
-
-async function getValidCachedStats({
-  env,
-  cacheKey,
-  logService,
-  warningMessage,
-}: {
-  env: Env;
-  cacheKey: string;
-  logService: { warn: (message: string, extra?: Map<string, string>) => void };
-  warningMessage: string;
-}): Promise<DiscordSeriesStats | null> {
-  const cached = await env.APP_DATA.get<DiscordSeriesStats>(cacheKey, { type: "json" });
-  if (cached == null || typeof cached !== "object") {
-    return null;
-  }
-
-  const cachedParseResult = discordSeriesStatsContract.safeParse(cached);
-  if (cachedParseResult.success) {
-    return cachedParseResult.data;
-  }
-
-  logService.warn(warningMessage, new Map([["cacheKey", cacheKey]]));
-  return null;
-}
-
-async function findDiscordSeriesLookupResult({
-  guildId,
-  queueNumber,
-  discordService,
-  env,
-}: {
-  guildId: string;
-  queueNumber: number;
-  discordService: DiscordService;
-  env: Env;
-}): Promise<DiscordSeriesLookupResult> {
-  const searchResponse = await discordService.searchGuildMessages(guildId, {
-    content: `Series stats for queue #${queueNumber.toString()}`,
-    author_id: [env.DISCORD_APP_ID],
-    author_type: [MessageSearchAuthorType.Bot],
-    sort_by: MessageSearchSortMode.Timestamp,
-    sort_order: "desc",
-    limit: 25,
-  });
-
-  if ("retry_after" in searchResponse) {
-    return {
-      status: "pending-index",
-      guildId,
-      queueNumber,
-      retryAfterSeconds: sanitizeRetryAfterSeconds(searchResponse.retry_after),
-    };
-  }
-
-  const flattenedMessages = searchResponse.messages.flatMap((messages: APIMessage[]): APIMessage[] => messages);
-  const blueOverviewCandidates = flattenedMessages.filter(
-    (message: APIMessage) => getOverviewEmbed(message, queueNumber) != null,
-  );
-
-  if (blueOverviewCandidates.length === 0) {
-    return {
-      status: "not-found",
-      guildId,
-      queueNumber,
-      reason: "No matching series overview embeds found",
-    };
-  }
-
-  const selectedOverviewMessage = Preconditions.checkExists(blueOverviewCandidates[0]);
-  const matchIds = extractMatchIdsFromEmbeds(selectedOverviewMessage.embeds);
-
-  if (matchIds.length === 0) {
-    return {
-      status: "not-found",
-      guildId,
-      queueNumber,
-      reason: "Series overview embed found but no match IDs were discoverable",
-    };
-  }
-
-  return {
-    status: "resolved",
-    guildId,
-    queueNumber,
-    matchIds,
-  };
-}
-
-function toLookupResponse(lookupResult: DiscordSeriesLookupResult | DiscordSeriesStatsForbidden): Response {
+function toLookupResponse(
+  lookupResult: DiscordSeriesStats | DiscordSeriesLookupResult | DiscordSeriesStatsForbidden,
+): Response {
   switch (lookupResult.status) {
     case "resolved": {
       return Response.json(
@@ -282,7 +57,7 @@ function toLookupResponse(lookupResult: DiscordSeriesLookupResult | DiscordSerie
           queueNumber: lookupResult.queueNumber,
           matchIds: lookupResult.matchIds,
         },
-        { status: 200, headers: { "Cache-Control": RESOLVED_CACHE_CONTROL_HEADER } },
+        { status: 200, headers: { "Cache-Control": DISCORD_SERIES_STATS_RESOLVED_CACHE_CONTROL_HEADER } },
       );
     }
     case "pending-index": {
@@ -297,84 +72,6 @@ function toLookupResponse(lookupResult: DiscordSeriesLookupResult | DiscordSerie
     default: {
       throw new UnreachableError(lookupResult);
     }
-  }
-}
-
-function splitGameTypeAndMap(gameTypeAndMap: string): { gameType: string; gameMap: string } {
-  const colonSplit = gameTypeAndMap.split(":");
-  if (colonSplit.length > 1) {
-    const gameType = (colonSplit[0] ?? "*Unknown Game Type*").trim() || "*Unknown Game Type*";
-    const gameMap = colonSplit.slice(1).join(":").trim() || "*Unknown Map*";
-    return { gameType, gameMap };
-  }
-
-  const separator = " on ";
-  const onIndex = gameTypeAndMap.indexOf(separator);
-  if (onIndex > 0) {
-    const gameType = gameTypeAndMap.slice(0, onIndex).trim();
-    const gameMap = gameTypeAndMap.slice(onIndex + separator.length).trim();
-    return {
-      gameType: gameType || "*Unknown Game Type*",
-      gameMap: gameMap || "*Unknown Map*",
-    };
-  }
-
-  return { gameType: "*Unknown Game Type*", gameMap: "*Unknown Map*" };
-}
-
-function getTeamPlayersFromMatch(match: MatchStats, teamId: number): MatchStats["Players"] {
-  return match.Players.filter((player) => {
-    if (!player.ParticipationInfo.PresentAtBeginning) {
-      return false;
-    }
-
-    return player.PlayerTeamStats.some((teamStats) => teamStats.TeamId === teamId);
-  });
-}
-
-async function getSubtitle(guildId: string, discordService: DiscordService, logService: LogService): Promise<string> {
-  let subtitle = `Guild ${guildId}`;
-  try {
-    const guild = await discordService.getGuild(guildId);
-    const guildName = guild.name.trim();
-    subtitle = guildName === "" ? `Guild ${guildId}` : guildName;
-  } catch (error) {
-    logService.warn(
-      "Failed to fetch guild name for discord series subtitle, falling back to guild id",
-      new Map([
-        ["guildId", guildId],
-        ["error", String(error)],
-      ]),
-    );
-  }
-  return subtitle;
-}
-
-async function getBestEffortMedalMetadata({
-  logService,
-  haloService,
-  matchesById,
-  guildId,
-  queueNumber,
-}: {
-  logService: LogService;
-  haloService: HaloService;
-  matchesById: Record<string, MatchStats>;
-  guildId: string;
-  queueNumber: number;
-}): Promise<DiscordSeriesStatsResolved["renderData"]["medalMetadata"]> {
-  try {
-    return await getMedalMetadataFromMatches(matchesById, async (medalId) => haloService.getMedal(medalId));
-  } catch (error) {
-    logService.warn(
-      "Failed to resolve medal metadata for discord series stats, using empty metadata",
-      new Map([
-        ["guildId", guildId],
-        ["queueNumber", queueNumber.toString()],
-        ["error", String(error)],
-      ]),
-    );
-    return {};
   }
 }
 
@@ -394,85 +91,15 @@ async function tryBuildRenderData({
   matchIds: string[];
 }): Promise<DiscordSeriesStatsResolved["renderData"]> {
   const matches = await haloService.getMatchDetails(matchIds);
-  if (matches.length === 0) {
-    throw new Error("No Halo match details were found for discovered match IDs");
-  }
 
-  const matchesById: Record<string, MatchStats> = {};
-  for (const match of matches) {
-    matchesById[match.MatchId] = match;
-  }
-
-  const [playerXuidToGametagMap, medalMetadata] = await Promise.all([
-    haloService.getPlayerXuidsToGametags(matches),
-    getBestEffortMedalMetadata({
-      logService,
-      haloService,
-      matchesById,
-      guildId,
-      queueNumber,
-    }),
-  ]);
-  const renderMatches = await Promise.all(
-    matches.map(async (match) => {
-      const [gameTypeAndMap, mapThumbnailUrl] = await Promise.all([
-        haloService.getGameTypeAndMap(match.MatchInfo),
-        haloService.getMapThumbnailUrl(match.MatchInfo.MapVariant.AssetId, match.MatchInfo.MapVariant.VersionId),
-      ]);
-      const { gameType, gameMap } = splitGameTypeAndMap(gameTypeAndMap);
-      const { gameScore, gameSubScore } = haloService.getMatchScore(match, "en-US");
-
-      const playerXuidToGametag: Record<string, string> = {};
-      for (const player of match.Players) {
-        if (!player.ParticipationInfo.PresentAtBeginning || player.PlayerType !== 1) {
-          continue;
-        }
-
-        const xuid = getPlayerXuid(player);
-        playerXuidToGametag[xuid] = playerXuidToGametagMap.get(xuid) ?? "*Unknown*";
-      }
-
-      return {
-        matchId: match.MatchId,
-        gameTypeAndMap,
-        gameVariantCategory: match.MatchInfo.GameVariantCategory,
-        gameType,
-        gameMap,
-        gameMapThumbnailUrl: mapThumbnailUrl ?? "data:,",
-        duration: getReadableDuration(match.MatchInfo.Duration, "en-US"),
-        gameScore,
-        gameSubScore,
-        startTime: new Date(match.MatchInfo.StartTime).toISOString(),
-        endTime: new Date(match.MatchInfo.EndTime).toISOString(),
-        playerXuidToGametag,
-        rawMatch: match,
-      };
-    }),
-  );
-
-  const lastMatch = Preconditions.checkExists(matches[matches.length - 1]);
-  const teams = lastMatch.Teams.map((team) => ({
-    name: getTeamName(team.TeamId),
-    players: getTeamPlayersFromMatch(lastMatch, team.TeamId).map((player) => {
-      if (player.PlayerType !== 1) {
-        return "Bot";
-      }
-
-      const xuid = getPlayerXuid(player);
-      return playerXuidToGametagMap.get(xuid) ?? "*Unknown*";
-    }),
-  }));
-
-  const subtitle = await getSubtitle(guildId, discordService, logService);
-
-  return {
-    title: `Queue #${queueNumber.toString()} Series Stats`,
-    subtitle,
-    seriesScore: haloService.getSeriesScore(matches, "en-US"),
-    medalMetadata,
-    teams,
-    matches: renderMatches,
-  };
+  return buildDiscordSeriesRenderDataFromMatches({
+    discordService,
+    logService,
+    haloService,
+    guildId,
+    queueNumber,
+    matches,
+  });
 }
 
 export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installServices) => {
@@ -489,71 +116,24 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
     }
 
     const { guildId, queueNumber } = parsedParams.data;
-    const cacheKey = getCacheKey(guildId, queueNumber);
 
     try {
-      const cached = await getValidCachedStats({
-        env,
-        cacheKey,
-        logService,
-        warningMessage: "Invalid cached discord series stats payload, treating as cache miss",
-      });
-      if (cached != null) {
-        return discordSeriesStatsContract.toResponse(cached, getResponseOptions(cached));
-      }
-
-      const lookupResult = await findDiscordSeriesLookupResult({ guildId, queueNumber, discordService, env });
-
-      if (lookupResult.status === "pending-index" || lookupResult.status === "not-found") {
-        await cacheLookupResultWhenNeeded({ env, cacheKey, lookupResult });
-      }
-
-      if (lookupResult.status === "pending-index") {
-        return discordSeriesStatsContract.toResponse(lookupResult, getResponseOptions(lookupResult));
-      }
-
-      if (lookupResult.status === "not-found") {
-        return discordSeriesStatsContract.toResponse(lookupResult, { status: 404 });
-      }
-
-      const renderData = await tryBuildRenderData({
-        discordService,
-        logService,
-        haloService,
+      const response = await discordService.getSeriesStats({
         guildId,
         queueNumber,
-        matchIds: lookupResult.matchIds,
+        resolveRenderData: async (matchIds: string[]) =>
+          tryBuildRenderData({
+            discordService,
+            logService,
+            haloService,
+            guildId,
+            queueNumber,
+            matchIds,
+          }),
       });
 
-      const resolvedResponse: DiscordSeriesStats = {
-        status: "resolved",
-        guildId,
-        queueNumber,
-        matchIds: lookupResult.matchIds,
-        renderData,
-      };
-
-      await env.APP_DATA.put(cacheKey, JSON.stringify(resolvedResponse), { expirationTtl: RESOLVED_CACHE_TTL_SECONDS });
-
-      return discordSeriesStatsContract.toResponse(resolvedResponse, getResponseOptions(resolvedResponse));
+      return discordSeriesStatsContract.toResponse(response, getResponseOptions(response));
     } catch (error) {
-      if (error instanceof DiscordError && error.httpStatus === 429) {
-        const retryAfterSeconds = sanitizeRetryAfterSeconds((error.restError as { retry_after?: unknown }).retry_after);
-        const pendingResponse = await cachePendingResponse({
-          env,
-          cacheKey,
-          guildId,
-          queueNumber,
-          retryAfterSeconds,
-        });
-
-        return discordSeriesStatsContract.toResponse(pendingResponse, getResponseOptions(pendingResponse));
-      }
-
-      if (error instanceof DiscordError && error.httpStatus === 403) {
-        return discordSeriesStatsContract.toResponse(getForbiddenResponseData(guildId, queueNumber), { status: 403 });
-      }
-
       logService.error(error, new Map([["context", "Failed to resolve discord series stats route"]]));
       return errorContract.toResponse(
         { error: "Failed to resolve discord series stats" },
@@ -575,43 +155,11 @@ export const statsDiscordSeriesRoute: RoutesRegisterHandler = (router, installSe
     }
 
     const { guildId, queueNumber } = parsedParams.data;
-    const cacheKey = getCacheKey(guildId, queueNumber);
 
     try {
-      const cached = await getValidCachedStats({
-        env,
-        cacheKey,
-        logService,
-        warningMessage: "Invalid cached discord series stats payload during lookup, treating as cache miss",
-      });
-      if (cached != null) {
-        return toLookupResponse(cached);
-      }
-
-      const lookupResult = await findDiscordSeriesLookupResult({ guildId, queueNumber, discordService, env });
-
-      if (lookupResult.status === "pending-index" || lookupResult.status === "not-found") {
-        await cacheLookupResultWhenNeeded({ env, cacheKey, lookupResult });
-      }
-
-      return toLookupResponse(lookupResult);
+      const lookupOrCached = await discordService.getSeriesStatsLookup(guildId, queueNumber);
+      return toLookupResponse(lookupOrCached);
     } catch (error) {
-      if (error instanceof DiscordError && error.httpStatus === 429) {
-        const pendingResponse = await cachePendingResponse({
-          env,
-          cacheKey,
-          guildId,
-          queueNumber,
-          retryAfterSeconds: sanitizeRetryAfterSeconds((error.restError as { retry_after?: unknown }).retry_after),
-        });
-
-        return toLookupResponse(pendingResponse);
-      }
-
-      if (error instanceof DiscordError && error.httpStatus === 403) {
-        return toLookupResponse(getForbiddenResponseData(guildId, queueNumber));
-      }
-
       logService.error(error, new Map([["context", "Failed to resolve discord series stats lookup route"]]));
       return errorContract.toResponse(
         { error: "Failed to resolve discord series stats lookup" },

--- a/api/routes/stats/discord-series.ts
+++ b/api/routes/stats/discord-series.ts
@@ -49,6 +49,17 @@ function toLookupResponse(
   lookupResult: DiscordSeriesStats | DiscordSeriesLookupResult | DiscordSeriesStatsForbidden,
 ): Response {
   switch (lookupResult.status) {
+    case "lookup-resolved": {
+      return Response.json(
+        {
+          status: "resolved",
+          guildId: lookupResult.guildId,
+          queueNumber: lookupResult.queueNumber,
+          matchIds: lookupResult.matchIds,
+        },
+        { status: 200, headers: { "Cache-Control": DISCORD_SERIES_STATS_RESOLVED_CACHE_CONTROL_HEADER } },
+      );
+    }
     case "resolved": {
       return Response.json(
         {

--- a/api/routes/stats/tests/discord-series.test.ts
+++ b/api/routes/stats/tests/discord-series.test.ts
@@ -806,6 +806,68 @@ describe("/api/stats/discord/:guildId/:queueNumber/lookup", () => {
     expect(appDataGetSpy).toHaveBeenCalledWith(cacheKey, { type: "json" });
   });
 
+  it("returns cached lookup-only response without calling Discord search", async () => {
+    const storedByKey = new Map<string, string>();
+    const appDataGetSpy: MockInstance = vi.spyOn(env.APP_DATA, "get");
+    const appDataPutSpy: MockInstance<(key: string, value: string, options?: KVNamespacePutOptions) => Promise<void>> =
+      vi.spyOn(env.APP_DATA, "put");
+
+    appDataGetSpy.mockImplementation(async (key: string, options?: { type?: string }) => {
+      await Promise.resolve();
+      const value = storedByKey.get(key);
+      if (value == null) {
+        return null;
+      }
+
+      if (options?.type === "json") {
+        return JSON.parse(value) as unknown;
+      }
+
+      return value;
+    });
+    appDataPutSpy.mockImplementation(async (key: string, value: string) => {
+      await Promise.resolve();
+      storedByKey.set(key, value);
+    });
+
+    const lookupCacheKey = "stats:discord:series:123456789012345678:7777:lookup";
+    await env.APP_DATA.put(
+      lookupCacheKey,
+      JSON.stringify({
+        status: "resolved",
+        guildId: "123456789012345678",
+        queueNumber: 7777,
+        matchIds: ["cached-match-lookup-1"],
+      }),
+    );
+
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      const searchSpy = vi.spyOn(services.discordService, "searchGuildMessages");
+      searchSpy.mockImplementation(() => {
+        throw new Error("searchGuildMessages should not be called when lookup cache hit exists");
+      });
+      return services;
+    });
+
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(
+      new Request("http://localhost/api/stats/discord/123456789012345678/7777/lookup"),
+      env,
+    )) as Response;
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      status: "resolved",
+      guildId: "123456789012345678",
+      queueNumber: 7777,
+      matchIds: ["cached-match-lookup-1"],
+    });
+    expect(appDataGetSpy).toHaveBeenCalledWith("stats:discord:series:123456789012345678:7777", { type: "json" });
+    expect(appDataGetSpy).toHaveBeenCalledWith(lookupCacheKey, { type: "json" });
+  });
+
   it("returns forbidden when Discord service throws 403", async () => {
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });

--- a/api/routes/stats/tests/discord-series.test.ts
+++ b/api/routes/stats/tests/discord-series.test.ts
@@ -834,7 +834,7 @@ describe("/api/stats/discord/:guildId/:queueNumber/lookup", () => {
     await env.APP_DATA.put(
       lookupCacheKey,
       JSON.stringify({
-        status: "resolved",
+        status: "lookup-resolved",
         guildId: "123456789012345678",
         queueNumber: 7777,
         matchIds: ["cached-match-lookup-1"],

--- a/api/routes/stats/tests/discord-series.test.ts
+++ b/api/routes/stats/tests/discord-series.test.ts
@@ -868,6 +868,79 @@ describe("/api/stats/discord/:guildId/:queueNumber/lookup", () => {
     expect(appDataGetSpy).toHaveBeenCalledWith(lookupCacheKey, { type: "json" });
   });
 
+  it("treats invalid cached lookup-only payload as cache miss", async () => {
+    const storedByKey = new Map<string, string>();
+    const appDataGetSpy: MockInstance = vi.spyOn(env.APP_DATA, "get");
+    const appDataPutSpy: MockInstance<(key: string, value: string, options?: KVNamespacePutOptions) => Promise<void>> =
+      vi.spyOn(env.APP_DATA, "put");
+
+    appDataGetSpy.mockImplementation(async (key: string, options?: { type?: string }) => {
+      await Promise.resolve();
+      const value = storedByKey.get(key);
+      if (value == null) {
+        return null;
+      }
+
+      if (options?.type === "json") {
+        return JSON.parse(value) as unknown;
+      }
+
+      return value;
+    });
+    appDataPutSpy.mockImplementation(async (key: string, value: string) => {
+      await Promise.resolve();
+      storedByKey.set(key, value);
+    });
+
+    const matchId = "d81554d7-ddfe-44da-a6cb-000000000ctf";
+    const lookupCacheKey = "stats:discord:series:123456789012345678:7777:lookup";
+    await env.APP_DATA.put(
+      lookupCacheKey,
+      JSON.stringify({
+        status: "lookup-resolved",
+        guildId: "123456789012345678",
+        queueNumber: 7777,
+        matchIds: [123],
+      }),
+    );
+
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env });
+      vi.spyOn(services.discordService, "searchGuildMessages").mockResolvedValue({
+        doing_deep_historical_index: false,
+        total_results: 1,
+        messages: [
+          [
+            aFakeMessageWith({
+              id: "m-lookup-invalid-cache",
+              color: EmbedColors.INFO,
+              title: "Series stats for queue #7777",
+              gameFieldValue: `[Slayer](https://halodatahive.com/Infinite/Match/${matchId})`,
+            }),
+          ],
+        ],
+      });
+      return services;
+    });
+
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(
+      new Request("http://localhost/api/stats/discord/123456789012345678/7777/lookup"),
+      env,
+    )) as Response;
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      status: "resolved",
+      guildId: "123456789012345678",
+      queueNumber: 7777,
+      matchIds: [matchId],
+    });
+    expect(appDataGetSpy).toHaveBeenCalledWith("stats:discord:series:123456789012345678:7777", { type: "json" });
+    expect(appDataGetSpy).toHaveBeenCalledWith(lookupCacheKey, { type: "json" });
+  });
+
   it("returns forbidden when Discord service throws 403", async () => {
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });

--- a/api/services/discord/discord-series-stats.ts
+++ b/api/services/discord/discord-series-stats.ts
@@ -237,4 +237,3 @@ export async function buildDiscordSeriesRenderDataFromMatches({
     matches: renderMatches,
   };
 }
-

--- a/api/services/discord/discord-series-stats.ts
+++ b/api/services/discord/discord-series-stats.ts
@@ -103,10 +103,10 @@ async function getSubtitle(guildId: string, discordService: DiscordService, logS
     subtitle = guildName === "" ? `Guild ${guildId}` : guildName;
   } catch (error) {
     logService.warn(
-      "Failed to fetch guild name for discord series subtitle, falling back to guild id",
+      error,
       new Map([
         ["guildId", guildId],
-        ["error", String(error)],
+        ["reason", "Failed to fetch guild name for discord series subtitle, falling back to guild id"],
       ]),
     );
   }
@@ -130,11 +130,11 @@ async function getBestEffortMedalMetadata({
     return await getMedalMetadataFromMatches(matchesById, async (medalId) => haloService.getMedal(medalId));
   } catch (error) {
     logService.warn(
-      "Failed to resolve medal metadata for discord series stats, using empty metadata",
+      error,
       new Map([
         ["guildId", guildId],
         ["queueNumber", queueNumber.toString()],
-        ["error", String(error)],
+        ["reason", "Failed to resolve medal metadata for discord series stats, using empty metadata"],
       ]),
     );
     return {};

--- a/api/services/discord/discord-series-stats.ts
+++ b/api/services/discord/discord-series-stats.ts
@@ -160,13 +160,17 @@ export async function buildDiscordSeriesRenderDataFromMatches({
     throw new Error("No Halo match details were found for discovered match IDs");
   }
 
+  const sortedMatches = [...matches].sort((left, right) =>
+    left.MatchInfo.StartTime.localeCompare(right.MatchInfo.StartTime),
+  );
+
   const matchesById: Record<string, MatchStats> = {};
-  for (const match of matches) {
+  for (const match of sortedMatches) {
     matchesById[match.MatchId] = match;
   }
 
   const [playerXuidToGametagMap, medalMetadata] = await Promise.all([
-    haloService.getPlayerXuidsToGametags(matches),
+    haloService.getPlayerXuidsToGametags(sortedMatches),
     getBestEffortMedalMetadata({
       logService,
       haloService,
@@ -177,7 +181,7 @@ export async function buildDiscordSeriesRenderDataFromMatches({
   ]);
 
   const renderMatches = await Promise.all(
-    matches.map(async (match) => {
+    sortedMatches.map(async (match) => {
       const [gameTypeAndMap, mapThumbnailUrl] = await Promise.all([
         haloService.getGameTypeAndMap(match.MatchInfo),
         haloService.getMapThumbnailUrl(match.MatchInfo.MapVariant.AssetId, match.MatchInfo.MapVariant.VersionId),
@@ -213,7 +217,7 @@ export async function buildDiscordSeriesRenderDataFromMatches({
     }),
   );
 
-  const lastMatch = Preconditions.checkExists(matches[matches.length - 1]);
+  const lastMatch = Preconditions.checkExists(sortedMatches[sortedMatches.length - 1]);
   const teams = lastMatch.Teams.map((team) => ({
     name: getTeamName(team.TeamId),
     players: getTeamPlayersFromMatch(lastMatch, team.TeamId).map((player) => {
@@ -231,7 +235,7 @@ export async function buildDiscordSeriesRenderDataFromMatches({
   return {
     title: `Queue #${queueNumber.toString()} Series Stats`,
     subtitle,
-    seriesScore: haloService.getSeriesScore(matches, "en-US"),
+    seriesScore: haloService.getSeriesScore(sortedMatches, "en-US"),
     medalMetadata,
     teams,
     matches: renderMatches,

--- a/api/services/discord/discord-series-stats.ts
+++ b/api/services/discord/discord-series-stats.ts
@@ -1,0 +1,240 @@
+import type { MatchStats } from "halo-infinite-api";
+import type { APIEmbed, APIMessage } from "discord-api-types/v10";
+import { EmbedType } from "discord-api-types/v10";
+import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import { getReadableDuration } from "@guilty-spark/shared/halo/duration";
+import { getTeamName } from "@guilty-spark/shared/halo/team";
+import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
+import { getMedalMetadataFromMatches } from "@guilty-spark/shared/halo/medals";
+import type { DiscordSeriesStatsResolved } from "@guilty-spark/shared/contracts/stats/discord-series";
+import { EmbedColors } from "../../embeds/colors";
+import type { HaloService } from "../halo/halo";
+import type { LogService } from "../log/types";
+import type { DiscordService } from "./discord";
+
+const MATCH_ID_REGEX = /https:\/\/halodatahive\.com\/Infinite\/Match\/([a-zA-Z0-9-]+)/g;
+
+export const DISCORD_SERIES_STATS_RESOLVED_CACHE_TTL_SECONDS = 60 * 60 * 24;
+export const DISCORD_SERIES_STATS_RESOLVED_STALE_WHILE_REVALIDATE_SECONDS = 60 * 5;
+export const DISCORD_SERIES_STATS_RESOLVED_CACHE_CONTROL_HEADER = `public, s-maxage=${DISCORD_SERIES_STATS_RESOLVED_CACHE_TTL_SECONDS.toString()}, stale-while-revalidate=${DISCORD_SERIES_STATS_RESOLVED_STALE_WHILE_REVALIDATE_SECONDS.toString()}`;
+
+export function getDiscordSeriesStatsCacheKey(guildId: string, queueNumber: number): string {
+  return `stats:discord:series:${guildId}:${queueNumber.toString()}`;
+}
+
+export function getDiscordSeriesOverviewEmbed(message: APIMessage, queueNumber: number): APIEmbed | null {
+  for (const embed of message.embeds) {
+    if (embed.type !== EmbedType.Rich) {
+      continue;
+    }
+    if (embed.color !== EmbedColors.INFO) {
+      continue;
+    }
+
+    const match = embed.title?.match(/^Series stats for queue #(\d+)\b/);
+    if (match?.[1] !== queueNumber.toString()) {
+      continue;
+    }
+
+    return embed;
+  }
+
+  return null;
+}
+
+export function extractDiscordSeriesMatchIdsFromEmbeds(embeds: readonly APIEmbed[]): string[] {
+  const matchIds = new Set<string>();
+
+  for (const embed of embeds) {
+    const gameFieldValue = embed.fields?.find((field) => field.name === "Game")?.value;
+    if (gameFieldValue == null) {
+      continue;
+    }
+
+    const matches = gameFieldValue.matchAll(MATCH_ID_REGEX);
+    for (const match of matches) {
+      const [, matchId] = match;
+      if (matchId != null) {
+        matchIds.add(matchId);
+      }
+    }
+  }
+
+  return [...matchIds];
+}
+
+function splitGameTypeAndMap(gameTypeAndMap: string): { gameType: string; gameMap: string } {
+  const colonSplit = gameTypeAndMap.split(":");
+  if (colonSplit.length > 1) {
+    const gameType = (colonSplit[0] ?? "*Unknown Game Type*").trim() || "*Unknown Game Type*";
+    const gameMap = colonSplit.slice(1).join(":").trim() || "*Unknown Map*";
+    return { gameType, gameMap };
+  }
+
+  const separator = " on ";
+  const onIndex = gameTypeAndMap.indexOf(separator);
+  if (onIndex > 0) {
+    const gameType = gameTypeAndMap.slice(0, onIndex).trim();
+    const gameMap = gameTypeAndMap.slice(onIndex + separator.length).trim();
+    return {
+      gameType: gameType || "*Unknown Game Type*",
+      gameMap: gameMap || "*Unknown Map*",
+    };
+  }
+
+  return { gameType: "*Unknown Game Type*", gameMap: "*Unknown Map*" };
+}
+
+function getTeamPlayersFromMatch(match: MatchStats, teamId: number): MatchStats["Players"] {
+  return match.Players.filter((player) => {
+    if (!player.ParticipationInfo.PresentAtBeginning) {
+      return false;
+    }
+
+    return player.PlayerTeamStats.some((teamStats) => teamStats.TeamId === teamId);
+  });
+}
+
+async function getSubtitle(guildId: string, discordService: DiscordService, logService: LogService): Promise<string> {
+  let subtitle = `Guild ${guildId}`;
+  try {
+    const guild = await discordService.getGuild(guildId);
+    const guildName = guild.name.trim();
+    subtitle = guildName === "" ? `Guild ${guildId}` : guildName;
+  } catch (error) {
+    logService.warn(
+      "Failed to fetch guild name for discord series subtitle, falling back to guild id",
+      new Map([
+        ["guildId", guildId],
+        ["error", String(error)],
+      ]),
+    );
+  }
+  return subtitle;
+}
+
+async function getBestEffortMedalMetadata({
+  logService,
+  haloService,
+  matchesById,
+  guildId,
+  queueNumber,
+}: {
+  logService: LogService;
+  haloService: HaloService;
+  matchesById: Record<string, MatchStats>;
+  guildId: string;
+  queueNumber: number;
+}): Promise<DiscordSeriesStatsResolved["renderData"]["medalMetadata"]> {
+  try {
+    return await getMedalMetadataFromMatches(matchesById, async (medalId) => haloService.getMedal(medalId));
+  } catch (error) {
+    logService.warn(
+      "Failed to resolve medal metadata for discord series stats, using empty metadata",
+      new Map([
+        ["guildId", guildId],
+        ["queueNumber", queueNumber.toString()],
+        ["error", String(error)],
+      ]),
+    );
+    return {};
+  }
+}
+
+export async function buildDiscordSeriesRenderDataFromMatches({
+  discordService,
+  logService,
+  haloService,
+  guildId,
+  queueNumber,
+  matches,
+}: {
+  discordService: DiscordService;
+  logService: LogService;
+  haloService: HaloService;
+  guildId: string;
+  queueNumber: number;
+  matches: MatchStats[];
+}): Promise<DiscordSeriesStatsResolved["renderData"]> {
+  if (matches.length === 0) {
+    throw new Error("No Halo match details were found for discovered match IDs");
+  }
+
+  const matchesById: Record<string, MatchStats> = {};
+  for (const match of matches) {
+    matchesById[match.MatchId] = match;
+  }
+
+  const [playerXuidToGametagMap, medalMetadata] = await Promise.all([
+    haloService.getPlayerXuidsToGametags(matches),
+    getBestEffortMedalMetadata({
+      logService,
+      haloService,
+      matchesById,
+      guildId,
+      queueNumber,
+    }),
+  ]);
+
+  const renderMatches = await Promise.all(
+    matches.map(async (match) => {
+      const [gameTypeAndMap, mapThumbnailUrl] = await Promise.all([
+        haloService.getGameTypeAndMap(match.MatchInfo),
+        haloService.getMapThumbnailUrl(match.MatchInfo.MapVariant.AssetId, match.MatchInfo.MapVariant.VersionId),
+      ]);
+      const { gameType, gameMap } = splitGameTypeAndMap(gameTypeAndMap);
+      const { gameScore, gameSubScore } = haloService.getMatchScore(match, "en-US");
+
+      const playerXuidToGametag: Record<string, string> = {};
+      for (const player of match.Players) {
+        if (!player.ParticipationInfo.PresentAtBeginning || player.PlayerType !== 1) {
+          continue;
+        }
+
+        const xuid = getPlayerXuid(player);
+        playerXuidToGametag[xuid] = playerXuidToGametagMap.get(xuid) ?? "*Unknown*";
+      }
+
+      return {
+        matchId: match.MatchId,
+        gameTypeAndMap,
+        gameVariantCategory: match.MatchInfo.GameVariantCategory,
+        gameType,
+        gameMap,
+        gameMapThumbnailUrl: mapThumbnailUrl ?? "data:,",
+        duration: getReadableDuration(match.MatchInfo.Duration, "en-US"),
+        gameScore,
+        gameSubScore,
+        startTime: new Date(match.MatchInfo.StartTime).toISOString(),
+        endTime: new Date(match.MatchInfo.EndTime).toISOString(),
+        playerXuidToGametag,
+        rawMatch: match,
+      };
+    }),
+  );
+
+  const lastMatch = Preconditions.checkExists(matches[matches.length - 1]);
+  const teams = lastMatch.Teams.map((team) => ({
+    name: getTeamName(team.TeamId),
+    players: getTeamPlayersFromMatch(lastMatch, team.TeamId).map((player) => {
+      if (player.PlayerType !== 1) {
+        return "Bot";
+      }
+
+      const xuid = getPlayerXuid(player);
+      return playerXuidToGametagMap.get(xuid) ?? "*Unknown*";
+    }),
+  }));
+
+  const subtitle = await getSubtitle(guildId, discordService, logService);
+
+  return {
+    title: `Queue #${queueNumber.toString()} Series Stats`,
+    subtitle,
+    seriesScore: haloService.getSeriesScore(matches, "en-US"),
+    medalMetadata,
+    teams,
+    matches: renderMatches,
+  };
+}
+

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -30,6 +30,8 @@ import type {
 import {
   ComponentType,
   ChannelType,
+  MessageSearchAuthorType,
+  MessageSearchSortMode,
   MessageFlags,
   APIVersion,
   ApplicationCommandType,
@@ -41,6 +43,14 @@ import {
 } from "discord-api-types/v10";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import {
+  discordSeriesStatsContract,
+  type DiscordSeriesStats,
+  type DiscordSeriesStatsForbidden,
+  type DiscordSeriesStatsNotFound,
+  type DiscordSeriesStatsPending,
+  type DiscordSeriesStatsResolved,
+} from "@guilty-spark/shared/contracts/stats/discord-series";
 import type { BaseCommand, BaseInteraction } from "../../commands/base/base-command";
 import type { DiscordAssociationsRow } from "../database/types/discord_associations";
 import { AssociationReason } from "../database/types/discord_associations";
@@ -50,6 +60,12 @@ import { TimeInSeconds } from "../halo/types";
 import { JsonResponse } from "./json-response";
 import { AppEmojis } from "./emoji";
 import { DiscordError } from "./discord-error";
+import {
+  DISCORD_SERIES_STATS_RESOLVED_CACHE_TTL_SECONDS,
+  extractDiscordSeriesMatchIdsFromEmbeds,
+  getDiscordSeriesOverviewEmbed,
+  getDiscordSeriesStatsCacheKey,
+} from "./discord-series-stats";
 
 export const NEAT_QUEUE_BOT_USER_ID = "857633321064595466";
 
@@ -74,6 +90,41 @@ export interface SubcommandData {
   name: string;
   options: APIApplicationCommandInteractionDataBasicOption[] | undefined;
   mappedOptions: Map<string, APIApplicationCommandInteractionDataBasicOption["value"]>;
+}
+
+export type DiscordSeriesLookupResult =
+  | {
+      status: "resolved";
+      guildId: string;
+      queueNumber: number;
+      matchIds: string[];
+    }
+  | DiscordSeriesStatsPending
+  | DiscordSeriesStatsNotFound;
+
+function getForbiddenDiscordSeriesStats(guildId: string, queueNumber: number): DiscordSeriesStatsForbidden {
+  return {
+    status: "forbidden",
+    guildId,
+    queueNumber,
+    reason: "Missing Discord permissions or message content access",
+  };
+}
+
+const DEFAULT_PENDING_RETRY_SECONDS = 2;
+const PENDING_CACHE_TTL_SECONDS = 60 * 5;
+const NOT_FOUND_CACHE_TTL_SECONDS = 60 * 5;
+
+function sanitizeRetryAfterSeconds(retryAfterValue: unknown): number {
+  if (typeof retryAfterValue !== "number") {
+    return DEFAULT_PENDING_RETRY_SECONDS;
+  }
+
+  if (!Number.isFinite(retryAfterValue) || retryAfterValue <= 0) {
+    return DEFAULT_PENDING_RETRY_SECONDS;
+  }
+
+  return retryAfterValue;
 }
 
 type VerifyDiscordResponse =
@@ -322,6 +373,208 @@ export class DiscordService {
     );
     this.logService.debug("Found queue data", new Map([["queueData", JSON.stringify(queueData)]]));
     return queueData;
+  }
+
+  async getSeriesStatsLookup(
+    guildId: string,
+    queueNumber: number,
+  ): Promise<DiscordSeriesStats | DiscordSeriesLookupResult | DiscordSeriesStatsForbidden> {
+    try {
+      const cached = await this.getCachedDiscordSeriesStats(guildId, queueNumber);
+      if (cached != null) {
+        return cached;
+      }
+
+      const lookupResult = await this.findDiscordSeriesLookupResult(guildId, queueNumber);
+      await this.cacheDiscordSeriesLookupResult(lookupResult);
+      return lookupResult;
+    } catch (error) {
+      if (error instanceof DiscordError && error.httpStatus === 429) {
+        return await this.cacheDiscordSeriesPending(guildId, queueNumber, (error.restError as { retry_after?: unknown }).retry_after);
+      }
+
+      if (error instanceof DiscordError && error.httpStatus === 403) {
+        return getForbiddenDiscordSeriesStats(guildId, queueNumber);
+      }
+
+      throw error;
+    }
+  }
+
+  async getSeriesStats({
+    guildId,
+    queueNumber,
+    resolveRenderData,
+  }: {
+    guildId: string;
+    queueNumber: number;
+    resolveRenderData: (matchIds: string[]) => Promise<DiscordSeriesStatsResolved["renderData"]>;
+  }): Promise<DiscordSeriesStats | DiscordSeriesStatsForbidden> {
+    const lookupOrCached = await this.getSeriesStatsLookup(guildId, queueNumber);
+
+    if (lookupOrCached.status === "pending-index") {
+      return lookupOrCached;
+    }
+
+    if (lookupOrCached.status === "not-found") {
+      return lookupOrCached;
+    }
+
+    if (lookupOrCached.status === "forbidden") {
+      return lookupOrCached;
+    }
+
+    if ("renderData" in lookupOrCached) {
+      return lookupOrCached;
+    }
+
+    const renderData = await resolveRenderData(lookupOrCached.matchIds);
+    const resolvedResponse: DiscordSeriesStats = {
+      status: "resolved",
+      guildId,
+      queueNumber,
+      matchIds: lookupOrCached.matchIds,
+      renderData,
+    };
+
+    await this.cacheResolvedDiscordSeriesStats({
+      guildId,
+      queueNumber,
+      matchIds: lookupOrCached.matchIds,
+      renderData,
+    });
+
+    return resolvedResponse;
+  }
+
+  private async getCachedDiscordSeriesStats(guildId: string, queueNumber: number): Promise<DiscordSeriesStats | null> {
+    const cacheKey = getDiscordSeriesStatsCacheKey(guildId, queueNumber);
+    const cached = await this.env.APP_DATA.get<DiscordSeriesStats>(cacheKey, { type: "json" });
+    if (cached == null || typeof cached !== "object") {
+      return null;
+    }
+
+    const cachedParseResult = discordSeriesStatsContract.safeParse(cached);
+    if (cachedParseResult.success) {
+      return cachedParseResult.data;
+    }
+
+    this.logService.warn("Invalid cached discord series stats payload, treating as cache miss", new Map([["cacheKey", cacheKey]]));
+    return null;
+  }
+
+  private async findDiscordSeriesLookupResult(guildId: string, queueNumber: number): Promise<DiscordSeriesLookupResult> {
+    const searchResponse = await this.searchGuildMessages(guildId, {
+      content: `Series stats for queue #${queueNumber.toString()}`,
+      author_id: [this.env.DISCORD_APP_ID],
+      author_type: [MessageSearchAuthorType.Bot],
+      sort_by: MessageSearchSortMode.Timestamp,
+      sort_order: "desc",
+      limit: 25,
+    });
+
+    if ("retry_after" in searchResponse) {
+      return {
+        status: "pending-index",
+        guildId,
+        queueNumber,
+        retryAfterSeconds: sanitizeRetryAfterSeconds(searchResponse.retry_after),
+      };
+    }
+
+    const flattenedMessages = searchResponse.messages.flatMap((messages: APIMessage[]): APIMessage[] => messages);
+    const blueOverviewCandidates = flattenedMessages.filter(
+      (message: APIMessage) => getDiscordSeriesOverviewEmbed(message, queueNumber) != null,
+    );
+
+    if (blueOverviewCandidates.length === 0) {
+      return {
+        status: "not-found",
+        guildId,
+        queueNumber,
+        reason: "No matching series overview embeds found",
+      };
+    }
+
+    const selectedOverviewMessage = Preconditions.checkExists(blueOverviewCandidates[0]);
+    const matchIds = extractDiscordSeriesMatchIdsFromEmbeds(selectedOverviewMessage.embeds);
+
+    if (matchIds.length === 0) {
+      return {
+        status: "not-found",
+        guildId,
+        queueNumber,
+        reason: "Series overview embed found but no match IDs were discoverable",
+      };
+    }
+
+    return {
+      status: "resolved",
+      guildId,
+      queueNumber,
+      matchIds,
+    };
+  }
+
+  private async cacheDiscordSeriesPending(
+    guildId: string,
+    queueNumber: number,
+    retryAfterValue: unknown,
+  ): Promise<DiscordSeriesStatsPending> {
+    const pendingResponse: DiscordSeriesStatsPending = {
+      status: "pending-index",
+      guildId,
+      queueNumber,
+      retryAfterSeconds: sanitizeRetryAfterSeconds(retryAfterValue),
+    };
+    const cacheKey = getDiscordSeriesStatsCacheKey(guildId, queueNumber);
+    await this.env.APP_DATA.put(cacheKey, JSON.stringify(pendingResponse), {
+      expirationTtl: PENDING_CACHE_TTL_SECONDS,
+    });
+
+    return pendingResponse;
+  }
+
+  private async cacheDiscordSeriesLookupResult(lookupResult: DiscordSeriesLookupResult): Promise<void> {
+    const cacheKey = getDiscordSeriesStatsCacheKey(lookupResult.guildId, lookupResult.queueNumber);
+
+    if (lookupResult.status === "pending-index") {
+      await this.env.APP_DATA.put(cacheKey, JSON.stringify(lookupResult), {
+        expirationTtl: PENDING_CACHE_TTL_SECONDS,
+      });
+      return;
+    }
+
+    if (lookupResult.status === "not-found") {
+      await this.env.APP_DATA.put(cacheKey, JSON.stringify(lookupResult), {
+        expirationTtl: NOT_FOUND_CACHE_TTL_SECONDS,
+      });
+    }
+  }
+
+  async cacheResolvedDiscordSeriesStats({
+    guildId,
+    queueNumber,
+    matchIds,
+    renderData,
+  }: {
+    guildId: string;
+    queueNumber: number;
+    matchIds: string[];
+    renderData: DiscordSeriesStatsResolved["renderData"];
+  }): Promise<void> {
+    const cacheKey = getDiscordSeriesStatsCacheKey(guildId, queueNumber);
+    const resolvedResponse: DiscordSeriesStatsResolved = {
+      status: "resolved",
+      guildId,
+      queueNumber,
+      matchIds,
+      renderData,
+    };
+
+    await this.env.APP_DATA.put(cacheKey, JSON.stringify(resolvedResponse), {
+      expirationTtl: DISCORD_SERIES_STATS_RESOLVED_CACHE_TTL_SECONDS,
+    });
   }
 
   async getTeamsFromMessage(guildId: string, message: APIMessage): Promise<QueueData> {

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -390,7 +390,11 @@ export class DiscordService {
       return lookupResult;
     } catch (error) {
       if (error instanceof DiscordError && error.httpStatus === 429) {
-        return await this.cacheDiscordSeriesPending(guildId, queueNumber, (error.restError as { retry_after?: unknown }).retry_after);
+        return await this.cacheDiscordSeriesPending(
+          guildId,
+          queueNumber,
+          (error.restError as { retry_after?: unknown }).retry_after,
+        );
       }
 
       if (error instanceof DiscordError && error.httpStatus === 403) {
@@ -459,11 +463,17 @@ export class DiscordService {
       return cachedParseResult.data;
     }
 
-    this.logService.warn("Invalid cached discord series stats payload, treating as cache miss", new Map([["cacheKey", cacheKey]]));
+    this.logService.warn(
+      "Invalid cached discord series stats payload, treating as cache miss",
+      new Map([["cacheKey", cacheKey]]),
+    );
     return null;
   }
 
-  private async findDiscordSeriesLookupResult(guildId: string, queueNumber: number): Promise<DiscordSeriesLookupResult> {
+  private async findDiscordSeriesLookupResult(
+    guildId: string,
+    queueNumber: number,
+  ): Promise<DiscordSeriesLookupResult> {
     const searchResponse = await this.searchGuildMessages(guildId, {
       content: `Series stats for queue #${queueNumber.toString()}`,
       author_id: [this.env.DISCORD_APP_ID],

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -591,6 +591,30 @@ export class DiscordService {
       return null;
     }
 
+    if (cached.guildId !== guildId || cached.queueNumber !== queueNumber) {
+      this.logService.warn(
+        "Invalid cached discord series lookup payload, treating as cache miss",
+        new Map([
+          ["cacheKey", lookupCacheKey],
+          ["reason", "Mismatched guildId or queueNumber"],
+        ]),
+      );
+      return null;
+    }
+
+    const hasValidMatchIds =
+      Array.isArray(cached.matchIds) && cached.matchIds.every((matchId) => typeof matchId === "string");
+    if (!hasValidMatchIds) {
+      this.logService.warn(
+        "Invalid cached discord series lookup payload, treating as cache miss",
+        new Map([
+          ["cacheKey", lookupCacheKey],
+          ["reason", "matchIds must be an array of strings"],
+        ]),
+      );
+      return null;
+    }
+
     return cached;
   }
 

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -115,6 +115,10 @@ const DEFAULT_PENDING_RETRY_SECONDS = 2;
 const PENDING_CACHE_TTL_SECONDS = 60 * 5;
 const NOT_FOUND_CACHE_TTL_SECONDS = 60 * 5;
 
+function getDiscordSeriesStatsLookupCacheKey(guildId: string, queueNumber: number): string {
+  return `${getDiscordSeriesStatsCacheKey(guildId, queueNumber)}:lookup`;
+}
+
 function sanitizeRetryAfterSeconds(retryAfterValue: unknown): number {
   if (typeof retryAfterValue !== "number") {
     return DEFAULT_PENDING_RETRY_SECONDS;
@@ -385,6 +389,11 @@ export class DiscordService {
         return cached;
       }
 
+      const cachedLookup = await this.getCachedDiscordSeriesLookupResult(guildId, queueNumber);
+      if (cachedLookup != null) {
+        return cachedLookup;
+      }
+
       const lookupResult = await this.findDiscordSeriesLookupResult(guildId, queueNumber);
       await this.cacheDiscordSeriesLookupResult(lookupResult);
       return lookupResult;
@@ -547,6 +556,7 @@ export class DiscordService {
 
   private async cacheDiscordSeriesLookupResult(lookupResult: DiscordSeriesLookupResult): Promise<void> {
     const cacheKey = getDiscordSeriesStatsCacheKey(lookupResult.guildId, lookupResult.queueNumber);
+    const lookupCacheKey = getDiscordSeriesStatsLookupCacheKey(lookupResult.guildId, lookupResult.queueNumber);
 
     if (lookupResult.status === "pending-index") {
       await this.env.APP_DATA.put(cacheKey, JSON.stringify(lookupResult), {
@@ -559,7 +569,29 @@ export class DiscordService {
       await this.env.APP_DATA.put(cacheKey, JSON.stringify(lookupResult), {
         expirationTtl: NOT_FOUND_CACHE_TTL_SECONDS,
       });
+      return;
     }
+
+    await this.env.APP_DATA.put(lookupCacheKey, JSON.stringify(lookupResult), {
+      expirationTtl: DISCORD_SERIES_STATS_RESOLVED_CACHE_TTL_SECONDS,
+    });
+  }
+
+  private async getCachedDiscordSeriesLookupResult(
+    guildId: string,
+    queueNumber: number,
+  ): Promise<DiscordSeriesLookupResult | null> {
+    const lookupCacheKey = getDiscordSeriesStatsLookupCacheKey(guildId, queueNumber);
+    const cached = await this.env.APP_DATA.get<DiscordSeriesLookupResult>(lookupCacheKey, { type: "json" });
+    if (cached == null || typeof cached !== "object") {
+      return null;
+    }
+
+    if (cached.status !== "resolved") {
+      return null;
+    }
+
+    return cached;
   }
 
   async cacheResolvedDiscordSeriesStats({

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -94,7 +94,7 @@ export interface SubcommandData {
 
 export type DiscordSeriesLookupResult =
   | {
-      status: "resolved";
+      status: "lookup-resolved";
       guildId: string;
       queueNumber: number;
       matchIds: string[];
@@ -437,7 +437,7 @@ export class DiscordService {
       return lookupOrCached;
     }
 
-    if ("renderData" in lookupOrCached) {
+    if (lookupOrCached.status === "resolved") {
       return lookupOrCached;
     }
 
@@ -528,7 +528,7 @@ export class DiscordService {
     }
 
     return {
-      status: "resolved",
+      status: "lookup-resolved",
       guildId,
       queueNumber,
       matchIds,
@@ -587,7 +587,7 @@ export class DiscordService {
       return null;
     }
 
-    if (cached.status !== "resolved") {
+    if (cached.status !== "lookup-resolved") {
       return null;
     }
 

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -2084,7 +2084,7 @@ export class NeatQueueService {
         new Map([
           ["guildId", guildId],
           ["queueNumber", queueNumber.toString()],
-          ["context", "Failed to cache discord series stats from neatqueue flow"],
+          ["reason", "Failed to cache discord series stats from neatqueue flow"],
         ]),
       );
     }

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -2075,7 +2075,7 @@ export class NeatQueueService {
       await discordService.cacheResolvedDiscordSeriesStats({
         guildId,
         queueNumber,
-        matchIds: series.map((match) => match.MatchId),
+        matchIds: renderData.matches.map((match) => match.matchId),
         renderData,
       });
     } catch (error) {

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -43,6 +43,7 @@ import { DiscordError } from "../discord/discord-error";
 import { MapsEmbed } from "../../embeds/maps-embed";
 import { isSuccessResponse } from "../../durable-objects/live-tracker/types";
 import { NeatQueuePlayersEmbed } from "../../embeds/neatqueue/neatqueue-players-embed";
+import { buildDiscordSeriesRenderDataFromMatches } from "../discord/discord-series-stats";
 import type { SeriesPlayer, SeriesTeam } from "../../durable-objects/individual-tracker/types";
 import type { IndividualTrackerService } from "../individual-tracker/individual-tracker";
 import type {
@@ -353,6 +354,8 @@ export class NeatQueueService {
       } else {
         await discordService.updateDeferredReply(interaction.token, data);
       }
+
+      await this.cacheDiscordSeriesStats(guildId, queue, series);
 
       if (channel.type !== ChannelType.PublicThread && channel.type !== ChannelType.AnnouncementThread) {
         const thread = await discordService.startThreadFromMessage(
@@ -1782,7 +1785,10 @@ export class NeatQueueService {
         components: seriesOverviewEmbed.components,
       });
 
-      await this.postSeriesDetailsToChannel(thread.id, request.guild, series);
+      await Promise.all([
+        this.cacheDiscordSeriesStats(request.guild, request.match_number, series),
+        this.postSeriesDetailsToChannel(thread.id, request.guild, series),
+      ]);
     } catch (error) {
       this.logService.warn(error, new Map([["reason", "Failed to post series data to thread"]]));
 
@@ -1897,7 +1903,10 @@ export class NeatQueueService {
       );
 
       channelId = thread.id;
-      await this.postSeriesDetailsToChannel(channelId, request.guild, series);
+      await Promise.all([
+        this.cacheDiscordSeriesStats(request.guild, request.match_number, series),
+        this.postSeriesDetailsToChannel(channelId, request.guild, series),
+      ]);
     } catch (error) {
       this.logService.error(error, new Map([["reason", "Failed to post series data direct to channel"]]));
 
@@ -2048,6 +2057,37 @@ export class NeatQueueService {
       substitutions,
       hideTeamsDescription: true,
     });
+  }
+
+  private async cacheDiscordSeriesStats(guildId: string, queueNumber: number, series: MatchStats[]): Promise<void> {
+    const { discordService, haloService, logService } = this;
+
+    try {
+      const renderData = await buildDiscordSeriesRenderDataFromMatches({
+        discordService,
+        logService,
+        haloService,
+        guildId,
+        queueNumber,
+        matches: series,
+      });
+
+      await discordService.cacheResolvedDiscordSeriesStats({
+        guildId,
+        queueNumber,
+        matchIds: series.map((match) => match.MatchId),
+        renderData,
+      });
+    } catch (error) {
+      logService.warn(
+        error,
+        new Map([
+          ["guildId", guildId],
+          ["queueNumber", queueNumber.toString()],
+          ["context", "Failed to cache discord series stats from neatqueue flow"],
+        ]),
+      );
+    }
   }
 
   private async clearTimeline(request: NeatQueueTimelineRequest, neatQueueConfig: NeatQueueConfigRow): Promise<void> {

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -915,8 +915,8 @@ describe("NeatQueueService", () => {
           expect(cacheResolvedDiscordSeriesStatsSpy).toHaveBeenCalledWith(
             expect.objectContaining({
               queueNumber: 2,
-              guildId: expect.any(String),
-              matchIds: expect.any(Array),
+              guildId: expect.any(String) as string,
+              matchIds: expect.any(Array) as string[],
             }),
           );
         });
@@ -1392,7 +1392,7 @@ describe("NeatQueueService", () => {
         expect.objectContaining({
           guildId: "guild-123",
           queueNumber: 1,
-          matchIds: expect.any(Array),
+          matchIds: expect.any(Array) as string[],
         }),
       );
     });

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -1278,6 +1278,8 @@ describe("NeatQueueService", () => {
     let fakeMessage: APIMessage;
     let fakeErrorEmbed: EndUserError;
     let cacheResolvedDiscordSeriesStatsSpy: MockInstance<typeof discordService.cacheResolvedDiscordSeriesStats>;
+    let getSeriesFromDiscordQueueSpy: MockInstance<typeof haloService.getSeriesFromDiscordQueue>;
+    let editMessageSpy: MockInstance<typeof discordService.editMessage>;
 
     beforeEach(() => {
       fakeMessage = {
@@ -1367,16 +1369,14 @@ describe("NeatQueueService", () => {
         return new Date();
       });
 
-      vi.spyOn(haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
-      vi.spyOn(discordService, "editMessage").mockResolvedValue(apiMessage);
+      getSeriesFromDiscordQueueSpy = vi.spyOn(haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
+      editMessageSpy = vi.spyOn(discordService, "editMessage").mockResolvedValue(apiMessage);
       cacheResolvedDiscordSeriesStatsSpy = vi
         .spyOn(discordService, "cacheResolvedDiscordSeriesStats")
         .mockResolvedValue();
     });
 
     it("processes retry for failed series fetch", async () => {
-      const getSeriesFromDiscordQueueSpy = vi.spyOn(haloService, "getSeriesFromDiscordQueue");
-      const editMessageSpy = vi.spyOn(discordService, "editMessage");
       const match = Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf"));
       getSeriesFromDiscordQueueSpy.mockResolvedValue([match]);
 
@@ -1401,7 +1401,7 @@ describe("NeatQueueService", () => {
       vi.spyOn(discordService, "getTeamsFromQueueResult").mockRejectedValue(
         new EndUserError("Error getting teams from queue result"),
       );
-      const editMessageSpy = vi.spyOn(discordService, "editMessage").mockResolvedValue(apiMessage);
+      const editMessageSpyForMissingQueue = vi.spyOn(discordService, "editMessage").mockResolvedValue(apiMessage);
 
       await neatQueueService.handleRetry({
         errorEmbed: fakeErrorEmbed,
@@ -1409,8 +1409,8 @@ describe("NeatQueueService", () => {
         message: fakeMessage,
       });
 
-      expect(editMessageSpy).toHaveBeenCalledOnce();
-      expect(editMessageSpy.mock.calls[0]).toMatchInlineSnapshot(`
+      expect(editMessageSpyForMissingQueue).toHaveBeenCalledOnce();
+      expect(editMessageSpyForMissingQueue.mock.calls[0]).toMatchInlineSnapshot(`
         [
           "channel-123",
           "1314562775950954626",
@@ -1464,7 +1464,7 @@ describe("NeatQueueService", () => {
         token: "fake-interaction-token",
       } as APIApplicationCommandInteraction;
 
-      const getSeriesFromDiscordQueueSpy = vi.spyOn(haloService, "getSeriesFromDiscordQueue");
+      const getSeriesFromDiscordQueueSpyForInteraction = vi.spyOn(haloService, "getSeriesFromDiscordQueue");
       const updateDeferredReplySpy = vi.spyOn(discordService, "updateDeferredReply").mockResolvedValue(apiMessage);
 
       await neatQueueService.handleRetry({
@@ -1473,7 +1473,7 @@ describe("NeatQueueService", () => {
         interaction: fakeInteraction,
       });
 
-      expect(getSeriesFromDiscordQueueSpy).toHaveBeenCalled();
+      expect(getSeriesFromDiscordQueueSpyForInteraction).toHaveBeenCalled();
       expect(updateDeferredReplySpy).toHaveBeenCalledWith("fake-interaction-token", expect.any(Object));
     });
 

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -645,6 +645,7 @@ describe("NeatQueueService", () => {
       let haloServiceUpdateDiscordAssociationsSpy: MockInstance<typeof haloService.updateDiscordAssociations>;
       let discordServiceStartThreadFromMessageSpy: MockInstance<typeof discordService.startThreadFromMessage>;
       let discordServiceCreateMessageSpy: MockInstance<typeof discordService.createMessage>;
+      let cacheResolvedDiscordSeriesStatsSpy: MockInstance<typeof discordService.cacheResolvedDiscordSeriesStats>;
 
       beforeEach(() => {
         appDataGetSpy = vi.spyOn(env.APP_DATA, "get");
@@ -659,6 +660,9 @@ describe("NeatQueueService", () => {
           }),
         );
         appDataDeleteSpy = vi.spyOn(env.APP_DATA, "delete").mockResolvedValue();
+        cacheResolvedDiscordSeriesStatsSpy = vi
+          .spyOn(discordService, "cacheResolvedDiscordSeriesStats")
+          .mockResolvedValue();
 
         // Mock live tracker to be inactive so tests fall back to timeline-based flow
         vi.spyOn(liveTrackerService, "getTrackerStatus").mockResolvedValue({
@@ -908,6 +912,13 @@ describe("NeatQueueService", () => {
           expect(discordServiceCreateMessageSpy).toHaveBeenCalledTimes(5);
           expect(discordServiceCreateMessageSpy.mock.calls).toMatchSnapshot();
           expect(appDataDeleteSpy).toHaveBeenCalledWith("neatqueue:state:guild-1:2");
+          expect(cacheResolvedDiscordSeriesStatsSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+              queueNumber: 2,
+              guildId: expect.any(String),
+              matchIds: expect.any(Array),
+            }),
+          );
         });
 
         it("creates the thread/message and posts overviews and game stats, clears timeline", async () => {
@@ -1141,7 +1152,7 @@ describe("NeatQueueService", () => {
 
             await jobToComplete?.();
 
-            expect(logServiceWarnSpy).toHaveBeenCalledExactlyOnceWith(
+            expect(logServiceWarnSpy).toHaveBeenCalledWith(
               error,
               new Map([["reason", "Failed to post series data to thread"]]),
             );
@@ -1266,6 +1277,7 @@ describe("NeatQueueService", () => {
   describe("handleRetry", () => {
     let fakeMessage: APIMessage;
     let fakeErrorEmbed: EndUserError;
+    let cacheResolvedDiscordSeriesStatsSpy: MockInstance<typeof discordService.cacheResolvedDiscordSeriesStats>;
 
     beforeEach(() => {
       fakeMessage = {
@@ -1357,11 +1369,16 @@ describe("NeatQueueService", () => {
 
       vi.spyOn(haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
       vi.spyOn(discordService, "editMessage").mockResolvedValue(apiMessage);
+      cacheResolvedDiscordSeriesStatsSpy = vi
+        .spyOn(discordService, "cacheResolvedDiscordSeriesStats")
+        .mockResolvedValue();
     });
 
     it("processes retry for failed series fetch", async () => {
       const getSeriesFromDiscordQueueSpy = vi.spyOn(haloService, "getSeriesFromDiscordQueue");
       const editMessageSpy = vi.spyOn(discordService, "editMessage");
+      const match = Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf"));
+      getSeriesFromDiscordQueueSpy.mockResolvedValue([match]);
 
       await neatQueueService.handleRetry({
         errorEmbed: fakeErrorEmbed,
@@ -1371,6 +1388,13 @@ describe("NeatQueueService", () => {
 
       expect(getSeriesFromDiscordQueueSpy).toHaveBeenCalled();
       expect(editMessageSpy).toHaveBeenCalled();
+      expect(cacheResolvedDiscordSeriesStatsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          guildId: "guild-123",
+          queueNumber: 1,
+          matchIds: expect.any(Array),
+        }),
+      );
     });
 
     it("handles missing queue message gracefully", async () => {

--- a/pages/worker-configuration.d.ts
+++ b/pages/worker-configuration.d.ts
@@ -10327,7 +10327,7 @@ type AIGatewayHeaders = {
     [key: string]: string | number | boolean | object;
 };
 type AIGatewayUniversalRequest = {
-    provider: AIGatewayProviders | string; // eslint-disable-line
+    provider: AIGatewayProviders | string;  
     endpoint: string;
     headers: Partial<AIGatewayHeaders>;
     query: unknown;
@@ -10344,7 +10344,7 @@ declare abstract class AiGateway {
         extraHeaders?: object;
         signal?: AbortSignal;
     }): Promise<Response>;
-    getUrl(provider?: AIGatewayProviders | string): Promise<string>; // eslint-disable-line
+    getUrl(provider?: AIGatewayProviders | string): Promise<string>;  
 }
 // Copyright (c) 2022-2025 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:


### PR DESCRIPTION
## Context
Discord Message Content privileged-intent re-application needs a stronger technical narrative: prefer state-first retrieval, narrow fallback behavior, and minimize repeated Discord search calls. This change continues the P0-03 hardening work by consolidating Discord series lookup/cache behavior into the Discord service and ensuring series overview posting paths hydrate cache reliably.

## This PR
- Centralizes series stats lookup and caching behavior in DiscordService via high-level APIs.
- Extracts shared series helpers into a dedicated module for cache keying, embed parsing, and render-data construction.
- Refactors stats route and stats command to call service-level APIs and direct cache write methods rather than ad hoc warm/fetch flows.
- Ensures NeatQueue series overview success paths write cache and, where appropriate, runs cache + detail posting concurrently with Promise.all.
- Adds/updates focused tests to assert cache hydration behavior on NeatQueue and stats paths.

Validation:
- npm run typecheck:api
- npx vitest run api/services/neatqueue/tests/neatqueue.test.ts
- npx vitest run api/commands/stats/tests/stats.test.ts api/routes/stats/tests/discord-series.test.ts

## Subsequent Work
- Expand integration-level coverage around partial failures (overview post succeeds, detail posting fails) to verify cache-first read behavior end-to-end.
- Apply the same cache-hydration guarantees to any remaining non-NeatQueue entrypoints that render series overview embeds.
