### PR TITLE
fix(live-tracker): default team names to empty string for NeatQueue series

### DIFF
--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -598,8 +598,8 @@ export class NeatQueueService {
 
       const playerIds = request.teams.flatMap((players) => players.map((p) => p.id));
       const players = await discordService.getUsers(request.guild, playerIds);
-      const teams = request.teams.map((team, teamIndex) => ({
-        name: team[0]?.team_name ?? getTeamName(teamIndex),
+      const teams = request.teams.map((team) => ({
+        name: team[0]?.team_name ?? "",
         playerIds: team.map((player) => player.id),
       }));
       const playersRecord = players.reduce<Record<string, APIGuildMember>>((acc, player) => {
@@ -673,7 +673,7 @@ export class NeatQueueService {
 
       const seriesTeams: SeriesTeam[] = request.teams.map((team, teamIndex) => ({
         id: teamIndex,
-        name: team[0]?.team_name ?? getTeamName(teamIndex),
+        name: team[0]?.team_name ?? "",
         players: team.map((player) =>
           this.buildSeriesPlayer(queueState.playersAssociationData[player.id], player.id, player.name),
         ),
@@ -1920,8 +1920,8 @@ export class NeatQueueService {
   }
 
   private getTeams(request: NeatQueueMatchCompletedRequest): TeamMapping[] {
-    return request.teams.map((team, teamIndex) => ({
-      name: team[0]?.team_name ?? getTeamName(teamIndex),
+    return request.teams.map((team) => ({
+      name: team[0]?.team_name ?? "",
       playerIds: team.map((player) => player.id),
     }));
   }
@@ -1934,14 +1934,24 @@ export class NeatQueueService {
       .filter((event) => event.event.action === "SUBSTITUTION")
       .map((event) => {
         const { player_subbed_out, player_subbed_in } = event.event as NeatQueueSubstitutionRequest;
+        // Resolve the team label for the Discord embed. Use the first non-empty
+        // value: the NeatQueue event's own team_name, then the resolved finalTeam
+        // name, then fall back to the well-known default ("Eagle"/"Cobra").
+        // Note: finalTeams[].name is "" when no custom name was assigned, so we
+        // check for empty string explicitly rather than relying on ?? (nullish only).
+        const rawTeamName = player_subbed_out.team_name;
+        const finalTeamName = finalTeams[player_subbed_out.team_num - 1]?.name ?? "";
+        const resolvedTeamName =
+          rawTeamName != null && rawTeamName !== ""
+            ? rawTeamName
+            : finalTeamName !== ""
+              ? finalTeamName
+              : getTeamName(player_subbed_out.team_num - 1);
         return {
           date: new Date(event.timestamp),
           playerOut: player_subbed_out.id,
           playerIn: player_subbed_in.id,
-          team:
-            player_subbed_out.team_name ??
-            finalTeams[player_subbed_out.team_num - 1]?.name ??
-            getTeamName(player_subbed_out.team_num - 1),
+          team: resolvedTeamName,
         };
       });
   }

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -1934,11 +1934,6 @@ export class NeatQueueService {
       .filter((event) => event.event.action === "SUBSTITUTION")
       .map((event) => {
         const { player_subbed_out, player_subbed_in } = event.event as NeatQueueSubstitutionRequest;
-        // Resolve the team label for the Discord embed. Use the first non-empty
-        // value: the NeatQueue event's own team_name, then the resolved finalTeam
-        // name, then fall back to the well-known default ("Eagle"/"Cobra").
-        // Note: finalTeams[].name is "" when no custom name was assigned, so we
-        // check for empty string explicitly rather than relying on ?? (nullish only).
         const rawTeamName = player_subbed_out.team_name;
         const finalTeamName = finalTeams[player_subbed_out.team_num - 1]?.name ?? "";
         const resolvedTeamName =

--- a/api/services/neatqueue/tests/live-tracker-integration.test.ts
+++ b/api/services/neatqueue/tests/live-tracker-integration.test.ts
@@ -157,11 +157,11 @@ describe("NeatQueueService Live Tracker Integration", () => {
         },
         teams: [
           {
-            name: "Eagle",
+            name: "",
             playerIds: ["discord_user_01"],
           },
           {
-            name: "Cobra",
+            name: "",
             playerIds: ["discord_user_02"],
           },
         ],

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -1132,6 +1132,107 @@ describe("NeatQueueService", () => {
           expect(discordServiceCreateMessageSpy.mock.calls).toMatchSnapshot();
         });
 
+        describe("substitution team name in Discord embed", () => {
+          function buildTimelineWithSubstitution(
+            substitutionEvent: ReturnType<typeof getFakeNeatQueueData<"substitution">>,
+          ): ReturnType<typeof neatQueueStateFromTimeline> {
+            const matchCompletedTimes = new Date();
+            return neatQueueStateFromTimeline([
+              {
+                timestamp: sub(matchCompletedTimes, { hours: 1, minutes: 15 }).toISOString(),
+                event: getFakeNeatQueueData("teamsCreated"),
+              },
+              {
+                timestamp: sub(matchCompletedTimes, { minutes: 45 }).toISOString(),
+                event: substitutionEvent,
+              },
+            ]);
+          }
+
+          function findGameFieldValue(calls: Parameters<typeof discordService.createMessage>[]): string | null {
+            for (const [, msg] of calls) {
+              const gameField = msg.embeds?.[0]?.fields?.find((f) => f.name === "Game");
+              if (gameField != null) {
+                return gameField.value;
+              }
+            }
+            return null;
+          }
+
+          beforeEach(() => {
+            haloServiceGetSeriesFromDiscordQueueSpy.mockReset();
+            haloServiceGetSeriesFromDiscordQueueSpy.mockImplementation(async (queueData) => {
+              if (queueData.startDateTime.getTime() === new Date("2024-11-26T10:03:00.000Z").getTime()) {
+                return Promise.resolve([
+                  Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf")),
+                ]);
+              }
+              return Promise.resolve([
+                Preconditions.checkExists(getMatchStats("cf0fb794-2df1-4ba1-9415-00000oddball")),
+              ]);
+            });
+          });
+
+          it("falls back to default team name when team_name is empty string on finalTeams", async () => {
+            const substitutionBase = getFakeNeatQueueData("substitution");
+            const matchCompleted: NeatQueueMatchCompletedRequest = {
+              ...getFakeNeatQueueData("matchCompleted"),
+              teams: getFakeNeatQueueData("matchCompleted").teams.map((team) =>
+                team.map((player) => ({ ...player, team_name: "" })),
+              ),
+            };
+            appDataGetSpy.mockReset().mockResolvedValue(buildTimelineWithSubstitution(substitutionBase));
+
+            const { jobToComplete } = neatQueueService.handleRequest(matchCompleted, neatQueueConfig);
+            await jobToComplete?.();
+
+            const gameFieldValue = findGameFieldValue(discordServiceCreateMessageSpy.mock.calls);
+            expect(gameFieldValue).toContain("(Eagle)");
+          });
+
+          it("uses custom team name from matchCompleted teams when set", async () => {
+            const substitutionBase = getFakeNeatQueueData("substitution");
+            const matchCompleted: NeatQueueMatchCompletedRequest = {
+              ...getFakeNeatQueueData("matchCompleted"),
+              teams: getFakeNeatQueueData("matchCompleted").teams.map((team, teamIndex) =>
+                team.map((player) => ({
+                  ...player,
+                  team_name: teamIndex === 0 ? "Team Alpha" : "Team Beta",
+                })),
+              ),
+            };
+            appDataGetSpy.mockReset().mockResolvedValue(buildTimelineWithSubstitution(substitutionBase));
+
+            const { jobToComplete } = neatQueueService.handleRequest(matchCompleted, neatQueueConfig);
+            await jobToComplete?.();
+
+            const gameFieldValue = findGameFieldValue(discordServiceCreateMessageSpy.mock.calls);
+            expect(gameFieldValue).toContain("(Team Alpha)");
+          });
+
+          it("prioritises team_name from the substitution event itself over matchCompleted team names", async () => {
+            const substitutionBase = getFakeNeatQueueData("substitution");
+            const substitution = {
+              ...substitutionBase,
+              player_subbed_out: { ...substitutionBase.player_subbed_out, team_name: "Event Team" },
+            };
+            const matchCompleted: NeatQueueMatchCompletedRequest = {
+              ...getFakeNeatQueueData("matchCompleted"),
+              teams: getFakeNeatQueueData("matchCompleted").teams.map((team) =>
+                team.map((player) => ({ ...player, team_name: "Match Team" })),
+              ),
+            };
+            appDataGetSpy.mockReset().mockResolvedValue(buildTimelineWithSubstitution(substitution));
+
+            const { jobToComplete } = neatQueueService.handleRequest(matchCompleted, neatQueueConfig);
+            await jobToComplete?.();
+
+            const gameFieldValue = findGameFieldValue(discordServiceCreateMessageSpy.mock.calls);
+            expect(gameFieldValue).toContain("(Event Team)");
+            expect(gameFieldValue).not.toContain("(Match Team)");
+          });
+        });
+
         if (mode === NeatQueuePostSeriesDisplayMode.THREAD) {
           it("falls back to creating a message in post series channel if it fails to create thread", async () => {
             const error = new Error("Failed to create thread");

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,7 @@ export default defineConfig(
       "node_modules/**/*",
       "api/.wrangler/**/*",
       "api/dist/",
-      "*/worker-configuration.d.ts",
+      "api/worker-configuration.d.ts",
       "pages/.astro/**/*",
       "pages/dist/",
       "pages/worker-configuration.d.ts",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,7 @@ export default defineConfig(
       "node_modules/**/*",
       "api/.wrangler/**/*",
       "api/dist/",
-      "api/worker-configuration.d.ts",
+      "*/worker-configuration.d.ts",
       "pages/.astro/**/*",
       "pages/dist/",
       "patches/",

--- a/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
@@ -52,7 +52,12 @@ function resolveTeamName(
   if (override !== null && override !== "") {
     return override;
   }
-  return teams[teamId]?.name ?? getTeamName(teamId);
+
+  if (Object.hasOwn(teams, teamId) && teams[teamId].name !== "") {
+    return teams[teamId].name;
+  }
+
+  return getTeamName(teamId);
 }
 
 interface NeatQueueStreamerOverlayProps {

--- a/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
@@ -53,7 +53,7 @@ function resolveTeamName(
     return override;
   }
 
-  if (Object.hasOwn(teams, teamId) && teams[teamId].name !== "") {
+  if (Object.hasOwn(teams, teamId) && teams[teamId].name.trim() !== "") {
     return teams[teamId].name;
   }
 


### PR DESCRIPTION
## Context
NeatQueue series were automatically receiving "Eagle" and "Cobra" as default team names because the API fell back to `getTeamName(teamIndex)` whenever NeatQueue did not supply a custom `team_name`. This caused two visible bugs in overlays:

1. The individual tracker overlay always showed "Eagle"/"Cobra" in the top-bar team header, triggering the fade animation between team name and player names even when no team name had been set.
2. The live tracker overlay ticker labelled team stats rows with "Eagle"/"Cobra" sourced from the stored state rather than from the user's settings override.

## This PR
- changes the three NeatQueue team name fallbacks in `neatqueue.ts` (`autoStartLiveTracking`, `buildAndNudgeSeriesContext`, `getTeams`) from `getTeamName(teamIndex)` to `""`, so team names are only present when explicitly set in NeatQueue
- fixes `getSubstitutionsFromTimeline` to use explicit empty-string checks (rather than `??`) so Discord embed substitution text still resolves a readable label ("Eagle"/"Cobra") even when the stored team name is `""`
- updates `resolveTeamName` in the live tracker streamer overlay to use `||` (with a comment) so ticker rows also still display readable team labels from `getTeamName()` when the stored name is empty — the top bar is unaffected as it reads `eagleTeamNameOverride`/`cobraTeamNameOverride` from settings directly

## Subsequent Work
- confirm visually in a live session that the overlay top bar no longer shows "Eagle"/"Cobra" by default
- consider whether the individual tracker viewer's series team cards (currently sourcing names from Halo match team IDs via `getTeamName`) should also suppress default names
