### PR TITLE
Align live-tracker reconnects with shared retry policy

### DIFF
--- a/pages/src/components/live-tracker/live-tracker-presenter.ts
+++ b/pages/src/components/live-tracker/live-tracker-presenter.ts
@@ -9,6 +9,7 @@ import type {
   LiveTrackerSubscription,
 } from "../../services/live-tracker/types";
 import type { MatchAnalyticsService } from "../../services/stats/match-analytics-types";
+import { getReconnectDelayMs } from "../../services/base/reconnect-policy";
 import type { MatchStatsData } from "../../controllers/stats/types";
 import { isMatchStats } from "../../controllers/stats/is-match-stats";
 import { ComponentLoaderStatus } from "../component-loader/component-loader";
@@ -50,7 +51,6 @@ export class LiveTrackerPresenter {
   private reconnectionAttempt = 0;
   private readonly maxReconnectionAttempts = 10;
   private readonly maxReconnectionDurationMs = 3 * 60 * 1000;
-  private readonly baseReconnectionDelayMs = 2000;
 
   private readonly fetchedMatchIds = new Set<string>();
   private stateMessageVersion = 0;
@@ -733,6 +733,10 @@ export class LiveTrackerPresenter {
       return;
     }
 
+    if (this.reconnectionTimer != null) {
+      return;
+    }
+
     const now = Date.now();
     this.firstReconnectionTimestamp ??= now;
 
@@ -754,10 +758,7 @@ export class LiveTrackerPresenter {
       return;
     }
 
-    const backoffFactor = Math.pow(1.5, this.reconnectionAttempt);
-    const delay = Math.min(this.baseReconnectionDelayMs * backoffFactor, 30000); // Cap at 30s
-    const jitter = Math.random() * 1000;
-    const totalDelay = delay + jitter;
+    const totalDelay = getReconnectDelayMs(this.reconnectionAttempt);
 
     this.config.store.setSnapshot({
       ...snapshot,
@@ -766,6 +767,7 @@ export class LiveTrackerPresenter {
     });
 
     this.reconnectionTimer = setTimeout(() => {
+      this.reconnectionTimer = null;
       void this.connectInternal(identity);
       this.reconnectionAttempt++;
     }, totalDelay);

--- a/pages/src/components/live-tracker/live-tracker-presenter.ts
+++ b/pages/src/components/live-tracker/live-tracker-presenter.ts
@@ -740,21 +740,9 @@ export class LiveTrackerPresenter {
     const now = Date.now();
     this.firstReconnectionTimestamp ??= now;
 
-    const elapsed = now - this.firstReconnectionTimestamp;
-
-    if (elapsed > this.maxReconnectionDurationMs || this.reconnectionAttempt >= this.maxReconnectionAttempts) {
-      const hasDetail = (detail?.length ?? 0) > 0;
-      const errorText = hasDetail ? `Connection error: ${detail ?? ""}` : "Connection lost";
-      const reason =
-        elapsed > this.maxReconnectionDurationMs
-          ? "Gave up after 3m"
-          : `Max retries reached (${String(this.maxReconnectionAttempts)})`;
-      this.config.store.setSnapshot({
-        ...snapshot,
-        connectionState: "error",
-        statusText: `${errorText} (${reason})`,
-      });
-      this.stopReconnection();
+    const limitReason = this.getReconnectionLimitReason(now);
+    if (limitReason != null) {
+      this.setReconnectionError(snapshot, detail, limitReason);
       return;
     }
 
@@ -767,9 +755,41 @@ export class LiveTrackerPresenter {
     });
 
     this.reconnectionTimer = setTimeout(() => {
+      const retryNow = Date.now();
+      const retryLimitReason = this.getReconnectionLimitReason(retryNow);
+      if (retryLimitReason != null) {
+        const currentSnapshot = this.config.store.getSnapshot();
+        this.setReconnectionError(currentSnapshot, detail, retryLimitReason);
+        return;
+      }
+
       this.reconnectionTimer = null;
       void this.connectInternal(identity);
       this.reconnectionAttempt++;
     }, totalDelay);
+  }
+
+  private getReconnectionLimitReason(now: number): string | null {
+    const elapsed = now - (this.firstReconnectionTimestamp ?? now);
+    if (elapsed > this.maxReconnectionDurationMs) {
+      return "Gave up after 3m";
+    }
+
+    if (this.reconnectionAttempt >= this.maxReconnectionAttempts) {
+      return `Max retries reached (${String(this.maxReconnectionAttempts)})`;
+    }
+
+    return null;
+  }
+
+  private setReconnectionError(snapshot: LiveTrackerSnapshot, detail: string | undefined, reason: string): void {
+    const hasDetail = (detail?.length ?? 0) > 0;
+    const errorText = hasDetail ? `Connection error: ${detail ?? ""}` : "Connection lost";
+    this.config.store.setSnapshot({
+      ...snapshot,
+      connectionState: "error",
+      statusText: `${errorText} (${reason})`,
+    });
+    this.stopReconnection();
   }
 }

--- a/pages/src/components/live-tracker/tests/live-tracker-presenter.test.ts
+++ b/pages/src/components/live-tracker/tests/live-tracker-presenter.test.ts
@@ -15,6 +15,7 @@ import type {
   LiveTrackerStatusListener,
 } from "../../../services/live-tracker/types";
 import { aFakeMatchAnalyticsServiceWith } from "../../../services/stats/fakes/match-analytics.fake";
+import * as reconnectPolicy from "../../../services/base/reconnect-policy";
 import { ComponentLoaderStatus } from "../../component-loader/component-loader";
 import type { LiveTrackerSnapshot } from "../live-tracker-store";
 
@@ -482,65 +483,113 @@ describe("LiveTrackerPresenter - Retry Behavior", () => {
     presenter.dispose();
   });
 
-  it("respects time limit (3 minutes) in addition to attempt limit", async (): Promise<void> => {
-    const mockService = new MockLiveTrackerService();
-    const mockStore = new MockLiveTrackerStore();
+  it("uses shared reconnect delay and ignores duplicate error events while a retry is pending", async (): Promise<void> => {
+    const reconnectDelaySpy = vi.spyOn(reconnectPolicy, "getReconnectDelayMs").mockReturnValue(1_000);
 
-    const createdConnections: MockLiveTrackerConnection[] = [];
-    vi.spyOn(mockService, "connect").mockImplementation(async (): Promise<LiveTrackerConnection> => {
-      const conn = new MockLiveTrackerConnection();
-      createdConnections.push(conn);
-      return Promise.resolve(conn);
-    });
+    try {
+      const mockService = new MockLiveTrackerService();
+      const mockStore = new MockLiveTrackerStore();
 
-    const presenter = new LiveTrackerPresenter({
-      getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
-      liveTrackerService: mockService,
-      store: mockStore,
-      matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
-      medalMetadataResolver: new HaloMedalMetadataResolver(aFakeHaloClientWith()),
-    });
+      const createdConnections: MockLiveTrackerConnection[] = [];
+      const connectSpy = vi
+        .spyOn(mockService, "connect")
+        .mockImplementation(async (): Promise<LiveTrackerConnection> => {
+          const conn = new MockLiveTrackerConnection();
+          createdConnections.push(conn);
+          return Promise.resolve(conn);
+        });
 
-    // Start the connection
-    presenter.start();
-    await vi.runAllTimersAsync();
+      const presenter = new LiveTrackerPresenter({
+        getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
+        liveTrackerService: mockService,
+        store: mockStore,
+        matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+        medalMetadataResolver: new HaloMedalMetadataResolver(aFakeHaloClientWith()),
+      });
 
-    // Simulate successful connection first
-    const [initialConnection] = createdConnections;
-    expect(initialConnection).toBeDefined();
-    initialConnection.emitStatus("connected");
-    await vi.runAllTimersAsync();
-    initialConnection.emitMessage(sampleLiveTrackerStateMessage);
-    await vi.runAllTimersAsync();
-    initialConnection.emitStatus("error", "Connection lost");
-    await vi.runAllTimersAsync();
-
-    // Try retrying for longer than 3 minutes
-    for (let i = 0; i < 6; i++) {
-      // Each iteration is 35 seconds, so 6 iterations = 210 seconds > 180 seconds (3 min)
-      await vi.advanceTimersByTimeAsync(35000);
+      presenter.start();
       await vi.runAllTimersAsync();
 
-      const [latestConnection] = createdConnections.slice(-1);
-      expect(latestConnection).toBeDefined();
-      latestConnection.emitStatus("error", "Still failing");
+      const initialConnection = Preconditions.checkExists(createdConnections[0]);
+      initialConnection.emitStatus("connected");
+      await vi.runAllTimersAsync();
+      initialConnection.emitMessage(sampleLiveTrackerStateMessage);
       await vi.runAllTimersAsync();
 
-      const snapshot = mockStore.getSnapshot();
-      if (snapshot.statusText.includes("Gave up")) {
-        break;
-      }
+      initialConnection.emitStatus("error", "Connection lost");
+      initialConnection.emitStatus("error", "Connection lost again");
+
+      expect(reconnectDelaySpy).toHaveBeenCalledTimes(1);
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.runAllTimersAsync();
+
+      expect(connectSpy).toHaveBeenCalledTimes(2);
+
+      presenter.dispose();
+    } finally {
+      reconnectDelaySpy.mockRestore();
     }
+  });
 
-    // Test passes if we eventually gave up due to time limit
-    const finalSnapshot = mockStore.getSnapshot();
+  it("respects time limit (3 minutes) in addition to attempt limit", async (): Promise<void> => {
+    const reconnectDelaySpy = vi.spyOn(reconnectPolicy, "getReconnectDelayMs").mockReturnValue(35_000);
 
-    const reachedTimeLimit =
-      finalSnapshot.statusText.includes("Gave up") || finalSnapshot.statusText.includes("Max retries");
+    try {
+      const mockService = new MockLiveTrackerService();
+      const mockStore = new MockLiveTrackerStore();
 
-    expect(reachedTimeLimit).toBe(true);
-    expect(finalSnapshot.connectionState).toMatch(/^(error|connecting)$/);
+      const createdConnections: MockLiveTrackerConnection[] = [];
+      vi.spyOn(mockService, "connect").mockImplementation(async (): Promise<LiveTrackerConnection> => {
+        const conn = new MockLiveTrackerConnection();
+        createdConnections.push(conn);
+        return Promise.resolve(conn);
+      });
 
-    presenter.dispose();
+      const presenter = new LiveTrackerPresenter({
+        getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
+        liveTrackerService: mockService,
+        store: mockStore,
+        matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+        medalMetadataResolver: new HaloMedalMetadataResolver(aFakeHaloClientWith()),
+      });
+
+      presenter.start();
+      await vi.runAllTimersAsync();
+
+      const [initialConnection] = createdConnections;
+      expect(initialConnection).toBeDefined();
+      initialConnection.emitStatus("connected");
+      await vi.runAllTimersAsync();
+      initialConnection.emitMessage(sampleLiveTrackerStateMessage);
+      await vi.runAllTimersAsync();
+      initialConnection.emitStatus("error", "Connection lost");
+      await vi.runAllTimersAsync();
+
+      for (let i = 0; i < 6; i++) {
+        await vi.advanceTimersByTimeAsync(35_000);
+        await vi.runAllTimersAsync();
+
+        const [latestConnection] = createdConnections.slice(-1);
+        expect(latestConnection).toBeDefined();
+        latestConnection.emitStatus("error", "Still failing");
+        await vi.runAllTimersAsync();
+
+        const snapshot = mockStore.getSnapshot();
+        if (snapshot.statusText.includes("Gave up")) {
+          break;
+        }
+      }
+
+      const finalSnapshot = mockStore.getSnapshot();
+
+      expect(finalSnapshot.statusText.includes("Gave up")).toBe(true);
+      expect(finalSnapshot.connectionState).toBe("error");
+
+      presenter.dispose();
+    } finally {
+      reconnectDelaySpy.mockRestore();
+    }
   });
 });

--- a/pages/src/components/live-tracker/tests/live-tracker-presenter.test.ts
+++ b/pages/src/components/live-tracker/tests/live-tracker-presenter.test.ts
@@ -592,4 +592,60 @@ describe("LiveTrackerPresenter - Retry Behavior", () => {
       reconnectDelaySpy.mockRestore();
     }
   });
+
+  it("gives up when the time limit is exceeded before a pending retry fires", async (): Promise<void> => {
+    const reconnectDelaySpy = vi.spyOn(reconnectPolicy, "getReconnectDelayMs").mockReturnValue(60_000);
+
+    try {
+      vi.setSystemTime(0);
+
+      const mockService = new MockLiveTrackerService();
+      const mockStore = new MockLiveTrackerStore();
+
+      const createdConnections: MockLiveTrackerConnection[] = [];
+      vi.spyOn(mockService, "connect").mockImplementation(async (): Promise<LiveTrackerConnection> => {
+        const conn = new MockLiveTrackerConnection();
+        createdConnections.push(conn);
+        return Promise.resolve(conn);
+      });
+
+      const presenter = new LiveTrackerPresenter({
+        getUrl: (): URL => new URL("http://localhost/tracker?server=1&queue=3"),
+        liveTrackerService: mockService,
+        store: mockStore,
+        matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+        medalMetadataResolver: new HaloMedalMetadataResolver(aFakeHaloClientWith()),
+      });
+
+      presenter.start();
+      await vi.runAllTimersAsync();
+
+      const firstConnection = Preconditions.checkExists(createdConnections[0]);
+      firstConnection.emitStatus("connected");
+      await vi.runAllTimersAsync();
+      firstConnection.emitMessage(sampleLiveTrackerStateMessage);
+      await vi.runAllTimersAsync();
+
+      firstConnection.emitStatus("error", "Connection lost");
+      await vi.runAllTimersAsync();
+
+      const secondConnection = Preconditions.checkExists(createdConnections[1]);
+      secondConnection.emitStatus("error", "Still failing");
+      await vi.runAllTimersAsync();
+
+      const thirdConnection = Preconditions.checkExists(createdConnections[2]);
+      await vi.advanceTimersByTimeAsync(1);
+      thirdConnection.emitStatus("error", "Still failing");
+
+      await vi.advanceTimersByTimeAsync(60_001);
+      await vi.runAllTimersAsync();
+
+      expect(createdConnections).toHaveLength(3);
+      expect(mockStore.getSnapshot().statusText).toContain("Gave up after 3m");
+
+      presenter.dispose();
+    } finally {
+      reconnectDelaySpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Context
PR #701 landed the follow, individual-tracker, and overlay reliability work. The remaining planned follow-up was to remove the last reconnect-policy drift in the pages realtime stack by aligning live-tracker with the shared retry behavior.

## This PR
- Replaced the bespoke live-tracker reconnect delay calculation with the shared reconnect policy utility.
- Prevented duplicate pending reconnect timers when repeated error statuses arrive before a retry fires.
- Fixed retry timer lifecycle so subsequent failed reconnect attempts can continue the bounded retry sequence correctly.
- Added focused regression coverage for shared-delay usage, duplicate-error suppression, and existing time-limit behavior.

## Subsequent Work
- If we want to close the plan fully, the remaining follow-up is mostly status bookkeeping: mark R2-03 complete once this merges and decide whether R4-03 needs broader terminal-state coverage beyond current presenter tests.