### PR TITLE
Deduplicate individual tracker series matches for score and tabs

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -42,6 +42,7 @@ import {
   analyzeMatchGroupings,
   buildMatchScore,
   buildTeamRosterSignature,
+  collapseSequentialSeriesEntries,
   getMatchOutcomeLabel,
 } from "@guilty-spark/shared/halo/match-enrichment";
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
@@ -244,6 +245,80 @@ function shouldEnrichSummary(summary: IndividualTrackerMatchSummary): boolean {
       summary.killsDeathsAssistsKda !== UNKNOWN_KDA_DISPLAY &&
       summary.damageDealtTakenRatio !== UNKNOWN_DAMAGE_RATIO_DISPLAY)
   );
+}
+
+function parseTeamRosterSignatureToCounts(signature: string): Map<number, number> | null {
+  const counts = new Map<number, number>();
+
+  for (const teamEntry of signature.split("|")) {
+    const [teamIdRaw, playersRaw] = teamEntry.split(":");
+    if (teamIdRaw == null || playersRaw == null) {
+      return null;
+    }
+
+    const teamId = Number(teamIdRaw);
+    if (!Number.isInteger(teamId) || teamId < 0) {
+      return null;
+    }
+
+    const playerCount = playersRaw === "" ? 0 : playersRaw.split(",").length;
+    counts.set(teamId, playerCount);
+  }
+
+  return counts;
+}
+
+function getExpectedSeriesTeamCounts(teams: readonly SeriesTeam[] | undefined): Map<number, number> | null {
+  if (teams == null || teams.length === 0) {
+    return null;
+  }
+
+  const expectedCounts = new Map<number, number>();
+  for (const team of teams) {
+    const playerCount = team.players.length;
+    if (playerCount === 0) {
+      return null;
+    }
+
+    expectedCounts.set(team.id, playerCount);
+  }
+
+  return expectedCounts;
+}
+
+function hasExpectedSeriesTeamCounts(
+  summary: IndividualTrackerMatchSummary,
+  expectedCounts: ReadonlyMap<number, number>,
+): boolean {
+  if (summary.teamRosterSignature == null) {
+    return false;
+  }
+
+  const actualCounts = parseTeamRosterSignatureToCounts(summary.teamRosterSignature);
+  if (actualCounts?.size !== expectedCounts.size) {
+    return false;
+  }
+
+  for (const [teamId, expectedPlayerCount] of expectedCounts.entries()) {
+    if (actualCounts.get(teamId) !== expectedPlayerCount) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function getSeriesSummariesForView(
+  groupSummaries: readonly IndividualTrackerMatchSummary[],
+  teams: readonly SeriesTeam[] | undefined,
+): IndividualTrackerMatchSummary[] {
+  const expectedTeamCounts = getExpectedSeriesTeamCounts(teams);
+  const summariesWithExpectedTeams =
+    expectedTeamCounts == null
+      ? groupSummaries
+      : groupSummaries.filter((summary) => hasExpectedSeriesTeamCounts(summary, expectedTeamCounts));
+
+  return collapseSequentialSeriesEntries(summariesWithExpectedTeams);
 }
 
 function normalizeRankTier(rankTier: string | null | undefined): string | null {
@@ -2082,8 +2157,15 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         .map((matchId) => summariesById.get(matchId))
         .filter((summary): summary is IndividualTrackerMatchSummary => summary != null);
 
+      const matchIdSet = new Set(matchIds);
+      const seriesContext = allSeriesContexts.find((ctx) => ctx.matchIds.some((id) => matchIdSet.has(id)));
+      const seriesGroupOverride = seriesGroupOverridesByKey.get(buildSeriesGroupKey(matchIds));
+      const teams = seriesContext?.teams;
+
+      const seriesSummariesForView = getSeriesSummariesForView(groupSummaries, teams);
+
       const teamWins = computeSeriesTeamWins(
-        groupSummaries.map((summary) => ({
+        seriesSummariesForView.map((summary) => ({
           startTime: summary.startTime,
           mapAssetId: summary.mapAssetId,
           mapVersionId: summary.mapVersionId,
@@ -2091,11 +2173,11 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           teamOutcomes: summary.teamOutcomes ?? [],
         })),
       );
-      const seriesSummaryStats = computeSeriesSummaryStats(groupSummaries);
+      const seriesSummaryStats = computeSeriesSummaryStats(seriesSummariesForView);
 
       const defaultTitle = getDefaultSeriesGroupTitle();
       const defaultSubtitle = getDefaultSeriesGroupSubtitle(
-        groupSummaries.map((summary) => ({
+        seriesSummariesForView.map((summary) => ({
           startTime: summary.startTime,
           mapAssetId: summary.mapAssetId,
           mapVersionId: summary.mapVersionId,
@@ -2104,19 +2186,14 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         })),
       );
 
-      const matchIdSet = new Set(matchIds);
-      const seriesContext = allSeriesContexts.find((ctx) => ctx.matchIds.some((id) => matchIdSet.has(id)));
-      const seriesGroupOverride = seriesGroupOverridesByKey.get(buildSeriesGroupKey(matchIds));
-
       const title = seriesContext?.title ?? seriesGroupOverride?.titleOverride ?? defaultTitle;
       const subtitle = seriesContext?.subtitle ?? seriesGroupOverride?.subtitleOverride ?? defaultSubtitle;
       const guildIconUrl = seriesContext?.guildIconUrl ?? null;
-      const teams = seriesContext?.teams;
 
       return {
         id: `series:${buildSeriesGroupKey(matchIds)}`,
-        matchIds,
-        matchBackgroundUrls: groupSummaries.map((summary) => summary.mapBackgroundUrl || "data:,"),
+        matchIds: seriesSummariesForView.map((summary) => summary.matchId),
+        matchBackgroundUrls: seriesSummariesForView.map((summary) => summary.mapBackgroundUrl || "data:,"),
         score: teamWins.length === 0 ? "0:0" : teamWins.join(":"),
         killsDeathsAssistsKda: seriesSummaryStats.killsDeathsAssistsKda,
         damageDealtTakenRatio: seriesSummaryStats.damageDealtTakenRatio,

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -585,6 +585,115 @@ describe("IndividualTrackerDO", () => {
       expect(series?.subtitle).toBe("Best of 3");
     });
 
+    it("dedupes sequential same map+mode entries in series matchIds and score", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2"],
+          selectedMatchIds: ["m1", "m2"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m1",
+              startTime: "2024-11-26T11:00:00.000Z",
+              mapAssetId: "map-a",
+              mapVersionId: "ver-a",
+              gameVariantCategory: 6,
+              outcome: "Win",
+              isMatchmaking: false,
+              teamRosterSignature: "0:1|1:2",
+              teamOutcomes: [2, 3],
+            }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m2",
+              startTime: "2024-11-26T11:05:00.000Z",
+              mapAssetId: "map-a",
+              mapVersionId: "ver-a",
+              gameVariantCategory: 6,
+              outcome: "Loss",
+              isMatchmaking: false,
+              teamRosterSignature: "0:1|1:2",
+              teamOutcomes: [3, 2],
+            }),
+          },
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect(body.state?.series).toHaveLength(1);
+      const series = body.state?.series[0];
+      expect(series?.matchIds).toEqual(["m2"]);
+      expect(series?.matchBackgroundUrls).toHaveLength(1);
+      expect(series?.score).toBe("0:1");
+    });
+
+    it("filters series matches by expected team sizes when series teams are known", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2"],
+          selectedMatchIds: ["m1", "m2"],
+          activeSeries: {
+            title: "NeatQueue League",
+            subtitle: "Bo3",
+            guildIconUrl: null,
+            teams: [
+              {
+                id: 0,
+                name: "Alpha",
+                players: [
+                  { discordId: null, discordName: "A1", gamertag: "A1", xboxId: null },
+                  { discordId: null, discordName: "A2", gamertag: "A2", xboxId: null },
+                ],
+              },
+              {
+                id: 1,
+                name: "Beta",
+                players: [
+                  { discordId: null, discordName: "B1", gamertag: "B1", xboxId: null },
+                  { discordId: null, discordName: "B2", gamertag: "B2", xboxId: null },
+                ],
+              },
+            ],
+            matchIds: ["m1", "m2"],
+            startedAt: "2024-11-26T11:00:00.000Z",
+            isActive: true,
+          },
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m1",
+              startTime: "2024-11-26T11:00:00.000Z",
+              mapAssetId: "map-a",
+              mapVersionId: "ver-a",
+              gameVariantCategory: 6,
+              outcome: "Win",
+              isMatchmaking: false,
+              teamRosterSignature: "0:a,b|1:c,d",
+              teamOutcomes: [2, 3],
+            }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m2",
+              startTime: "2024-11-26T11:20:00.000Z",
+              mapAssetId: "map-b",
+              mapVersionId: "ver-b",
+              gameVariantCategory: 7,
+              outcome: "Loss",
+              isMatchmaking: false,
+              teamRosterSignature: "0:a,b,e|1:c,d,f",
+              teamOutcomes: [3, 2],
+            }),
+          },
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect(body.state?.series).toHaveLength(1);
+      const series = body.state?.series[0];
+      expect(series?.matchIds).toEqual(["m1"]);
+      expect(series?.score).toBe("1:0");
+    });
+
     it("orders matches chronologically and groups time-adjacent matches regardless of discovery order", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
@@ -594,6 +703,8 @@ describe("IndividualTrackerDO", () => {
             m1: aFakeIndividualTrackerMatchSummaryWith({
               matchId: "m1",
               startTime: "2024-11-26T11:00:00.000Z",
+              mapAssetId: "map-a",
+              mapVersionId: "ver-a",
               outcome: "Win",
               isMatchmaking: false,
               teamRosterSignature: "0:1|1:2",
@@ -602,6 +713,8 @@ describe("IndividualTrackerDO", () => {
             m2: aFakeIndividualTrackerMatchSummaryWith({
               matchId: "m2",
               startTime: "2024-11-26T11:30:00.000Z",
+              mapAssetId: "map-b",
+              mapVersionId: "ver-b",
               outcome: "Loss",
               isMatchmaking: false,
               teamRosterSignature: "0:1|1:2",
@@ -610,6 +723,8 @@ describe("IndividualTrackerDO", () => {
             m3: aFakeIndividualTrackerMatchSummaryWith({
               matchId: "m3",
               startTime: "2024-11-26T12:00:00.000Z",
+              mapAssetId: "map-c",
+              mapVersionId: "ver-c",
               outcome: "Win",
               isMatchmaking: false,
               teamRosterSignature: "0:1|1:2",


### PR DESCRIPTION
## Context
Individual tracker series presentation was still using raw grouped matches, which allowed duplicate sequential map+mode entries to influence tab and icon lists and score calculations. We also needed to prevent non-series warmup-style matches from being counted in a series when the roster sizes do not match the active series teams.

## This PR
- Added Durable Object view-state filtering so series output only uses matches that match expected team roster counts when active/completed series teams are known.
- Applied sequential same map+mode deduplication (keep latest result) to the series summaries used for score, subtitle generation, series match id list, and background/icon lists.
- Added regression coverage for:
  - sequential same map+mode dedupe behavior in series match id list and score
  - roster-size qualification behavior so mismatched matches are excluded
- Updated the chronology/grouping test fixture to use distinct map signatures so it continues testing ordering/grouping semantics independently of the new dedupe rule.

## Subsequent Work
- Optionally add a focused overlay-level assertion proving that icon rendering now exactly reflects deduped series match ids from API view-state across mixed warmup and series match histories.
