### PR TITLE
fix(medals): resolve tracker medals in browser with injected resolver

### DIFF
--- a/api/routes/stats/series-matches.ts
+++ b/api/routes/stats/series-matches.ts
@@ -2,27 +2,8 @@ import type { MatchStats } from "halo-infinite-api";
 import { parseQueryParams } from "@guilty-spark/shared/base/request-parsing";
 import { errorContract } from "@guilty-spark/shared/contracts/error";
 import { getReadableDuration } from "@guilty-spark/shared/halo/duration";
-import { getMedalMetadataFromMatches } from "@guilty-spark/shared/halo/medals";
 import { seriesMatchesContract, seriesMatchesQuerySchema } from "@guilty-spark/shared/contracts/stats/series-matches";
 import type { RoutesRegisterHandler } from "../base/types";
-import type { HaloService } from "../../services/halo/halo";
-import type { LogService } from "../../services/log/types";
-
-async function getBestEffortMedalMetadata(
-  haloService: HaloService,
-  logService: LogService,
-  matchesById: Record<string, MatchStats>,
-): Promise<Record<string, { name: string; sortingWeight: number }>> {
-  try {
-    return await getMedalMetadataFromMatches(matchesById, async (medalId) => haloService.getMedal(medalId));
-  } catch (error) {
-    logService.warn(
-      "Failed to resolve medal metadata for series matches, using empty metadata",
-      new Map([["error", String(error)]]),
-    );
-    return {};
-  }
-}
 
 export const seriesMatchesRoute: RoutesRegisterHandler = (router, installServices) => {
   router.get("/api/stats/series-matches", async (request, env: Env) => {
@@ -48,10 +29,7 @@ export const seriesMatchesRoute: RoutesRegisterHandler = (router, installService
         .map((matchId) => matchesById[matchId])
         .filter((match): match is MatchStats => match != null);
 
-      const [playerXuidToGametagMap, medalMetadata] = await Promise.all([
-        haloService.getPlayerXuidsToGametags(orderedMatches),
-        getBestEffortMedalMetadata(haloService, logService, matchesById),
-      ]);
+      const playerXuidToGametagMap = await haloService.getPlayerXuidsToGametags(orderedMatches);
 
       const responseMatches = await Promise.all(
         orderedMatches.map(async (match) => {
@@ -83,10 +61,7 @@ export const seriesMatchesRoute: RoutesRegisterHandler = (router, installService
         playerXuidToGametag[xuid] = gamertag;
       }
 
-      return seriesMatchesContract.toResponse(
-        { medalMetadata, playerXuidToGametag, matches: responseMatches },
-        { noStore: true },
-      );
+      return seriesMatchesContract.toResponse({ playerXuidToGametag, matches: responseMatches }, { noStore: true });
     } catch (error) {
       logService.error(error, new Map([["context", "Failed to resolve series matches route"]]));
       return errorContract.toResponse({ error: "Failed to resolve series matches" }, { status: 500, noStore: true });

--- a/api/routes/stats/tests/series-matches.test.ts
+++ b/api/routes/stats/tests/series-matches.test.ts
@@ -46,6 +46,7 @@ describe("/api/stats/series-matches", () => {
 
     expect(response.status).toBe(200);
     const body = await seriesMatchesContract.fromResponse(response);
+    expect(body).not.toHaveProperty("medalMetadata");
     expect(body.matches[0]).toMatchObject({
       gameTypeAndMap: "Assault:Neutral Bomb: Live Fire",
       gameType: "Assault:Neutral Bomb",

--- a/pages/src/apps/follow-live/create.tsx
+++ b/pages/src/apps/follow-live/create.tsx
@@ -77,7 +77,7 @@ export function FollowLiveApp({ apiHost, gamertag, variant = "viewer" }: FollowL
             individualTrackerViewService: services.individualTrackerViewService,
             matchAnalyticsService: services.matchAnalyticsService,
             seriesMatchesService: services.seriesMatchesService,
-            haloClient: services.haloClient,
+            medalMetadataResolver: services.medalMetadataResolver,
           }),
     [services],
   );
@@ -92,6 +92,7 @@ export function FollowLiveApp({ apiHost, gamertag, variant = "viewer" }: FollowL
             matchAnalyticsService: services.matchAnalyticsService,
             seriesMatchesService: services.seriesMatchesService,
             haloClient: services.haloClient,
+            medalMetadataResolver: services.medalMetadataResolver,
           }),
     [services],
   );

--- a/pages/src/apps/follow-live/services.ts
+++ b/pages/src/apps/follow-live/services.ts
@@ -1,5 +1,6 @@
 import type { HaloInfiniteClient } from "halo-infinite-api";
 import { createHaloInfiniteClientProxy } from "@guilty-spark/shared/halo/halo-infinite-client-proxy";
+import { HaloMedalMetadataResolver } from "../../services/halo/medal-metadata-resolver";
 import { installFollowLiveService } from "../../services/follow/install";
 import type { FollowLiveService } from "../../services/follow/follow-types";
 import { installIndividualTrackerViewService } from "../../services/individual-tracker/install";
@@ -15,6 +16,7 @@ export interface Services {
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
   readonly haloClient: HaloInfiniteClient;
+  readonly medalMetadataResolver: HaloMedalMetadataResolver;
 }
 
 export async function installServices(apiHost: string): Promise<Services> {
@@ -32,12 +34,15 @@ export async function installServices(apiHost: string): Promise<Services> {
       import("../../services/stats/fakes/series-matches.fake"),
       import("../../services/fakes/halo-client.fake"),
     ]);
+    const haloClient = aFakeHaloClientWith();
+
     return {
       followLiveService: aFakeFollowLiveServiceWith(),
       individualTrackerViewService: aFakeIndividualTrackerViewServiceWith(),
       matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
       seriesMatchesService: aFakeSeriesMatchesServiceWith(),
-      haloClient: aFakeHaloClientWith(),
+      haloClient,
+      medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
     };
   }
 
@@ -49,5 +54,12 @@ export async function installServices(apiHost: string): Promise<Services> {
       installSeriesMatchesService(apiHost),
     ]);
   const haloClient = createHaloInfiniteClientProxy({ proxyBaseUrl: apiHost });
-  return { followLiveService, individualTrackerViewService, matchAnalyticsService, seriesMatchesService, haloClient };
+  return {
+    followLiveService,
+    individualTrackerViewService,
+    matchAnalyticsService,
+    seriesMatchesService,
+    haloClient,
+    medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
+  };
 }

--- a/pages/src/apps/individual-tracker-overlay/create.tsx
+++ b/pages/src/apps/individual-tracker-overlay/create.tsx
@@ -24,6 +24,7 @@ export function IndividualTrackerOverlayApp({ apiHost, trackerId }: IndividualTr
             matchAnalyticsService: services.matchAnalyticsService,
             seriesMatchesService: services.seriesMatchesService,
             haloClient: services.haloClient,
+            medalMetadataResolver: services.medalMetadataResolver,
           }),
     [services],
   );

--- a/pages/src/apps/individual-tracker-viewer/create.tsx
+++ b/pages/src/apps/individual-tracker-viewer/create.tsx
@@ -34,7 +34,7 @@ export function IndividualTrackerViewerApp({ apiHost, trackerId }: IndividualTra
             individualTrackerViewService: services.individualTrackerViewService,
             matchAnalyticsService: services.matchAnalyticsService,
             seriesMatchesService: services.seriesMatchesService,
-            haloClient: services.haloClient,
+            medalMetadataResolver: services.medalMetadataResolver,
           }),
     [services],
   );

--- a/pages/src/apps/individual-tracker-viewer/services.ts
+++ b/pages/src/apps/individual-tracker-viewer/services.ts
@@ -1,5 +1,6 @@
 import type { HaloInfiniteClient } from "halo-infinite-api";
 import { createHaloInfiniteClientProxy } from "@guilty-spark/shared/halo/halo-infinite-client-proxy";
