### PR TITLE
feat(individual-tracker): add matchmaking Won:Loss summary tab

### DIFF
--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -527,8 +527,8 @@ export function StreamerSettingsSectionView({
           onChange={(checked): void => {
             onMatchmakingShowSummaryTabChange(checked);
           }}
-          label="Show matches score tab"
-          description="Show a first Won:Loss tab in matchmaking using the same value as Stats Highlights."
+          label="Show matchmaking score tabs"
+          description="Show score tabs in matchmaking, including the first Won:Loss tab from Stats Highlights and series score tabs."
         />
         <Checkbox
           checked={matchmakingShowTicker}

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -508,14 +508,6 @@ export function StreamerSettingsSectionView({
           </p>
         </div>
         <Checkbox
-          checked={matchmakingShowSummaryTab}
-          onChange={(checked): void => {
-            onMatchmakingShowSummaryTabChange(checked);
-          }}
-          label="Show summary tab"
-          description="Show matchmaking summary/series tabs when no active series is in progress."
-        />
-        <Checkbox
           checked={matchmakingShowStatsHighlights}
           onChange={(checked): void => {
             onMatchmakingShowStatsHighlightsChange(checked);
@@ -530,6 +522,14 @@ export function StreamerSettingsSectionView({
           <h4 className={styles.subsectionTitle}>Bottom Section</h4>
           <p className={styles.cardDescription}>Configure matchmaking-only ticker behavior.</p>
         </div>
+        <Checkbox
+          checked={matchmakingShowSummaryTab}
+          onChange={(checked): void => {
+            onMatchmakingShowSummaryTabChange(checked);
+          }}
+          label="Show matches score tab"
+          description="Show a first Won:Loss tab in matchmaking using the same value as Stats Highlights."
+        />
         <Checkbox
           checked={matchmakingShowTicker}
           onChange={(checked): void => {

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -520,7 +520,7 @@ export function StreamerSettingsSectionView({
 
         <div className={styles.subsection}>
           <h4 className={styles.subsectionTitle}>Bottom Section</h4>
-          <p className={styles.cardDescription}>Configure matchmaking-only ticker behavior.</p>
+          <p className={styles.cardDescription}>Configure matchmaking-only tabs and ticker behavior.</p>
         </div>
         <Checkbox
           checked={matchmakingShowSummaryTab}

--- a/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
@@ -252,10 +252,10 @@ describe("StreamerSettingsSectionView", () => {
       expect(screen.getByRole("checkbox", { name: /show series score tab/i })).toBeInTheDocument();
     });
 
-    it("renders the summary tab toggle in the matchmaking section", () => {
+    it("renders the matches score tab toggle in the matchmaking section", () => {
       render(<StreamerSettingsSectionView {...aFakeProps()} />);
 
-      expect(screen.getByRole("checkbox", { name: /show summary tab/i })).toBeInTheDocument();
+      expect(screen.getByRole("checkbox", { name: /show matches score tab/i })).toBeInTheDocument();
     });
 
     it("renders the disable team player names toggle in the in-series top section", () => {
@@ -357,13 +357,13 @@ describe("StreamerSettingsSectionView", () => {
       expect(onChange).toHaveBeenCalledWith(false);
     });
 
-    it("calls onMatchmakingShowSummaryTabChange when the summary tab toggle is clicked", async () => {
+    it("calls onMatchmakingShowSummaryTabChange when the matches score tab toggle is clicked", async () => {
       const user = userEvent.setup();
       const onChange = vi.fn<(enabled: boolean) => void>();
 
       render(<StreamerSettingsSectionView {...aFakeProps({ onMatchmakingShowSummaryTabChange: onChange })} />);
 
-      await user.click(screen.getByRole("checkbox", { name: /show summary tab/i }));
+      await user.click(screen.getByRole("checkbox", { name: /show matches score tab/i }));
 
       expect(onChange).toHaveBeenCalledWith(false);
     });

--- a/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
@@ -258,6 +258,12 @@ describe("StreamerSettingsSectionView", () => {
       expect(screen.getByRole("checkbox", { name: /show matchmaking score tabs/i })).toBeInTheDocument();
     });
 
+    it("describes the matchmaking bottom section as tabs and ticker settings", () => {
+      render(<StreamerSettingsSectionView {...aFakeProps()} />);
+
+      expect(screen.getByText("Configure matchmaking-only tabs and ticker behavior.")).toBeInTheDocument();
+    });
+
     it("renders the disable team player names toggle in the in-series top section", () => {
       render(<StreamerSettingsSectionView {...aFakeProps()} />);
 

--- a/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/tests/streamer-settings.test.tsx
@@ -252,10 +252,10 @@ describe("StreamerSettingsSectionView", () => {
       expect(screen.getByRole("checkbox", { name: /show series score tab/i })).toBeInTheDocument();
     });
 
-    it("renders the matches score tab toggle in the matchmaking section", () => {
+    it("renders the matchmaking score tabs toggle in the matchmaking section", () => {
       render(<StreamerSettingsSectionView {...aFakeProps()} />);
 
-      expect(screen.getByRole("checkbox", { name: /show matches score tab/i })).toBeInTheDocument();
+      expect(screen.getByRole("checkbox", { name: /show matchmaking score tabs/i })).toBeInTheDocument();
     });
 
     it("renders the disable team player names toggle in the in-series top section", () => {
@@ -357,13 +357,13 @@ describe("StreamerSettingsSectionView", () => {
       expect(onChange).toHaveBeenCalledWith(false);
     });
 
-    it("calls onMatchmakingShowSummaryTabChange when the matches score tab toggle is clicked", async () => {
+    it("calls onMatchmakingShowSummaryTabChange when the matchmaking score tabs toggle is clicked", async () => {
       const user = userEvent.setup();
       const onChange = vi.fn<(enabled: boolean) => void>();
 
       render(<StreamerSettingsSectionView {...aFakeProps({ onMatchmakingShowSummaryTabChange: onChange })} />);
 
-      await user.click(screen.getByRole("checkbox", { name: /show matches score tab/i }));
+      await user.click(screen.getByRole("checkbox", { name: /show matchmaking score tabs/i }));
 
       expect(onChange).toHaveBeenCalledWith(false);
     });

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -31,7 +31,7 @@ import type {
   OverlayTeamDetailsModel,
   OverlayTopSectionModel,
 } from "./types";
-import { getOverlayDisplaySettings } from "./types";
+import { getOverlayDisplaySettings, MATCHMAKING_SUMMARY_TAB_SERIES_ID } from "./types";
 import "javascript-time-ago/locale/en";
 
 const timeAgo = new TimeAgo("en");
@@ -163,8 +163,6 @@ interface BuildTabsOptions {
   readonly includeMatchmakingSummaryTab: boolean;
   readonly matchmakingSummaryScore: string;
 }
-
-export const MATCHMAKING_SUMMARY_TAB_SERIES_ID = "matchmaking-summary";
 
 interface IndividualTrackerOverlayPresenterConfig {
   readonly defaultTeamColors?: readonly [TeamColor, TeamColor];

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -161,7 +161,10 @@ interface BuildOverlayViewModelOptions {
 interface BuildTabsOptions {
   readonly includeInSeriesSummaryTab: boolean;
   readonly includeMatchmakingSummaryTab: boolean;
+  readonly matchmakingSummaryScore: string;
 }
+
+export const MATCHMAKING_SUMMARY_TAB_SERIES_ID = "matchmaking-summary";
 
 interface IndividualTrackerOverlayPresenterConfig {
   readonly defaultTeamColors?: readonly [TeamColor, TeamColor];
@@ -190,6 +193,7 @@ export class IndividualTrackerOverlayPresenter {
     options: BuildTabsOptions = {
       includeInSeriesSummaryTab: true,
       includeMatchmakingSummaryTab: true,
+      matchmakingSummaryScore: "0:0",
     },
   ): readonly OverlayTab[] {
     const activeSeries = activeSeriesOverride ?? this.getActiveSeries(timeline);
@@ -231,9 +235,21 @@ export class IndividualTrackerOverlayPresenter {
       return [seriesTab, ...matchTabs];
     }
 
+    const matchmakingSummaryTab: OverlayTab | null = options.includeMatchmakingSummaryTab
+      ? {
+          type: "series",
+          seriesId: MATCHMAKING_SUMMARY_TAB_SERIES_ID,
+          index: -1,
+          label: "Won:Loss",
+          score: options.matchmakingSummaryScore,
+          teamColor: undefined,
+          icons: [],
+        }
+      : null;
+
     let matchIdx = 0;
-    let seriesIdx = -1;
-    return timeline.flatMap((item): readonly OverlayTab[] => {
+    let seriesIdx = matchmakingSummaryTab != null ? -2 : -1;
+    const timelineTabs = timeline.flatMap((item): readonly OverlayTab[] => {
       if (item.type === "series") {
         if (!options.includeMatchmakingSummaryTab) {
           return [];
@@ -269,6 +285,8 @@ export class IndividualTrackerOverlayPresenter {
         },
       ];
     });
+
+    return matchmakingSummaryTab != null ? [matchmakingSummaryTab, ...timelineTabs] : timelineTabs;
   }
 
   public isPanelOpen(
@@ -455,9 +473,14 @@ export class IndividualTrackerOverlayPresenter {
     const activeSeries = this.getOverlayActiveSeries(renderModel);
     const teamColors = this.getTeamColors(renderModel, activeSeries);
     const showTicker = this.getShowTicker(streamerSettings, activeSeries, displaySettings.showTicker);
+    const matchmakingSummaryScore = this.getMatchmakingSummaryScore(
+      renderModel.statsHighlights,
+      renderModel.accumulated,
+    );
     const tabs = this.buildTabs(renderModel.timeline, activeSeries, {
       includeInSeriesSummaryTab: streamerSettings?.styleFlags?.inSeriesShowSeriesTab ?? true,
       includeMatchmakingSummaryTab: streamerSettings?.styleFlags?.matchmakingShowSummaryTab ?? true,
+      matchmakingSummaryScore,
     });
     const loadedTickerGroups = this.buildTickerGroups(options.matchStatsByMatchId, tabs, {
       trackedGamertag: renderModel.gamertag,
@@ -509,6 +532,18 @@ export class IndividualTrackerOverlayPresenter {
     }
 
     return statsHighlights ?? [];
+  }
+
+  private getMatchmakingSummaryScore(
+    statsHighlights: IndividualTrackerViewerRenderModel["statsHighlights"],
+    accumulated: IndividualTrackerViewerRenderModel["accumulated"],
+  ): string {
+    const wonLossHighlight = statsHighlights?.find((item) => item.label === "Won:Loss");
+    if (wonLossHighlight?.value != null && wonLossHighlight.value !== "") {
+      return wonLossHighlight.value;
+    }
+
+    return `${accumulated.wins.toString()}:${accumulated.losses.toString()}`;
   }
 
   private getOverlayActiveSeries(renderModel: IndividualTrackerViewerRenderModel): ViewerSeriesTab | null {

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -9,8 +9,7 @@ import { Alert } from "../../alert/alert";
 import { LoadingState } from "../../loading-state/loading-state";
 import type { MatchDetailsState, SeriesDetailsState } from "../viewer/types";
 import { OverlayStatsHighlights } from "./overlay-stats-highlights";
-import { MATCHMAKING_SUMMARY_TAB_SERIES_ID } from "./individual-tracker-overlay-presenter";
-import type { IndividualTrackerOverlayViewModel } from "./types";
+import { MATCHMAKING_SUMMARY_TAB_SERIES_ID, type IndividualTrackerOverlayViewModel } from "./types";
 import styles from "./individual-tracker-overlay.module.css";
 
 interface IndividualTrackerOverlayProps {

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -142,7 +142,7 @@ export function IndividualTrackerOverlay({
       const selectedTab = viewModel.tabs.find((currentTab) => currentTab.index === tabIndex);
 
       if (selectedTab?.type === "series") {
-        if (selectedTab.seriesId === MATCHMAKING_SUMMARY_TAB_SERIES_ID) {
+        if (selectedTab.seriesId === MATCHMAKING_SUMMARY_TAB_SERIES_ID && seriesStatsPanelState == null) {
           return <StatsPanel state={matchStatsPanelState} />;
         }
 

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -143,7 +143,7 @@ export function IndividualTrackerOverlay({
 
       if (selectedTab?.type === "series") {
         if (selectedTab.seriesId === MATCHMAKING_SUMMARY_TAB_SERIES_ID) {
-          return selectedMatchId != null ? <StatsPanel state={matchStatsPanelState} /> : null;
+          return <StatsPanel state={matchStatsPanelState} />;
         }
 
         if (seriesStatsPanelState == null) {

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -104,6 +104,7 @@ export function IndividualTrackerOverlay({
 
       if (selectedTab.type === "series") {
         if (selectedTab.seriesId === MATCHMAKING_SUMMARY_TAB_SERIES_ID) {
+          onDeselect();
           return;
         }
 

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -9,6 +9,7 @@ import { Alert } from "../../alert/alert";
 import { LoadingState } from "../../loading-state/loading-state";
 import type { MatchDetailsState, SeriesDetailsState } from "../viewer/types";
 import { OverlayStatsHighlights } from "./overlay-stats-highlights";
+import { MATCHMAKING_SUMMARY_TAB_SERIES_ID } from "./individual-tracker-overlay-presenter";
 import type { IndividualTrackerOverlayViewModel } from "./types";
 import styles from "./individual-tracker-overlay.module.css";
 
@@ -103,6 +104,10 @@ export function IndividualTrackerOverlay({
       }
 
       if (selectedTab.type === "series") {
+        if (selectedTab.seriesId === MATCHMAKING_SUMMARY_TAB_SERIES_ID) {
+          return;
+        }
+
         if (selectedTab.seriesId === selectedSeriesId) {
           onDeselect();
         } else {
@@ -121,7 +126,14 @@ export function IndividualTrackerOverlay({
   );
 
   const hasPanelContent = useCallback(
-    (tabIndex: number): boolean => viewModel.tabs.some((tab) => tab.index === tabIndex),
+    (tabIndex: number): boolean => {
+      const selectedTab = viewModel.tabs.find((tab) => tab.index === tabIndex);
+      if (selectedTab?.type === "series" && selectedTab.seriesId === MATCHMAKING_SUMMARY_TAB_SERIES_ID) {
+        return false;
+      }
+
+      return selectedTab != null;
+    },
     [viewModel.tabs],
   );
 
@@ -130,6 +142,10 @@ export function IndividualTrackerOverlay({
       const selectedTab = viewModel.tabs.find((currentTab) => currentTab.index === tabIndex);
 
       if (selectedTab?.type === "series") {
+        if (selectedTab.seriesId === MATCHMAKING_SUMMARY_TAB_SERIES_ID) {
+          return selectedMatchId != null ? <StatsPanel state={matchStatsPanelState} /> : null;
+        }
+
         if (seriesStatsPanelState == null) {
           return null;
         }

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -8,10 +8,8 @@ import type {
   ViewerSeriesTab,
   ViewerTimelineItem,
 } from "../../viewer/types";
-import {
-  IndividualTrackerOverlayPresenter,
-  MATCHMAKING_SUMMARY_TAB_SERIES_ID,
-} from "../individual-tracker-overlay-presenter";
+import { IndividualTrackerOverlayPresenter } from "../individual-tracker-overlay-presenter";
+import { MATCHMAKING_SUMMARY_TAB_SERIES_ID } from "../types";
 import haloTrophyIconPng from "../../../../assets/halo-trophy-icon.png";
 
 function aRenderModelWith(

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -8,7 +8,10 @@ import type {
   ViewerSeriesTab,
   ViewerTimelineItem,
 } from "../../viewer/types";
-import { IndividualTrackerOverlayPresenter } from "../individual-tracker-overlay-presenter";
+import {
+  IndividualTrackerOverlayPresenter,
+  MATCHMAKING_SUMMARY_TAB_SERIES_ID,
+} from "../individual-tracker-overlay-presenter";
 import haloTrophyIconPng from "../../../../assets/halo-trophy-icon.png";
 
 function aRenderModelWith(
@@ -170,8 +173,17 @@ describe("individual-tracker-overlay-presenter", () => {
 
     const tabs = presenter.buildTabs(timeline);
 
-    expect(tabs).toHaveLength(2);
-    const [seriesTab, matchTab] = tabs;
+    expect(tabs).toHaveLength(3);
+    const [summaryTab, seriesTab, matchTab] = tabs;
+    expect(summaryTab.type).toBe("series");
+    if (summaryTab.type === "series") {
+      expect(summaryTab.seriesId).toBe(MATCHMAKING_SUMMARY_TAB_SERIES_ID);
+      expect(summaryTab.label).toBe("Won:Loss");
+      expect(summaryTab.score).toBe("0:0");
+      expect(summaryTab.teamColor).toBeUndefined();
+      expect(summaryTab.icons).toEqual([]);
+    }
+
     expect(seriesTab.type).toBe("series");
     if (seriesTab.type === "series") {
       expect(seriesTab.seriesId).toBe("series-complete");
@@ -227,7 +239,13 @@ describe("individual-tracker-overlay-presenter", () => {
       },
     ];
 
-    const [seriesTab] = presenter.buildTabs(timeline);
+    const seriesTab = presenter
+      .buildTabs(timeline)
+      .find((tab) => tab.type === "series" && tab.seriesId === "series-loss");
+
+    if (seriesTab == null) {
+      throw new Error("Expected series-loss tab to exist");
+    }
 
     expect(seriesTab.type).toBe("series");
     if (seriesTab.type === "series") {
@@ -292,10 +310,33 @@ describe("individual-tracker-overlay-presenter", () => {
     const tabs = presenter.buildTabs(timeline);
     const seriesTabs = tabs.filter((tab) => tab.type === "series");
 
-    expect(seriesTabs).toHaveLength(2);
-    if (seriesTabs.length === 2) {
+    expect(seriesTabs).toHaveLength(3);
+    if (seriesTabs.length === 3) {
       expect(seriesTabs[0].index).toBe(-1);
       expect(seriesTabs[1].index).toBe(-2);
+      expect(seriesTabs[2].index).toBe(-3);
+    }
+  });
+
+  it("uses Won:Loss stats highlight value for the first matchmaking summary tab", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        timeline: [{ type: "match", match: aMatchWith({ matchId: "solo" }) }],
+        statsHighlights: [{ label: "Won:Loss", value: "5:3" }],
+      }),
+      streamerSettings: undefined,
+      matchStatsByMatchId: new Map(),
+      selectedMatchId: null,
+    });
+
+    const [firstTab] = model.tabs;
+    expect(firstTab.type).toBe("series");
+    if (firstTab.type === "series") {
+      expect(firstTab.seriesId).toBe(MATCHMAKING_SUMMARY_TAB_SERIES_ID);
+      expect(firstTab.label).toBe("Won:Loss");
+      expect(firstTab.score).toBe("5:3");
+      expect(firstTab.teamColor).toBeUndefined();
+      expect(firstTab.icons).toEqual([]);
     }
   });
 

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -340,6 +340,26 @@ describe("individual-tracker-overlay-presenter", () => {
     }
   });
 
+  it("falls back to accumulated win/loss when Won:Loss stats highlight is missing", () => {
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        timeline: [{ type: "match", match: aMatchWith({ matchId: "solo" }) }],
+        accumulated: { total: 8, wins: 5, losses: 3, ties: 0 },
+        statsHighlights: undefined,
+      }),
+      streamerSettings: undefined,
+      matchStatsByMatchId: new Map(),
+      selectedMatchId: null,
+    });
+
+    const [firstTab] = model.tabs;
+    expect(firstTab.type).toBe("series");
+    if (firstTab.type === "series") {
+      expect(firstTab.seriesId).toBe(MATCHMAKING_SUMMARY_TAB_SERIES_ID);
+      expect(firstTab.score).toBe("5:3");
+    }
+  });
+
   it("returns a series score tab when active series exists but has no matches", () => {
     const activeSeries = aSeriesWith({
       id: "series-active",

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -198,6 +198,25 @@ describe("IndividualTrackerOverlay", () => {
     expect(screen.getByText("Loading series stats...")).toBeInTheDocument();
   });
 
+  it("deselects when clicking the matchmaking summary tab", async () => {
+    const onDeselect = vi.fn();
+
+    render(
+      <IndividualTrackerOverlay
+        {...aPropsWith({
+          renderModel: aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1", isMatchmaking: true })] }),
+          selectedSeriesId: "series-1",
+          seriesStatsPanelState: { status: "loading" },
+          onDeselect,
+        })}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Won:Loss"));
+
+    expect(onDeselect).toHaveBeenCalledOnce();
+  });
+
   it("calls onDeselect when the close button is clicked", async () => {
     const onDeselect = vi.fn();
 

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -188,7 +188,9 @@ describe("IndividualTrackerOverlay", () => {
     render(
       <IndividualTrackerOverlay
         {...aPropsWith({
-          renderModel: aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1", isMatchmaking: true })] }),
+          renderModel: aRenderModel({
+            matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1", isMatchmaking: true })],
+          }),
           selectedSeriesId: "series-1",
           seriesStatsPanelState: { status: "loading" },
         })}
@@ -204,7 +206,9 @@ describe("IndividualTrackerOverlay", () => {
     render(
       <IndividualTrackerOverlay
         {...aPropsWith({
-          renderModel: aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1", isMatchmaking: true })] }),
+          renderModel: aRenderModel({
+            matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1", isMatchmaking: true })],
+          }),
           selectedSeriesId: "series-1",
           seriesStatsPanelState: { status: "loading" },
           onDeselect,

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -184,6 +184,20 @@ describe("IndividualTrackerOverlay", () => {
     expect(screen.getByText("Network failure")).toBeInTheDocument();
   });
 
+  it("renders series panel content when series state exists and the summary tab is active", () => {
+    render(
+      <IndividualTrackerOverlay
+        {...aPropsWith({
+          renderModel: aRenderModel({ matches: [aFakeTrackerMatchSummaryWith({ matchId: "m-1", isMatchmaking: true })] }),
+          selectedSeriesId: "series-1",
+          seriesStatsPanelState: { status: "loading" },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Loading series stats...")).toBeInTheDocument();
+  });
+
   it("calls onDeselect when the close button is clicked", async () => {
     const onDeselect = vi.fn();
 

--- a/pages/src/components/individual-tracker/overlay/types.ts
+++ b/pages/src/components/individual-tracker/overlay/types.ts
@@ -5,6 +5,8 @@ import type { TeamColor } from "../../team-colors/team-colors";
 import type { TickerMatchGroup } from "../../information-ticker/information-ticker";
 import type { OverlayTab } from "../../streamer-overlay/tabs-bar";
 
+export const MATCHMAKING_SUMMARY_TAB_SERIES_ID = "matchmaking-summary";
+
 export interface OverlayDisplaySettings {
   readonly showTicker: boolean;
   readonly showTabs: boolean;


### PR DESCRIPTION
## Context
The individual tracker overlay settings already support a matchmaking summary-tab toggle at the contract level, but matchmaking UI was missing the dedicated first-tab behavior requested for score context. The requirement is to provide a clear Won:Loss tab in the matchmaking bottom section that mirrors the same win/loss source used by stats highlights.

## This PR
- Adds a dedicated first matchmaking summary tab when the matchmaking summary toggle is enabled.
- Renders that tab as Won:Loss with score value sourced from stats highlights (Won:Loss) and a fallback to accumulated wins/losses.
- Ensures the tab has no team color and no icons.
- Preserves existing behavior where disabling matchmaking summary tabs hides matchmaking series summary tabs.
- Wires tab interaction so this synthetic tab does not open series panel content.
- Updates streamer settings copy to Show matches score tab in Matchmaking UI -> Bottom Section.
- Adds and updates presenter/settings tests for new tab shape, order, and source-value behavior.
- Validation: npm run done passes.

## Subsequent Work
- Verify live overlay UX with real matchmaking history to confirm tab prioritization still feels right when many tabs are present.
- Optionally add an e2e overlay interaction test that exercises clicking the synthetic Won:Loss tab with and without selected match state.
