### PR TITLE
fix(streamer-overlay): ensure team/player swap works in OBS

### DIFF
--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 vi.mock("../../../icons/team-icon", () => ({
@@ -70,6 +70,41 @@ function aPropsWith(options?: {
     onSelectMatch: options?.onSelectMatch ?? ((): void => undefined),
     onSelectSeries: options?.onSelectSeries ?? ((): void => undefined),
     onDeselect: options?.onDeselect ?? ((): void => undefined),
+  };
+}
+
+function installTeamDetailsSwapSpy(): {
+  triggerAllSwaps: () => void;
+  restore: () => void;
+} {
+  const teamDetailsSwapHandlers: (() => void)[] = [];
+  const setIntervalSpy = vi
+    .spyOn(globalThis, "setInterval")
+    .mockImplementation((handler: TimerHandler): ReturnType<typeof setInterval> => {
+      if (typeof handler === "function") {
+        teamDetailsSwapHandlers.push((): void => {
+          Reflect.apply(handler, globalThis, []);
+        });
+      }
+
+      // Return a valid timer object for Node typing in tests.
+      return setTimeout((): void => undefined, 60_000);
+    });
+  const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval").mockImplementation((): void => undefined);
+
+  return {
+    triggerAllSwaps: (): void => {
+      expect(teamDetailsSwapHandlers.length).toBeGreaterThan(0);
+      act(() => {
+        for (const swapHandler of teamDetailsSwapHandlers) {
+          swapHandler();
+        }
+      });
+    },
+    restore: (): void => {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    },
   };
 }
 
@@ -181,6 +216,8 @@ describe("IndividualTrackerOverlay", () => {
   });
 
   it("renders active series team details using display-name fallbacks", () => {
+    const teamDetailsSwap = installTeamDetailsSwapSpy();
+
     render(
       <IndividualTrackerOverlay
         {...aPropsWith({
@@ -224,13 +261,22 @@ describe("IndividualTrackerOverlay", () => {
     );
 
     expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText(/Gamertag Name/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Xbox Only/)).not.toBeInTheDocument();
+
+    teamDetailsSwap.triggerAllSwaps();
+
     expect(screen.getByText(/Gamertag Name/)).toBeInTheDocument();
     expect(screen.getByText(/Xbox Only/)).toBeInTheDocument();
     expect(screen.getByText("Beta")).toBeInTheDocument();
     expect(screen.getByText("Unknown")).toBeInTheDocument();
+
+    teamDetailsSwap.restore();
   });
 
   it("maps team details by team id regardless of active-series team order", () => {
+    const teamDetailsSwap = installTeamDetailsSwapSpy();
+
     render(
       <IndividualTrackerOverlay
         {...aPropsWith({
@@ -279,10 +325,15 @@ describe("IndividualTrackerOverlay", () => {
     const rightTeamContainer = screen.getByTestId("team-icon-1").parentElement;
 
     expect(leftTeamContainer?.textContent).toContain("Alpha");
-    expect(leftTeamContainer?.textContent).toContain("Alpha Player");
     expect(rightTeamContainer?.textContent).toContain("Beta");
+
+    teamDetailsSwap.triggerAllSwaps();
+
+    expect(leftTeamContainer?.textContent).toContain("Alpha Player");
     expect(rightTeamContainer?.textContent).toContain("Beta Player");
     expect(screen.queryByText("Ignored Player")).not.toBeInTheDocument();
+
+    teamDetailsSwap.restore();
   });
 
   it("shows a 0:0 series tab and no waiting banner when in-series has no matches yet and ticker is disabled", () => {
@@ -404,6 +455,8 @@ describe("IndividualTrackerOverlay", () => {
   });
 
   it("uses xbox names in team details when discord names are hidden", () => {
+    const teamDetailsSwap = installTeamDetailsSwapSpy();
+
     const renderModel = aRenderModel({
       matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" }), aFakeTrackerMatchSummaryWith({ matchId: "m-2" })],
       series: [
@@ -443,10 +496,17 @@ describe("IndividualTrackerOverlay", () => {
 
     render(<IndividualTrackerOverlay {...aPropsWith({ renderModel, streamerSettings })} />);
 
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+
+    teamDetailsSwap.triggerAllSwaps();
+
     expect(screen.getByText("XboxAlpha")).toBeInTheDocument();
     expect(screen.getByText("XboxBeta")).toBeInTheDocument();
     expect(screen.queryByText("DiscordAlpha")).not.toBeInTheDocument();
     expect(screen.queryByText("DiscordBeta")).not.toBeInTheDocument();
+
+    teamDetailsSwap.restore();
   });
 
   it("shows only team names when both discord and xbox names are hidden", () => {

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -90,7 +90,6 @@ function installTeamDetailsSwapSpy(): {
       // Return a valid timer object for Node typing in tests.
       return setTimeout((): void => undefined, 60_000);
     });
-  const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval").mockImplementation((): void => undefined);
 
   return {
     triggerAllSwaps: (): void => {
@@ -103,13 +102,13 @@ function installTeamDetailsSwapSpy(): {
     },
     restore: (): void => {
       setIntervalSpy.mockRestore();
-      clearIntervalSpy.mockRestore();
     },
   };
 }
 
 describe("IndividualTrackerOverlay", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     cleanup();
   });
 

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -509,6 +509,7 @@ describe("IndividualTrackerOverlay", () => {
   });
 
   it("shows only team names when both discord and xbox names are hidden", () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
     const renderModel = aRenderModel({
       matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" }), aFakeTrackerMatchSummaryWith({ matchId: "m-2" })],
       series: [
@@ -554,6 +555,7 @@ describe("IndividualTrackerOverlay", () => {
     expect(screen.queryByText("XboxAlpha")).not.toBeInTheDocument();
     expect(screen.queryByText("DiscordBeta")).not.toBeInTheDocument();
     expect(screen.queryByText("XboxBeta")).not.toBeInTheDocument();
+    expect(setIntervalSpy).not.toHaveBeenCalled();
   });
 
   it("shows only team names when disableTeamPlayerNames is enabled", () => {
@@ -605,6 +607,53 @@ describe("IndividualTrackerOverlay", () => {
     expect(screen.queryByText("XboxAlpha")).not.toBeInTheDocument();
     expect(screen.queryByText("DiscordBeta")).not.toBeInTheDocument();
     expect(screen.queryByText("XboxBeta")).not.toBeInTheDocument();
+  });
+
+  it("shows player names when team names are missing even with disableTeamPlayerNames enabled", () => {
+    const renderModel = aRenderModel({
+      matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1" }), aFakeTrackerMatchSummaryWith({ matchId: "m-2" })],
+      series: [
+        aFakeTrackerSeriesGroupWith({
+          id: "series-1",
+          title: "Alpha vs Beta",
+          subtitle: "Bo3",
+          matchIds: ["m-1", "m-2"],
+          score: "1:0",
+        }),
+      ],
+      hasActiveSeries: true,
+      activeSeriesContext: {
+        title: "Alpha vs Beta",
+        subtitle: "Bo3",
+        teams: [
+          {
+            id: 0,
+            name: "",
+            players: [{ discordId: null, discordName: "DiscordAlpha", gamertag: "XboxAlpha", xboxId: null }],
+          },
+          {
+            id: 1,
+            name: "",
+            players: [{ discordId: null, discordName: "DiscordBeta", gamertag: "XboxBeta", xboxId: null }],
+          },
+        ],
+      },
+    });
+
+    const streamerSettings: StreamerViewSettings = {
+      visibleSections: {
+        showDiscordNames: true,
+        showXboxNames: true,
+      },
+      styleFlags: {
+        disableTeamPlayerNames: true,
+      },
+    };
+
+    render(<IndividualTrackerOverlay {...aPropsWith({ renderModel, streamerSettings })} />);
+
+    expect(screen.getByText("DiscordAlpha")).toBeInTheDocument();
+    expect(screen.getByText("DiscordBeta")).toBeInTheDocument();
   });
 
   it("renders the server icon when showServerIcon is enabled", () => {

--- a/pages/src/components/streamer-overlay/streamer-overlay.module.css
+++ b/pages/src/components/streamer-overlay/streamer-overlay.module.css
@@ -185,6 +185,14 @@
   justify-self: center;
 }
 
+.teamWithPlayers .teamName {
+  z-index: 2;
+}
+
+.teamWithPlayers .teamPlayersScroll {
+  z-index: 1;
+}
+
 /* Transition states for content fading between team name and player names.
    Used by react-transition-group to ensure the content actually swaps in the DOM
    even if CSS animations don't render properly (e.g., in OBS capture). */

--- a/pages/src/components/streamer-overlay/streamer-overlay.module.css
+++ b/pages/src/components/streamer-overlay/streamer-overlay.module.css
@@ -185,58 +185,25 @@
   justify-self: center;
 }
 
-.animateTeamNames .teamName {
-  animation: fadeTeamName 40s infinite;
-  z-index: 2;
+/* Transition states for content fading between team name and player names.
+   Used by react-transition-group to ensure the content actually swaps in the DOM
+   even if CSS animations don't render properly (e.g., in OBS capture). */
+.contentEnter {
+  opacity: 0;
 }
 
-.animateTeamNames .teamPlayersScroll {
-  animation: fadePlayerNames 40s infinite;
-  z-index: 1;
+.contentEnterActive {
+  opacity: 1;
+  transition: opacity 500ms ease-in-out;
 }
 
-@keyframes fadeTeamName {
-  0% {
-    opacity: 1;
-  }
-
-  47% {
-    opacity: 1;
-  }
-
-  50% {
-    opacity: 0;
-  }
-
-  97% {
-    opacity: 0;
-  }
-
-  100% {
-    opacity: 1;
-  }
+.contentExit {
+  opacity: 1;
 }
 
-@keyframes fadePlayerNames {
-  0% {
-    opacity: 0;
-  }
-
-  47% {
-    opacity: 0;
-  }
-
-  50% {
-    opacity: 1;
-  }
-
-  97% {
-    opacity: 1;
-  }
-
-  100% {
-    opacity: 0;
-  }
+.contentExitActive {
+  opacity: 0;
+  transition: opacity 500ms ease-in-out;
 }
 
 .teamName,

--- a/pages/src/components/streamer-overlay/team-details-content.tsx
+++ b/pages/src/components/streamer-overlay/team-details-content.tsx
@@ -30,7 +30,9 @@ function TeamDetailsContentComponent({
   renderPlayerNameContent,
 }: TeamDetailsContentProps): React.ReactElement {
   const hasTeamName = teamName !== null && teamName !== "";
-  const shouldAnimateBetween = hasTeamName && !disableTeamPlayerNames;
+  const hasPlayerNames = team.players.length > 0;
+  const showPlayerNames = hasPlayerNames && (!disableTeamPlayerNames || !hasTeamName);
+  const shouldAnimateBetween = hasTeamName && hasPlayerNames && !disableTeamPlayerNames;
 
   // Track which content to show when animating between team name and players
   const [showTeamName, setShowTeamName] = useState(true);
@@ -52,28 +54,12 @@ function TeamDetailsContentComponent({
     };
   }, [shouldAnimateBetween]);
 
-  if (!hasTeamName && !disableTeamPlayerNames) {
-    // No team name and player names are enabled: show only players (no animation needed)
-    return (
-      <div className={styles.teamWithPlayers}>
-        <ScrollingContent maxWidth={600} className={styles.teamPlayersScroll}>
-          {team.players.map((player, idx) => (
-            <React.Fragment key={player.id}>
-              {idx > 0 && ", "}
-              {renderPlayerNameContent(player.id, player.displayName)}
-            </React.Fragment>
-          ))}
-        </ScrollingContent>
-      </div>
-    );
-  }
-
-  if (!hasTeamName || disableTeamPlayerNames) {
-    // Either no team name or player names are disabled: show only what's available (no animation)
+  if (!shouldAnimateBetween) {
+    // Show static content when only one variant is available.
     return (
       <div className={styles.teamWithPlayers}>
         {hasTeamName && <div className={styles.teamName}>{teamName}</div>}
-        {!disableTeamPlayerNames && (
+        {showPlayerNames && (
           <ScrollingContent maxWidth={600} className={styles.teamPlayersScroll}>
             {team.players.map((player, idx) => (
               <React.Fragment key={player.id}>

--- a/pages/src/components/streamer-overlay/team-details-content.tsx
+++ b/pages/src/components/streamer-overlay/team-details-content.tsx
@@ -1,5 +1,5 @@
-import React, { memo } from "react";
-import classNames from "classnames";
+import React, { memo, useState, useEffect, useRef } from "react";
+import { CSSTransition } from "react-transition-group";
 import { ScrollingContent } from "../scrolling-content/scrolling-content";
 import styles from "./streamer-overlay.module.css";
 
@@ -19,6 +19,10 @@ interface TeamDetailsContentProps {
   readonly renderPlayerNameContent: (playerId: string, displayName: string) => React.ReactElement;
 }
 
+// Show each content for 19 seconds, fade for 1 second = 20 second cycle (matches old 40s animation / 2)
+const CONTENT_DISPLAY_DURATION_MS = 19000;
+const TRANSITION_DURATION_MS = 500;
+
 function TeamDetailsContentComponent({
   team,
   teamName,
@@ -26,12 +30,32 @@ function TeamDetailsContentComponent({
   renderPlayerNameContent,
 }: TeamDetailsContentProps): React.ReactElement {
   const hasTeamName = teamName !== null && teamName !== "";
-  const showPlayerNames = !hasTeamName || !disableTeamPlayerNames;
+  const shouldAnimateBetween = hasTeamName && !disableTeamPlayerNames;
 
-  return (
-    <div className={classNames(styles.teamWithPlayers, { [styles.animateTeamNames]: hasTeamName && showPlayerNames })}>
-      {hasTeamName && <div className={styles.teamName}>{teamName}</div>}
-      {showPlayerNames ? (
+  // Track which content to show when animating between team name and players
+  const [showTeamName, setShowTeamName] = useState(true);
+  const teamNameRef = useRef<HTMLDivElement | null>(null);
+  const playersRef = useRef<HTMLDivElement | null>(null);
+
+  // Toggle between team name and players every CONTENT_DISPLAY_DURATION_MS
+  useEffect(() => {
+    if (!shouldAnimateBetween) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      setShowTeamName((prev) => !prev);
+    }, CONTENT_DISPLAY_DURATION_MS + TRANSITION_DURATION_MS);
+
+    return (): void => {
+      clearInterval(interval);
+    };
+  }, [shouldAnimateBetween]);
+
+  if (!hasTeamName && !disableTeamPlayerNames) {
+    // No team name and player names are enabled: show only players (no animation needed)
+    return (
+      <div className={styles.teamWithPlayers}>
         <ScrollingContent maxWidth={600} className={styles.teamPlayersScroll}>
           {team.players.map((player, idx) => (
             <React.Fragment key={player.id}>
@@ -40,7 +64,73 @@ function TeamDetailsContentComponent({
             </React.Fragment>
           ))}
         </ScrollingContent>
-      ) : null}
+      </div>
+    );
+  }
+
+  if (!hasTeamName || disableTeamPlayerNames) {
+    // Either no team name or player names are disabled: show only what's available (no animation)
+    return (
+      <div className={styles.teamWithPlayers}>
+        {hasTeamName && <div className={styles.teamName}>{teamName}</div>}
+        {!disableTeamPlayerNames && (
+          <ScrollingContent maxWidth={600} className={styles.teamPlayersScroll}>
+            {team.players.map((player, idx) => (
+              <React.Fragment key={player.id}>
+                {idx > 0 && ", "}
+                {renderPlayerNameContent(player.id, player.displayName)}
+              </React.Fragment>
+            ))}
+          </ScrollingContent>
+        )}
+      </div>
+    );
+  }
+
+  // Both team name and player names should be shown: animate between them
+  // using react-transition-group to ensure proper DOM mount/unmount
+  return (
+    <div className={styles.teamWithPlayers}>
+      <CSSTransition
+        in={showTeamName}
+        timeout={TRANSITION_DURATION_MS}
+        classNames={{
+          enter: styles.contentEnter,
+          enterActive: styles.contentEnterActive,
+          exit: styles.contentExit,
+          exitActive: styles.contentExitActive,
+        }}
+        nodeRef={teamNameRef}
+        unmountOnExit
+      >
+        <div ref={teamNameRef} className={styles.teamName}>
+          {teamName}
+        </div>
+      </CSSTransition>
+
+      <CSSTransition
+        in={!showTeamName}
+        timeout={TRANSITION_DURATION_MS}
+        classNames={{
+          enter: styles.contentEnter,
+          enterActive: styles.contentEnterActive,
+          exit: styles.contentExit,
+          exitActive: styles.contentExitActive,
+        }}
+        nodeRef={playersRef}
+        unmountOnExit
+      >
+        <div ref={playersRef}>
+          <ScrollingContent maxWidth={600} className={styles.teamPlayersScroll}>
+            {team.players.map((player, idx) => (
+              <React.Fragment key={player.id}>
+                {idx > 0 && ", "}
+                {renderPlayerNameContent(player.id, player.displayName)}
+              </React.Fragment>
+            ))}
+          </ScrollingContent>
+        </div>
+      </CSSTransition>
     </div>
   );
 }

--- a/pages/src/components/streamer-overlay/team-details-content.tsx
+++ b/pages/src/components/streamer-overlay/team-details-content.tsx
@@ -19,7 +19,7 @@ interface TeamDetailsContentProps {
   readonly renderPlayerNameContent: (playerId: string, displayName: string) => React.ReactElement;
 }
 
-// Show each content for 19 seconds, fade for 1 second = 20 second cycle (matches old 40s animation / 2)
+// Show each content for 19 seconds, fade for 0.5 seconds = 19.5 second cycle.
 const CONTENT_DISPLAY_DURATION_MS = 19000;
 const TRANSITION_DURATION_MS = 500;
 
@@ -120,8 +120,8 @@ function TeamDetailsContentComponent({
         nodeRef={playersRef}
         unmountOnExit
       >
-        <div ref={playersRef}>
-          <ScrollingContent maxWidth={600} className={styles.teamPlayersScroll}>
+        <div ref={playersRef} className={styles.teamPlayersScroll}>
+          <ScrollingContent maxWidth={600}>
             {team.players.map((player, idx) => (
               <React.Fragment key={player.id}>
                 {idx > 0 && ", "}


### PR DESCRIPTION
## Context
Some OBS environments fail to render pure CSS keyframe animations reliably. In the team details area this could leave team names and player names visually overlapping, because the previous approach depended on CSS-only fade timing while both variants were present in DOM behavior assumptions.

## This PR
- Replaced the team-name/player-name crossfade in TeamDetailsContent with a react-transition-group mount/unmount transition cycle.
- Preserved fade behavior for normal environments via transition classes in the overlay CSS module.
- Ensured fallback behavior is safe for OBS-like failures by swapping active content via React state and transition lifecycle rather than relying solely on keyframes.
- Updated IndividualTrackerOverlay tests to assert initial state and post-swap state under the new transition-driven DOM behavior.
- Added a deterministic test swap helper that captures and triggers interval handlers so tests remain stable without brittle timing assumptions.
- Validation: npm run done passes on this branch.

## Subsequent Work
- Verify the overlay behavior in the affected streamer OBS setup and tune the display/transition durations if needed for readability.
