### PR TITLE
fix(individual-tracker): keep in-series first tab neutral

### DIFF
--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -214,16 +214,10 @@ export class IndividualTrackerOverlayPresenter {
         type: "series",
         seriesId: activeSeries.id,
         index: -1,
-        label: activeSeries.matches.length === 0 ? "Series score" : activeSeries.title,
+        label: "Series score",
         score: activeSeries.score,
-        teamColor: getSeriesOutcomeColorHex(activeSeries),
-        icons:
-          activeSeries.matches.length > 0
-            ? activeSeries.matches.map((match) => ({
-                src: gameModeIconSrc(match.gameVariantCategory),
-                dimmed: false,
-              }))
-            : undefined,
+        teamColor: undefined,
+        icons: [],
       };
 
       if (activeSeries.matches.length === 0) {

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -115,6 +115,11 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(tabs[0]?.type).toBe("series");
     expect(tabs[1]?.type).toBe("match");
     expect(tabs[2]?.type).toBe("match");
+    if (tabs[0]?.type === "series") {
+      expect(tabs[0].label).toBe("Series score");
+      expect(tabs[0].teamColor).toBeUndefined();
+      expect(tabs[0].icons).toEqual([]);
+    }
     expect(tabs.map((tab) => (tab.type === "series" ? tab.seriesId : tab.matchId))).toEqual([
       "series-active",
       "a",
@@ -375,6 +380,8 @@ describe("individual-tracker-overlay-presenter", () => {
       expect(seriesTab.label).toBe("Series score");
       expect(seriesTab.score).toBe("0:0");
       expect(seriesTab.index).toBe(-1);
+      expect(seriesTab.teamColor).toBeUndefined();
+      expect(seriesTab.icons).toEqual([]);
     }
   });
 


### PR DESCRIPTION
## Context
In the individual tracker overlay, enabling the in-series first tab currently allows dynamic formatting (title/icons/color) that can surface as game-mode/server styled tabs in live streams. The expected behavior is a consistent neutral summary presentation that mirrors the intended scoreboard role of that first tab.

## This PR
- Updates the active-series first tab to always render as `Series score`.
- Keeps the score value unchanged (series score).
- Removes icon rendering for that in-series first tab.
- Removes team color styling for that in-series first tab so it stays neutral (default dark tab styling).
- Adds/updates presenter test assertions to lock the in-series first tab format for both active-series-with-matches and active-series-without-matches paths.
- Validation: `npm run done` passes.

## Subsequent Work
- Verify in a live NeatQueue series OBS capture that the first tab now consistently appears as neutral `Series score • <score>` with no icon/color bleed.
