### PR TITLE
ci: shard vitest test runs across 4 parallel jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,13 +36,13 @@ jobs:
         run: cp api/.example.dev.vars api/.dev.vars
 
       - name: Run test shard
-        run: npx vitest run --shard=${{ matrix.shardIndex }}/${{ matrix.shardCount }} --reporter=blob --coverage.enabled true
+        run: npx vitest run --shard=${{ matrix.shardIndex }}/${{ matrix.shardCount }} --reporter=blob --outputFile.blob=blob-report/blob-${{ matrix.shardIndex }}-${{ matrix.shardCount }}.json --coverage.enabled true
 
       - name: Upload blob report
         uses: actions/upload-artifact@v4
         with:
           name: blob-report-${{ matrix.shardIndex }}
-          path: .vitest-reports/*
+          path: blob-report/*
           retention-days: 1
 
   merge-reports:
@@ -72,12 +72,12 @@ jobs:
       - name: Download blob reports
         uses: actions/download-artifact@v4
         with:
-          path: .vitest-reports
+          path: blob-report
           pattern: blob-report-*
           merge-multiple: true
 
       - name: Merge test reports
-        run: npx vitest run --merge-reports --reporter=junit --reporter=default --coverage.enabled true
+        run: npx vitest run --mergeReports=blob-report --reporter=junit --reporter=default --coverage.enabled true
 
       - name: Publish test results
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4]
-        shardCount: [4]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
+        shardCount: [8]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,46 @@ on:
       - main
 
 jobs:
-  run-build:
-    name: Run Test
+  run-test:
+    name: Run Test (Shard ${{ matrix.shardIndex }}/${{ matrix.shardCount }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        shardCount: [4]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "npm"
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Copy API environment file
+        run: cp api/.example.dev.vars api/.dev.vars
+
+      - name: Run test shard
+        run: npx vitest run --shard=${{ matrix.shardIndex }}/${{ matrix.shardCount }} --reporter=blob --coverage.enabled true
+
+      - name: Upload blob report
+        uses: actions/upload-artifact@v4
+        with:
+          name: blob-report-${{ matrix.shardIndex }}
+          path: .vitest-reports/*
+          retention-days: 1
+
+  merge-reports:
+    name: Merge Test Reports
+    needs: run-test
+    if: always()
     runs-on: ubuntu-latest
 
     permissions:
@@ -31,11 +69,15 @@ jobs:
       - name: Install Node.js dependencies
         run: npm ci
 
-      - name: Copy API environment file
-        run: cp api/.example.dev.vars api/.dev.vars
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          path: .vitest-reports
+          pattern: blob-report-*
+          merge-multiple: true
 
-      - name: Run test
-        run: npx vitest --coverage.enabled true
+      - name: Merge test reports
+        run: npx vitest run --merge-reports --reporter=junit --reporter=default --coverage.enabled true
 
       - name: Publish test results
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,12 @@ jobs:
       - name: Merge test reports
         run: npx vitest run --mergeReports=blob-report --reporter=junit --reporter=default --coverage.enabled true
 
+      - name: Fail if any shard did not succeed
+        if: needs.run-test.result != 'success'
+        run: |
+          echo "One or more test shards did not succeed (result: ${{ needs.run-test.result }})"
+          exit 1
+
       - name: Publish test results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
## Context

The Test GitHub Action (`.github/workflows/test.yml`) is the slowest part of our CI, taking ~2m56s total, with the `Run test` step alone accounting for ~2m17s of that.

## This change

Investigated whether vitest's sharding support could meaningfully speed this up:

- Confirmed the CI runner (ubuntu-latest, 4 cores) is the bottleneck — the same suite runs several times faster locally on a higher-core machine, and `--coverage.enabled true` roughly doubles execution time on top of that.
- Verified vitest 4's `--shard=<index>/<count>` works correctly with this repo's `projects` workspace setup (api/pages/shared), and that `--reporter=blob` + `--merge-reports` reconstitutes an identical junit report and coverage summary (verified byte-for-byte matching coverage percentages against an unsharded run).

Updated the workflow to:
1. **`run-test`**: a 4-way matrix job, each shard running `vitest run --shard=N/4 --reporter=blob --coverage.enabled true` and uploading its blob report as an artifact.
2. **`merge-reports`**: downloads all shard blobs, runs `vitest run --merge-reports` to reconstruct the full junit + coverage output, then runs the existing `publish-unit-test-result-action` and `vitest-coverage-report-action` steps unchanged.

This trades some duplicated fixed overhead (checkout/`npm ci` per shard, now running in parallel) for ~4x parallelism on the actual test execution, which is the dominant cost.

## Test plan

- [ ] Confirm the `Test` workflow passes on this PR
- [ ] Compare total wall-clock time of this PR's CI run against a recent `main` run
- [ ] Confirm the coverage report comment and published test results look correct (unchanged from before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)