### PR TITLE
Fix stats routes to use user OAuth credentials instead of bot account

### DIFF
--- a/api/routes/stats/batch-analytics.ts
+++ b/api/routes/stats/batch-analytics.ts
@@ -3,11 +3,13 @@ import {
   batchMatchAnalyticsContract,
   batchMatchAnalyticsQuerySchema,
 } from "@guilty-spark/shared/contracts/stats/batch-match-analytics";
+import { AnalyticsService } from "../../services/analytics/analytics";
 import type { RoutesRegisterHandler } from "../base/types";
 
 export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installServices) => {
   router.get("/api/stats/match-analytics", async (request, env: Env) => {
     const services = installServices({ env });
+    const { haloService, haloFilmService, logService, databaseService, userTokenProvider } = services;
 
     const url = new URL(request.url);
     const queryParams = parseQueryParams(url, batchMatchAnalyticsQuerySchema, "Invalid query parameters");
@@ -17,8 +19,29 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
 
     const { matchIds: rawMatchIds, modules } = queryParams.data;
     const matchIds = [...new Set(rawMatchIds)];
+    const trackerId = url.searchParams.get("trackerId") ?? undefined;
 
-    const results = await services.analyticsService.getBatchMatchAnalytics(matchIds, modules);
+    let resolvedAnalyticsService = services.analyticsService;
+    if (trackerId != null) {
+      try {
+        const tracker = await databaseService.getIndividualTracker(trackerId);
+        if (tracker != null) {
+          const userClient = await userTokenProvider.getClientForUser(tracker.UserId);
+          if (userClient != null) {
+            const userHaloService = haloService.withUserClient(userClient);
+            resolvedAnalyticsService = new AnalyticsService({
+              haloService: userHaloService,
+              haloFilmService,
+              logService,
+            });
+          }
+        }
+      } catch {
+        logService.debug("Failed to resolve user credentials for tracker", new Map([["trackerId", trackerId]]));
+      }
+    }
+
+    const results = await resolvedAnalyticsService.getBatchMatchAnalytics(matchIds, modules);
 
     const failureCount = Object.values(results).filter((v) => v === null).length;
     if (failureCount > 0) {

--- a/api/routes/stats/batch-analytics.ts
+++ b/api/routes/stats/batch-analytics.ts
@@ -5,6 +5,7 @@ import {
 } from "@guilty-spark/shared/contracts/stats/batch-match-analytics";
 import { AnalyticsService } from "../../services/analytics/analytics";
 import type { RoutesRegisterHandler } from "../base/types";
+import { normalizeTrackerId } from "./normalize-tracker-id";
 
 export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installServices) => {
   router.get("/api/stats/match-analytics", async (request, env: Env) => {
@@ -19,13 +20,13 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
 
     const { matchIds: rawMatchIds, modules } = queryParams.data;
     const matchIds = [...new Set(rawMatchIds)];
-    const trackerId = url.searchParams.get("trackerId") ?? undefined;
+    const trackerId = normalizeTrackerId(url.searchParams.get("trackerId"));
 
     let resolvedAnalyticsService = services.analyticsService;
     if (trackerId != null) {
       try {
         const tracker = await databaseService.getIndividualTracker(trackerId);
-        if (tracker != null) {
+        if (tracker?.IsLive === 1) {
           const userClient = await userTokenProvider.getClientForUser(tracker.UserId);
           if (userClient != null) {
             const userHaloService = haloService.withUserClient(userClient);
@@ -36,8 +37,14 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
             });
           }
         }
-      } catch {
-        logService.debug("Failed to resolve user credentials for tracker", new Map([["trackerId", trackerId]]));
+      } catch (error) {
+        logService.error(
+          error,
+          new Map([
+            ["context", "Failed to resolve user credentials for batch analytics tracker"],
+            ["trackerId", trackerId],
+          ]),
+        );
       }
     }
 

--- a/api/routes/stats/normalize-tracker-id.ts
+++ b/api/routes/stats/normalize-tracker-id.ts
@@ -1,0 +1,12 @@
+export function normalizeTrackerId(rawTrackerId: string | null): string | undefined {
+  if (rawTrackerId == null) {
+    return undefined;
+  }
+
+  const normalizedTrackerId = rawTrackerId.trim();
+  if (normalizedTrackerId.length === 0) {
+    return undefined;
+  }
+
+  return normalizedTrackerId;
+}

--- a/api/routes/stats/series-matches.ts
+++ b/api/routes/stats/series-matches.ts
@@ -8,7 +8,7 @@ import type { RoutesRegisterHandler } from "../base/types";
 export const seriesMatchesRoute: RoutesRegisterHandler = (router, installServices) => {
   router.get("/api/stats/series-matches", async (request, env: Env) => {
     const services = installServices({ env });
-    const { haloService, logService } = services;
+    const { haloService, logService, databaseService, userTokenProvider } = services;
 
     try {
       const url = new URL(request.url);
@@ -19,8 +19,24 @@ export const seriesMatchesRoute: RoutesRegisterHandler = (router, installService
 
       const { matchIds } = queryParams.data;
       const uniqueMatchIds = [...new Set(matchIds)];
+      const trackerId = url.searchParams.get("trackerId") ?? undefined;
 
-      const matches = await haloService.getMatchDetails(uniqueMatchIds);
+      let resolvedHaloService = haloService;
+      if (trackerId != null) {
+        try {
+          const tracker = await databaseService.getIndividualTracker(trackerId);
+          if (tracker != null) {
+            const userClient = await userTokenProvider.getClientForUser(tracker.UserId);
+            if (userClient != null) {
+              resolvedHaloService = haloService.withUserClient(userClient);
+            }
+          }
+        } catch {
+          logService.debug("Failed to resolve user credentials for tracker", new Map([["trackerId", trackerId]]));
+        }
+      }
+
+      const matches = await resolvedHaloService.getMatchDetails(uniqueMatchIds);
       const matchesById: Record<string, MatchStats> = {};
       for (const match of matches) {
         matchesById[match.MatchId] = match;
@@ -29,15 +45,18 @@ export const seriesMatchesRoute: RoutesRegisterHandler = (router, installService
         .map((matchId) => matchesById[matchId])
         .filter((match): match is MatchStats => match != null);
 
-      const playerXuidToGametagMap = await haloService.getPlayerXuidsToGametags(orderedMatches);
+      const playerXuidToGametagMap = await resolvedHaloService.getPlayerXuidsToGametags(orderedMatches);
 
       const responseMatches = await Promise.all(
         orderedMatches.map(async (match) => {
           const [{ gameType, gameMap }, mapThumbnailUrl] = await Promise.all([
-            haloService.getGameTypeAndMapParts(match.MatchInfo),
-            haloService.getMapThumbnailUrl(match.MatchInfo.MapVariant.AssetId, match.MatchInfo.MapVariant.VersionId),
+            resolvedHaloService.getGameTypeAndMapParts(match.MatchInfo),
+            resolvedHaloService.getMapThumbnailUrl(
+              match.MatchInfo.MapVariant.AssetId,
+              match.MatchInfo.MapVariant.VersionId,
+            ),
           ]);
-          const { gameScore, gameSubScore } = haloService.getMatchScore(match, "en-US");
+          const { gameScore, gameSubScore } = resolvedHaloService.getMatchScore(match, "en-US");
 
           return {
             matchId: match.MatchId,

--- a/api/routes/stats/series-matches.ts
+++ b/api/routes/stats/series-matches.ts
@@ -4,6 +4,7 @@ import { errorContract } from "@guilty-spark/shared/contracts/error";
 import { getReadableDuration } from "@guilty-spark/shared/halo/duration";
 import { seriesMatchesContract, seriesMatchesQuerySchema } from "@guilty-spark/shared/contracts/stats/series-matches";
 import type { RoutesRegisterHandler } from "../base/types";
+import { normalizeTrackerId } from "./normalize-tracker-id";
 
 export const seriesMatchesRoute: RoutesRegisterHandler = (router, installServices) => {
   router.get("/api/stats/series-matches", async (request, env: Env) => {
@@ -19,20 +20,26 @@ export const seriesMatchesRoute: RoutesRegisterHandler = (router, installService
 
       const { matchIds } = queryParams.data;
       const uniqueMatchIds = [...new Set(matchIds)];
-      const trackerId = url.searchParams.get("trackerId") ?? undefined;
+      const trackerId = normalizeTrackerId(url.searchParams.get("trackerId"));
 
       let resolvedHaloService = haloService;
       if (trackerId != null) {
         try {
           const tracker = await databaseService.getIndividualTracker(trackerId);
-          if (tracker != null) {
+          if (tracker?.IsLive === 1) {
             const userClient = await userTokenProvider.getClientForUser(tracker.UserId);
             if (userClient != null) {
               resolvedHaloService = haloService.withUserClient(userClient);
             }
           }
-        } catch {
-          logService.debug("Failed to resolve user credentials for tracker", new Map([["trackerId", trackerId]]));
+        } catch (error) {
+          logService.error(
+            error,
+            new Map([
+              ["context", "Failed to resolve user credentials for series matches tracker"],
+              ["trackerId", trackerId],
+            ]),
+          );
         }
       }
 

--- a/api/routes/stats/tests/batch-analytics.test.ts
+++ b/api/routes/stats/tests/batch-analytics.test.ts
@@ -6,6 +6,7 @@ import { createApiRouter } from "../../../base/router";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import type { AnalyticsService } from "../../../services/analytics/analytics";
 import { aFakeMatchAnalyticsWith } from "../../../services/analytics/fakes/analytics.fake";
+import { aFakeIndividualTrackersRow } from "../../../services/database/fakes/database.fake";
 import { installFakeServicesWith } from "../../../services/fakes/services";
 import { statsRoutesRegisterHandler } from "../stats";
 
@@ -142,5 +143,69 @@ describe("/api/stats/match-analytics (batch)", () => {
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body).toEqual({ error: "Invalid query parameters" });
+  });
+
+  it("treats blank trackerId as absent and skips credential resolution", async () => {
+    const analytics = aFakeMatchAnalyticsWith();
+    const services = installFakeServicesWith({ env });
+    const getTrackerSpy = vi.spyOn(services.databaseService, "getIndividualTracker");
+    const getClientForUserSpy = vi.spyOn(services.userTokenProvider, "getClientForUser");
+    vi.spyOn(services.analyticsService, "getBatchMatchAnalytics").mockResolvedValue({ "match-1": analytics });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request("http://localhost/api/stats/match-analytics?matchIds=match-1&trackerId=%20%20"),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(200);
+    expect(getTrackerSpy).not.toHaveBeenCalled();
+    expect(getClientForUserSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not resolve user credentials when tracker is not live", async () => {
+    const analytics = aFakeMatchAnalyticsWith();
+    const services = installFakeServicesWith({ env });
+    vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(
+      aFakeIndividualTrackersRow({ TrackerId: "tracker-1", UserId: "owner-user-1", IsLive: 0 }),
+    );
+    const getClientForUserSpy = vi.spyOn(services.userTokenProvider, "getClientForUser");
+    vi.spyOn(services.analyticsService, "getBatchMatchAnalytics").mockResolvedValue({ "match-1": analytics });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request("http://localhost/api/stats/match-analytics?matchIds=match-1&trackerId=tracker-1"),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(200);
+    expect(getClientForUserSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to bot analytics service and logs when tracker lookup throws", async () => {
+    const analytics = aFakeMatchAnalyticsWith();
+    const services = installFakeServicesWith({ env });
+    const lookupError = new Error("db down");
+    vi.spyOn(services.databaseService, "getIndividualTracker").mockRejectedValue(lookupError);
+    vi.spyOn(services.analyticsService, "getBatchMatchAnalytics").mockResolvedValue({ "match-1": analytics });
+    const logErrorSpy: MockInstance<LogService["error"]> = vi.spyOn(services.logService, "error");
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request("http://localhost/api/stats/match-analytics?matchIds=match-1&trackerId=tracker-1"),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(200);
+    expect(logErrorSpy).toHaveBeenCalledWith(
+      lookupError,
+      new Map([
+        ["context", "Failed to resolve user credentials for batch analytics tracker"],
+        ["trackerId", "tracker-1"],
+      ]),
+    );
   });
 });

--- a/api/routes/stats/tests/series-matches.test.ts
+++ b/api/routes/stats/tests/series-matches.test.ts
@@ -3,6 +3,8 @@ import type { MockInstance } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { seriesMatchesContract } from "@guilty-spark/shared/contracts/stats/series-matches";
 import type { LogService } from "../../../services/log/types";
+import { aFakeHaloInfiniteClient } from "../../../services/halo/fakes/infinite-client.fake";
+import { aFakeIndividualTrackersRow } from "../../../services/database/fakes/database.fake";
 import { getMatchStats, getPlayerMatches } from "../../../services/halo/fakes/data";
 import { createApiRouter } from "../../../base/router";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
@@ -123,6 +125,104 @@ describe("/api/stats/series-matches", () => {
     expect(logErrorSpy).toHaveBeenCalledWith(
       expect.any(Error),
       new Map([["context", "Failed to resolve series matches route"]]),
+    );
+  });
+
+  it("uses tracker owner credentials when trackerId resolves to a live tracker", async () => {
+    const [playerMatch] = getPlayerMatches();
+    if (playerMatch == null) {
+      throw new Error("Expected fake player match data");
+    }
+
+    const match = getMatchStats(playerMatch.MatchId);
+    if (match == null) {
+      throw new Error("Expected fake match stats");
+    }
+
+    const services = installFakeServicesWith({ env });
+    const userClient = aFakeHaloInfiniteClient();
+    const getTrackerSpy = vi
+      .spyOn(services.databaseService, "getIndividualTracker")
+      .mockResolvedValue(aFakeIndividualTrackersRow({ TrackerId: "tracker-1", UserId: "owner-user-1", IsLive: 1 }));
+    const getClientForUserSpy = vi.spyOn(services.userTokenProvider, "getClientForUser").mockResolvedValue(userClient);
+    const withUserClientSpy = vi.spyOn(services.haloService, "withUserClient").mockReturnValue(services.haloService);
+    vi.spyOn(services.haloService, "getMatchDetails").mockResolvedValue([match]);
+    vi.spyOn(services.haloService, "getMapThumbnailUrl").mockResolvedValue("data:,");
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request(`http://localhost/api/stats/series-matches?matchIds=${playerMatch.MatchId}&trackerId=tracker-1`),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(200);
+    expect(getTrackerSpy).toHaveBeenCalledWith("tracker-1");
+    expect(getClientForUserSpy).toHaveBeenCalledWith("owner-user-1");
+    expect(withUserClientSpy).toHaveBeenCalledWith(userClient);
+  });
+
+  it("treats blank trackerId as absent and skips credential resolution", async () => {
+    const [playerMatch] = getPlayerMatches();
+    if (playerMatch == null) {
+      throw new Error("Expected fake player match data");
+    }
+
+    const match = getMatchStats(playerMatch.MatchId);
+    if (match == null) {
+      throw new Error("Expected fake match stats");
+    }
+
+    const services = installFakeServicesWith({ env });
+    const getTrackerSpy = vi.spyOn(services.databaseService, "getIndividualTracker");
+    const getClientForUserSpy = vi.spyOn(services.userTokenProvider, "getClientForUser");
+    vi.spyOn(services.haloService, "getMatchDetails").mockResolvedValue([match]);
+    vi.spyOn(services.haloService, "getMapThumbnailUrl").mockResolvedValue("data:,");
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request(`http://localhost/api/stats/series-matches?matchIds=${playerMatch.MatchId}&trackerId=%20%20`),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(200);
+    expect(getTrackerSpy).not.toHaveBeenCalled();
+    expect(getClientForUserSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to bot credentials and logs the error when tracker lookup throws", async () => {
+    const [playerMatch] = getPlayerMatches();
+    if (playerMatch == null) {
+      throw new Error("Expected fake player match data");
+    }
+
+    const match = getMatchStats(playerMatch.MatchId);
+    if (match == null) {
+      throw new Error("Expected fake match stats");
+    }
+
+    const services = installFakeServicesWith({ env });
+    const lookupError = new Error("db down");
+    vi.spyOn(services.databaseService, "getIndividualTracker").mockRejectedValue(lookupError);
+    vi.spyOn(services.haloService, "getMatchDetails").mockResolvedValue([match]);
+    vi.spyOn(services.haloService, "getMapThumbnailUrl").mockResolvedValue("data:,");
+    const logErrorSpy: MockInstance<LogService["error"]> = vi.spyOn(services.logService, "error");
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request(`http://localhost/api/stats/series-matches?matchIds=${playerMatch.MatchId}&trackerId=tracker-1`),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(200);
+    expect(logErrorSpy).toHaveBeenCalledWith(
+      lookupError,
+      new Map([
+        ["context", "Failed to resolve user credentials for series matches tracker"],
+        ["trackerId", "tracker-1"],
+      ]),
     );
   });
 });

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -690,7 +690,7 @@ describe("useIndividualTrackerViewer", () => {
       expect(getSeriesMatchesSpy).toHaveBeenCalledTimes(1);
     });
 
-    expect(getSeriesMatchesSpy).toHaveBeenCalledWith(matchIds);
+    expect(getSeriesMatchesSpy).toHaveBeenCalledWith(matchIds, "tracker-1");
 
     const state = result.current.snapshot.entryStates.get("series:series-1");
     expect(state?.kind).toBe("series");
@@ -831,9 +831,9 @@ describe("useIndividualTrackerViewer", () => {
       expect(getSeriesMatchesSpy).toHaveBeenCalledTimes(3);
     });
 
-    expect(getSeriesMatchesSpy).toHaveBeenNthCalledWith(1, matchIds.slice(0, 30));
-    expect(getSeriesMatchesSpy).toHaveBeenNthCalledWith(2, matchIds.slice(30, 60));
-    expect(getSeriesMatchesSpy).toHaveBeenNthCalledWith(3, matchIds.slice(60, 61));
+    expect(getSeriesMatchesSpy).toHaveBeenNthCalledWith(1, matchIds.slice(0, 30), "tracker-1");
+    expect(getSeriesMatchesSpy).toHaveBeenNthCalledWith(2, matchIds.slice(30, 60), "tracker-1");
+    expect(getSeriesMatchesSpy).toHaveBeenNthCalledWith(3, matchIds.slice(60, 61), "tracker-1");
   });
 
   it("uses the latest chronological match for series team cards", async () => {

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -323,9 +323,9 @@ export class IndividualTrackerViewerPresenter {
 
   private async fetchMatchSource(matchId: string): Promise<MatchStatsLoadedState> {
     const [seriesMatches, analytics] = await Promise.all([
-      this.config.seriesMatchesService.getSeriesMatches([matchId]),
+      this.config.seriesMatchesService.getSeriesMatches([matchId], this.config.trackerId),
       this.config.matchAnalyticsService
-        .getBatchMatchAnalytics([matchId], ["killMatrix", "scoreProgression"])
+        .getBatchMatchAnalytics([matchId], ["killMatrix", "scoreProgression"], this.config.trackerId)
         .then((results) => results[matchId] ?? null)
         .catch(() => null),
     ]);
@@ -423,7 +423,10 @@ export class IndividualTrackerViewerPresenter {
           return;
         }
         const batchMatchIds = uniqueMatchIds.slice(index, index + SERIES_MATCHES_BATCH_SIZE);
-        const batchSeriesData = await this.config.seriesMatchesService.getSeriesMatches(batchMatchIds);
+        const batchSeriesData = await this.config.seriesMatchesService.getSeriesMatches(
+          batchMatchIds,
+          this.config.trackerId,
+        );
         if (this.shouldAbort()) {
           return;
         }

--- a/pages/src/services/stats/fakes/match-analytics.fake.ts
+++ b/pages/src/services/stats/fakes/match-analytics.fake.ts
@@ -44,8 +44,10 @@ export class FakeMatchAnalyticsService implements MatchAnalyticsService {
   async getBatchMatchAnalytics(
     matchIds: readonly string[],
     modules?: readonly AnalyticsModule[],
+    trackerId?: string,
   ): Promise<Record<string, MatchAnalytics | null>> {
     void modules;
+    void trackerId;
     const resultsMap = new Map<string, MatchAnalytics | null>(
       matchIds.map((matchId) => [matchId, this.failMatchIds.has(matchId) ? null : this.analytics]),
     );

--- a/pages/src/services/stats/fakes/series-matches.fake.ts
+++ b/pages/src/services/stats/fakes/series-matches.fake.ts
@@ -3,11 +3,14 @@ import type { SeriesMatchesService } from "../series-matches-types";
 
 export function aFakeSeriesMatchesServiceWith(response: Partial<SeriesMatchesResponse> = {}): SeriesMatchesService {
   return {
-    getSeriesMatches: async () =>
-      Promise.resolve({
+    getSeriesMatches: async (matchIds, trackerId): Promise<SeriesMatchesResponse> => {
+      void matchIds;
+      void trackerId;
+      return Promise.resolve({
         playerXuidToGametag: {},
         matches: [],
         ...response,
-      }),
+      });
+    },
   };
 }

--- a/pages/src/services/stats/match-analytics-types.ts
+++ b/pages/src/services/stats/match-analytics-types.ts
@@ -4,5 +4,6 @@ export interface MatchAnalyticsService {
   getBatchMatchAnalytics(
     matchIds: readonly string[],
     modules?: readonly AnalyticsModule[],
+    trackerId?: string,
   ): Promise<Record<string, MatchAnalytics | null>>;
 }

--- a/pages/src/services/stats/match-analytics.ts
+++ b/pages/src/services/stats/match-analytics.ts
@@ -22,12 +22,16 @@ export class RealMatchAnalyticsService implements MatchAnalyticsService {
   async getBatchMatchAnalytics(
     matchIds: readonly string[],
     modules: readonly AnalyticsModule[] = DEFAULT_MODULES,
+    trackerId?: string,
   ): Promise<Record<string, MatchAnalytics | null>> {
     const normalizedModules = modules.length === 0 ? DEFAULT_MODULES : modules;
     const query = new URLSearchParams({
       matchIds: matchIds.join(","),
       modules: buildModulesQuery(normalizedModules),
     });
+    if (trackerId != null) {
+      query.set("trackerId", trackerId);
+    }
     const response = await fetch(`${this.apiHost}/api/stats/match-analytics?${query.toString()}`, {
       credentials: "include",
     });

--- a/pages/src/services/stats/match-analytics.ts
+++ b/pages/src/services/stats/match-analytics.ts
@@ -1,5 +1,6 @@
 import { type MatchAnalytics, type AnalyticsModule } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { batchMatchAnalyticsContract } from "@guilty-spark/shared/contracts/stats/batch-match-analytics";
+import { normalizeTrackerId } from "./normalize-tracker-id";
 import type { MatchAnalyticsService } from "./match-analytics-types";
 
 interface RealMatchAnalyticsServiceOptions {
@@ -29,8 +30,9 @@ export class RealMatchAnalyticsService implements MatchAnalyticsService {
       matchIds: matchIds.join(","),
       modules: buildModulesQuery(normalizedModules),
     });
-    if (trackerId != null) {
-      query.set("trackerId", trackerId);
+    const normalizedTrackerId = normalizeTrackerId(trackerId);
+    if (normalizedTrackerId != null) {
+      query.set("trackerId", normalizedTrackerId);
     }
     const response = await fetch(`${this.apiHost}/api/stats/match-analytics?${query.toString()}`, {
       credentials: "include",

--- a/pages/src/services/stats/normalize-tracker-id.ts
+++ b/pages/src/services/stats/normalize-tracker-id.ts
@@ -1,0 +1,12 @@
+export function normalizeTrackerId(trackerId: string | undefined): string | undefined {
+  if (trackerId == null) {
+    return undefined;
+  }
+
+  const normalizedTrackerId = trackerId.trim();
+  if (normalizedTrackerId.length === 0) {
+    return undefined;
+  }
+
+  return normalizedTrackerId;
+}

--- a/pages/src/services/stats/series-matches-types.ts
+++ b/pages/src/services/stats/series-matches-types.ts
@@ -1,5 +1,5 @@
 import type { SeriesMatchesResponse } from "@guilty-spark/shared/contracts/stats/series-matches";
 
 export interface SeriesMatchesService {
-  getSeriesMatches(matchIds: readonly string[]): Promise<SeriesMatchesResponse>;
+  getSeriesMatches(matchIds: readonly string[], trackerId?: string): Promise<SeriesMatchesResponse>;
 }

--- a/pages/src/services/stats/series-matches.ts
+++ b/pages/src/services/stats/series-matches.ts
@@ -12,8 +12,14 @@ export class RealSeriesMatchesService implements SeriesMatchesService {
     this.apiHost = apiHost;
   }
 
-  async getSeriesMatches(matchIds: readonly string[]): ReturnType<SeriesMatchesService["getSeriesMatches"]> {
+  async getSeriesMatches(
+    matchIds: readonly string[],
+    trackerId?: string,
+  ): ReturnType<SeriesMatchesService["getSeriesMatches"]> {
     const query = new URLSearchParams({ matchIds: matchIds.join(",") });
+    if (trackerId != null) {
+      query.set("trackerId", trackerId);
+    }
     const response = await fetch(`${this.apiHost}/api/stats/series-matches?${query.toString()}`, {
       credentials: "include",
     });

--- a/pages/src/services/stats/series-matches.ts
+++ b/pages/src/services/stats/series-matches.ts
@@ -1,4 +1,5 @@
 import { seriesMatchesContract } from "@guilty-spark/shared/contracts/stats/series-matches";
+import { normalizeTrackerId } from "./normalize-tracker-id";
 import type { SeriesMatchesService } from "./series-matches-types";
 
 interface RealSeriesMatchesServiceOptions {
@@ -17,8 +18,9 @@ export class RealSeriesMatchesService implements SeriesMatchesService {
     trackerId?: string,
   ): ReturnType<SeriesMatchesService["getSeriesMatches"]> {
     const query = new URLSearchParams({ matchIds: matchIds.join(",") });
-    if (trackerId != null) {
-      query.set("trackerId", trackerId);
+    const normalizedTrackerId = normalizeTrackerId(trackerId);
+    if (normalizedTrackerId != null) {
+      query.set("trackerId", normalizedTrackerId);
     }
     const response = await fetch(`${this.apiHost}/api/stats/series-matches?${query.toString()}`, {
       credentials: "include",

--- a/pages/src/services/stats/tests/match-analytics.test.ts
+++ b/pages/src/services/stats/tests/match-analytics.test.ts
@@ -100,4 +100,21 @@ describe("RealMatchAnalyticsService.getBatchMatchAnalytics", () => {
 
     expect(result).toEqual({ "match-ok": analytics, "match-fail": null });
   });
+
+  it("omits trackerId query param when trackerId is blank after trimming", async () => {
+    const analytics = aFakeAnalyticsResponseWith();
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ results: { "match-1": analytics } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await service.getBatchMatchAnalytics(["match-1"], ["killMatrix"], "   ");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/stats/match-analytics?matchIds=match-1&modules=killMatrix",
+      { credentials: "include" },
+    );
+  });
 });

--- a/pages/src/services/stats/tests/series-matches.test.ts
+++ b/pages/src/services/stats/tests/series-matches.test.ts
@@ -1,0 +1,50 @@
+import type { MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RealSeriesMatchesService } from "../series-matches";
+
+describe("RealSeriesMatchesService.getSeriesMatches", () => {
+  let fetchSpy: MockInstance<typeof globalThis.fetch>;
+  let service: RealSeriesMatchesService;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    service = new RealSeriesMatchesService({ apiHost: "https://api.example.com" });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("fetches series matches and returns the parsed response", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ playerXuidToGametag: {}, matches: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const result = await service.getSeriesMatches(["match-1", "match-2"], "tracker-1");
+
+    expect(result).toEqual({ playerXuidToGametag: {}, matches: [] });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/stats/series-matches?matchIds=match-1%2Cmatch-2&trackerId=tracker-1",
+      { credentials: "include" },
+    );
+  });
+
+  it("omits trackerId query param when trackerId is blank after trimming", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ playerXuidToGametag: {}, matches: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await service.getSeriesMatches(["match-1"], "   ");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/api/stats/series-matches?matchIds=match-1",
+      { credentials: "include" },
+    );
+  });
+});

--- a/pages/src/services/stats/tests/series-matches.test.ts
+++ b/pages/src/services/stats/tests/series-matches.test.ts
@@ -42,9 +42,8 @@ describe("RealSeriesMatchesService.getSeriesMatches", () => {
 
     await service.getSeriesMatches(["match-1"], "   ");
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "https://api.example.com/api/stats/series-matches?matchIds=match-1",
-      { credentials: "include" },
-    );
+    expect(fetchSpy).toHaveBeenCalledWith("https://api.example.com/api/stats/series-matches?matchIds=match-1", {
+      credentials: "include",
+    });
   });
 });


### PR DESCRIPTION
## Context

Stats routes were failing in development with Xbox authentication errors ("The authentication has failed") because they were always falling back to bot account credentials from `.dev.vars`, which can expire. Meanwhile, the individual tracker DO correctly accesses user credentials via `userTokenProvider.getClientForUser(userId)`, demonstrating that user OAuth tokens are available in the database.

The root cause: stats routes had no way to know which user was requesting stats data, so they couldn't look up the user's OAuth token. This PR adds an optional `trackerId` query parameter that enables stats routes to:
1. Resolve the tracker owner's userId from the database
2. Fetch the user's OAuth token via the existing `userTokenProvider`
3. Use a user-scoped HaloInfiniteClient instead of bot credentials

## This change

- **Pages service types** (`series-matches-types.ts`, `match-analytics-types.ts`): Added optional `trackerId?: string` parameter to interface methods
- **Pages service implementations** (`series-matches.ts`, `match-analytics.ts`): Thread trackerId through as a query parameter when present
- **Individual-tracker presenter** (`viewer-presenter.ts`): Pass `this.config.trackerId` to all stats service calls
- **API routes** (`series-matches.ts`, `batch-analytics.ts`):
  - Extract optional `trackerId` from query params
  - If trackerId present: look up tracker owner → retrieve user OAuth token → create user-scoped haloService
  - If trackerId absent: use global haloService with bot credentials (backward compatible)
- **Test fixtures** (`series-matches.fake.ts`, `match-analytics.fake.ts`): Updated to accept the new parameter
- **Tests**: Updated viewer test expectations to include trackerId argument

**Backward Compatibility**: The `trackerId` parameter is optional on all routes. Existing callers (Discord stats, batch analytics without context) continue working with bot credentials.

## Subsequent work

- `HaloFilmService.warmAuthCache()` is still hardwired to bot credentials → kill-matrix analytics will warn on expired bot credentials but won't block match data. This is acceptable for now; can be addressed in a future PR if needed.
- Consider adding integration tests that verify user-scoped credential resolution works end-to-end