+import { HaloMedalMetadataResolver } from "../../services/halo/medal-metadata-resolver";
 import { installAuthService } from "../../services/auth/install";
 import type { AuthService } from "../../services/auth/types";
 import {
@@ -17,12 +18,14 @@ export interface Services {
   readonly individualTrackerService: IndividualTrackerService;
   readonly individualTrackerViewService: IndividualTrackerViewService;
   readonly haloClient: HaloInfiniteClient;
+  readonly medalMetadataResolver: HaloMedalMetadataResolver;
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
 }
 
 export async function installServices(apiHost: string): Promise<Services> {
   const haloClient = createHaloInfiniteClientProxy({ proxyBaseUrl: apiHost, credentials: "include" });
+  const medalMetadataResolver = new HaloMedalMetadataResolver(haloClient);
   const [
     authService,
     individualTrackerService,
@@ -41,6 +44,7 @@ export async function installServices(apiHost: string): Promise<Services> {
     individualTrackerService,
     individualTrackerViewService,
     haloClient,
+    medalMetadataResolver,
     matchAnalyticsService,
     seriesMatchesService,
   };

--- a/pages/src/components/follow/follow-live-overlay/create.tsx
+++ b/pages/src/components/follow/follow-live-overlay/create.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { HaloInfiniteClient } from "halo-infinite-api";
 import type { FollowLiveService } from "../../../services/follow/follow-types";
+import type { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { SeriesMatchesService } from "../../../services/stats/series-matches-types";
@@ -14,6 +15,7 @@ export interface FollowLiveOverlayDependencies {
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
   readonly haloClient: HaloInfiniteClient;
+  readonly medalMetadataResolver: HaloMedalMetadataResolver;
 }
 
 export interface FollowLiveOverlayProps {
@@ -28,6 +30,7 @@ export function createFollowLiveOverlay({
   matchAnalyticsService,
   seriesMatchesService,
   haloClient,
+  medalMetadataResolver,
 }: FollowLiveOverlayDependencies) {
   return function FollowLiveOverlayCreate({
     gamertag,
@@ -56,6 +59,7 @@ export function createFollowLiveOverlay({
         matchAnalyticsService={matchAnalyticsService}
         seriesMatchesService={seriesMatchesService}
         haloClient={haloClient}
+        medalMetadataResolver={medalMetadataResolver}
         showPreview={showPreview}
         previewMode={previewMode}
       />

--- a/pages/src/components/follow/follow-live-overlay/follow-live-overlay.tsx
+++ b/pages/src/components/follow/follow-live-overlay/follow-live-overlay.tsx
@@ -6,6 +6,7 @@ import { ComponentLoader } from "../../component-loader/component-loader";
 import { ErrorState } from "../../error-state/error-state";
 import { LoadingState } from "../../loading-state/loading-state";
 import { createIndividualTrackerOverlayPage } from "../../individual-tracker/overlay/create";
+import type { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { SeriesMatchesService } from "../../../services/stats/series-matches-types";
@@ -18,6 +19,7 @@ export interface FollowLiveOverlayProps {
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
   readonly haloClient: HaloInfiniteClient;
+  readonly medalMetadataResolver: HaloMedalMetadataResolver;
   readonly showPreview?: boolean;
   readonly previewMode?: "player" | "observer";
   readonly onRetry: () => void;
@@ -31,6 +33,7 @@ export function FollowLiveOverlay({
   matchAnalyticsService,
   seriesMatchesService,
   haloClient,
+  medalMetadataResolver,
   showPreview = false,
   previewMode = "observer",
   onRetry,
@@ -42,8 +45,9 @@ export function FollowLiveOverlay({
         matchAnalyticsService,
         seriesMatchesService,
         haloClient,
+        medalMetadataResolver,
       }),
-    [haloClient, individualTrackerViewService, matchAnalyticsService, seriesMatchesService],
+    [haloClient, individualTrackerViewService, matchAnalyticsService, medalMetadataResolver, seriesMatchesService],
   );
 
   const loadedState =

--- a/pages/src/components/follow/follow-live-overlay/tests/follow-live-overlay-create.test.tsx
+++ b/pages/src/components/follow/follow-live-overlay/tests/follow-live-overlay-create.test.tsx
@@ -8,6 +8,7 @@ import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual
 import { aDirectoryWith, aTrackerWith } from "@guilty-spark/shared/contracts/individual-tracker/fakes/follow.fake";
 import { aFakeHaloClientWith } from "../../../../services/fakes/halo-client.fake";
 import { aFakeFollowLiveServiceWith } from "../../../../services/follow/fakes/follow.fake";
+import { HaloMedalMetadataResolver } from "../../../../services/halo/medal-metadata-resolver";
 import { aFakeIndividualTrackerViewServiceWith } from "../../../../services/individual-tracker/fakes/view.fake";
 import { aFakeMatchAnalyticsServiceWith } from "../../../../services/stats/fakes/match-analytics.fake";
 import { aFakeSeriesMatchesServiceWith } from "../../../../services/stats/fakes/series-matches.fake";
@@ -53,12 +54,14 @@ function createFollowLiveOverlayWith(
   readonly followLiveService: ReturnType<typeof aFakeFollowLiveServiceWith>;
   readonly individualTrackerViewService: ReturnType<typeof aFakeIndividualTrackerViewServiceWith>;
 } {
+  const haloClient = aFakeHaloClientWith();
   const FollowLiveOverlay = createFollowLiveOverlay({
     followLiveService,
     individualTrackerViewService,
     matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     seriesMatchesService: aFakeSeriesMatchesServiceWith(),
-    haloClient: aFakeHaloClientWith(),
+    haloClient,
+    medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
   });
 
   return {

--- a/pages/src/components/follow/follow-live-viewer/create.tsx
+++ b/pages/src/components/follow/follow-live-viewer/create.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import type { HaloInfiniteClient } from "halo-infinite-api";
 import type { FollowLiveService } from "../../../services/follow/follow-types";
+import type { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { SeriesMatchesService } from "../../../services/stats/series-matches-types";
@@ -13,7 +13,7 @@ export interface FollowLiveViewerDependencies {
   readonly individualTrackerViewService: IndividualTrackerViewService;
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
-  readonly haloClient: HaloInfiniteClient;
+  readonly medalMetadataResolver: HaloMedalMetadataResolver;
 }
 
 export interface FollowLiveViewerProps {
@@ -25,7 +25,7 @@ export function createFollowLiveViewer({
   individualTrackerViewService,
   matchAnalyticsService,
   seriesMatchesService,
-  haloClient,
+  medalMetadataResolver,
 }: FollowLiveViewerDependencies) {
   return function FollowLiveViewerCreate({ gamertag }: FollowLiveViewerProps): React.ReactElement {
     const presenter = React.useMemo(() => new FollowLiveViewerPresenter(), []);
@@ -50,7 +50,7 @@ export function createFollowLiveViewer({
         individualTrackerViewService={individualTrackerViewService}
         matchAnalyticsService={matchAnalyticsService}
         seriesMatchesService={seriesMatchesService}
-        haloClient={haloClient}
+        medalMetadataResolver={medalMetadataResolver}
       />
     );
   };

--- a/pages/src/components/follow/follow-live-viewer/follow-live-viewer.tsx
+++ b/pages/src/components/follow/follow-live-viewer/follow-live-viewer.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import type { HaloInfiniteClient } from "halo-infinite-api";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { ComponentLoaderStatus } from "../../component-loader/component-loader";
@@ -7,6 +6,7 @@ import { ComponentLoader } from "../../component-loader/component-loader";
 import { ErrorState } from "../../error-state/error-state";
 import { LoadingState } from "../../loading-state/loading-state";
 import { createIndividualTrackerViewerPage } from "../../individual-tracker/viewer/create";
+import type { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type {
   IndividualTrackerViewService,
   TrackerViewConnectionStatus,
@@ -29,7 +29,7 @@ export interface FollowLiveViewerProps {
   readonly individualTrackerViewService: IndividualTrackerViewService;
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
-  readonly haloClient: HaloInfiniteClient;
+  readonly medalMetadataResolver: HaloMedalMetadataResolver;
   readonly onSelectTracker: (trackerId: string) => void;
   readonly onRetry: () => void;
 }
@@ -46,7 +46,7 @@ export function FollowLiveViewer({
   individualTrackerViewService,
   matchAnalyticsService,
   seriesMatchesService,
-  haloClient,
+  medalMetadataResolver,
   onSelectTracker,
   onRetry,
 }: FollowLiveViewerProps): React.ReactElement {
@@ -56,9 +56,9 @@ export function FollowLiveViewer({
         individualTrackerViewService,
         matchAnalyticsService,
         seriesMatchesService,
-        haloClient,
+        medalMetadataResolver,
       }),
-    [haloClient, individualTrackerViewService, matchAnalyticsService, seriesMatchesService],
+    [individualTrackerViewService, matchAnalyticsService, medalMetadataResolver, seriesMatchesService],
   );
 
   const loadedState =

--- a/pages/src/components/follow/follow-live-viewer/tests/follow-live-viewer-create.test.tsx
+++ b/pages/src/components/follow/follow-live-viewer/tests/follow-live-viewer-create.test.tsx
@@ -8,6 +8,7 @@ import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual
 import { aDirectoryWith, aTrackerWith } from "@guilty-spark/shared/contracts/individual-tracker/fakes/follow.fake";
 import { aFakeHaloClientWith } from "../../../../services/fakes/halo-client.fake";
 import { aFakeFollowLiveServiceWith } from "../../../../services/follow/fakes/follow.fake";
+import { HaloMedalMetadataResolver } from "../../../../services/halo/medal-metadata-resolver";
 import { aFakeIndividualTrackerViewServiceWith } from "../../../../services/individual-tracker/fakes/view.fake";
 import { aFakeMatchAnalyticsServiceWith } from "../../../../services/stats/fakes/match-analytics.fake";
 import { aFakeSeriesMatchesServiceWith } from "../../../../services/stats/fakes/series-matches.fake";
@@ -59,12 +60,13 @@ function createFollowLiveViewerWith(
   readonly followLiveService: ReturnType<typeof aFakeFollowLiveServiceWith>;
   readonly individualTrackerViewService: ReturnType<typeof aFakeIndividualTrackerViewServiceWith>;
 } {
+  const haloClient = aFakeHaloClientWith();
   const FollowLiveViewer = createFollowLiveViewer({
     followLiveService,
     individualTrackerViewService,
     matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     seriesMatchesService: aFakeSeriesMatchesServiceWith(),
-    haloClient: aFakeHaloClientWith(),
+    medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
   });
 
   return {

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -4,6 +4,7 @@ import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual
 import { ComponentLoader } from "../../component-loader/component-loader";
 import { ErrorState } from "../../error-state/error-state";
 import { LoadingState } from "../../loading-state/loading-state";
+import type { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { SeriesMatchesService } from "../../../services/stats/series-matches-types";
@@ -18,6 +19,7 @@ export interface CreateIndividualTrackerOverlayPageConfig {
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
   readonly haloClient: HaloInfiniteClient;
+  readonly medalMetadataResolver: HaloMedalMetadataResolver;
 }
 
 export interface IndividualTrackerOverlayPageProps {
@@ -38,23 +40,30 @@ function IndividualTrackerOverlayPageInternal({
   showPreview = false,
   previewMode = "observer",
 }: IndividualTrackerOverlayPageInternalProps): React.ReactElement {
-  const { individualTrackerViewService, matchAnalyticsService, seriesMatchesService, haloClient } = config;
+  const {
+    individualTrackerViewService,
+    matchAnalyticsService,
+    seriesMatchesService,
+    haloClient,
+    medalMetadataResolver,
+  } = config;
   const store = useMemo(() => new OverlayPageStore(), []);
   const presenter = useMemo(
     () =>
       new OverlayPagePresenter({
         store,
         haloClient,
+        medalMetadataResolver,
         matchAnalyticsService,
       }),
-    [haloClient, matchAnalyticsService, store],
+    [haloClient, medalMetadataResolver, matchAnalyticsService, store],
   );
 
   const { snapshot, model, onRetry, onToggleEntry } = useIndividualTrackerViewer({
     individualTrackerViewService,
     matchAnalyticsService,
     seriesMatchesService,
-    haloClient,
+    medalMetadataResolver,
     trackerId,
     externalView,
   });

--- a/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
@@ -4,7 +4,7 @@ import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-
 import { StatsController } from "../../../controllers/stats/stats-controller";
 import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPlayer } from "../../../controllers/stats/kill-matrix/types";
-import { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
+import type { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { MatchDetailsState, ViewerTimelineItem } from "../viewer/types";
 import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
@@ -13,6 +13,7 @@ import type { OverlayPageSnapshot, OverlayPageStore } from "./overlay-page-store
 interface OverlayPagePresenterConfig {
   readonly store: OverlayPageStore;
   readonly haloClient: HaloInfiniteClient;
+  readonly medalMetadataResolver: HaloMedalMetadataResolver;
   readonly matchAnalyticsService: MatchAnalyticsService;
 }
 
@@ -26,7 +27,6 @@ export interface OverlayPageViewModel {
 export class OverlayPagePresenter {
   private readonly config: OverlayPagePresenterConfig;
   private isDisposed = false;
-  private readonly medalMetadataResolver: HaloMedalMetadataResolver;
 
   private shouldAbort(): boolean {
     return this.isDisposed;
@@ -34,7 +34,6 @@ export class OverlayPagePresenter {
 
   public constructor(config: OverlayPagePresenterConfig) {
     this.config = config;
-    this.medalMetadataResolver = new HaloMedalMetadataResolver(config.haloClient);
   }
 
   public dispose(): void {
@@ -115,7 +114,7 @@ export class OverlayPagePresenter {
         this.config.matchAnalyticsService
           .getBatchMatchAnalytics([matchId])
           .catch((): Record<string, MatchAnalytics | null> => ({})),
-        this.medalMetadataResolver.getMedalMetadataForMatch(stats),
+        this.config.medalMetadataResolver.getMedalMetadataForMatch(stats),
       ]);
 
       if (this.shouldAbort()) {

--- a/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
@@ -1,10 +1,10 @@
 import type { HaloInfiniteClient } from "halo-infinite-api";
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
-import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { StatsController } from "../../../controllers/stats/stats-controller";
 import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPlayer } from "../../../controllers/stats/kill-matrix/types";
+import { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { MatchDetailsState, ViewerTimelineItem } from "../viewer/types";
 import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
@@ -26,6 +26,7 @@ export interface OverlayPageViewModel {
 export class OverlayPagePresenter {
   private readonly config: OverlayPagePresenterConfig;
   private isDisposed = false;
+  private readonly medalMetadataResolver: HaloMedalMetadataResolver;
 
   private shouldAbort(): boolean {
     return this.isDisposed;
@@ -33,6 +34,7 @@ export class OverlayPagePresenter {
 
   public constructor(config: OverlayPagePresenterConfig) {
     this.config = config;
+    this.medalMetadataResolver = new HaloMedalMetadataResolver(config.haloClient);
   }
 
   public dispose(): void {
@@ -108,13 +110,13 @@ export class OverlayPagePresenter {
 
       const xuids = stats.Players.filter((player) => player.PlayerType === 1).map((player) => getPlayerXuid(player));
 
-      const [users, analyticsByMatchId] = await Promise.all([
+      const [users, analyticsByMatchId, medalMetadata] = await Promise.all([
         this.config.haloClient.getUsers(xuids).catch(() => []),
         this.config.matchAnalyticsService
           .getBatchMatchAnalytics([matchId])
           .catch((): Record<string, MatchAnalytics | null> => ({})),
+        this.medalMetadataResolver.getMedalMetadataForMatch(stats),
       ]);
-      const medalMetadata: MedalMetadata = {};
 
       if (this.shouldAbort()) {
         return;

--- a/pages/src/components/individual-tracker/overlay/tests/create.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/create.test.tsx
@@ -6,6 +6,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 import { aFakeHaloClientWith } from "../../../../services/fakes/halo-client.fake";
+import { HaloMedalMetadataResolver } from "../../../../services/halo/medal-metadata-resolver";
 import {
   aFakeTrackerMatchSummaryWith,
   aFakeTrackerViewStateWith,
@@ -87,6 +88,7 @@ describe("IndividualTrackerOverlayPage", () => {
       matchAnalyticsService,
       seriesMatchesService: aFakeSeriesMatchesServiceWith(),
       haloClient,
+      medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
     });
 
     render(<IndividualTrackerOverlayPage trackerId="tracker-1" />);
@@ -134,6 +136,7 @@ describe("IndividualTrackerOverlayPage", () => {
       matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
       seriesMatchesService: aFakeSeriesMatchesServiceWith(),
       haloClient,
+      medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
     });
 
     render(<IndividualTrackerOverlayPage trackerId="tracker-1" />);
@@ -169,6 +172,7 @@ describe("IndividualTrackerOverlayPage", () => {
       matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
       seriesMatchesService: aFakeSeriesMatchesServiceWith(),
       haloClient,
+      medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
     });
 
     const { rerender } = render(<IndividualTrackerOverlayPage trackerId="tracker-1" />);
@@ -217,6 +221,7 @@ describe("IndividualTrackerOverlayPage", () => {
       matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
       seriesMatchesService: aFakeSeriesMatchesServiceWith(),
       haloClient,
+      medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
     });
 
     const { rerender } = render(<IndividualTrackerOverlayPage key="first" trackerId="tracker-1" />);

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { waitFor } from "@testing-library/react";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 import { aFakeHaloClientWith } from "../../../../services/fakes/halo-client.fake";
+import { HaloMedalMetadataResolver } from "../../../../services/halo/medal-metadata-resolver";
 import { aFakeMatchAnalyticsServiceWith } from "../../../../services/stats/fakes/match-analytics.fake";
 import type { ViewerTimelineItem } from "../../viewer/types";
 import { OverlayPagePresenter } from "../overlay-page-presenter";
@@ -64,6 +65,7 @@ describe("OverlayPagePresenter", () => {
     const presenter = new OverlayPagePresenter({
       store,
       haloClient,
+      medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
       matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     });
 
@@ -91,6 +93,7 @@ describe("OverlayPagePresenter", () => {
     const presenter = new OverlayPagePresenter({
       store,
       haloClient,
+      medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
       matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     });
 
@@ -120,6 +123,7 @@ describe("OverlayPagePresenter", () => {
     const presenter = new OverlayPagePresenter({
       store,
       haloClient,
+      medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
       matchAnalyticsService,
     });
 
@@ -146,6 +150,7 @@ describe("OverlayPagePresenter", () => {
     const presenter = new OverlayPagePresenter({
       store,
       haloClient,
+      medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
       matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     });
 
@@ -182,6 +187,7 @@ describe("OverlayPagePresenter", () => {
     const presenter = new OverlayPagePresenter({
       store,
       haloClient,
+      medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
       matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     });
 
@@ -199,11 +205,13 @@ describe("OverlayPagePresenter", () => {
 
   it("selects a series and toggles the matching timeline item when present", () => {
     const store = new OverlayPageStore();
+    const haloClient = aFakeHaloClientWith({
+      getMatchStats: vi.fn(async () => Promise.resolve(aFakeMatchStatsWith())),
+    });
     const presenter = new OverlayPagePresenter({
       store,
-      haloClient: aFakeHaloClientWith({
-        getMatchStats: vi.fn(async () => Promise.resolve(aFakeMatchStatsWith())),
-      }),
+      haloClient,
+      medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
       matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     });
     const timeline: readonly ViewerTimelineItem[] = [
@@ -237,11 +245,13 @@ describe("OverlayPagePresenter", () => {
 
   it("clears selection with a single store notification", () => {
     const store = new OverlayPageStore();
+    const haloClient = aFakeHaloClientWith({
+      getMatchStats: vi.fn(async () => Promise.resolve(aFakeMatchStatsWith())),
+    });
     const presenter = new OverlayPagePresenter({
       store,
-      haloClient: aFakeHaloClientWith({
-        getMatchStats: vi.fn(async () => Promise.resolve(aFakeMatchStatsWith())),
-      }),
+      haloClient,
+      medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
       matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     });
     const listener = vi.fn<() => void>();

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
@@ -1,3 +1,4 @@
+import type { HaloInfiniteClient } from "halo-infinite-api";
 import { describe, expect, it, vi } from "vitest";
 import { waitFor } from "@testing-library/react";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
@@ -15,6 +16,40 @@ function aUsersFor(
     gamertag: `Spartan ${xuid}`,
     gamerpic: { small: "", medium: "", large: "", xlarge: "" },
   }));
+}
+
+function aMedalsMetadataFile(): Awaited<ReturnType<HaloInfiniteClient["getMedalsMetadataFile"]>> {
+  return {
+    difficulties: ["normal", "heroic", "legendary", "mythic"],
+    types: ["spree", "mode", "multikill", "proficiency", "skill", "style"],
+    sprites: {
+      small: { path: "small.png", columns: 16, size: 72 },
+      medium: { path: "medium.png", columns: 16, size: 128 },
+      "extra-large": { path: "large.png", columns: 16, size: 256 },
+    },
+    medals: [
+      {
+        name: { value: "Killing Spree", translations: {} },
+        description: { value: "Kill 5 enemies without dying", translations: {} },
+        spriteIndex: 1,
+        sortingWeight: 100,
+        difficultyIndex: 1,
+        typeIndex: 0,
+        personalScore: 10,
+        nameId: 622331684,
+      },
+      {
+        name: { value: "Double Kill", translations: {} },
+        description: { value: "Kill 2 enemies in quick succession", translations: {} },
+        spriteIndex: 2,
+        sortingWeight: 50,
+        difficultyIndex: 1,
+        typeIndex: 2,
+        personalScore: 10,
+        nameId: 1169571763,
+      },
+    ],
+  };
 }
 
 describe("OverlayPagePresenter", () => {
@@ -76,6 +111,7 @@ describe("OverlayPagePresenter", () => {
     const haloClient = aFakeHaloClientWith({
       getMatchStats: vi.fn(async () => Promise.resolve(aFakeMatchStatsWith({ MatchId: "match-1" }))),
       getUsers: vi.fn(async () => Promise.reject(new Error("users down"))),
+      getMedalsMetadataFile: vi.fn(async () => Promise.reject(new Error("medals down"))),
     });
 
     const matchAnalyticsService = aFakeMatchAnalyticsServiceWith();
@@ -96,6 +132,41 @@ describe("OverlayPagePresenter", () => {
     const model = presenter.present(store.getSnapshot());
     expect(model.matchStatsState?.status).toBe("loaded");
     expect(model.matchStatsPanelState?.status).toBe("loaded");
+  });
+
+  it("resolves medal metadata from the proxied medals file and caches it across loads", async () => {
+    const store = new OverlayPageStore();
+    const getMedalsMetadataFile = vi.fn(async () => Promise.resolve(aMedalsMetadataFile()));
+    const haloClient = aFakeHaloClientWith({
+      getMatchStats: vi.fn(async (matchId: string) => Promise.resolve(aFakeMatchStatsWith({ MatchId: matchId }))),
+      getUsers: vi.fn(async (xuids: string[]) => Promise.resolve(aUsersFor(xuids))),
+      getMedalsMetadataFile,
+    });
+
+    const presenter = new OverlayPagePresenter({
+      store,
+      haloClient,
+      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+    });
+
+    presenter.preloadMatchStats(["match-1", "match-2"]);
+
+    await waitFor(() => {
+      expect(store.getSnapshot().matchStatsByMatchId.get("match-1")?.status).toBe("loaded");
+      expect(store.getSnapshot().matchStatsByMatchId.get("match-2")?.status).toBe("loaded");
+    });
+
+    const firstState = store.getSnapshot().matchStatsByMatchId.get("match-1");
+    expect(firstState).toMatchObject({ status: "loaded" });
+    if (firstState?.status !== "loaded") {
+      throw new Error("expected loaded overlay match stats state");
+    }
+
+    expect(firstState.medalMetadata).toEqual({
+      622331684: { name: "Killing Spree", sortingWeight: 100 },
+      1169571763: { name: "Double Kill", sortingWeight: 50 },
+    });
+    expect(getMedalsMetadataFile).toHaveBeenCalledTimes(1);
   });
 
   it("preloads stats for all provided matches", async () => {

--- a/pages/src/components/individual-tracker/viewer/create.tsx
+++ b/pages/src/components/individual-tracker/viewer/create.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import type { HaloInfiniteClient } from "halo-infinite-api";
 import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { ComponentLoader } from "../../component-loader/component-loader";
 import { ErrorState } from "../../error-state/error-state";
 import { LoadingState } from "../../loading-state/loading-state";
+import type { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
 import type {
   IndividualTrackerViewService,
@@ -19,7 +19,7 @@ export interface CreateIndividualTrackerViewerPageConfig {
   readonly individualTrackerViewService: IndividualTrackerViewService;
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
-  readonly haloClient: HaloInfiniteClient;
+  readonly medalMetadataResolver: HaloMedalMetadataResolver;
   readonly individualTrackerService?: IndividualTrackerService;
 }
 
@@ -48,7 +48,7 @@ function IndividualTrackerViewerPageInternal({
     individualTrackerViewService,
     matchAnalyticsService,
     seriesMatchesService,
-    haloClient,
+    medalMetadataResolver,
   } = config;
   const canManage = individualTrackerService != null;
 
@@ -57,7 +57,7 @@ function IndividualTrackerViewerPageInternal({
     individualTrackerViewService,
     matchAnalyticsService,
     seriesMatchesService,
-    haloClient,
+    medalMetadataResolver,
     trackerId,
     streamerSettings,
     externalView,

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -514,7 +514,6 @@ describe("useIndividualTrackerViewer", () => {
     const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
     const getSeriesMatchesSpy = vi.spyOn(seriesMatchesService, "getSeriesMatches").mockImplementation(async (ids) =>
       Promise.resolve({
-        medalMetadata: {},
         playerXuidToGametag: {},
         matches: ids.map((matchId) => ({
           matchId,
@@ -584,7 +583,6 @@ describe("useIndividualTrackerViewer", () => {
       .spyOn(seriesMatchesService, "getSeriesMatches")
       .mockRejectedValueOnce(new Error("boom"))
       .mockResolvedValueOnce({
-        medalMetadata: {},
         playerXuidToGametag: {},
         matches: ["m-1", "m-2"].map((matchId) => ({
           matchId,
@@ -657,7 +655,6 @@ describe("useIndividualTrackerViewer", () => {
     const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
     const getSeriesMatchesSpy = vi.spyOn(seriesMatchesService, "getSeriesMatches").mockImplementation(async (ids) =>
       Promise.resolve({
-        medalMetadata: {},
         playerXuidToGametag: {},
         matches: ids.map((matchId) => ({
           matchId,
@@ -746,7 +743,6 @@ describe("useIndividualTrackerViewer", () => {
     });
 
     vi.spyOn(seriesMatchesService, "getSeriesMatches").mockResolvedValue({
-      medalMetadata: {},
       playerXuidToGametag: {},
       matches: [
         {
@@ -864,7 +860,6 @@ describe("useIndividualTrackerViewer", () => {
 
     expect(resolveFirstBatch).toBeDefined();
     resolveFirstBatch?.({
-      medalMetadata: {},
       playerXuidToGametag: {},
       matches: matchIds.slice(0, 30).map((matchId) => ({
         matchId,

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -6,6 +6,7 @@ import type { StreamerViewSettings } from "@guilty-spark/shared/individual-track
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import { aFakeIndividualTrackerServiceWith } from "../../../../services/individual-tracker/fakes/individual-tracker.fake";
+import { HaloMedalMetadataResolver } from "../../../../services/halo/medal-metadata-resolver";
 import {
   aFakeIndividualTrackerViewServiceWith,
   aFakeTrackerLiveViewWith,
@@ -24,13 +25,17 @@ interface ViewerTestDependencies {
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
   readonly haloClient: HaloInfiniteClient;
+  readonly medalMetadataResolver: HaloMedalMetadataResolver;
 }
 
 function aViewerTestDependenciesWith(): ViewerTestDependencies {
+  const haloClient = aFakeHaloClientWith();
+
   return {
     matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     seriesMatchesService: aFakeSeriesMatchesServiceWith(),
-    haloClient: aFakeHaloClientWith(),
+    haloClient,
+    medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
   };
 }
 
@@ -41,7 +46,7 @@ describe("useIndividualTrackerViewer", () => {
       view: aFakeTrackerViewStateWith({ trackerId: "tracker-1", status: "active" }),
     });
     const connectSpy = vi.spyOn(individualTrackerViewService, "connect");
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
 
     const initialSettings: StreamerViewSettings = {
       styleFlags: {
@@ -56,7 +61,7 @@ describe("useIndividualTrackerViewer", () => {
           individualTrackerViewService,
           matchAnalyticsService,
           seriesMatchesService,
-          haloClient,
+          medalMetadataResolver,
           trackerId: "tracker-1",
           streamerSettings: settings,
         }),
@@ -89,7 +94,7 @@ describe("useIndividualTrackerViewer", () => {
     const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
       view: aFakeTrackerViewStateWith({ trackerId: "tracker-1", status: "active" }),
     });
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
 
     const { result } = renderHook(() =>
       useIndividualTrackerViewer({
@@ -97,7 +102,7 @@ describe("useIndividualTrackerViewer", () => {
         individualTrackerViewService,
         matchAnalyticsService,
         seriesMatchesService,
-        haloClient,
+        medalMetadataResolver,
         trackerId: "tracker-1",
       }),
     );
@@ -131,7 +136,8 @@ describe("useIndividualTrackerViewer", () => {
     const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
       view: aFakeTrackerViewStateWith({ trackerId: "tracker-1", status: "active" }),
     });
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, haloClient, medalMetadataResolver } =
+      aViewerTestDependenciesWith();
     const getSeriesMatchesSpy = vi.spyOn(seriesMatchesService, "getSeriesMatches");
     const getMatchStatsSpy = vi.spyOn(haloClient, "getMatchStats");
 
@@ -140,7 +146,7 @@ describe("useIndividualTrackerViewer", () => {
         individualTrackerViewService,
         matchAnalyticsService,
         seriesMatchesService,
-        haloClient,
+        medalMetadataResolver,
         trackerId: "tracker-1",
       }),
     );
@@ -158,14 +164,14 @@ describe("useIndividualTrackerViewer", () => {
       view: aFakeTrackerViewStateWith({ trackerId: "tracker-1", status: "active" }),
     });
     const connectSpy = vi.spyOn(individualTrackerViewService, "connect");
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
 
     const { result } = renderHook(() =>
       useIndividualTrackerViewer({
         individualTrackerViewService,
         matchAnalyticsService,
         seriesMatchesService,
-        haloClient,
+        medalMetadataResolver,
         trackerId: "tracker-1",
       }),
     );
@@ -188,14 +194,14 @@ describe("useIndividualTrackerViewer", () => {
     });
     const getViewSpy = vi.spyOn(individualTrackerViewService, "getView");
     const connectSpy = vi.spyOn(individualTrackerViewService, "connect");
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
 
     const { result } = renderHook(() =>
       useIndividualTrackerViewer({
         individualTrackerViewService,
         matchAnalyticsService,
         seriesMatchesService,
-        haloClient,
+        medalMetadataResolver,
         trackerId: "tracker-1",
         externalView,
       }),
@@ -227,7 +233,7 @@ describe("useIndividualTrackerViewer", () => {
     const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
       view: aFakeTrackerViewStateWith({ trackerId: "tracker-1", status: "active" }),
     });
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
 
     const { result, rerender } = renderHook(
       ({ externalView }: { externalView: ReturnType<typeof aFakeTrackerViewStateWith> }) =>
@@ -235,7 +241,7 @@ describe("useIndividualTrackerViewer", () => {
           individualTrackerViewService,
           matchAnalyticsService,
           seriesMatchesService,
-          haloClient,
+          medalMetadataResolver,
           trackerId: "tracker-1",
           externalView,
         }),
@@ -277,7 +283,7 @@ describe("useIndividualTrackerViewer", () => {
     });
     vi.spyOn(individualTrackerViewService, "getView").mockImplementationOnce(async () => getViewPending);
 
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
 
     const { result, rerender } = renderHook<
       ReturnType<typeof useIndividualTrackerViewer>,
@@ -288,7 +294,7 @@ describe("useIndividualTrackerViewer", () => {
           individualTrackerViewService,
           matchAnalyticsService,
           seriesMatchesService,
-          haloClient,
+          medalMetadataResolver,
           trackerId: "tracker-1",
           externalView: nextExternalView,
         }),
@@ -317,7 +323,7 @@ describe("useIndividualTrackerViewer", () => {
       statsHighlights: [{ label: "KDA", value: "9.9" }],
     });
     const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({ view: managedView });
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
 
     const { result, rerender } = renderHook<
       ReturnType<typeof useIndividualTrackerViewer>,
@@ -328,7 +334,7 @@ describe("useIndividualTrackerViewer", () => {
           individualTrackerViewService,
           matchAnalyticsService,
           seriesMatchesService,
-          haloClient,
+          medalMetadataResolver,
           trackerId: "tracker-1",
           externalView: nextExternalView,
         }),
@@ -370,14 +376,14 @@ describe("useIndividualTrackerViewer", () => {
     });
     const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({ view: firstView });
     const getViewSpy = vi.spyOn(individualTrackerViewService, "getView");
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
 
     const { result } = renderHook(() =>
       useIndividualTrackerViewer({
         individualTrackerViewService,
         matchAnalyticsService,
         seriesMatchesService,
-        haloClient,
+        medalMetadataResolver,
         trackerId: "tracker-1",
       }),
     );
@@ -412,14 +418,14 @@ describe("useIndividualTrackerViewer", () => {
     });
     const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({ view: firstView });
     const getViewSpy = vi.spyOn(individualTrackerViewService, "getView");
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
 
     const { result } = renderHook(() =>
       useIndividualTrackerViewer({
         individualTrackerViewService,
         matchAnalyticsService,
         seriesMatchesService,
-        haloClient,
+        medalMetadataResolver,
         trackerId: "tracker-1",
       }),
     );
@@ -471,14 +477,14 @@ describe("useIndividualTrackerViewer", () => {
     });
     const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({ view: firstView });
     const getViewSpy = vi.spyOn(individualTrackerViewService, "getView");
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
 
     const { result } = renderHook(() =>
       useIndividualTrackerViewer({
         individualTrackerViewService,
         matchAnalyticsService,
         seriesMatchesService,
-        haloClient,
+        medalMetadataResolver,
         trackerId: "tracker-1",
         streamerSettings: localSettings,
       }),
@@ -511,7 +517,7 @@ describe("useIndividualTrackerViewer", () => {
         series: [aFakeTrackerSeriesGroupWith({ id: "series-1", title: "Long Series", matchIds })],
       }),
     });
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
     const getSeriesMatchesSpy = vi.spyOn(seriesMatchesService, "getSeriesMatches").mockImplementation(async (ids) =>
       Promise.resolve({
         playerXuidToGametag: {},
@@ -537,7 +543,7 @@ describe("useIndividualTrackerViewer", () => {
         individualTrackerViewService,
         matchAnalyticsService,
         seriesMatchesService,
-        haloClient,
+        medalMetadataResolver,
         trackerId: "tracker-1",
       }),
     );
@@ -578,7 +584,7 @@ describe("useIndividualTrackerViewer", () => {
         series: [aFakeTrackerSeriesGroupWith({ id: "series-1", title: "Retry Series", matchIds: ["m-1", "m-2"] })],
       }),
     });
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
     const getSeriesMatchesSpy = vi
       .spyOn(seriesMatchesService, "getSeriesMatches")
       .mockRejectedValueOnce(new Error("boom"))
@@ -605,7 +611,7 @@ describe("useIndividualTrackerViewer", () => {
         individualTrackerViewService,
         matchAnalyticsService,
         seriesMatchesService,
-        haloClient,
+        medalMetadataResolver,
         trackerId: "tracker-1",
       }),
     );
@@ -652,7 +658,7 @@ describe("useIndividualTrackerViewer", () => {
         series: [aFakeTrackerSeriesGroupWith({ id: "series-1", title: "Huge Series", matchIds })],
       }),
     });
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
     const getSeriesMatchesSpy = vi.spyOn(seriesMatchesService, "getSeriesMatches").mockImplementation(async (ids) =>
       Promise.resolve({
         playerXuidToGametag: {},
@@ -678,7 +684,7 @@ describe("useIndividualTrackerViewer", () => {
         individualTrackerViewService,
         matchAnalyticsService,
         seriesMatchesService,
-        haloClient,
+        medalMetadataResolver,
         trackerId: "tracker-1",
       }),
     );
@@ -716,7 +722,7 @@ describe("useIndividualTrackerViewer", () => {
         series: [aFakeTrackerSeriesGroupWith({ id: "series-1", title: "Roster Source", matchIds })],
       }),
     });
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
     const matchA = aFakeMatchStatsWith({
       MatchId: "m-1",
       MatchInfo: {
@@ -781,7 +787,7 @@ describe("useIndividualTrackerViewer", () => {
         individualTrackerViewService,
         matchAnalyticsService,
         seriesMatchesService,
-        haloClient,
+        medalMetadataResolver,
         trackerId: "tracker-1",
       }),
     );
@@ -819,7 +825,7 @@ describe("useIndividualTrackerViewer", () => {
         series: [aFakeTrackerSeriesGroupWith({ id: "series-1", title: "Huge Series", matchIds })],
       }),
     });
-    const { matchAnalyticsService, seriesMatchesService, haloClient } = aViewerTestDependenciesWith();
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
     let resolveFirstBatch: ((value: SeriesMatchesResponse) => void) | undefined;
     const firstBatchPromise = new Promise<SeriesMatchesResponse>((resolve) => {
       resolveFirstBatch = resolve;
@@ -834,7 +840,7 @@ describe("useIndividualTrackerViewer", () => {
         individualTrackerViewService,
         matchAnalyticsService,
         seriesMatchesService,
-        haloClient,
+        medalMetadataResolver,
         trackerId: "tracker-1",
       }),
     );

--- a/pages/src/components/individual-tracker/viewer/use-individual-tracker-viewer.ts
+++ b/pages/src/components/individual-tracker/viewer/use-individual-tracker-viewer.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
-import type { HaloInfiniteClient } from "halo-infinite-api";
 import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import type { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
 import type { IndividualTrackerViewService } from "../../../services/individual-tracker/view-types";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
@@ -16,7 +16,7 @@ interface UseIndividualTrackerViewerOpts {
   readonly individualTrackerViewService: IndividualTrackerViewService;
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
-  readonly haloClient: HaloInfiniteClient;
+  readonly medalMetadataResolver: HaloMedalMetadataResolver;
   readonly trackerId: string;
   readonly streamerSettings?: StreamerViewSettings;
   readonly externalView?: TrackerViewState;
@@ -35,7 +35,7 @@ export function useIndividualTrackerViewer({
   individualTrackerViewService,
   matchAnalyticsService,
   seriesMatchesService,
-  haloClient,
+  medalMetadataResolver,
   trackerId,
   streamerSettings,
   externalView,
@@ -49,7 +49,7 @@ export function useIndividualTrackerViewer({
         individualTrackerViewService,
         matchAnalyticsService,
         seriesMatchesService,
-        haloClient,
+        medalMetadataResolver,
         store,
         trackerId,
       }),
@@ -58,7 +58,7 @@ export function useIndividualTrackerViewer({
       individualTrackerViewService,
       matchAnalyticsService,
       seriesMatchesService,
-      haloClient,
+      medalMetadataResolver,
       store,
       trackerId,
     ],

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -1,4 +1,4 @@
-import type { HaloInfiniteClient, MatchStats } from "halo-infinite-api";
+import type { MatchStats } from "halo-infinite-api";
 import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
 import { getTeamName } from "@guilty-spark/shared/halo/team";
@@ -6,7 +6,7 @@ import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-
 import type { SeriesMatchesResponse } from "@guilty-spark/shared/contracts/stats/series-matches";
 import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
-import { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
+import type { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { SeriesMatchesService } from "../../../services/stats/series-matches-types";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
@@ -51,7 +51,7 @@ interface Config {
   readonly individualTrackerViewService: IndividualTrackerViewService;
   readonly matchAnalyticsService: MatchAnalyticsService;
   readonly seriesMatchesService: SeriesMatchesService;
-  readonly haloClient: HaloInfiniteClient;
+  readonly medalMetadataResolver: HaloMedalMetadataResolver;
   readonly store: IndividualTrackerViewerStore;
   readonly trackerId: string;
 }
@@ -226,11 +226,9 @@ export class IndividualTrackerViewerPresenter {
   private streamerSettingsKey = "null";
   private hasServerStreamerSettings = false;
   private modeVersion = 0;
-  private readonly medalMetadataResolver: HaloMedalMetadataResolver;
 
   public constructor(config: Config) {
     this.config = config;
-    this.medalMetadataResolver = new HaloMedalMetadataResolver(config.haloClient);
   }
 
   private static entryKey(item: ViewerTimelineItem): string {
@@ -365,7 +363,7 @@ export class IndividualTrackerViewerPresenter {
       }
     }
 
-    const medalMetadata = await this.medalMetadataResolver.getMedalMetadataForMatch(stats);
+    const medalMetadata = await this.config.medalMetadataResolver.getMedalMetadataForMatch(stats);
 
     return { stats, playerMap, medalMetadata, analytics, gameMapThumbnailUrl: matchSummary.gameMapThumbnailUrl };
   }
@@ -455,7 +453,7 @@ export class IndividualTrackerViewerPresenter {
       const rawMatches = mergedSeriesData.matches
         .map((m) => m.rawMatch)
         .filter((m): m is MatchStats => isMatchStats(m));
-      const medalMetadata = await this.medalMetadataResolver.getMedalMetadataForMatches(rawMatches);
+      const medalMetadata = await this.config.medalMetadataResolver.getMedalMetadataForMatches(rawMatches);
 
       const teamColors = this.resolveTeamColors();
       const viewModel = buildSeriesViewModel({

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -82,7 +82,7 @@ function isMatchStats(value: unknown): value is MatchStats {
 
 interface BuildSeriesViewModelArgs {
   readonly series: ViewerSeriesTab;
-  readonly seriesData: Omit<SeriesMatchesResponse, "matches"> & { matches: SeriesMatchesResponse["matches"] };
+  readonly seriesData: SeriesMatchesResponse;
   readonly rawMatches: readonly MatchStats[];
   readonly medalMetadata: MedalMetadata;
   readonly playerMap: Map<string, string>;

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -6,6 +6,7 @@ import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-
 import type { SeriesMatchesResponse } from "@guilty-spark/shared/contracts/stats/series-matches";
 import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { SeriesMatchesService } from "../../../services/stats/series-matches-types";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/types";
@@ -81,8 +82,9 @@ function isMatchStats(value: unknown): value is MatchStats {
 
 interface BuildSeriesViewModelArgs {
   readonly series: ViewerSeriesTab;
-  readonly seriesData: SeriesMatchesResponse;
+  readonly seriesData: Omit<SeriesMatchesResponse, "matches"> & { matches: SeriesMatchesResponse["matches"] };
   readonly rawMatches: readonly MatchStats[];
+  readonly medalMetadata: MedalMetadata;
   readonly playerMap: Map<string, string>;
   readonly teamColors: readonly TeamColor[];
 }
@@ -109,11 +111,10 @@ function buildSeriesViewModel({
   series,
   seriesData,
   rawMatches,
+  medalMetadata,
   playerMap,
   teamColors,
 }: BuildSeriesViewModelArgs): SeriesStatsViewModel {
-  const medalMetadata: MedalMetadata = seriesData.medalMetadata;
-
   // --- Series totals ---
   const seriesController = new StatsController();
   seriesController.loadSeries([...rawMatches], playerMap, medalMetadata);
@@ -225,9 +226,11 @@ export class IndividualTrackerViewerPresenter {
   private streamerSettingsKey = "null";
   private hasServerStreamerSettings = false;
   private modeVersion = 0;
+  private readonly medalMetadataResolver: HaloMedalMetadataResolver;
 
   public constructor(config: Config) {
     this.config = config;
+    this.medalMetadataResolver = new HaloMedalMetadataResolver(config.haloClient);
   }
 
   private static entryKey(item: ViewerTimelineItem): string {
@@ -362,7 +365,7 @@ export class IndividualTrackerViewerPresenter {
       }
     }
 
-    const medalMetadata: MedalMetadata = seriesMatches.medalMetadata;
+    const medalMetadata = await this.medalMetadataResolver.getMedalMetadataForMatch(stats);
 
     return { stats, playerMap, medalMetadata, analytics, gameMapThumbnailUrl: matchSummary.gameMapThumbnailUrl };
   }
@@ -442,7 +445,6 @@ export class IndividualTrackerViewerPresenter {
 
       const mergedMatchesById = new Map(seriesDataChunks.flatMap((chunk) => chunk.matches).map((m) => [m.matchId, m]));
       const mergedSeriesData: SeriesMatchesResponse = {
-        medalMetadata: Object.assign({}, ...seriesDataChunks.map((chunk) => chunk.medalMetadata)),
         playerXuidToGametag: Object.assign({}, ...seriesDataChunks.map((chunk) => chunk.playerXuidToGametag)),
         matches: requestedMatchIds
           .map((matchId) => mergedMatchesById.get(matchId))
@@ -453,12 +455,14 @@ export class IndividualTrackerViewerPresenter {
       const rawMatches = mergedSeriesData.matches
         .map((m) => m.rawMatch)
         .filter((m): m is MatchStats => isMatchStats(m));
+      const medalMetadata = await this.medalMetadataResolver.getMedalMetadataForMatches(rawMatches);
 
       const teamColors = this.resolveTeamColors();
       const viewModel = buildSeriesViewModel({
         series,
         seriesData: mergedSeriesData,
         rawMatches,
+        medalMetadata,
         playerMap,
         teamColors,
       });

--- a/pages/src/services/halo/medal-metadata-resolver.ts
+++ b/pages/src/services/halo/medal-metadata-resolver.ts
@@ -27,7 +27,12 @@ export class HaloMedalMetadataResolver {
 
   private async getMedalLookupAsync(): Promise<MedalLookup> {
     this.medalLookupPromise ??= this.loadMedalLookupAsync();
-    return this.medalLookupPromise;
+    try {
+      return await this.medalLookupPromise;
+    } catch (error) {
+      this.medalLookupPromise = null;
+      throw error;
+    }
   }
 
   private async loadMedalLookupAsync(): Promise<MedalLookup> {

--- a/pages/src/services/halo/medal-metadata-resolver.ts
+++ b/pages/src/services/halo/medal-metadata-resolver.ts
@@ -6,16 +6,19 @@ type MedalLookup = ReadonlyMap<number, { name: string; sortingWeight: number }>;
 export class HaloMedalMetadataResolver {
   private medalLookupPromise: Promise<MedalLookup> | null = null;
 
-  public constructor(
-    private readonly haloClient: Pick<HaloInfiniteClient, "getMedalsMetadataFile">,
-  ) {}
+  public constructor(private readonly haloClient: Pick<HaloInfiniteClient, "getMedalsMetadataFile">) {}
 
   public async getMedalMetadataForMatch(stats: MatchStats): Promise<MedalMetadata> {
+    return this.getMedalMetadataForMatches([stats]);
+  }
+
+  public async getMedalMetadataForMatches(stats: readonly MatchStats[]): Promise<MedalMetadata> {
     try {
       const medalLookup = await this.getMedalLookupAsync();
-      return await getMedalMetadataFromMatches(
-        { [stats.MatchId]: stats },
-        async (medalId) => Promise.resolve(medalLookup.get(medalId)),
+      const matchesById = Object.fromEntries(stats.map((match) => [match.MatchId, match]));
+
+      return await getMedalMetadataFromMatches(matchesById, async (medalId) =>
+        Promise.resolve(medalLookup.get(medalId)),
       );
     } catch {
       return {};

--- a/pages/src/services/halo/medal-metadata-resolver.ts
+++ b/pages/src/services/halo/medal-metadata-resolver.ts
@@ -1,0 +1,43 @@
+import type { HaloInfiniteClient, MatchStats } from "halo-infinite-api";
+import { getMedalMetadataFromMatches, type MedalMetadata } from "@guilty-spark/shared/halo/medals";
+
+type MedalLookup = ReadonlyMap<number, { name: string; sortingWeight: number }>;
+
+export class HaloMedalMetadataResolver {
+  private medalLookupPromise: Promise<MedalLookup> | null = null;
+
+  public constructor(
+    private readonly haloClient: Pick<HaloInfiniteClient, "getMedalsMetadataFile">,
+  ) {}
+
+  public async getMedalMetadataForMatch(stats: MatchStats): Promise<MedalMetadata> {
+    try {
+      const medalLookup = await this.getMedalLookupAsync();
+      return await getMedalMetadataFromMatches(
+        { [stats.MatchId]: stats },
+        async (medalId) => Promise.resolve(medalLookup.get(medalId)),
+      );
+    } catch {
+      return {};
+    }
+  }
+
+  private async getMedalLookupAsync(): Promise<MedalLookup> {
+    this.medalLookupPromise ??= this.loadMedalLookupAsync();
+    return this.medalLookupPromise;
+  }
+
+  private async loadMedalLookupAsync(): Promise<MedalLookup> {
+    const metadataFile = await this.haloClient.getMedalsMetadataFile();
+    const medalLookup = new Map<number, { name: string; sortingWeight: number }>();
+
+    for (const medal of metadataFile.medals) {
+      medalLookup.set(medal.nameId, {
+        name: medal.name.value,
+        sortingWeight: medal.sortingWeight,
+      });
+    }
+
+    return medalLookup;
+  }
+}

--- a/pages/src/services/halo/tests/medal-metadata-resolver.test.ts
+++ b/pages/src/services/halo/tests/medal-metadata-resolver.test.ts
@@ -1,0 +1,61 @@
+import type { HaloInfiniteClient } from "halo-infinite-api";
+import { describe, expect, it, vi } from "vitest";
+import { aFakeMatchStatsWith } from "../../../controllers/stats/fakes/data";
+import { aFakeHaloClientWith } from "../../fakes/halo-client.fake";
+import { HaloMedalMetadataResolver } from "../medal-metadata-resolver";
+
+function aMedalsMetadataFile(): Awaited<ReturnType<HaloInfiniteClient["getMedalsMetadataFile"]>> {
+  return {
+    difficulties: ["normal", "heroic", "legendary", "mythic"],
+    types: ["spree", "mode", "multikill", "proficiency", "skill", "style"],
+    sprites: {
+      small: { path: "small.png", columns: 16, size: 72 },
+      medium: { path: "medium.png", columns: 16, size: 128 },
+      "extra-large": { path: "large.png", columns: 16, size: 256 },
+    },
+    medals: [
+      {
+        name: { value: "Killing Spree", translations: {} },
+        description: { value: "Kill 5 enemies without dying", translations: {} },
+        spriteIndex: 1,
+        sortingWeight: 100,
+        difficultyIndex: 1,
+        typeIndex: 0,
+        personalScore: 10,
+        nameId: 622331684,
+      },
+      {
+        name: { value: "Double Kill", translations: {} },
+        description: { value: "Kill 2 enemies in quick succession", translations: {} },
+        spriteIndex: 2,
+        sortingWeight: 50,
+        difficultyIndex: 1,
+        typeIndex: 2,
+        personalScore: 10,
+        nameId: 1169571763,
+      },
+    ],
+  };
+}
+
+describe("HaloMedalMetadataResolver", () => {
+  it("retries metadata loading after a transient failure", async () => {
+    const getMedalsMetadataFile = vi.fn<Pick<HaloInfiniteClient, "getMedalsMetadataFile">["getMedalsMetadataFile"]>();
+    getMedalsMetadataFile.mockRejectedValueOnce(new Error("temporary failure"));
+    getMedalsMetadataFile.mockResolvedValueOnce(aMedalsMetadataFile());
+
+    const haloClient = aFakeHaloClientWith({ getMedalsMetadataFile });
+    const resolver = new HaloMedalMetadataResolver(haloClient);
+    const stats = aFakeMatchStatsWith();
+
+    const firstResult = await resolver.getMedalMetadataForMatches([stats]);
+    const secondResult = await resolver.getMedalMetadataForMatches([stats]);
+
+    expect(firstResult).toEqual({});
+    expect(secondResult).toEqual({
+      622331684: { name: "Killing Spree", sortingWeight: 100 },
+      1169571763: { name: "Double Kill", sortingWeight: 50 },
+    });
+    expect(getMedalsMetadataFile).toHaveBeenCalledTimes(2);
+  });
+});

--- a/pages/src/services/stats/fakes/series-matches.fake.ts
+++ b/pages/src/services/stats/fakes/series-matches.fake.ts
@@ -5,7 +5,6 @@ export function aFakeSeriesMatchesServiceWith(response: Partial<SeriesMatchesRes
   return {
     getSeriesMatches: async () =>
       Promise.resolve({
-        medalMetadata: {},
         playerXuidToGametag: {},
         matches: [],
         ...response,

--- a/shared/src/contracts/stats/series-matches.ts
+++ b/shared/src/contracts/stats/series-matches.ts
@@ -18,7 +18,6 @@ export type SeriesMatchesQuery = z.infer<typeof seriesMatchesQuerySchema>;
 
 export const seriesMatchesContract = defineContract(
   z.object({
-    medalMetadata: z.record(z.string().regex(/^\d+$/), z.object({ name: z.string(), sortingWeight: z.number() })),
     playerXuidToGametag: z.record(z.string(), z.string()),
     matches: z.array(
       z.object({


### PR DESCRIPTION
## Context
We discovered a medals rendering regression in individual tracker overlays caused by inconsistent metadata ownership across server and client paths. This work fixes the overlay issue and moves the tracker medal metadata flow toward a single browser-side resolution strategy, while keeping resolver creation high in app wiring and passing it down through create/hook/presenter boundaries.

## This PR
- fixes overlay medals not rendering by resolving medal metadata in the frontend presenter path
- adds a reusable Halo medal metadata resolver service with cached metadata-file loading
- removes `medalMetadata` from the `series-matches` API contract/route and resolves series medals client-side in viewer flows
- applies dependency injection for the resolver from app/service wiring into viewer, overlay, and follow-live create paths
- updates focused tests/fakes and validates the full workspace quality gate (`npm run done`)

## Subsequent Work
- migrate `discord-series-stats` off server-provided `medalMetadata` to the shared browser-side resolver approach
- define and implement live-tracker websocket medal metadata convergence (single source of truth, cache/refresh strategy, and payload ownership)
- run Copilot review loop focused on medal metadata boundary consistency and regression coverage across all tracker surfaces
