### PR TITLE
fix(score-progression): derive tooltip team names from teamId, not color name

### DIFF
--- a/pages/src/components/stats/score-progression/score-progression-formatter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-formatter.ts
@@ -1,4 +1,5 @@
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import { getTeamName } from "@guilty-spark/shared/halo/team";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type { ScoreProgressionPoint, ScoreProgressionTeamLine, ScoreProgressionViewData } from "./types";
 
@@ -24,7 +25,7 @@ export function formatScoreProgression(
     teamIds.map((teamId, slotIndex) => [
       teamId,
       {
-        name: teamColors[slotIndex]?.name ?? `Team ${String(slotIndex + 1)}`,
+        name: getTeamName(teamId),
         color: teamColors[slotIndex]?.hex ?? FALLBACK_COLORS[slotIndex % FALLBACK_COLORS.length],
         prevScore: 0,
         points: [{ timestampMs: 0, score: 0 }] as ScoreProgressionPoint[],

--- a/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
@@ -30,16 +30,16 @@ describe("formatScoreProgression", () => {
     expect(result?.teamLines[1]?.color).toBe("#ff0000");
   });
 
-  it("assigns team names from teamColors by slot index order", () => {
+  it("assigns team names from teamId using getTeamName", () => {
     const result = formatScoreProgression(aFakeScoreProgressionWith(), TEAM_COLORS);
     expect(result?.teamLines[0]?.name).toBe("Eagle");
     expect(result?.teamLines[1]?.name).toBe("Cobra");
   });
 
-  it("uses fallback name when teamColors has no entry for that slot", () => {
+  it("assigns team names from teamId even when teamColors has no entries", () => {
     const result = formatScoreProgression(aFakeScoreProgressionWith(), []);
-    expect(result?.teamLines[0]?.name).toBe("Team 1");
-    expect(result?.teamLines[1]?.name).toBe("Team 2");
+    expect(result?.teamLines[0]?.name).toBe("Eagle");
+    expect(result?.teamLines[1]?.name).toBe("Cobra");
   });
 
   it("uses fallback colors when teamColors has no entries", () => {


### PR DESCRIPTION
## Context

Follow-up fix to [#697](https://github.com/davidhouweling/guilty-spark/pull/697) (score progression timeline). After testing, the tooltip showed incorrect team labels — color swatch names like "Salmon" or "Cerulean" rather than actual team names.

## This change

`TeamColor.name` is the display name of a colour swatch (e.g. "Salmon", "Cerulean") — it has no relationship to team identity. The formatter was incorrectly using it as the series label in the chart tooltip.

Team names are now derived from `getTeamName(teamId)` in `@guilty-spark/shared/halo/team`, which maps TeamId → "Eagle", "Cobra", etc. — consistent with how the rest of the codebase names teams. The `teamColors` array retains its sole responsibility of providing hex colour values.

- `score-progression-formatter.ts` — import `getTeamName`; replace `teamColors[slotIndex]?.name` with `getTeamName(teamId)` when setting the team line `name`
- Tests updated to assert names come from `teamId` (both with and without `teamColors` provided)

🤖 Generated with [Claude Code](https://claude.com/claude-code)