### PR TITLE
Add state-first active queue lookup for live tracker parity

### DIFF
--- a/api/commands/track/tests/track.test.ts
+++ b/api/commands/track/tests/track.test.ts
@@ -220,11 +220,7 @@ describe("TrackCommand", () => {
     let repostTrackerSpy: MockInstance<LiveTrackerService["repostTracker"]>;
 
     beforeEach(() => {
-      const mockQueueData = {
-        ...discordNeatQueueData,
-        queue: 42,
-      };
-      vi.spyOn(services.discordService, "getTeamsFromQueueChannel").mockResolvedValue(mockQueueData);
+      vi.spyOn(services.discordService, "getActiveQueueNumber").mockResolvedValue(42);
 
       pauseTrackerSpy = vi.spyOn(services.liveTrackerService, "pauseTracker");
       resumeTrackerSpy = vi.spyOn(services.liveTrackerService, "resumeTracker");

--- a/api/commands/track/track.ts
+++ b/api/commands/track/track.ts
@@ -427,13 +427,11 @@ export class TrackCommand extends BaseCommand {
 
   private async getTrackerStatus(guildId: string, channelId: string): Promise<LiveTrackerState | null> {
     try {
-      // First try to get active queue data to determine the queue number
-      const activeQueueData = await this.services.discordService.getTeamsFromQueueChannel(guildId, channelId);
-      if (!activeQueueData) {
+      const queueNumber = await this.services.discordService.getActiveQueueNumber(guildId, channelId);
+      if (queueNumber == null) {
         return null;
       }
 
-      const queueNumber = activeQueueData.queue;
       const statusResponse = await this.services.liveTrackerService.getTrackerStatus({
         userId: "", // Not needed for status check
         guildId,

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -749,11 +749,18 @@ export class DiscordService {
       return cachedQueueNumber;
     }
 
-    const activeQueueData = Preconditions.checkExists(
-      await this.getTeamsFromQueueChannel(guildId, channelId),
-      "No active queue data found",
-    );
-    return activeQueueData.queue;
+    try {
+      const activeQueueData = Preconditions.checkExists(
+        await this.getTeamsFromQueueChannel(guildId, channelId),
+        "No active queue data found",
+      );
+      return activeQueueData.queue;
+    } catch (error) {
+      if (error instanceof EndUserError && error.errorType === EndUserErrorType.WARNING) {
+        return null;
+      }
+      throw error;
+    }
   }
 
   private cacheActiveQueueNumber(guildId: string, channelId: string, queueNumber: number): void {

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -761,16 +761,38 @@ export class DiscordService {
     const cacheKey = getActiveQueueLookupCacheKey(guildId, channelId);
     const payload = { guildId, channelId, queueNumber };
 
-    await this.env.APP_DATA.put(cacheKey, JSON.stringify(payload), {
-      expirationTtl: ACTIVE_QUEUE_LOOKUP_CACHE_TTL_SECONDS,
-    });
+    try {
+      await this.env.APP_DATA.put(cacheKey, JSON.stringify(payload), {
+        expirationTtl: ACTIVE_QUEUE_LOOKUP_CACHE_TTL_SECONDS,
+      });
+    } catch (error) {
+      this.logService.warn(
+        error,
+        new Map([
+          ["cacheKey", cacheKey],
+          ["reason", "Failed to cache active queue number"],
+        ]),
+      );
+    }
   }
 
   private async getCachedActiveQueueNumber(guildId: string, channelId: string): Promise<number | null> {
     const cacheKey = getActiveQueueLookupCacheKey(guildId, channelId);
-    const cached = await this.env.APP_DATA.get<{ guildId: string; channelId: string; queueNumber: number }>(cacheKey, {
-      type: "json",
-    });
+    let cached: { guildId: string; channelId: string; queueNumber: number } | null;
+    try {
+      cached = await this.env.APP_DATA.get<{ guildId: string; channelId: string; queueNumber: number }>(cacheKey, {
+        type: "json",
+      });
+    } catch (error) {
+      this.logService.warn(
+        error,
+        new Map([
+          ["cacheKey", cacheKey],
+          ["reason", "Failed to read cached active queue number"],
+        ]),
+      );
+      return null;
+    }
 
     if (cached == null || typeof cached !== "object") {
       return null;

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -732,7 +732,7 @@ export class DiscordService {
       });
     }
 
-    await this.cacheActiveQueueNumber(guildId, channelId, queueNumber);
+    this.cacheActiveQueueNumber(guildId, channelId, queueNumber);
 
     return this.buildQueueDataFromMessage(
       guildId,
@@ -757,7 +757,11 @@ export class DiscordService {
     return activeQueueData.queue;
   }
 
-  private async cacheActiveQueueNumber(guildId: string, channelId: string, queueNumber: number): Promise<void> {
+  private cacheActiveQueueNumber(guildId: string, channelId: string, queueNumber: number): void {
+    void this.cacheActiveQueueNumberAsync(guildId, channelId, queueNumber);
+  }
+
+  private async cacheActiveQueueNumberAsync(guildId: string, channelId: string, queueNumber: number): Promise<void> {
     const cacheKey = getActiveQueueLookupCacheKey(guildId, channelId);
     const payload = { guildId, channelId, queueNumber };
 

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -749,11 +749,10 @@ export class DiscordService {
       return cachedQueueNumber;
     }
 
-    const activeQueueData = await this.getTeamsFromQueueChannel(guildId, channelId);
-    if (activeQueueData == null) {
-      return null;
-    }
-
+    const activeQueueData = Preconditions.checkExists(
+      await this.getTeamsFromQueueChannel(guildId, channelId),
+      "No active queue data found",
+    );
     return activeQueueData.queue;
   }
 

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -114,9 +114,14 @@ function getForbiddenDiscordSeriesStats(guildId: string, queueNumber: number): D
 const DEFAULT_PENDING_RETRY_SECONDS = 2;
 const PENDING_CACHE_TTL_SECONDS = 60 * 5;
 const NOT_FOUND_CACHE_TTL_SECONDS = 60 * 5;
+const ACTIVE_QUEUE_LOOKUP_CACHE_TTL_SECONDS = 60 * 5;
 
 function getDiscordSeriesStatsLookupCacheKey(guildId: string, queueNumber: number): string {
   return `${getDiscordSeriesStatsCacheKey(guildId, queueNumber)}:lookup`;
+}
+
+function getActiveQueueLookupCacheKey(guildId: string, channelId: string): string {
+  return `live-tracker:active-queue:${guildId}:${channelId}`;
 }
 
 function sanitizeRetryAfterSeconds(retryAfterValue: unknown): number {
@@ -727,6 +732,8 @@ export class DiscordService {
       });
     }
 
+    await this.cacheActiveQueueNumber(guildId, channelId, queueNumber);
+
     return this.buildQueueDataFromMessage(
       guildId,
       activeTeamsMessage,
@@ -734,6 +741,64 @@ export class DiscordService {
       queueNumber,
       true, // Clean team names for active queue messages
     );
+  }
+
+  async getActiveQueueNumber(guildId: string, channelId: string): Promise<number | null> {
+    const cachedQueueNumber = await this.getCachedActiveQueueNumber(guildId, channelId);
+    if (cachedQueueNumber != null) {
+      return cachedQueueNumber;
+    }
+
+    const activeQueueData = await this.getTeamsFromQueueChannel(guildId, channelId);
+    if (activeQueueData == null) {
+      return null;
+    }
+
+    return activeQueueData.queue;
+  }
+
+  private async cacheActiveQueueNumber(guildId: string, channelId: string, queueNumber: number): Promise<void> {
+    const cacheKey = getActiveQueueLookupCacheKey(guildId, channelId);
+    const payload = { guildId, channelId, queueNumber };
+
+    await this.env.APP_DATA.put(cacheKey, JSON.stringify(payload), {
+      expirationTtl: ACTIVE_QUEUE_LOOKUP_CACHE_TTL_SECONDS,
+    });
+  }
+
+  private async getCachedActiveQueueNumber(guildId: string, channelId: string): Promise<number | null> {
+    const cacheKey = getActiveQueueLookupCacheKey(guildId, channelId);
+    const cached = await this.env.APP_DATA.get<{ guildId: string; channelId: string; queueNumber: number }>(cacheKey, {
+      type: "json",
+    });
+
+    if (cached == null || typeof cached !== "object") {
+      return null;
+    }
+
+    if (cached.guildId !== guildId || cached.channelId !== channelId) {
+      this.logService.warn(
+        "Invalid cached active queue payload, treating as cache miss",
+        new Map([
+          ["cacheKey", cacheKey],
+          ["reason", "Mismatched guildId or channelId"],
+        ]),
+      );
+      return null;
+    }
+
+    if (typeof cached.queueNumber !== "number" || !Number.isFinite(cached.queueNumber) || cached.queueNumber <= 0) {
+      this.logService.warn(
+        "Invalid cached active queue payload, treating as cache miss",
+        new Map([
+          ["cacheKey", cacheKey],
+          ["reason", "queueNumber must be a positive number"],
+        ]),
+      );
+      return null;
+    }
+
+    return cached.queueNumber;
   }
 
   private findNeatQueueMessage(messages: APIMessage[], predicate: (message: APIMessage) => boolean): APIMessage | null {

--- a/api/services/discord/tests/discord.test.ts
+++ b/api/services/discord/tests/discord.test.ts
@@ -877,8 +877,8 @@ describe("DiscordService", () => {
         guildId: "fake-guild-id",
         channelId: "fake-channel",
         queueNumber: 4680,
-      } as unknown as Map<string, unknown>;
-      vi.spyOn(env.APP_DATA, "get").mockResolvedValue(cachedLookup);
+      };
+      vi.spyOn(env.APP_DATA, "get").mockResolvedValue(cachedLookup as never);
 
       const queueNumber = await discordService.getActiveQueueNumber("fake-guild-id", "fake-channel");
 

--- a/api/services/discord/tests/discord.test.ts
+++ b/api/services/discord/tests/discord.test.ts
@@ -872,6 +872,34 @@ describe("DiscordService", () => {
       );
     });
 
+    it("continues queue discovery when caching active queue number fails", async () => {
+      const cacheWriteError = new Error("KV put failed");
+      vi.spyOn(env.APP_DATA, "put").mockRejectedValue(cacheWriteError);
+      const logWarnSpy = vi.spyOn(logService, "warn");
+
+      mockFetch.mockImplementation(async () =>
+        Promise.resolve(
+          new Response(JSON.stringify(activeTeamsMessages), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+      );
+
+      const queueData = Preconditions.checkExists(
+        await discordService.getTeamsFromQueueChannel("fake-guild-id", "fake-channel"),
+      );
+
+      expect(queueData.queue).toBe(4680);
+      expect(logWarnSpy).toHaveBeenCalledWith(
+        cacheWriteError,
+        new Map([
+          ["cacheKey", "live-tracker:active-queue:fake-guild-id:fake-channel"],
+          ["reason", "Failed to cache active queue number"],
+        ]),
+      );
+    });
+
     it("getActiveQueueNumber returns cached value without Discord API call", async () => {
       const cachedLookup = {
         guildId: "fake-guild-id",
@@ -887,14 +915,11 @@ describe("DiscordService", () => {
     });
 
     it("getActiveQueueNumber falls back to Discord lookup when cache payload is invalid", async () => {
-      await env.APP_DATA.put(
-        "live-tracker:active-queue:fake-guild-id:fake-channel",
-        JSON.stringify({
-          guildId: "fake-guild-id",
-          channelId: "fake-channel",
-          queueNumber: 0,
-        }),
-      );
+      vi.spyOn(env.APP_DATA, "get").mockResolvedValue({
+        guildId: "fake-guild-id",
+        channelId: "fake-channel",
+        queueNumber: 0,
+      } as never);
 
       mockFetch.mockImplementation(async () =>
         Promise.resolve(
@@ -909,6 +934,40 @@ describe("DiscordService", () => {
 
       expect(queueNumber).toBe(4680);
       expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it("getActiveQueueNumber falls back to Discord lookup when cache read fails", async () => {
+      const cacheReadError = new Error("KV get failed");
+      vi.spyOn(env.APP_DATA, "get").mockImplementation(async (...args) => {
+        const [key] = args;
+        if (!Array.isArray(key) && key === "live-tracker:active-queue:fake-guild-id:fake-channel") {
+          return Promise.reject(cacheReadError);
+        }
+
+        return Promise.resolve(null as never);
+      });
+      const logWarnSpy = vi.spyOn(logService, "warn");
+
+      mockFetch.mockImplementation(async () =>
+        Promise.resolve(
+          new Response(JSON.stringify(activeTeamsMessages), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+      );
+
+      const queueNumber = await discordService.getActiveQueueNumber("fake-guild-id", "fake-channel");
+
+      expect(queueNumber).toBe(4680);
+      expect(mockFetch).toHaveBeenCalled();
+      expect(logWarnSpy).toHaveBeenCalledWith(
+        cacheReadError,
+        new Map([
+          ["cacheKey", "live-tracker:active-queue:fake-guild-id:fake-channel"],
+          ["reason", "Failed to read cached active queue number"],
+        ]),
+      );
     });
   });
 

--- a/api/services/discord/tests/discord.test.ts
+++ b/api/services/discord/tests/discord.test.ts
@@ -861,15 +861,17 @@ describe("DiscordService", () => {
 
       await discordService.getTeamsFromQueueChannel("fake-guild-id", "fake-channel");
 
-      expect(appDataPutSpy).toHaveBeenCalledWith(
-        "live-tracker:active-queue:fake-guild-id:fake-channel",
-        JSON.stringify({
-          guildId: "fake-guild-id",
-          channelId: "fake-channel",
-          queueNumber: 4680,
-        }),
-        { expirationTtl: 60 * 5 },
-      );
+      await vi.waitFor(() => {
+        expect(appDataPutSpy).toHaveBeenCalledWith(
+          "live-tracker:active-queue:fake-guild-id:fake-channel",
+          JSON.stringify({
+            guildId: "fake-guild-id",
+            channelId: "fake-channel",
+            queueNumber: 4680,
+          }),
+          { expirationTtl: 60 * 5 },
+        );
+      });
     });
 
     it("continues queue discovery when caching active queue number fails", async () => {

--- a/api/services/discord/tests/discord.test.ts
+++ b/api/services/discord/tests/discord.test.ts
@@ -940,6 +940,33 @@ describe("DiscordService", () => {
       expect(mockFetch).toHaveBeenCalled();
     });
 
+    it("getActiveQueueNumber returns null when no active queue is found", async () => {
+      vi.spyOn(env.APP_DATA, "get").mockResolvedValue(null as never);
+
+      const neatQueueMessagesWithoutActiveQueue = [
+        {
+          ...activeTeamsMessages[0],
+          embeds: [
+            {
+              ...activeTeamsMessages[0]?.embeds[0],
+              title: "Queue status",
+            },
+          ],
+        },
+      ];
+
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(neatQueueMessagesWithoutActiveQueue), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const queueNumber = await discordService.getActiveQueueNumber("fake-guild-id", "fake-channel");
+
+      expect(queueNumber).toBeNull();
+    });
+
     it("getActiveQueueNumber falls back to Discord lookup when cache read fails", async () => {
       const cacheReadError = new Error("KV get failed");
       vi.spyOn(env.APP_DATA, "get").mockImplementation(async (...args) => {

--- a/api/services/discord/tests/discord.test.ts
+++ b/api/services/discord/tests/discord.test.ts
@@ -846,6 +846,70 @@ describe("DiscordService", () => {
         "Could not extract queue number from active teams message.",
       );
     });
+
+    it("caches discovered active queue number", async () => {
+      const appDataPutSpy: MockInstance<typeof env.APP_DATA.put> = vi.spyOn(env.APP_DATA, "put").mockResolvedValue();
+
+      mockFetch.mockImplementation(async () =>
+        Promise.resolve(
+          new Response(JSON.stringify(activeTeamsMessages), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+      );
+
+      await discordService.getTeamsFromQueueChannel("fake-guild-id", "fake-channel");
+
+      expect(appDataPutSpy).toHaveBeenCalledWith(
+        "live-tracker:active-queue:fake-guild-id:fake-channel",
+        JSON.stringify({
+          guildId: "fake-guild-id",
+          channelId: "fake-channel",
+          queueNumber: 4680,
+        }),
+        { expirationTtl: 60 * 5 },
+      );
+    });
+
+    it("getActiveQueueNumber returns cached value without Discord API call", async () => {
+      const cachedLookup = {
+        guildId: "fake-guild-id",
+        channelId: "fake-channel",
+        queueNumber: 4680,
+      } as unknown as Map<string, unknown>;
+      vi.spyOn(env.APP_DATA, "get").mockResolvedValue(cachedLookup);
+
+      const queueNumber = await discordService.getActiveQueueNumber("fake-guild-id", "fake-channel");
+
+      expect(queueNumber).toBe(4680);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("getActiveQueueNumber falls back to Discord lookup when cache payload is invalid", async () => {
+      await env.APP_DATA.put(
+        "live-tracker:active-queue:fake-guild-id:fake-channel",
+        JSON.stringify({
+          guildId: "fake-guild-id",
+          channelId: "fake-channel",
+          queueNumber: 0,
+        }),
+      );
+
+      mockFetch.mockImplementation(async () =>
+        Promise.resolve(
+          new Response(JSON.stringify(activeTeamsMessages), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+      );
+
+      const queueNumber = await discordService.getActiveQueueNumber("fake-guild-id", "fake-channel");
+
+      expect(queueNumber).toBe(4680);
+      expect(mockFetch).toHaveBeenCalled();
+    });
   });
 
   describe("updateDeferredReply()", () => {

--- a/api/services/discord/tests/discord.test.ts
+++ b/api/services/discord/tests/discord.test.ts
@@ -891,13 +891,15 @@ describe("DiscordService", () => {
       );
 
       expect(queueData.queue).toBe(4680);
-      expect(logWarnSpy).toHaveBeenCalledWith(
-        cacheWriteError,
-        new Map([
-          ["cacheKey", "live-tracker:active-queue:fake-guild-id:fake-channel"],
-          ["reason", "Failed to cache active queue number"],
-        ]),
-      );
+      await vi.waitFor(() => {
+        expect(logWarnSpy).toHaveBeenCalledWith(
+          cacheWriteError,
+          new Map([
+            ["cacheKey", "live-tracker:active-queue:fake-guild-id:fake-channel"],
+            ["reason", "Failed to cache active queue number"],
+          ]),
+        );
+      });
     });
 
     it("getActiveQueueNumber returns cached value without Discord API call", async () => {

--- a/api/services/live-tracker/live-tracker.ts
+++ b/api/services/live-tracker/live-tracker.ts
@@ -385,9 +385,8 @@ export class LiveTrackerService {
    */
   async discoverActiveTracker({ guildId, channelId }: DiscoverActiveTrackerOpts): Promise<LiveTrackerState | null> {
     try {
-      // First try to get active queue data to determine the queue number
-      const activeQueueData = await this.discordService.getTeamsFromQueueChannel(guildId, channelId);
-      if (!activeQueueData) {
+      const queueNumber = await this.discordService.getActiveQueueNumber(guildId, channelId);
+      if (queueNumber == null) {
         return null;
       }
 
@@ -395,7 +394,7 @@ export class LiveTrackerService {
         userId: "", // Not needed for status check
         guildId,
         channelId,
-        queueNumber: activeQueueData.queue,
+        queueNumber,
       };
 
       const statusResponse = await this.getTrackerStatus(context);

--- a/api/services/live-tracker/tests/live-tracker.test.ts
+++ b/api/services/live-tracker/tests/live-tracker.test.ts
@@ -27,7 +27,7 @@ import type { LiveTrackerDO } from "../../../durable-objects/live-tracker/live-t
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import { aFakeLogServiceWith } from "../../log/fakes/log.fake";
 import { aFakeDiscordServiceWith } from "../../discord/fakes/discord.fake";
-import { apiMessage, discordNeatQueueData, fakeButtonClickInteraction } from "../../discord/fakes/data";
+import { apiMessage, fakeButtonClickInteraction } from "../../discord/fakes/data";
 import { aFakeDurableObjectId } from "../../../base/fakes/do.fake";
 
 describe("LiveTrackerService", () => {
@@ -583,9 +583,7 @@ describe("LiveTrackerService", () => {
 
   describe("discoverActiveTracker", () => {
     it("discovers an active tracker successfully", async () => {
-      const getTeamsFromQueueChannelSpy = vi
-        .spyOn(discordService, "getTeamsFromQueueChannel")
-        .mockResolvedValue(discordNeatQueueData);
+      const getActiveQueueNumberSpy = vi.spyOn(discordService, "getActiveQueueNumber").mockResolvedValue(42);
 
       fetch.mockResolvedValue(
         aFakeResponseWith({
@@ -599,11 +597,11 @@ describe("LiveTrackerService", () => {
       });
 
       expect(result).toEqual(state);
-      expect(getTeamsFromQueueChannelSpy).toHaveBeenCalledWith("test-guild", "test-channel");
+      expect(getActiveQueueNumberSpy).toHaveBeenCalledWith("test-guild", "test-channel");
     });
 
     it("returns null when no queue data found", async () => {
-      vi.spyOn(discordService, "getTeamsFromQueueChannel").mockResolvedValue(null);
+      vi.spyOn(discordService, "getActiveQueueNumber").mockResolvedValue(null);
 
       const result = await service.discoverActiveTracker({
         guildId: "test-guild",
@@ -614,7 +612,7 @@ describe("LiveTrackerService", () => {
     });
 
     it("returns null when status check fails", async () => {
-      vi.spyOn(discordService, "getTeamsFromQueueChannel").mockResolvedValue(discordNeatQueueData);
+      vi.spyOn(discordService, "getActiveQueueNumber").mockResolvedValue(42);
 
       fetch.mockResolvedValue(
         aFakeResponseWith({
@@ -632,7 +630,7 @@ describe("LiveTrackerService", () => {
     });
 
     it("handles errors gracefully", async () => {
-      vi.spyOn(discordService, "getTeamsFromQueueChannel").mockRejectedValue(new Error("Discord API error"));
+      vi.spyOn(discordService, "getActiveQueueNumber").mockRejectedValue(new Error("Discord API error"));
 
       const result = await service.discoverActiveTracker({
         guildId: "test-guild",


### PR DESCRIPTION
## Context
Follow-up to merged retrieval/cache hardening: live-tracker status/discovery still relied on direct channel reads where a state-first lookup is preferred.

## This PR
- Adds state-first active queue lookup in DiscordService via getActiveQueueNumber(guildId, channelId).
- Caches active queue discovery under key live-tracker:active-queue:{guildId}:{channelId} with bounded TTL.
- Refactors LiveTrackerService.discoverActiveTracker(...) and TrackCommand.getTrackerStatus(...) to use queue-number lookup API.
- Adds focused tests for cache write, cache hit without Discord API call, invalid-cache fallback, and caller parity updates.

Validation:
- npm run done (format, typecheck, lint, test:changed all passing)

## Subsequent Work
- Continue degraded-path verification for any remaining retrieval entrypoints.
- Proceed to privacy/policy tightening once retrieval parity is complete.