### PR TITLE
Harden individual tracker series lifecycle: nudge fallback and stale-state flush

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -564,7 +564,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
       const isMatchmakingMatch = match.MatchInfo.Playlist != null;
       if (trackerState.activeSeries != null && isMatchmakingMatch) {
-        this.retireActiveSeries(trackerState);
+        this.clearSeriesState(trackerState);
         this.logService.info(
           "IndividualTracker: series ended after matchmaking match was discovered",
           new Map([
@@ -1582,7 +1582,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       players: team.members.map((gamertag) => ({ discordId: null, discordName: null, gamertag, xboxId: null })),
     }));
 
-    this.retireActiveSeries(trackerState);
+    this.clearSeriesState(trackerState);
     trackerState.activeSeries = {
       title: body.titleOverride ?? getDefaultSeriesGroupTitle(),
       subtitle: body.subtitleOverride,
@@ -1720,7 +1720,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     switch (payload.type) {
       case "ended": {
-        this.retireActiveSeries(trackerState);
+        this.clearSeriesState(trackerState);
         break;
       }
       case "substituted": {
@@ -1734,7 +1734,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           trackedGamertag === payload.playerIn.gamertag;
 
         if (isTrackedPlayerOut) {
-          this.retireActiveSeries(trackerState);
+          this.clearSeriesState(trackerState);
           this.logService.info(
             "IndividualTracker: series retired (tracked player subbed out via nudge)",
             new Map([
@@ -1791,7 +1791,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         break;
       }
       case "started": {
-        this.retireActiveSeries(trackerState);
+        this.clearSeriesState(trackerState);
         trackerState.activeSeries = {
           title: payload.title,
           subtitle: payload.subtitle,
@@ -2100,6 +2100,12 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
     state.completedSeries = [...(state.completedSeries ?? []), { ...state.activeSeries, isActive: false }];
     delete state.activeSeries;
+  }
+
+  private clearSeriesState(state: IndividualTrackerInternalState): void {
+    delete state.activeSeries;
+    delete state.completedSeries;
+    delete state.seriesGroupOverrides;
   }
 
   private sanitizeState(state: IndividualTrackerInternalState): IndividualTrackerDoState {

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -2105,7 +2105,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   private clearSeriesState(state: IndividualTrackerInternalState): void {
     delete state.activeSeries;
     delete state.completedSeries;
-    delete state.seriesGroupOverrides;
   }
 
   private sanitizeState(state: IndividualTrackerInternalState): IndividualTrackerDoState {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1761,6 +1761,9 @@ describe("IndividualTrackerDO", () => {
       ownerClient.getPlayerMatches
         .mockResolvedValueOnce([aFakePlayerMatch("match-matchmaking", "2024-11-26T11:30:00.000Z", 2, "PT5M", true)])
         .mockResolvedValueOnce([]);
+      const persistedSeriesGroupOverrides = [
+        { matchIds: ["series-custom-match"], titleOverride: "My Series", subtitleOverride: null },
+      ];
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
           startTime: now.toISOString(),
@@ -1781,6 +1784,7 @@ describe("IndividualTrackerDO", () => {
             startedAt: "2024-11-26T11:00:00.000Z",
             isActive: true,
           },
+          seriesGroupOverrides: persistedSeriesGroupOverrides,
         }),
       );
 
@@ -1789,6 +1793,7 @@ describe("IndividualTrackerDO", () => {
       const persisted = lastPersistedState(storagePutSpy);
       expect(persisted.activeSeries).toBeUndefined();
       expect(persisted.completedSeries).toBeUndefined();
+      expect(persisted.seriesGroupOverrides).toEqual(persistedSeriesGroupOverrides);
       expect(persisted.matchIds).toEqual(["series-custom-match", "match-matchmaking"]);
       expect(persisted.discoveredMatches["match-matchmaking"]?.isMatchmaking).toBe(true);
     });
@@ -2994,9 +2999,13 @@ describe("IndividualTrackerDO", () => {
     });
 
     it("flushes existing series metadata when nudging with ended event", async () => {
+      const persistedSeriesGroupOverrides = [
+        { matchIds: ["match-1"], titleOverride: "Custom Label", subtitleOverride: null },
+      ];
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
           activeSeries: anActiveSeries({ matchIds: ["match-1"] }),
+          seriesGroupOverrides: persistedSeriesGroupOverrides,
         }),
       );
 
@@ -3009,10 +3018,14 @@ describe("IndividualTrackerDO", () => {
       const persisted = lastPersistedState(storagePutSpy);
       expect(persisted.activeSeries).toBeUndefined();
       expect(persisted.completedSeries).toBeUndefined();
+      expect(persisted.seriesGroupOverrides).toEqual(persistedSeriesGroupOverrides);
       expect(storageSetAlarmSpy).toHaveBeenCalledWith(Date.now());
     });
 
     it("flushes active/completed series metadata when tracked player is subbed out", async () => {
+      const persistedSeriesGroupOverrides = [
+        { matchIds: ["match-1"], titleOverride: "Custom Label", subtitleOverride: null },
+      ];
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
           gamertag: "GT1",
@@ -3025,6 +3038,7 @@ describe("IndividualTrackerDO", () => {
               },
             ],
           }),
+          seriesGroupOverrides: persistedSeriesGroupOverrides,
         }),
       );
 
@@ -3036,6 +3050,7 @@ describe("IndividualTrackerDO", () => {
       const persisted = lastPersistedState(storagePutSpy);
       expect(persisted.activeSeries).toBeUndefined();
       expect(persisted.completedSeries).toBeUndefined();
+      expect(persisted.seriesGroupOverrides).toEqual(persistedSeriesGroupOverrides);
     });
 
     it("resumes completed series and applies substitution when tracked player is subbed in", async () => {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1757,7 +1757,7 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.selectedMatchIds).toEqual(["match-new"]);
     });
 
-    it("ends an active series before appending a newly discovered matchmaking match", async () => {
+    it("flushes active/completed series metadata before appending a newly discovered matchmaking match", async () => {
       ownerClient.getPlayerMatches
         .mockResolvedValueOnce([aFakePlayerMatch("match-matchmaking", "2024-11-26T11:30:00.000Z", 2, "PT5M", true)])
         .mockResolvedValueOnce([]);
@@ -1788,17 +1788,12 @@ describe("IndividualTrackerDO", () => {
 
       const persisted = lastPersistedState(storagePutSpy);
       expect(persisted.activeSeries).toBeUndefined();
-      expect(persisted.completedSeries).toHaveLength(1);
-      expect(persisted.completedSeries?.[0]).toMatchObject({
-        title: "Active Series",
-        matchIds: ["series-custom-match"],
-        isActive: false,
-      });
+      expect(persisted.completedSeries).toBeUndefined();
       expect(persisted.matchIds).toEqual(["series-custom-match", "match-matchmaking"]);
       expect(persisted.discoveredMatches["match-matchmaking"]?.isMatchmaking).toBe(true);
     });
 
-    it("keeps older custom matches in the completed series when a newer matchmaking match appears in the same batch", async () => {
+    it("flushes completed series metadata when a newer matchmaking match appears in the same batch", async () => {
       ownerClient.getPlayerMatches
         .mockResolvedValueOnce([
           aFakePlayerMatch("match-matchmaking", "2024-11-26T11:32:00.000Z", 2, "PT5M", true),
@@ -1832,14 +1827,13 @@ describe("IndividualTrackerDO", () => {
 
       const persisted = lastPersistedState(storagePutSpy);
       expect(persisted.activeSeries).toBeUndefined();
-      expect(persisted.completedSeries).toHaveLength(1);
-      expect(persisted.completedSeries?.[0]?.matchIds).toEqual(["series-custom-existing", "match-custom-older"]);
+      expect(persisted.completedSeries).toBeUndefined();
       expect(persisted.matchIds).toEqual(["series-custom-existing", "match-custom-older", "match-matchmaking"]);
       expect(persisted.discoveredMatches["match-matchmaking"]?.isMatchmaking).toBe(true);
       expect(persisted.discoveredMatches["match-custom-older"]?.isMatchmaking).toBe(false);
     });
 
-    it("does not include newer custom matches in completed series when an older matchmaking match is the boundary", async () => {
+    it("flushes completed series metadata when an older matchmaking match is the boundary", async () => {
       ownerClient.getPlayerMatches
         .mockResolvedValueOnce([
           aFakePlayerMatch("match-custom-newer", "2024-11-26T11:32:00.000Z", 2, "PT5M", false),
@@ -1873,8 +1867,7 @@ describe("IndividualTrackerDO", () => {
 
       const persisted = lastPersistedState(storagePutSpy);
       expect(persisted.activeSeries).toBeUndefined();
-      expect(persisted.completedSeries).toHaveLength(1);
-      expect(persisted.completedSeries?.[0]?.matchIds).toEqual(["series-custom-existing"]);
+      expect(persisted.completedSeries).toBeUndefined();
       expect(persisted.matchIds).toEqual(["series-custom-existing", "match-matchmaking-older", "match-custom-newer"]);
       expect(persisted.discoveredMatches["match-matchmaking-older"]?.isMatchmaking).toBe(true);
       expect(persisted.discoveredMatches["match-custom-newer"]?.isMatchmaking).toBe(false);
@@ -2834,7 +2827,7 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.activeSeries?.subtitle).toBeNull();
     });
 
-    it("moves existing activeSeries to completedSeries when starting a new one", async () => {
+    it("flushes old series metadata when starting a new one", async () => {
       const existingSeries: ActiveSeries = {
         title: "Old Series",
         subtitle: "",
@@ -2852,8 +2845,7 @@ describe("IndividualTrackerDO", () => {
 
       expect(response.status).toBe(200);
       const persisted = lastPersistedState(storagePutSpy);
-      expect(persisted.completedSeries).toHaveLength(1);
-      expect(persisted.completedSeries?.[0]).toMatchObject({ title: "Old Series", isActive: false });
+      expect(persisted.completedSeries).toBeUndefined();
       expect(persisted.activeSeries).toMatchObject({ title: "New Series", isActive: true });
     });
   });
@@ -3001,7 +2993,7 @@ describe("IndividualTrackerDO", () => {
       expect(response.status).toBe(400);
     });
 
-    it("moves existing activeSeries to completedSeries when nudging with ended event", async () => {
+    it("flushes existing series metadata when nudging with ended event", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
           activeSeries: anActiveSeries({ matchIds: ["match-1"] }),
@@ -3016,11 +3008,11 @@ describe("IndividualTrackerDO", () => {
 
       const persisted = lastPersistedState(storagePutSpy);
       expect(persisted.activeSeries).toBeUndefined();
-      expect(persisted.completedSeries).toHaveLength(1);
+      expect(persisted.completedSeries).toBeUndefined();
       expect(storageSetAlarmSpy).toHaveBeenCalledWith(Date.now());
     });
 
-    it("retires active series when tracked player is subbed out", async () => {
+    it("flushes active/completed series metadata when tracked player is subbed out", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
           gamertag: "GT1",
@@ -3043,7 +3035,7 @@ describe("IndividualTrackerDO", () => {
       expect(response.status).toBe(200);
       const persisted = lastPersistedState(storagePutSpy);
       expect(persisted.activeSeries).toBeUndefined();
-      expect(persisted.completedSeries).toHaveLength(1);
+      expect(persisted.completedSeries).toBeUndefined();
     });
 
     it("resumes completed series and applies substitution when tracked player is subbed in", async () => {
@@ -3215,7 +3207,7 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.activeSeries?.teams[0]?.players[0]?.xboxId).toBe("xuid-3");
     });
 
-    it("moves existing activeSeries to completedSeries when starting a new one via nudge", async () => {
+    it("flushes existing series metadata when starting a new one via nudge", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
           activeSeries: anActiveSeries({ title: "Old Queue", matchIds: ["stale-match-id"] }),
@@ -3229,8 +3221,7 @@ describe("IndividualTrackerDO", () => {
       expect(response.status).toBe(200);
 
       const persisted = lastPersistedState(storagePutSpy);
-      expect(persisted.completedSeries).toHaveLength(1);
-      expect(persisted.completedSeries?.[0]).toMatchObject({ title: "Old Queue", isActive: false });
+      expect(persisted.completedSeries).toBeUndefined();
       expect(persisted.activeSeries).toMatchObject({ title: "Guilty Spark", matchIds: [], isActive: true });
     });
   });

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -1260,23 +1260,45 @@ export class NeatQueueService {
 
   private async extractXuidsWithFallback(data: Record<string, PlayerAssociationData>): Promise<string[]> {
     const xuidSet = new Set<string>();
+    const discordIdsMissingXuids: string[] = [];
 
     for (const [discordId, associationData] of Object.entries(data)) {
       if (associationData.xboxId != null) {
         xuidSet.add(associationData.xboxId);
         continue;
       }
+      discordIdsMissingXuids.push(discordId);
+    }
 
-      const linkedIdentities = await this.databaseService.findLinkedIdentitiesByUserId(discordId);
-      const activeXboxIdentity = linkedIdentities.find(
-        (identity) => identity.Provider === "xbox" && identity.IsActive === 1,
-      );
-      if (activeXboxIdentity != null) {
-        xuidSet.add(activeXboxIdentity.ProviderUserId);
+    const fallbackXuids = await Promise.all(
+      discordIdsMissingXuids.map(async (discordId) => this.findActiveXboxIdentityXuid(discordId)),
+    );
+    for (const fallbackXuid of fallbackXuids) {
+      if (fallbackXuid != null) {
+        xuidSet.add(fallbackXuid);
       }
     }
 
     return [...xuidSet];
+  }
+
+  private async findActiveXboxIdentityXuid(discordId: string): Promise<string | null> {
+    try {
+      const linkedIdentities = await this.databaseService.findLinkedIdentitiesByUserId(discordId);
+      const activeXboxIdentity = linkedIdentities.find(
+        (identity) => identity.Provider === "xbox" && identity.IsActive === 1,
+      );
+      return activeXboxIdentity?.ProviderUserId ?? null;
+    } catch (error: unknown) {
+      this.logService.warn(
+        "Failed to resolve fallback Xbox identity for player, continuing without fallback XUID",
+        new Map([
+          ["discordId", discordId],
+          ["error", String(error)],
+        ]),
+      );
+      return null;
+    }
   }
 
   private getQueueStateKey(guildId: string, queueNumber: number): string {

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -687,7 +687,7 @@ export class NeatQueueService {
       };
       queueState.seriesContext = seriesContext;
       this.setQueueState(request.guild, request.match_number, queueState);
-      const allPlayerXuids = this.extractXuids(queueState.playersAssociationData);
+      const allPlayerXuids = await this.extractXuidsWithFallback(queueState.playersAssociationData);
       await this.individualTrackerService.nudgeTrackers(allPlayerXuids, seriesContext);
     } catch (error) {
       this.logService.warn(
@@ -1104,7 +1104,7 @@ export class NeatQueueService {
     }
 
     const completedQueueState = await this.getQueueState(neatQueueConfig.GuildId, request.match_number);
-    const allPlayerXuids = this.extractXuids(completedQueueState.playersAssociationData);
+    const allPlayerXuids = await this.extractXuidsWithFallback(completedQueueState.playersAssociationData);
 
     await Promise.all([
       this.nudgeIndividualTrackersForMatchCompletion(request, neatQueueConfig, allPlayerXuids),
@@ -1258,10 +1258,25 @@ export class NeatQueueService {
     };
   }
 
-  private extractXuids(data: Record<string, PlayerAssociationData>): string[] {
-    return Object.values(data)
-      .map((d) => d.xboxId)
-      .filter((xuid): xuid is string => xuid != null);
+  private async extractXuidsWithFallback(data: Record<string, PlayerAssociationData>): Promise<string[]> {
+    const xuidSet = new Set<string>();
+
+    for (const [discordId, associationData] of Object.entries(data)) {
+      if (associationData.xboxId != null) {
+        xuidSet.add(associationData.xboxId);
+        continue;
+      }
+
+      const linkedIdentities = await this.databaseService.findLinkedIdentitiesByUserId(discordId);
+      const activeXboxIdentity = linkedIdentities.find(
+        (identity) => identity.Provider === "xbox" && identity.IsActive === 1,
+      );
+      if (activeXboxIdentity != null) {
+        xuidSet.add(activeXboxIdentity.ProviderUserId);
+      }
+    }
+
+    return [...xuidSet];
   }
 
   private getQueueStateKey(guildId: string, queueNumber: number): string {

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -19,6 +19,7 @@ import {
   aFakeDatabaseServiceWith,
   aFakeDiscordAssociationsRow,
   aFakeGuildConfigRow,
+  aFakeLinkedIdentitiesRow,
   aFakeNeatQueueConfigRow,
 } from "../../database/fakes/database.fake";
 import { aFakeLogServiceWith } from "../../log/fakes/log.fake";
@@ -2163,6 +2164,70 @@ describe("NeatQueueService", () => {
         expect(xuids).toContain("xuid_discord_user_02");
       });
 
+      it("falls back to active linked Xbox identities when player association xboxId is missing", async () => {
+        const teamsCreatedRequest = getFakeNeatQueueData("teamsCreated");
+        const playersAssociationData = {
+          discord_user_01: {
+            ...createSamplePlayerAssociationData("discord_user_01", "soundmanD", "SoundmanD"),
+            xboxId: null,
+          },
+          discord_user_02: {
+            ...createSamplePlayerAssociationData("discord_user_02", "discord_user_02", "User02"),
+            xboxId: null,
+          },
+        };
+        (vi.spyOn(env.APP_DATA, "get") as MockInstance).mockResolvedValue(
+          aFakeNeatQueueStateWith({ playersAssociationData }),
+        );
+        vi.spyOn(env.APP_DATA, "put").mockResolvedValue();
+        vi.spyOn(databaseService, "getDiscordAssociations").mockResolvedValue([]);
+        vi.spyOn(databaseService, "findLinkedIdentitiesByUserId").mockImplementation(async (userId) => {
+          if (userId === "discord_user_01") {
+            return Promise.resolve([
+              aFakeLinkedIdentitiesRow({
+                UserId: "discord_user_01",
+                Provider: "xbox",
+                ProviderUserId: "xuid_linked_01",
+                IsActive: 1,
+              }),
+            ]);
+          }
+
+          if (userId === "discord_user_02") {
+            return Promise.resolve([
+              aFakeLinkedIdentitiesRow({
+                UserId: "discord_user_02",
+                Provider: "xbox",
+                ProviderUserId: "xuid_linked_02",
+                IsActive: 1,
+              }),
+            ]);
+          }
+
+          return Promise.resolve([]);
+        });
+        vi.spyOn(haloService, "getUsersByXuids").mockResolvedValue([]);
+        vi.spyOn(haloService, "getRankedArenaCsrs").mockResolvedValue(new Map());
+        vi.spyOn(haloService, "getPlayersEsras").mockResolvedValue(new Map());
+        vi.spyOn(discordService, "getGuild").mockResolvedValue({
+          ...guild,
+          id: "guild-1",
+          name: "Test Server",
+          icon: null,
+        });
+        vi.spyOn(databaseService, "getGuildConfig").mockResolvedValue(
+          aFakeGuildConfigRow({ NeatQueueInformerLiveTracking: "N" }),
+        );
+
+        const { jobToComplete } = neatQueueService.handleRequest(teamsCreatedRequest, neatQueueConfig);
+        await jobToComplete?.();
+
+        expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
+        const [xuids] = nudgeTrackersSpy.mock.calls[0] as [string[], unknown];
+        expect(xuids).toContain("xuid_linked_01");
+        expect(xuids).toContain("xuid_linked_02");
+      });
+
       it("uses guild display name for title even when explicit team names are set", async () => {
         const teamsCreatedRequest = getFakeNeatQueueData("teamsCreated");
         const team0Player = teamsCreatedRequest.teams[0]?.[0];
@@ -2456,6 +2521,68 @@ describe("NeatQueueService", () => {
 
         expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
         expect(nudgeTrackersSpy).toHaveBeenCalledWith([], { type: "ended" });
+      });
+
+      it("falls back to active linked Xbox identities when completion association xboxId is missing", async () => {
+        const matchCompletedRequest = getFakeNeatQueueData("matchCompleted");
+        const playersAssociationData = {
+          discord_user_01: {
+            ...createSamplePlayerAssociationData("discord_user_01", "soundmanD", "SoundmanD"),
+            xboxId: null,
+          },
+          discord_user_02: {
+            ...createSamplePlayerAssociationData("discord_user_02", "discord_user_02", "User02"),
+            xboxId: null,
+          },
+        };
+        (vi.spyOn(env.APP_DATA, "get") as MockInstance).mockResolvedValue(
+          aFakeNeatQueueStateWith({
+            playersAssociationData,
+            timeline: [{ timestamp: new Date().toISOString(), event: getFakeNeatQueueData("teamsCreated") }],
+          }),
+        );
+        vi.spyOn(env.APP_DATA, "delete").mockResolvedValue();
+        vi.spyOn(databaseService, "findLinkedIdentitiesByUserId").mockImplementation(async (userId) => {
+          if (userId === "discord_user_01") {
+            return Promise.resolve([
+              aFakeLinkedIdentitiesRow({
+                UserId: "discord_user_01",
+                Provider: "xbox",
+                ProviderUserId: "xuid_linked_01",
+                IsActive: 1,
+              }),
+            ]);
+          }
+
+          if (userId === "discord_user_02") {
+            return Promise.resolve([
+              aFakeLinkedIdentitiesRow({
+                UserId: "discord_user_02",
+                Provider: "xbox",
+                ProviderUserId: "xuid_linked_02",
+                IsActive: 1,
+              }),
+            ]);
+          }
+
+          return Promise.resolve([]);
+        });
+        vi.spyOn(liveTrackerService, "getTrackerStatus").mockResolvedValue({
+          state: aFakeLiveTrackerStateWith({ status: "stopped" }),
+        });
+        vi.spyOn(haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
+        vi.spyOn(haloService, "updateDiscordAssociations").mockResolvedValue();
+        vi.spyOn(discordService, "getTeamsFromQueueResult").mockResolvedValue(discordNeatQueueData);
+        vi.spyOn(discordService, "getUsers").mockResolvedValue([guildMember]);
+
+        const { jobToComplete } = neatQueueService.handleRequest(matchCompletedRequest, neatQueueConfig);
+        await jobToComplete?.();
+
+        expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
+        const [xuids, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], { type: "ended" }];
+        expect(xuids).toContain("xuid_linked_01");
+        expect(xuids).toContain("xuid_linked_02");
+        expect(payload).toEqual({ type: "ended" });
       });
     });
   });

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -2584,6 +2584,65 @@ describe("NeatQueueService", () => {
         expect(xuids).toContain("xuid_linked_02");
         expect(payload).toEqual({ type: "ended" });
       });
+
+      it("continues match completion cleanup when one fallback linked identity lookup fails", async () => {
+        const matchCompletedRequest = getFakeNeatQueueData("matchCompleted");
+        const playersAssociationData = {
+          discord_user_01: {
+            ...createSamplePlayerAssociationData("discord_user_01", "soundmanD", "SoundmanD"),
+            xboxId: null,
+          },
+          discord_user_02: {
+            ...createSamplePlayerAssociationData("discord_user_02", "discord_user_02", "User02"),
+            xboxId: null,
+          },
+        };
+        (vi.spyOn(env.APP_DATA, "get") as MockInstance).mockResolvedValue(
+          aFakeNeatQueueStateWith({
+            playersAssociationData,
+            timeline: [{ timestamp: new Date().toISOString(), event: getFakeNeatQueueData("teamsCreated") }],
+          }),
+        );
+        const appDataDeleteSpy = vi.spyOn(env.APP_DATA, "delete").mockResolvedValue();
+        const haloUpdateDiscordAssociationsSpy = vi.spyOn(haloService, "updateDiscordAssociations").mockResolvedValue();
+        const logWarnSpy = vi.spyOn(logService, "warn");
+        vi.spyOn(databaseService, "findLinkedIdentitiesByUserId").mockImplementation(async (userId) => {
+          if (userId === "discord_user_01") {
+            throw new Error("temporary d1 error");
+          }
+
+          if (userId === "discord_user_02") {
+            return Promise.resolve([
+              aFakeLinkedIdentitiesRow({
+                UserId: "discord_user_02",
+                Provider: "xbox",
+                ProviderUserId: "xuid_linked_02",
+                IsActive: 1,
+              }),
+            ]);
+          }
+
+          return Promise.resolve([]);
+        });
+        vi.spyOn(liveTrackerService, "getTrackerStatus").mockResolvedValue({
+          state: aFakeLiveTrackerStateWith({ status: "stopped" }),
+        });
+        vi.spyOn(haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
+        vi.spyOn(discordService, "getTeamsFromQueueResult").mockResolvedValue(discordNeatQueueData);
+        vi.spyOn(discordService, "getUsers").mockResolvedValue([guildMember]);
+
+        const { jobToComplete } = neatQueueService.handleRequest(matchCompletedRequest, neatQueueConfig);
+        await jobToComplete?.();
+
+        expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
+        expect(nudgeTrackersSpy).toHaveBeenCalledWith(["xuid_linked_02"], { type: "ended" });
+        expect(haloUpdateDiscordAssociationsSpy).toHaveBeenCalledOnce();
+        expect(appDataDeleteSpy).toHaveBeenCalledOnce();
+        expect(logWarnSpy).toHaveBeenCalledWith(
+          "Failed to resolve fallback Xbox identity for player, continuing without fallback XUID",
+          expect.any(Map),
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
## Context
Individual tracker series state could become stale across NeatQueue lifecycle transitions. Two failure modes were observed: nudges could miss trackers when queue association data lacked Xbox IDs, and old series metadata could persist into the next series when transitions happened quickly (auto-close, ended nudge, or a new started event).

## This PR
- Added a linked-identity fallback for NeatQueue individual-tracker nudge fan-out so active Xbox linked identities are used when `playersAssociationData` has null `xboxId`.
- Applied that fallback to both series lifecycle nudge paths:
  - TEAMS_CREATED (`type: "started"`)
  - MATCH_COMPLETED (`type: "ended"`)
- Added focused NeatQueue regression tests for both fallback paths.
- Added explicit series-state flush behavior in IndividualTrackerDO so stale series context is cleared before creating new context.
- Applied forced flush on:
  - auto-close when a matchmaking match ends an active custom series during polling
  - `type: "ended"` nudge handling
  - tracked-player sub-out retirement path
  - new series creation via start-series and via `type: "started"` nudge
- Updated DO lifecycle tests to assert flushed-state semantics.

## Subsequent Work
- Monitor production nudge fan-out counts (resolved XUIDs vs queue participants) for started/ended events.
- Optionally add transient diagnostics in DO logs for series flush triggers to confirm expected runtime transitions in live traffic.
