### PR TITLE
feat(score-progression): add chart selector with Score Delta chart

### DIFF
--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.module.css
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.module.css
@@ -254,14 +254,11 @@
     justify-content: flex-end;
     max-width: 92px;
   }
-
-  .entryHeaderRight {
-    align-items: flex-end;
-  }
 }
 
 @media (--desktop-viewport) {
   .entryHeaderRight {
+    align-items: center;
     flex-direction: row;
   }
 

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -13,7 +13,7 @@ import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPivotData } from "../../co
 import type { MatchStatsData, MatchStatsPlayerData } from "../../controllers/stats/types";
 import { sortByMedals, getTeamMedalsMap, getPlayerMedalsMap } from "../../controllers/stats/medals-sorting";
 import { KillMatrixTable } from "./kill-matrix/kill-matrix-table";
-import { ScoreProgression } from "./score-progression/score-progression";
+import { createScoreProgression } from "./score-progression/create";
 import type { ScoreProgressionViewData } from "./score-progression/types";
 import { StatsHeader } from "./stats-header";
 import styles from "./match-stats.module.css";
@@ -62,6 +62,7 @@ export function MatchStats({
   const [activeTab, setActiveTab] = React.useState<"players" | "timeline" | "kill-matrix">("players");
   const safeActiveTab: "players" | "timeline" | "kill-matrix" =
     activeTab === "timeline" && scoreProgressionViewData == null ? "players" : activeTab;
+  const ScoreProgressionComponent = React.useMemo(() => createScoreProgression(), []);
   const hasTeamStats = data.length > 0 && data[0].teamStats.length > 0;
 
   // Define team stats columns
@@ -271,7 +272,7 @@ export function MatchStats({
                   id: "timeline" as const,
                   label: "Timeline",
                   content: (
-                    <ScoreProgression
+                    <ScoreProgressionComponent
                       durationMs={scoreProgressionViewData.durationMs}
                       teamLines={scoreProgressionViewData.teamLines}
                       scoreDelta={scoreProgressionViewData.scoreDelta}

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -274,6 +274,7 @@ export function MatchStats({
                     <ScoreProgression
                       durationMs={scoreProgressionViewData.durationMs}
                       teamLines={scoreProgressionViewData.teamLines}
+                      scoreDelta={scoreProgressionViewData.scoreDelta}
                       ariaLabel="Match score progression timeline"
                     />
                   ),

--- a/pages/src/components/stats/score-progression/chart-constants.ts
+++ b/pages/src/components/stats/score-progression/chart-constants.ts
@@ -1,0 +1,19 @@
+export const GRID_STROKE = "rgba(93, 212, 216, 0.12)";
+export const AXIS_STROKE = "rgba(93, 212, 216, 0.3)";
+export const TICK_FILL = "#8fa3b0";
+export const TICK_FONT_SIZE = 11;
+
+export const tooltipContentStyle = {
+  background: "var(--halo-bg-card)",
+  border: "1px solid rgba(93, 212, 216, 0.3)",
+  borderRadius: "var(--radius-base)",
+  color: "var(--halo-white)",
+  fontSize: "12px",
+};
+
+export function formatTime(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes)}:${String(seconds).padStart(2, "0")}`;
+}

--- a/pages/src/components/stats/score-progression/chart-constants.ts
+++ b/pages/src/components/stats/score-progression/chart-constants.ts
@@ -17,3 +17,13 @@ export function formatTime(ms: number): string {
   const seconds = totalSeconds % 60;
   return `${String(minutes)}:${String(seconds).padStart(2, "0")}`;
 }
+
+export function formatTooltipLabel(label: unknown): string {
+  if (typeof label === "number") {
+    return formatTime(label);
+  }
+  if (typeof label === "string") {
+    return label;
+  }
+  return "";
+}

--- a/pages/src/components/stats/score-progression/chart-constants.ts
+++ b/pages/src/components/stats/score-progression/chart-constants.ts
@@ -18,7 +18,9 @@ export function formatTime(ms: number): string {
   return `${String(minutes)}:${String(seconds).padStart(2, "0")}`;
 }
 
-export function formatTooltipLabel(label: unknown): string {
+import type { ReactNode } from "react";
+
+export function formatTooltipLabel(label: ReactNode): string {
   if (typeof label === "number") {
     return formatTime(label);
   }
@@ -26,4 +28,30 @@ export function formatTooltipLabel(label: unknown): string {
     return label;
   }
   return "";
+}
+
+export const tooltipLabelStyle = { color: TICK_FILL };
+
+export const TICK_STYLE = { fill: TICK_FILL, fontSize: TICK_FONT_SIZE };
+
+export const CHART_MARGIN = { top: 8, right: 16, bottom: 8, left: 8 };
+
+export function timeAxisProps(durationMs: number): {
+  type: "number";
+  dataKey: string;
+  domain: [number, number];
+  tickCount: number;
+  tickFormatter: (ms: number) => string;
+  stroke: string;
+  tick: { fill: string; fontSize: number };
+} {
+  return {
+    type: "number",
+    dataKey: "timestampMs",
+    domain: [0, durationMs],
+    tickCount: 6,
+    tickFormatter: formatTime,
+    stroke: AXIS_STROKE,
+    tick: TICK_STYLE,
+  };
 }

--- a/pages/src/components/stats/score-progression/chart-constants.ts
+++ b/pages/src/components/stats/score-progression/chart-constants.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 export const GRID_STROKE = "rgba(93, 212, 216, 0.12)";
 export const AXIS_STROKE = "rgba(93, 212, 216, 0.3)";
 export const TICK_FILL = "#8fa3b0";
@@ -17,8 +19,6 @@ export function formatTime(ms: number): string {
   const seconds = totalSeconds % 60;
   return `${String(minutes)}:${String(seconds).padStart(2, "0")}`;
 }
-
-import type { ReactNode } from "react";
 
 export function formatTooltipLabel(label: ReactNode): string {
   if (typeof label === "number") {

--- a/pages/src/components/stats/score-progression/create.tsx
+++ b/pages/src/components/stats/score-progression/create.tsx
@@ -1,0 +1,42 @@
+import React, { useMemo, useSyncExternalStore } from "react";
+import { ScoreProgressionPresenter } from "./score-progression-presenter";
+import { ScoreProgressionStore } from "./score-progression-store";
+import { ScoreProgression } from "./score-progression";
+import type { ScoreDeltaData, ScoreProgressionTeamLine } from "./types";
+
+export interface ScoreProgressionProps {
+  readonly durationMs: number;
+  readonly teamLines: readonly ScoreProgressionTeamLine[];
+  readonly scoreDelta: ScoreDeltaData | null;
+  readonly ariaLabel: string;
+}
+
+function ScoreProgressionInternal({
+  durationMs,
+  teamLines,
+  scoreDelta,
+  ariaLabel,
+}: ScoreProgressionProps): React.ReactElement {
+  const store = useMemo(() => new ScoreProgressionStore(), []);
+  const presenter = useMemo(() => new ScoreProgressionPresenter({ store }), [store]);
+
+  const snapshot = useSyncExternalStore(
+    (listener) => store.subscribe(listener),
+    () => store.getSnapshot(),
+    () => store.getSnapshot(),
+  );
+
+  const model = useMemo(
+    () => presenter.present(snapshot, { durationMs, teamLines, scoreDelta, ariaLabel }),
+    [presenter, snapshot, durationMs, teamLines, scoreDelta, ariaLabel],
+  );
+
+  return <ScoreProgression {...model} />;
+}
+
+export function createScoreProgression(): (props: ScoreProgressionProps) => React.ReactElement {
+  const Component = (props: ScoreProgressionProps): React.ReactElement => (
+    <ScoreProgressionInternal {...props} />
+  );
+  return Component;
+}

--- a/pages/src/components/stats/score-progression/create.tsx
+++ b/pages/src/components/stats/score-progression/create.tsx
@@ -20,11 +20,7 @@ function ScoreProgressionInternal({
   const store = useMemo(() => new ScoreProgressionStore(), []);
   const presenter = useMemo(() => new ScoreProgressionPresenter({ store }), [store]);
 
-  const snapshot = useSyncExternalStore(
-    (listener) => store.subscribe(listener),
-    () => store.getSnapshot(),
-    () => store.getSnapshot(),
-  );
+  const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
 
   const model = useMemo(
     () => presenter.present(snapshot, { durationMs, teamLines, scoreDelta, ariaLabel }),
@@ -35,8 +31,5 @@ function ScoreProgressionInternal({
 }
 
 export function createScoreProgression(): (props: ScoreProgressionProps) => React.ReactElement {
-  const Component = (props: ScoreProgressionProps): React.ReactElement => (
-    <ScoreProgressionInternal {...props} />
-  );
-  return Component;
+  return ScoreProgressionInternal;
 }

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -9,15 +9,7 @@ import {
   TICK_FONT_SIZE,
   tooltipContentStyle,
 } from "../chart-constants";
-import type { ScoreDeltaData } from "../types";
-
-export interface DeltaChartProps {
-  readonly durationMs: number;
-  readonly scoreDelta: ScoreDeltaData;
-  readonly team0Color: string;
-  readonly team1Color: string;
-  readonly tooltipFormatter: (value: unknown) => [string, string];
-}
+import type { ScoreProgressionDeltaViewModel } from "../types";
 
 export function DeltaChart({
   durationMs,
@@ -25,7 +17,7 @@ export function DeltaChart({
   team0Color,
   team1Color,
   tooltipFormatter,
-}: DeltaChartProps): React.ReactElement {
+}: ScoreProgressionDeltaViewModel): React.ReactElement {
   const { points, minScore, maxScore, zeroFraction } = scoreDelta;
   const gradientId = React.useId();
   const zeroPercent = `${(zeroFraction * 100).toFixed(2)}%`;

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -1,5 +1,13 @@
 import React from "react";
 import { Area, AreaChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import {
+  AXIS_STROKE,
+  formatTime,
+  GRID_STROKE,
+  TICK_FILL,
+  TICK_FONT_SIZE,
+  tooltipContentStyle,
+} from "../chart-constants";
 import type { ScoreDeltaData } from "../types";
 
 export interface DeltaChartProps {
@@ -11,25 +19,14 @@ export interface DeltaChartProps {
   readonly team1Name: string;
 }
 
-const GRID_STROKE = "rgba(93, 212, 216, 0.12)";
-const AXIS_STROKE = "rgba(93, 212, 216, 0.3)";
-const TICK_FILL = "#8fa3b0";
-const TICK_FONT_SIZE = 11;
 const DELTA_LABEL = "Score Delta";
 
-const tooltipContentStyle = {
-  background: "var(--halo-bg-card)",
-  border: "1px solid rgba(93, 212, 216, 0.3)",
-  borderRadius: "var(--radius-base)",
-  color: "var(--halo-white)",
-  fontSize: "12px",
-};
-
-function formatTime(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${String(minutes)}:${String(seconds).padStart(2, "0")}`;
+export function formatDeltaTooltip(value: unknown, team0Name: string, team1Name: string): [string, string] {
+  if (typeof value !== "number" || value === 0) {
+    return ["Tied", DELTA_LABEL];
+  }
+  const leader = value > 0 ? team0Name : team1Name;
+  return [`${leader} +${String(Math.abs(value))}`, DELTA_LABEL];
 }
 
 export function DeltaChart({
@@ -76,22 +73,9 @@ export function DeltaChart({
           contentStyle={tooltipContentStyle}
           labelStyle={{ color: TICK_FILL }}
           labelFormatter={(label) => (typeof label === "number" ? formatTime(label) : String(label ?? ""))}
-          formatter={(value) => {
-            if (typeof value !== "number" || value === 0) {
-              return ["Tied", DELTA_LABEL];
-            }
-            const leader = value > 0 ? team0Name : team1Name;
-            return [`${leader} +${String(Math.abs(value))}`, DELTA_LABEL];
-          }}
+          formatter={(value) => formatDeltaTooltip(value, team0Name, team1Name)}
         />
-        <Area
-          dataKey="score"
-          stroke={TICK_FILL}
-          strokeWidth={2}
-          fill={`url(#${gradientId})`}
-          dot={false}
-          type="linear"
-        />
+        <Area dataKey="score" stroke={TICK_FILL} strokeWidth={2} fill={`url(#${gradientId})`} dot={false} type="step" />
       </AreaChart>
     </ResponsiveContainer>
   );

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { Area, AreaChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import type { ScoreDeltaData } from "../types";
+
+export interface DeltaChartProps {
+  readonly durationMs: number;
+  readonly scoreDelta: ScoreDeltaData;
+  readonly team0Color: string;
+  readonly team1Color: string;
+  readonly team0Name: string;
+  readonly team1Name: string;
+}
+
+const GRID_STROKE = "rgba(93, 212, 216, 0.12)";
+const AXIS_STROKE = "rgba(93, 212, 216, 0.3)";
+const TICK_FILL = "#8fa3b0";
+const TICK_FONT_SIZE = 11;
+const DELTA_LABEL = "Score Delta";
+
+const tooltipContentStyle = {
+  background: "var(--halo-bg-card)",
+  border: "1px solid rgba(93, 212, 216, 0.3)",
+  borderRadius: "var(--radius-base)",
+  color: "var(--halo-white)",
+  fontSize: "12px",
+};
+
+function formatTime(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes)}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function DeltaChart({
+  durationMs,
+  scoreDelta,
+  team0Color,
+  team1Color,
+  team0Name,
+  team1Name,
+}: DeltaChartProps): React.ReactElement {
+  const { points, minScore, maxScore, zeroFraction } = scoreDelta;
+  const gradientId = React.useId();
+  const zeroPercent = `${String(Math.round(zeroFraction * 100))}%`;
+
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <AreaChart data={points} margin={{ top: 8, right: 16, bottom: 8, left: 8 }}>
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset={zeroPercent} stopColor={team0Color} stopOpacity={0.4} />
+            <stop offset={zeroPercent} stopColor={team1Color} stopOpacity={0.4} />
+            <stop offset="100%" stopColor={team1Color} stopOpacity={0.4} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
+        <XAxis
+          type="number"
+          dataKey="timestampMs"
+          domain={[0, durationMs]}
+          tickCount={6}
+          tickFormatter={formatTime}
+          stroke={AXIS_STROKE}
+          tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
+        />
+        <YAxis
+          allowDecimals={false}
+          width={36}
+          domain={[minScore, maxScore]}
+          stroke={AXIS_STROKE}
+          tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
+        />
+        <ReferenceLine y={0} stroke={AXIS_STROKE} strokeDasharray="3 3" />
+        <Tooltip
+          contentStyle={tooltipContentStyle}
+          labelStyle={{ color: TICK_FILL }}
+          labelFormatter={(label) => (typeof label === "number" ? formatTime(label) : String(label ?? ""))}
+          formatter={(value) => {
+            if (typeof value !== "number" || value === 0) {
+              return ["Tied", DELTA_LABEL];
+            }
+            const leader = value > 0 ? team0Name : team1Name;
+            return [`${leader} +${String(Math.abs(value))}`, DELTA_LABEL];
+          }}
+        />
+        <Area
+          dataKey="score"
+          stroke={TICK_FILL}
+          strokeWidth={2}
+          fill={`url(#${gradientId})`}
+          dot={false}
+          type="linear"
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -2,12 +2,14 @@ import React from "react";
 import { Area, AreaChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
   AXIS_STROKE,
-  formatTime,
-  formatTooltipLabel,
+  CHART_MARGIN,
   GRID_STROKE,
   TICK_FILL,
-  TICK_FONT_SIZE,
+  TICK_STYLE,
+  timeAxisProps,
   tooltipContentStyle,
+  tooltipLabelStyle,
+  formatTooltipLabel,
 } from "../chart-constants";
 import type { ScoreProgressionDeltaViewModel } from "../types";
 
@@ -24,7 +26,7 @@ export function DeltaChart({
 
   return (
     <ResponsiveContainer width="100%" height={260}>
-      <AreaChart data={points} margin={{ top: 8, right: 16, bottom: 8, left: 8 }}>
+      <AreaChart data={points} margin={CHART_MARGIN}>
         <defs>
           <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
             <stop offset={zeroPercent} stopColor={team0Color} stopOpacity={0.4} />
@@ -33,26 +35,12 @@ export function DeltaChart({
           </linearGradient>
         </defs>
         <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
-        <XAxis
-          type="number"
-          dataKey="timestampMs"
-          domain={[0, durationMs]}
-          tickCount={6}
-          tickFormatter={formatTime}
-          stroke={AXIS_STROKE}
-          tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
-        />
-        <YAxis
-          allowDecimals={false}
-          width={36}
-          domain={[minScore, maxScore]}
-          stroke={AXIS_STROKE}
-          tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
-        />
+        <XAxis {...timeAxisProps(durationMs)} />
+        <YAxis allowDecimals={false} width={36} domain={[minScore, maxScore]} stroke={AXIS_STROKE} tick={TICK_STYLE} />
         <ReferenceLine y={0} stroke={AXIS_STROKE} strokeDasharray="3 3" />
         <Tooltip
           contentStyle={tooltipContentStyle}
-          labelStyle={{ color: TICK_FILL }}
+          labelStyle={tooltipLabelStyle}
           labelFormatter={formatTooltipLabel}
           formatter={tooltipFormatter}
         />

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -58,6 +58,7 @@ export function DeltaChart({
         />
         <Area
           dataKey="score"
+          baseValue={0}
           stroke={TICK_FILL}
           strokeWidth={2}
           fill={`url(#${gradientId})`}

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -4,7 +4,6 @@ import {
   AXIS_STROKE,
   CHART_MARGIN,
   GRID_STROKE,
-  TICK_FILL,
   TICK_STYLE,
   timeAxisProps,
   tooltipContentStyle,
@@ -22,6 +21,7 @@ export function DeltaChart({
 }: ScoreProgressionDeltaViewModel): React.ReactElement {
   const { points, minScore, maxScore, zeroFraction } = scoreDelta;
   const gradientId = React.useId();
+  const strokeGradientId = `${gradientId}-stroke`;
   const zeroPercent = `${(zeroFraction * 100).toFixed(2)}%`;
 
   return (
@@ -32,6 +32,10 @@ export function DeltaChart({
             <stop offset={zeroPercent} stopColor={team0Color} stopOpacity={0.4} />
             <stop offset={zeroPercent} stopColor={team1Color} stopOpacity={0.4} />
             <stop offset="100%" stopColor={team1Color} stopOpacity={0.4} />
+          </linearGradient>
+          <linearGradient id={strokeGradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset={zeroPercent} stopColor={team0Color} />
+            <stop offset={zeroPercent} stopColor={team1Color} />
           </linearGradient>
         </defs>
         <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
@@ -47,7 +51,7 @@ export function DeltaChart({
         <Area
           dataKey="score"
           baseValue={0}
-          stroke={TICK_FILL}
+          stroke={`url(#${strokeGradientId})`}
           strokeWidth={2}
           fill={`url(#${gradientId})`}
           dot={false}

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -3,6 +3,7 @@ import { Area, AreaChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Too
 import {
   AXIS_STROKE,
   formatTime,
+  formatTooltipLabel,
   GRID_STROKE,
   TICK_FILL,
   TICK_FONT_SIZE,
@@ -15,18 +16,7 @@ export interface DeltaChartProps {
   readonly scoreDelta: ScoreDeltaData;
   readonly team0Color: string;
   readonly team1Color: string;
-  readonly team0Name: string;
-  readonly team1Name: string;
-}
-
-const DELTA_LABEL = "Score Delta";
-
-export function formatDeltaTooltip(value: unknown, team0Name: string, team1Name: string): [string, string] {
-  if (typeof value !== "number" || value === 0) {
-    return ["Tied", DELTA_LABEL];
-  }
-  const leader = value > 0 ? team0Name : team1Name;
-  return [`${leader} +${String(Math.abs(value))}`, DELTA_LABEL];
+  readonly tooltipFormatter: (value: unknown) => [string, string];
 }
 
 export function DeltaChart({
@@ -34,12 +24,11 @@ export function DeltaChart({
   scoreDelta,
   team0Color,
   team1Color,
-  team0Name,
-  team1Name,
+  tooltipFormatter,
 }: DeltaChartProps): React.ReactElement {
   const { points, minScore, maxScore, zeroFraction } = scoreDelta;
   const gradientId = React.useId();
-  const zeroPercent = `${String(Math.round(zeroFraction * 100))}%`;
+  const zeroPercent = `${(zeroFraction * 100).toFixed(2)}%`;
 
   return (
     <ResponsiveContainer width="100%" height={260}>
@@ -72,8 +61,8 @@ export function DeltaChart({
         <Tooltip
           contentStyle={tooltipContentStyle}
           labelStyle={{ color: TICK_FILL }}
-          labelFormatter={(label) => (typeof label === "number" ? formatTime(label) : String(label ?? ""))}
-          formatter={(value) => formatDeltaTooltip(value, team0Name, team1Name)}
+          labelFormatter={formatTooltipLabel}
+          formatter={tooltipFormatter}
         />
         <Area
           dataKey="score"

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -75,7 +75,14 @@ export function DeltaChart({
           labelFormatter={(label) => (typeof label === "number" ? formatTime(label) : String(label ?? ""))}
           formatter={(value) => formatDeltaTooltip(value, team0Name, team1Name)}
         />
-        <Area dataKey="score" stroke={TICK_FILL} strokeWidth={2} fill={`url(#${gradientId})`} dot={false} type="step" />
+        <Area
+          dataKey="score"
+          stroke={TICK_FILL}
+          strokeWidth={2}
+          fill={`url(#${gradientId})`}
+          dot={false}
+          type="stepAfter"
+        />
       </AreaChart>
     </ResponsiveContainer>
   );

--- a/pages/src/components/stats/score-progression/delta-chart/tests/delta-chart.test.ts
+++ b/pages/src/components/stats/score-progression/delta-chart/tests/delta-chart.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { formatDeltaTooltip } from "../delta-chart";
+
+describe("formatDeltaTooltip", () => {
+  it("returns Tied when value is 0", () => {
+    const [label] = formatDeltaTooltip(0, "Eagle", "Cobra");
+    expect(label).toBe("Tied");
+  });
+
+  it("returns Tied when value is not a number", () => {
+    const [label] = formatDeltaTooltip("unknown", "Eagle", "Cobra");
+    expect(label).toBe("Tied");
+  });
+
+  it("returns team0Name with lead when value is positive", () => {
+    const [label] = formatDeltaTooltip(3, "Eagle", "Cobra");
+    expect(label).toBe("Eagle +3");
+  });
+
+  it("returns team1Name with lead when value is negative", () => {
+    const [label] = formatDeltaTooltip(-2, "Eagle", "Cobra");
+    expect(label).toBe("Cobra +2");
+  });
+
+  it("always returns Score Delta as the series name", () => {
+    expect(formatDeltaTooltip(1, "Eagle", "Cobra")[1]).toBe("Score Delta");
+    expect(formatDeltaTooltip(0, "Eagle", "Cobra")[1]).toBe("Score Delta");
+  });
+});

--- a/pages/src/components/stats/score-progression/delta-chart/tests/delta-chart.test.ts
+++ b/pages/src/components/stats/score-progression/delta-chart/tests/delta-chart.test.ts
@@ -1,29 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { formatDeltaTooltip } from "../delta-chart";
+import type { DeltaChartProps } from "../delta-chart";
 
-describe("formatDeltaTooltip", () => {
-  it("returns Tied when value is 0", () => {
-    const [label] = formatDeltaTooltip(0, "Eagle", "Cobra");
-    expect(label).toBe("Tied");
-  });
-
-  it("returns Tied when value is not a number", () => {
-    const [label] = formatDeltaTooltip("unknown", "Eagle", "Cobra");
-    expect(label).toBe("Tied");
-  });
-
-  it("returns team0Name with lead when value is positive", () => {
-    const [label] = formatDeltaTooltip(3, "Eagle", "Cobra");
-    expect(label).toBe("Eagle +3");
-  });
-
-  it("returns team1Name with lead when value is negative", () => {
-    const [label] = formatDeltaTooltip(-2, "Eagle", "Cobra");
-    expect(label).toBe("Cobra +2");
-  });
-
-  it("always returns Score Delta as the series name", () => {
-    expect(formatDeltaTooltip(1, "Eagle", "Cobra")[1]).toBe("Score Delta");
-    expect(formatDeltaTooltip(0, "Eagle", "Cobra")[1]).toBe("Score Delta");
+describe("DeltaChartProps", () => {
+  it("accepts a tooltipFormatter callback", () => {
+    const props: DeltaChartProps = {
+      durationMs: 600000,
+      scoreDelta: {
+        points: [{ timestampMs: 0, score: 0 }],
+        minScore: 0,
+        maxScore: 1,
+        zeroFraction: 1,
+      },
+      team0Color: "#ff0000",
+      team1Color: "#0000ff",
+      tooltipFormatter: (value: unknown): [string, string] => [String(value), "Delta"],
+    };
+    expect(props.tooltipFormatter(3)).toEqual(["3", "Delta"]);
   });
 });

--- a/pages/src/components/stats/score-progression/delta-chart/tests/delta-chart.test.ts
+++ b/pages/src/components/stats/score-progression/delta-chart/tests/delta-chart.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
-import type { DeltaChartProps } from "../delta-chart";
+import type { ScoreProgressionDeltaViewModel } from "../../types";
 
-describe("DeltaChartProps", () => {
+describe("ScoreProgressionDeltaViewModel", () => {
   it("accepts a tooltipFormatter callback", () => {
-    const props: DeltaChartProps = {
+    const props: ScoreProgressionDeltaViewModel = {
       durationMs: 600000,
       scoreDelta: {
         points: [{ timestampMs: 0, score: 0 }],

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -12,13 +12,6 @@ import {
 } from "../chart-constants";
 import type { ScoreProgressionProgressionViewModel } from "../types";
 
-function formatProgressionValue(
-  value: number | string | readonly (number | string)[] | undefined,
-  name: string | number | undefined,
-): [number | string | readonly (number | string)[] | undefined, string | number | undefined] {
-  return [value, name];
-}
-
 export function ProgressionChart({ durationMs, teamLines }: ScoreProgressionProgressionViewModel): React.ReactElement {
   return (
     <ResponsiveContainer width="100%" height={260}>
@@ -30,7 +23,6 @@ export function ProgressionChart({ durationMs, teamLines }: ScoreProgressionProg
           contentStyle={tooltipContentStyle}
           labelStyle={tooltipLabelStyle}
           labelFormatter={formatTooltipLabel}
-          formatter={formatProgressionValue}
         />
         {teamLines.map((line) => (
           <Area

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -3,6 +3,7 @@ import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YA
 import {
   AXIS_STROKE,
   formatTime,
+  formatTooltipLabel,
   GRID_STROKE,
   TICK_FILL,
   TICK_FONT_SIZE,
@@ -38,7 +39,7 @@ export function ProgressionChart({ durationMs, teamLines }: ProgressionChartProp
         <Tooltip
           contentStyle={tooltipContentStyle}
           labelStyle={{ color: TICK_FILL }}
-          labelFormatter={(label) => (typeof label === "number" ? formatTime(label) : String(label ?? ""))}
+          labelFormatter={formatTooltipLabel}
           formatter={(value, name) => [value ?? "", name]}
         />
         {teamLines.map((line) => (

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -9,14 +9,9 @@ import {
   TICK_FONT_SIZE,
   tooltipContentStyle,
 } from "../chart-constants";
-import type { ScoreProgressionTeamLine } from "../types";
+import type { ScoreProgressionProgressionViewModel } from "../types";
 
-export interface ProgressionChartProps {
-  readonly durationMs: number;
-  readonly teamLines: readonly ScoreProgressionTeamLine[];
-}
-
-export function ProgressionChart({ durationMs, teamLines }: ProgressionChartProps): React.ReactElement {
+export function ProgressionChart({ durationMs, teamLines }: ScoreProgressionProgressionViewModel): React.ReactElement {
   return (
     <ResponsiveContainer width="100%" height={260}>
       <AreaChart margin={{ top: 8, right: 16, bottom: 8, left: 8 }}>

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -2,40 +2,35 @@ import React from "react";
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
   AXIS_STROKE,
-  formatTime,
-  formatTooltipLabel,
+  CHART_MARGIN,
   GRID_STROKE,
-  TICK_FILL,
-  TICK_FONT_SIZE,
+  TICK_STYLE,
+  timeAxisProps,
   tooltipContentStyle,
+  tooltipLabelStyle,
+  formatTooltipLabel,
 } from "../chart-constants";
 import type { ScoreProgressionProgressionViewModel } from "../types";
+
+function formatProgressionValue(
+  value: number | string | readonly (number | string)[] | undefined,
+  name: string | number | undefined,
+): [number | string | readonly (number | string)[] | undefined, string | number | undefined] {
+  return [value, name];
+}
 
 export function ProgressionChart({ durationMs, teamLines }: ScoreProgressionProgressionViewModel): React.ReactElement {
   return (
     <ResponsiveContainer width="100%" height={260}>
-      <AreaChart margin={{ top: 8, right: 16, bottom: 8, left: 8 }}>
+      <AreaChart margin={CHART_MARGIN}>
         <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
-        <XAxis
-          type="number"
-          dataKey="timestampMs"
-          domain={[0, durationMs]}
-          tickCount={6}
-          tickFormatter={formatTime}
-          stroke={AXIS_STROKE}
-          tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
-        />
-        <YAxis
-          allowDecimals={false}
-          width={36}
-          stroke={AXIS_STROKE}
-          tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
-        />
+        <XAxis {...timeAxisProps(durationMs)} />
+        <YAxis allowDecimals={false} width={36} stroke={AXIS_STROKE} tick={TICK_STYLE} />
         <Tooltip
           contentStyle={tooltipContentStyle}
-          labelStyle={{ color: TICK_FILL }}
+          labelStyle={tooltipLabelStyle}
           labelFormatter={formatTooltipLabel}
-          formatter={(value, name) => [value ?? "", name]}
+          formatter={formatProgressionValue}
         />
         {teamLines.map((line) => (
           <Area

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import type { ScoreProgressionTeamLine } from "../types";
+
+export interface ProgressionChartProps {
+  readonly durationMs: number;
+  readonly teamLines: readonly ScoreProgressionTeamLine[];
+}
+
+const GRID_STROKE = "rgba(93, 212, 216, 0.12)";
+const AXIS_STROKE = "rgba(93, 212, 216, 0.3)";
+const TICK_FILL = "#8fa3b0";
+const TICK_FONT_SIZE = 11;
+
+const tooltipContentStyle = {
+  background: "var(--halo-bg-card)",
+  border: "1px solid rgba(93, 212, 216, 0.3)",
+  borderRadius: "var(--radius-base)",
+  color: "var(--halo-white)",
+  fontSize: "12px",
+};
+
+function formatTime(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes)}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function ProgressionChart({ durationMs, teamLines }: ProgressionChartProps): React.ReactElement {
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <AreaChart margin={{ top: 8, right: 16, bottom: 8, left: 8 }}>
+        <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
+        <XAxis
+          type="number"
+          dataKey="timestampMs"
+          domain={[0, durationMs]}
+          tickCount={6}
+          tickFormatter={formatTime}
+          stroke={AXIS_STROKE}
+          tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
+        />
+        <YAxis
+          allowDecimals={false}
+          width={36}
+          stroke={AXIS_STROKE}
+          tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
+        />
+        <Tooltip
+          contentStyle={tooltipContentStyle}
+          labelStyle={{ color: TICK_FILL }}
+          labelFormatter={(label) => (typeof label === "number" ? formatTime(label) : String(label ?? ""))}
+          formatter={(value, name) => [value ?? "", name]}
+        />
+        {teamLines.map((line) => (
+          <Area
+            key={line.teamId}
+            data={line.points}
+            dataKey="score"
+            name={line.name}
+            stroke={line.color}
+            strokeWidth={2}
+            fill={line.color}
+            fillOpacity={0.2}
+            dot={false}
+            type="linear"
+          />
+        ))}
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -1,30 +1,18 @@
 import React from "react";
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import {
+  AXIS_STROKE,
+  formatTime,
+  GRID_STROKE,
+  TICK_FILL,
+  TICK_FONT_SIZE,
+  tooltipContentStyle,
+} from "../chart-constants";
 import type { ScoreProgressionTeamLine } from "../types";
 
 export interface ProgressionChartProps {
   readonly durationMs: number;
   readonly teamLines: readonly ScoreProgressionTeamLine[];
-}
-
-const GRID_STROKE = "rgba(93, 212, 216, 0.12)";
-const AXIS_STROKE = "rgba(93, 212, 216, 0.3)";
-const TICK_FILL = "#8fa3b0";
-const TICK_FONT_SIZE = 11;
-
-const tooltipContentStyle = {
-  background: "var(--halo-bg-card)",
-  border: "1px solid rgba(93, 212, 216, 0.3)",
-  borderRadius: "var(--radius-base)",
-  color: "var(--halo-white)",
-  fontSize: "12px",
-};
-
-function formatTime(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${String(minutes)}:${String(seconds).padStart(2, "0")}`;
 }
 
 export function ProgressionChart({ durationMs, teamLines }: ProgressionChartProps): React.ReactElement {

--- a/pages/src/components/stats/score-progression/progression-chart/tests/progression-chart.test.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/tests/progression-chart.test.tsx
@@ -1,0 +1,32 @@
+import "@testing-library/jest-dom/vitest";
+
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProgressionChart } from "../progression-chart";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }): React.ReactElement => <div>{children}</div>,
+  AreaChart: ({ children }: { children: React.ReactNode }): React.ReactElement => <div>{children}</div>,
+  CartesianGrid: (): null => null,
+  XAxis: (): null => null,
+  YAxis: (): null => null,
+  Tooltip: (): null => null,
+  Area: ({ name }: { name: string }): React.ReactElement => <div data-testid="area">{name}</div>,
+}));
+
+describe("ProgressionChart", () => {
+  it("renders an Area for each team line", () => {
+    const teamLines = [
+      { teamId: 0, name: "Eagle", color: "#0000ff", points: [] },
+      { teamId: 1, name: "Cobra", color: "#ff0000", points: [] },
+    ] as const;
+
+    render(<ProgressionChart durationMs={600000} teamLines={teamLines} />);
+
+    const areas = screen.getAllByTestId("area");
+    expect(areas).toHaveLength(2);
+    expect(areas[0]).toHaveTextContent("Eagle");
+    expect(areas[1]).toHaveTextContent("Cobra");
+  });
+});

--- a/pages/src/components/stats/score-progression/score-progression-formatter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-formatter.ts
@@ -1,9 +1,54 @@
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { getTeamName } from "@guilty-spark/shared/halo/team";
 import type { TeamColor } from "../../team-colors/team-colors";
-import type { ScoreProgressionPoint, ScoreProgressionTeamLine, ScoreProgressionViewData } from "./types";
+import type {
+  ScoreDeltaData,
+  ScoreProgressionPoint,
+  ScoreProgressionTeamLine,
+  ScoreProgressionViewData,
+} from "./types";
 
 const FALLBACK_COLORS = ["#888888", "#aaaaaa"];
+
+type KillRaceEvent = NonNullable<MatchAnalytics["scoreProgression"]>["timeline"]["events"][number];
+
+function buildScoreDelta(
+  teamIds: readonly number[],
+  events: readonly KillRaceEvent[],
+  teamLines: readonly ScoreProgressionTeamLine[],
+  durationMs: number,
+): ScoreDeltaData | null {
+  if (teamIds.length < 2 || teamLines.length < 2) {
+    return null;
+  }
+
+  const [teamId0, teamId1] = teamIds;
+  const [line0, line1] = teamLines;
+
+  const points: ScoreProgressionPoint[] = [{ timestampMs: 0, score: 0 }];
+
+  for (const event of events) {
+    const score0 = event.runningScores[String(teamId0)] ?? 0;
+    const score1 = event.runningScores[String(teamId1)] ?? 0;
+    const prevScore = points.at(-1)?.score ?? 0;
+    const newScore = score0 - score1;
+    points.push({ timestampMs: event.timestampMs, score: prevScore });
+    points.push({ timestampMs: event.timestampMs, score: newScore });
+  }
+
+  points.push({
+    timestampMs: durationMs,
+    score: (line0.points.at(-1)?.score ?? 0) - (line1.points.at(-1)?.score ?? 0),
+  });
+
+  const scores = points.map((p) => p.score);
+  const minScore = Math.min(...scores);
+  const maxScore = Math.max(...scores);
+  const range = maxScore - minScore;
+  const zeroFraction = range === 0 ? 0.5 : maxScore / range;
+
+  return { points, minScore, maxScore, zeroFraction };
+}
 
 export function formatScoreProgression(
   scoreProgression: MatchAnalytics["scoreProgression"],
@@ -53,5 +98,5 @@ export function formatScoreProgression(
     teamLines.push({ teamId, name: state.name, color: state.color, points: state.points });
   }
 
-  return { durationMs, teamLines };
+  return { durationMs, teamLines, scoreDelta: buildScoreDelta(teamIds, events, teamLines, durationMs) };
 }

--- a/pages/src/components/stats/score-progression/score-progression-formatter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-formatter.ts
@@ -1,5 +1,6 @@
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { getTeamName } from "@guilty-spark/shared/halo/team";
+import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type {
   ScoreDeltaData,
@@ -7,8 +8,6 @@ import type {
   ScoreProgressionTeamLine,
   ScoreProgressionViewData,
 } from "./types";
-
-const FALLBACK_COLORS = ["#888888", "#aaaaaa"];
 
 type KillRaceEvent = NonNullable<MatchAnalytics["scoreProgression"]>["timeline"]["events"][number];
 
@@ -44,7 +43,10 @@ function buildScoreDelta(
 
   points.push({ timestampMs: durationMs, score: points.at(-1)?.score ?? 0 });
   const range = maxScore - minScore;
-  const zeroFraction = range === 0 ? 0.5 : maxScore / range;
+  if (range === 0) {
+    return null;
+  }
+  const zeroFraction = maxScore / range;
 
   return { points, minScore, maxScore, zeroFraction };
 }
@@ -70,7 +72,7 @@ export function formatScoreProgression(
       teamId,
       {
         name: getTeamName(teamId),
-        color: teamColors[slotIndex]?.hex ?? FALLBACK_COLORS[slotIndex % FALLBACK_COLORS.length],
+        color: teamColors[slotIndex]?.hex ?? getTeamColorOrDefault(undefined, slotIndex).hex,
         prevScore: 0,
         points: [{ timestampMs: 0, score: 0 }] as ScoreProgressionPoint[],
       },

--- a/pages/src/components/stats/score-progression/score-progression-formatter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-formatter.ts
@@ -15,31 +15,29 @@ type KillRaceEvent = NonNullable<MatchAnalytics["scoreProgression"]>["timeline"]
 function buildScoreDelta(
   teamIds: readonly number[],
   events: readonly KillRaceEvent[],
-  teamLines: readonly ScoreProgressionTeamLine[],
   durationMs: number,
 ): ScoreDeltaData | null {
-  if (teamIds.length < 2 || teamLines.length < 2) {
+  if (teamIds.length < 2) {
     return null;
   }
 
   const [teamId0, teamId1] = teamIds;
-  const [line0, line1] = teamLines;
+  const key0 = String(teamId0);
+  const key1 = String(teamId1);
 
   const points: ScoreProgressionPoint[] = [{ timestampMs: 0, score: 0 }];
+  let prevScore = 0;
 
   for (const event of events) {
-    const score0 = event.runningScores[String(teamId0)] ?? 0;
-    const score1 = event.runningScores[String(teamId1)] ?? 0;
-    const prevScore = points.at(-1)?.score ?? 0;
+    const score0 = event.runningScores[key0] ?? 0;
+    const score1 = event.runningScores[key1] ?? 0;
     const newScore = score0 - score1;
     points.push({ timestampMs: event.timestampMs, score: prevScore });
     points.push({ timestampMs: event.timestampMs, score: newScore });
+    prevScore = newScore;
   }
 
-  points.push({
-    timestampMs: durationMs,
-    score: (line0.points.at(-1)?.score ?? 0) - (line1.points.at(-1)?.score ?? 0),
-  });
+  points.push({ timestampMs: durationMs, score: prevScore });
 
   const scores = points.map((p) => p.score);
   const minScore = Math.min(...scores);
@@ -98,5 +96,5 @@ export function formatScoreProgression(
     teamLines.push({ teamId, name: state.name, color: state.color, points: state.points });
   }
 
-  return { durationMs, teamLines, scoreDelta: buildScoreDelta(teamIds, events, teamLines, durationMs) };
+  return { durationMs, teamLines, scoreDelta: buildScoreDelta(teamIds, events, durationMs) };
 }

--- a/pages/src/components/stats/score-progression/score-progression-formatter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-formatter.ts
@@ -26,22 +26,23 @@ function buildScoreDelta(
   const key1 = String(teamId1);
 
   const points: ScoreProgressionPoint[] = [{ timestampMs: 0, score: 0 }];
-  let prevScore = 0;
+  let minScore = 0;
+  let maxScore = 0;
 
   for (const event of events) {
     const score0 = event.runningScores[key0] ?? 0;
     const score1 = event.runningScores[key1] ?? 0;
-    const newScore = score0 - score1;
-    points.push({ timestampMs: event.timestampMs, score: prevScore });
-    points.push({ timestampMs: event.timestampMs, score: newScore });
-    prevScore = newScore;
+    const score = score0 - score1;
+    points.push({ timestampMs: event.timestampMs, score });
+    if (score < minScore) {
+      minScore = score;
+    }
+    if (score > maxScore) {
+      maxScore = score;
+    }
   }
 
-  points.push({ timestampMs: durationMs, score: prevScore });
-
-  const scores = points.map((p) => p.score);
-  const minScore = Math.min(...scores);
-  const maxScore = Math.max(...scores);
+  points.push({ timestampMs: durationMs, score: points.at(-1)?.score ?? 0 });
   const range = maxScore - minScore;
   const zeroFraction = range === 0 ? 0.5 : maxScore / range;
 

--- a/pages/src/components/stats/score-progression/score-progression-presenter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-presenter.ts
@@ -1,0 +1,75 @@
+import { TICK_FILL } from "./chart-constants";
+import type { ScoreProgressionSnapshot, ScoreProgressionStore } from "./score-progression-store";
+import type {
+  ChartType,
+  ScoreDeltaData,
+  ScoreProgressionDeltaViewModel,
+  ScoreProgressionTeamLine,
+  ScoreProgressionViewModel,
+} from "./types";
+
+export interface ScoreProgressionPresenterConfig {
+  readonly store: ScoreProgressionStore;
+}
+
+export interface ScoreProgressionInput {
+  readonly durationMs: number;
+  readonly teamLines: readonly ScoreProgressionTeamLine[];
+  readonly scoreDelta: ScoreDeltaData | null;
+  readonly ariaLabel: string;
+}
+
+const DELTA_LABEL = "Score Delta";
+
+function formatDeltaTooltip(value: unknown, team0Name: string, team1Name: string): [string, string] {
+  if (typeof value !== "number" || value === 0) {
+    return ["Tied", DELTA_LABEL];
+  }
+  const leader = value > 0 ? team0Name : team1Name;
+  return [`${leader} +${String(Math.abs(value))}`, DELTA_LABEL];
+}
+
+export class ScoreProgressionPresenter {
+  constructor(private readonly config: ScoreProgressionPresenterConfig) {}
+
+  setChartType(value: string): void {
+    if (value === "progression" || value === "delta") {
+      this.config.store.update({ chartType: value });
+    }
+  }
+
+  present(snapshot: ScoreProgressionSnapshot, input: ScoreProgressionInput): ScoreProgressionViewModel {
+    const { chartType } = snapshot;
+    const effectiveChartType: ChartType =
+      chartType === "delta" && input.scoreDelta == null ? "progression" : chartType;
+
+    const team0Name = input.teamLines[0]?.name ?? "Team 1";
+    const team1Name = input.teamLines[1]?.name ?? "Team 2";
+
+    const deltaViewModel: ScoreProgressionDeltaViewModel | null =
+      effectiveChartType === "delta" && input.scoreDelta != null
+        ? {
+            durationMs: input.durationMs,
+            scoreDelta: input.scoreDelta,
+            team0Color: input.teamLines[0]?.color ?? TICK_FILL,
+            team1Color: input.teamLines[1]?.color ?? TICK_FILL,
+            tooltipFormatter: (value: unknown): [string, string] =>
+              formatDeltaTooltip(value, team0Name, team1Name),
+          }
+        : null;
+
+    return {
+      ariaLabel: input.ariaLabel,
+      effectiveChartType,
+      hasDelta: input.scoreDelta != null,
+      onChartTypeChange: (value: string): void => {
+        this.setChartType(value);
+      },
+      deltaViewModel,
+      progressionViewModel: {
+        durationMs: input.durationMs,
+        teamLines: input.teamLines,
+      },
+    };
+  }
+}

--- a/pages/src/components/stats/score-progression/score-progression-presenter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-presenter.ts
@@ -44,7 +44,7 @@ export class ScoreProgressionPresenter {
             scoreDelta: input.scoreDelta,
             team0Color: input.teamLines[0]?.color ?? TICK_FILL,
             team1Color: input.teamLines[1]?.color ?? TICK_FILL,
-            tooltipFormatter: (value: unknown): [string, string] =>
+            tooltipFormatter: (value: number | string | readonly (number | string)[] | undefined): [string, string] =>
               this.formatDeltaTooltip(value, team0Name, team1Name),
           }
         : null;
@@ -68,8 +68,12 @@ export class ScoreProgressionPresenter {
     }
   }
 
-  private formatDeltaTooltip(value: unknown, team0Name: string, team1Name: string): [string, string] {
-    if (typeof value !== "number" || value === 0) {
+  private formatDeltaTooltip(
+    value: number | string | readonly (number | string)[] | undefined,
+    team0Name: string,
+    team1Name: string,
+  ): [string, string] {
+    if (typeof value !== "number" || value === 0 || Number.isNaN(value)) {
       return ["Tied", DELTA_LABEL];
     }
     const leader = value > 0 ? team0Name : team1Name;

--- a/pages/src/components/stats/score-progression/score-progression-presenter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-presenter.ts
@@ -21,14 +21,6 @@ export interface ScoreProgressionInput {
 
 const DELTA_LABEL = "Score Delta";
 
-function formatDeltaTooltip(value: unknown, team0Name: string, team1Name: string): [string, string] {
-  if (typeof value !== "number" || value === 0) {
-    return ["Tied", DELTA_LABEL];
-  }
-  const leader = value > 0 ? team0Name : team1Name;
-  return [`${leader} +${String(Math.abs(value))}`, DELTA_LABEL];
-}
-
 export class ScoreProgressionPresenter {
   readonly onChartTypeChange: (value: string) => void;
 
@@ -36,12 +28,6 @@ export class ScoreProgressionPresenter {
     this.onChartTypeChange = (value: string): void => {
       this.setChartType(value);
     };
-  }
-
-  setChartType(value: string): void {
-    if (value === "progression" || value === "delta") {
-      this.config.store.update({ chartType: value });
-    }
   }
 
   present(snapshot: ScoreProgressionSnapshot, input: ScoreProgressionInput): ScoreProgressionViewModel {
@@ -58,7 +44,8 @@ export class ScoreProgressionPresenter {
             scoreDelta: input.scoreDelta,
             team0Color: input.teamLines[0]?.color ?? TICK_FILL,
             team1Color: input.teamLines[1]?.color ?? TICK_FILL,
-            tooltipFormatter: (value: unknown): [string, string] => formatDeltaTooltip(value, team0Name, team1Name),
+            tooltipFormatter: (value: unknown): [string, string] =>
+              this.formatDeltaTooltip(value, team0Name, team1Name),
           }
         : null;
 
@@ -66,12 +53,26 @@ export class ScoreProgressionPresenter {
       ariaLabel: input.ariaLabel,
       effectiveChartType,
       hasDelta: input.scoreDelta != null,
-      onChartTypeChange: this.onChartTypeChange,
       deltaViewModel,
       progressionViewModel: {
         durationMs: input.durationMs,
         teamLines: input.teamLines,
       },
+      onChartTypeChange: this.onChartTypeChange,
     };
+  }
+
+  private setChartType(value: string): void {
+    if (value === "progression" || value === "delta") {
+      this.config.store.update({ chartType: value });
+    }
+  }
+
+  private formatDeltaTooltip(value: unknown, team0Name: string, team1Name: string): [string, string] {
+    if (typeof value !== "number" || value === 0) {
+      return ["Tied", DELTA_LABEL];
+    }
+    const leader = value > 0 ? team0Name : team1Name;
+    return [`${leader} +${String(Math.abs(value))}`, DELTA_LABEL];
   }
 }

--- a/pages/src/components/stats/score-progression/score-progression-presenter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-presenter.ts
@@ -30,7 +30,13 @@ function formatDeltaTooltip(value: unknown, team0Name: string, team1Name: string
 }
 
 export class ScoreProgressionPresenter {
-  constructor(private readonly config: ScoreProgressionPresenterConfig) {}
+  readonly onChartTypeChange: (value: string) => void;
+
+  constructor(private readonly config: ScoreProgressionPresenterConfig) {
+    this.onChartTypeChange = (value: string): void => {
+      this.setChartType(value);
+    };
+  }
 
   setChartType(value: string): void {
     if (value === "progression" || value === "delta") {
@@ -40,8 +46,7 @@ export class ScoreProgressionPresenter {
 
   present(snapshot: ScoreProgressionSnapshot, input: ScoreProgressionInput): ScoreProgressionViewModel {
     const { chartType } = snapshot;
-    const effectiveChartType: ChartType =
-      chartType === "delta" && input.scoreDelta == null ? "progression" : chartType;
+    const effectiveChartType: ChartType = chartType === "delta" && input.scoreDelta == null ? "progression" : chartType;
 
     const team0Name = input.teamLines[0]?.name ?? "Team 1";
     const team1Name = input.teamLines[1]?.name ?? "Team 2";
@@ -53,8 +58,7 @@ export class ScoreProgressionPresenter {
             scoreDelta: input.scoreDelta,
             team0Color: input.teamLines[0]?.color ?? TICK_FILL,
             team1Color: input.teamLines[1]?.color ?? TICK_FILL,
-            tooltipFormatter: (value: unknown): [string, string] =>
-              formatDeltaTooltip(value, team0Name, team1Name),
+            tooltipFormatter: (value: unknown): [string, string] => formatDeltaTooltip(value, team0Name, team1Name),
           }
         : null;
 
@@ -62,9 +66,7 @@ export class ScoreProgressionPresenter {
       ariaLabel: input.ariaLabel,
       effectiveChartType,
       hasDelta: input.scoreDelta != null,
-      onChartTypeChange: (value: string): void => {
-        this.setChartType(value);
-      },
+      onChartTypeChange: this.onChartTypeChange,
       deltaViewModel,
       progressionViewModel: {
         durationMs: input.durationMs,

--- a/pages/src/components/stats/score-progression/score-progression-store.ts
+++ b/pages/src/components/stats/score-progression/score-progression-store.ts
@@ -1,0 +1,26 @@
+import type { ChartType } from "./types";
+
+export interface ScoreProgressionSnapshot {
+  readonly chartType: ChartType;
+}
+
+export class ScoreProgressionStore {
+  private _snapshot: ScoreProgressionSnapshot = { chartType: "progression" };
+  private readonly listeners = new Set<() => void>();
+
+  getSnapshot = (): ScoreProgressionSnapshot => this._snapshot;
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  update(patch: Partial<ScoreProgressionSnapshot>): void {
+    this._snapshot = { ...this._snapshot, ...patch };
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}

--- a/pages/src/components/stats/score-progression/score-progression.module.css
+++ b/pages/src/components/stats/score-progression/score-progression.module.css
@@ -1,3 +1,24 @@
 .container {
   width: 100%;
 }
+
+.toolbar {
+  align-items: center;
+  display: flex;
+  padding: 0 8px 8px;
+}
+
+.chartSelect {
+  background: var(--halo-bg-card, #1a1a2e);
+  border: 1px solid rgb(93 212 216 / 30%);
+  border-radius: var(--radius-base, 4px);
+  color: var(--halo-white, #fff);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px 8px;
+}
+
+.chartSelect:focus {
+  outline: 1px solid rgb(93 212 216 / 60%);
+  outline-offset: 1px;
+}

--- a/pages/src/components/stats/score-progression/score-progression.module.css
+++ b/pages/src/components/stats/score-progression/score-progression.module.css
@@ -12,4 +12,9 @@
 .toolbarLabel {
   color: var(--halo-white);
   font-size: 12px;
+  white-space: nowrap;
+}
+
+.toolbarSelect {
+  width: fit-content;
 }

--- a/pages/src/components/stats/score-progression/score-progression.module.css
+++ b/pages/src/components/stats/score-progression/score-progression.module.css
@@ -5,20 +5,11 @@
 .toolbar {
   align-items: center;
   display: flex;
+  gap: 8px;
   padding: 0 8px 8px;
 }
 
-.chartSelect {
-  background: var(--halo-bg-card, #1a1a2e);
-  border: 1px solid rgb(93 212 216 / 30%);
-  border-radius: var(--radius-base, 4px);
-  color: var(--halo-white, #fff);
-  cursor: pointer;
+.toolbarLabel {
+  color: var(--halo-white);
   font-size: 12px;
-  padding: 4px 8px;
-}
-
-.chartSelect:focus {
-  outline: 1px solid rgb(93 212 216 / 60%);
-  outline-offset: 1px;
 }

--- a/pages/src/components/stats/score-progression/score-progression.tsx
+++ b/pages/src/components/stats/score-progression/score-progression.tsx
@@ -14,19 +14,21 @@ export function ScoreProgression({
 }: ScoreProgressionViewModel): React.ReactElement {
   return (
     <div className={styles.container} role="img" aria-label={ariaLabel}>
-      <div className={styles.toolbar}>
-        <select
-          className={styles.chartSelect}
-          value={effectiveChartType}
-          onChange={(e) => {
-            onChartTypeChange(e.target.value);
-          }}
-          aria-label="Chart type"
-        >
-          <option value="progression">Score Progression</option>
-          {hasDelta && <option value="delta">Score Delta</option>}
-        </select>
-      </div>
+      {hasDelta && (
+        <div className={styles.toolbar}>
+          <select
+            className={styles.chartSelect}
+            value={effectiveChartType}
+            onChange={(e) => {
+              onChartTypeChange(e.target.value);
+            }}
+            aria-label="Chart type"
+          >
+            <option value="progression">Score Progression</option>
+            <option value="delta">Score Delta</option>
+          </select>
+        </div>
+      )}
       {effectiveChartType === "delta" && deltaViewModel != null ? (
         <DeltaChart {...deltaViewModel} />
       ) : (

--- a/pages/src/components/stats/score-progression/score-progression.tsx
+++ b/pages/src/components/stats/score-progression/score-progression.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Select } from "../../select/select";
 import { DeltaChart } from "./delta-chart/delta-chart";
 import { ProgressionChart } from "./progression-chart/progression-chart";
 import type { ScoreProgressionViewModel } from "./types";
@@ -16,17 +17,19 @@ export function ScoreProgression({
     <div className={styles.container}>
       {hasDelta && (
         <div className={styles.toolbar}>
-          <select
-            className={styles.chartSelect}
+          <label htmlFor="chart-type-select" className={styles.toolbarLabel}>
+            Chart type
+          </label>
+          <Select
+            id="chart-type-select"
             value={effectiveChartType}
             onChange={(e) => {
               onChartTypeChange(e.target.value);
             }}
-            aria-label="Chart type"
           >
             <option value="progression">Score Progression</option>
             <option value="delta">Score Delta</option>
-          </select>
+          </Select>
         </div>
       )}
       <div role="img" aria-label={ariaLabel}>

--- a/pages/src/components/stats/score-progression/score-progression.tsx
+++ b/pages/src/components/stats/score-progression/score-progression.tsx
@@ -1,29 +1,17 @@
 import React from "react";
-import { TICK_FILL } from "./chart-constants";
 import { DeltaChart } from "./delta-chart/delta-chart";
 import { ProgressionChart } from "./progression-chart/progression-chart";
-import type { ScoreDeltaData, ScoreProgressionTeamLine } from "./types";
+import type { ScoreProgressionViewModel } from "./types";
 import styles from "./score-progression.module.css";
 
-interface ScoreProgressionProps {
-  readonly durationMs: number;
-  readonly teamLines: readonly ScoreProgressionTeamLine[];
-  readonly scoreDelta: ScoreDeltaData | null;
-  readonly ariaLabel: string;
-}
-
-type ChartType = "progression" | "delta";
-
 export function ScoreProgression({
-  durationMs,
-  teamLines,
-  scoreDelta,
   ariaLabel,
-}: ScoreProgressionProps): React.ReactElement {
-  const [chartType, setChartType] = React.useState<ChartType>("progression");
-
-  const effectiveChartType: ChartType = chartType === "delta" && scoreDelta == null ? "progression" : chartType;
-
+  effectiveChartType,
+  hasDelta,
+  onChartTypeChange,
+  deltaViewModel,
+  progressionViewModel,
+}: ScoreProgressionViewModel): React.ReactElement {
   return (
     <div className={styles.container} role="img" aria-label={ariaLabel}>
       <div className={styles.toolbar}>
@@ -31,28 +19,18 @@ export function ScoreProgression({
           className={styles.chartSelect}
           value={effectiveChartType}
           onChange={(e) => {
-            const { value } = e.target;
-            if (value === "progression" || value === "delta") {
-              setChartType(value);
-            }
+            onChartTypeChange(e.target.value);
           }}
           aria-label="Chart type"
         >
           <option value="progression">Score Progression</option>
-          {scoreDelta != null && <option value="delta">Score Delta</option>}
+          {hasDelta && <option value="delta">Score Delta</option>}
         </select>
       </div>
-      {effectiveChartType === "delta" && scoreDelta != null ? (
-        <DeltaChart
-          durationMs={durationMs}
-          scoreDelta={scoreDelta}
-          team0Color={teamLines[0]?.color ?? TICK_FILL}
-          team1Color={teamLines[1]?.color ?? TICK_FILL}
-          team0Name={teamLines[0]?.name ?? "Team 1"}
-          team1Name={teamLines[1]?.name ?? "Team 2"}
-        />
+      {effectiveChartType === "delta" && deltaViewModel != null ? (
+        <DeltaChart {...deltaViewModel} />
       ) : (
-        <ProgressionChart durationMs={durationMs} teamLines={teamLines} />
+        <ProgressionChart {...progressionViewModel} />
       )}
     </div>
   );

--- a/pages/src/components/stats/score-progression/score-progression.tsx
+++ b/pages/src/components/stats/score-progression/score-progression.tsx
@@ -8,9 +8,9 @@ export function ScoreProgression({
   ariaLabel,
   effectiveChartType,
   hasDelta,
-  onChartTypeChange,
   deltaViewModel,
   progressionViewModel,
+  onChartTypeChange,
 }: ScoreProgressionViewModel): React.ReactElement {
   return (
     <div className={styles.container} role="img" aria-label={ariaLabel}>

--- a/pages/src/components/stats/score-progression/score-progression.tsx
+++ b/pages/src/components/stats/score-progression/score-progression.tsx
@@ -22,6 +22,7 @@ export function ScoreProgression({
           </label>
           <Select
             id="chart-type-select"
+            containerClassName={styles.toolbarSelect}
             value={effectiveChartType}
             onChange={(e) => {
               onChartTypeChange(e.target.value);

--- a/pages/src/components/stats/score-progression/score-progression.tsx
+++ b/pages/src/components/stats/score-progression/score-progression.tsx
@@ -13,7 +13,7 @@ export function ScoreProgression({
   onChartTypeChange,
 }: ScoreProgressionViewModel): React.ReactElement {
   return (
-    <div className={styles.container} role="img" aria-label={ariaLabel}>
+    <div className={styles.container}>
       {hasDelta && (
         <div className={styles.toolbar}>
           <select
@@ -29,11 +29,13 @@ export function ScoreProgression({
           </select>
         </div>
       )}
-      {effectiveChartType === "delta" && deltaViewModel != null ? (
-        <DeltaChart {...deltaViewModel} />
-      ) : (
-        <ProgressionChart {...progressionViewModel} />
-      )}
+      <div role="img" aria-label={ariaLabel}>
+        {effectiveChartType === "delta" && deltaViewModel != null ? (
+          <DeltaChart {...deltaViewModel} />
+        ) : (
+          <ProgressionChart {...progressionViewModel} />
+        )}
+      </div>
     </div>
   );
 }

--- a/pages/src/components/stats/score-progression/score-progression.tsx
+++ b/pages/src/components/stats/score-progression/score-progression.tsx
@@ -1,13 +1,16 @@
 import React from "react";
-import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import type { ScoreProgressionTeamLine } from "./types";
+import { Area, AreaChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import type { ScoreDeltaData, ScoreProgressionTeamLine } from "./types";
 import styles from "./score-progression.module.css";
 
 interface ScoreProgressionProps {
   readonly durationMs: number;
   readonly teamLines: readonly ScoreProgressionTeamLine[];
+  readonly scoreDelta: ScoreDeltaData | null;
   readonly ariaLabel: string;
 }
+
+type ChartType = "progression" | "delta";
 
 const GRID_STROKE = "rgba(93, 212, 216, 0.12)";
 const AXIS_STROKE = "rgba(93, 212, 216, 0.3)";
@@ -21,54 +24,172 @@ function formatTime(ms: number): string {
   return `${String(minutes)}:${String(seconds).padStart(2, "0")}`;
 }
 
-export function ScoreProgression({ durationMs, teamLines, ariaLabel }: ScoreProgressionProps): React.ReactElement {
+const tooltipContentStyle = {
+  background: "var(--halo-bg-card)",
+  border: "1px solid rgba(93, 212, 216, 0.3)",
+  borderRadius: "var(--radius-base)",
+  color: "var(--halo-white)",
+  fontSize: "12px",
+};
+
+interface ProgressionChartProps {
+  readonly durationMs: number;
+  readonly teamLines: readonly ScoreProgressionTeamLine[];
+}
+
+function ProgressionChart({ durationMs, teamLines }: ProgressionChartProps): React.ReactElement {
+  return (
+    <AreaChart margin={{ top: 8, right: 16, bottom: 8, left: 8 }}>
+      <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
+      <XAxis
+        type="number"
+        dataKey="timestampMs"
+        domain={[0, durationMs]}
+        tickCount={6}
+        tickFormatter={formatTime}
+        stroke={AXIS_STROKE}
+        tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
+      />
+      <YAxis
+        allowDecimals={false}
+        width={36}
+        stroke={AXIS_STROKE}
+        tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
+      />
+      <Tooltip
+        contentStyle={tooltipContentStyle}
+        labelStyle={{ color: TICK_FILL }}
+        labelFormatter={(label) => (typeof label === "number" ? formatTime(label) : String(label ?? ""))}
+        formatter={(value, name) => [value ?? "", name]}
+      />
+      {teamLines.map((line) => (
+        <Area
+          key={line.teamId}
+          data={line.points}
+          dataKey="score"
+          name={line.name}
+          stroke={line.color}
+          strokeWidth={2}
+          fill={line.color}
+          fillOpacity={0.2}
+          dot={false}
+          type="linear"
+        />
+      ))}
+    </AreaChart>
+  );
+}
+
+interface DeltaChartProps {
+  readonly durationMs: number;
+  readonly scoreDelta: ScoreDeltaData;
+  readonly team0Color: string;
+  readonly team1Color: string;
+  readonly team0Name: string;
+  readonly team1Name: string;
+}
+
+function DeltaChart({
+  durationMs,
+  scoreDelta,
+  team0Color,
+  team1Color,
+  team0Name,
+  team1Name,
+}: DeltaChartProps): React.ReactElement {
+  const { points, minScore, maxScore, zeroFraction } = scoreDelta;
+  const zeroPercent = `${String(Math.round(zeroFraction * 100))}%`;
+
+  return (
+    <AreaChart data={points} margin={{ top: 8, right: 16, bottom: 8, left: 8 }}>
+      <defs>
+        <linearGradient id="scoreDeltaGradient" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={team0Color} stopOpacity={0.4} />
+          <stop offset={zeroPercent} stopColor={team0Color} stopOpacity={0.4} />
+          <stop offset={zeroPercent} stopColor={team1Color} stopOpacity={0.4} />
+          <stop offset="100%" stopColor={team1Color} stopOpacity={0.4} />
+        </linearGradient>
+      </defs>
+      <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
+      <XAxis
+        type="number"
+        dataKey="timestampMs"
+        domain={[0, durationMs]}
+        tickCount={6}
+        tickFormatter={formatTime}
+        stroke={AXIS_STROKE}
+        tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
+      />
+      <YAxis
+        allowDecimals={false}
+        width={36}
+        domain={[minScore, maxScore]}
+        stroke={AXIS_STROKE}
+        tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
+      />
+      <ReferenceLine y={0} stroke={AXIS_STROKE} strokeDasharray="3 3" />
+      <Tooltip
+        contentStyle={tooltipContentStyle}
+        labelStyle={{ color: TICK_FILL }}
+        labelFormatter={(label) => (typeof label === "number" ? formatTime(label) : String(label ?? ""))}
+        formatter={(value) => {
+          if (typeof value !== "number" || value === 0) {
+            return ["Tied", "Score Delta"];
+          }
+          const leader = value > 0 ? team0Name : team1Name;
+          return [`${leader} +${String(Math.abs(value))}`, "Score Delta"];
+        }}
+      />
+      <Area
+        dataKey="score"
+        stroke={TICK_FILL}
+        strokeWidth={2}
+        fill="url(#scoreDeltaGradient)"
+        dot={false}
+        type="linear"
+      />
+    </AreaChart>
+  );
+}
+
+export function ScoreProgression({
+  durationMs,
+  teamLines,
+  scoreDelta,
+  ariaLabel,
+}: ScoreProgressionProps): React.ReactElement {
+  const [chartType, setChartType] = React.useState<ChartType>("progression");
+
+  const effectiveChartType: ChartType = chartType === "delta" && scoreDelta == null ? "progression" : chartType;
+
   return (
     <div className={styles.container} role="img" aria-label={ariaLabel}>
+      <div className={styles.toolbar}>
+        <select
+          className={styles.chartSelect}
+          value={effectiveChartType}
+          onChange={(e) => {
+            setChartType(e.target.value as ChartType);
+          }}
+          aria-label="Chart type"
+        >
+          <option value="progression">Score Progression</option>
+          {scoreDelta != null && <option value="delta">Score Delta</option>}
+        </select>
+      </div>
       <ResponsiveContainer width="100%" height={260}>
-        <AreaChart margin={{ top: 8, right: 16, bottom: 8, left: 8 }}>
-          <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
-          <XAxis
-            type="number"
-            dataKey="timestampMs"
-            domain={[0, durationMs]}
-            tickCount={6}
-            tickFormatter={formatTime}
-            stroke={AXIS_STROKE}
-            tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
+        {effectiveChartType === "delta" && scoreDelta != null ? (
+          <DeltaChart
+            durationMs={durationMs}
+            scoreDelta={scoreDelta}
+            team0Color={teamLines[0]?.color ?? TICK_FILL}
+            team1Color={teamLines[1]?.color ?? TICK_FILL}
+            team0Name={teamLines[0]?.name ?? "Team 1"}
+            team1Name={teamLines[1]?.name ?? "Team 2"}
           />
-          <YAxis
-            allowDecimals={false}
-            width={36}
-            stroke={AXIS_STROKE}
-            tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
-          />
-          <Tooltip
-            contentStyle={{
-              background: "var(--halo-bg-card)",
-              border: "1px solid rgba(93, 212, 216, 0.3)",
-              borderRadius: "var(--radius-base)",
-              color: "var(--halo-white)",
-              fontSize: "12px",
-            }}
-            labelStyle={{ color: TICK_FILL }}
-            labelFormatter={(label) => (typeof label === "number" ? formatTime(label) : String(label ?? ""))}
-            formatter={(value, name) => [value ?? "", name]}
-          />
-          {teamLines.map((line) => (
-            <Area
-              key={line.teamId}
-              data={line.points}
-              dataKey="score"
-              name={line.name}
-              stroke={line.color}
-              strokeWidth={2}
-              fill={line.color}
-              fillOpacity={0.2}
-              dot={false}
-              type="linear"
-            />
-          ))}
-        </AreaChart>
+        ) : (
+          <ProgressionChart durationMs={durationMs} teamLines={teamLines} />
+        )}
       </ResponsiveContainer>
     </div>
   );

--- a/pages/src/components/stats/score-progression/score-progression.tsx
+++ b/pages/src/components/stats/score-progression/score-progression.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import type { ScoreDeltaData, ScoreProgressionTeamLine } from "./types";
+import { TICK_FILL } from "./chart-constants";
 import { DeltaChart } from "./delta-chart/delta-chart";
 import { ProgressionChart } from "./progression-chart/progression-chart";
+import type { ScoreDeltaData, ScoreProgressionTeamLine } from "./types";
 import styles from "./score-progression.module.css";
 
 interface ScoreProgressionProps {
@@ -45,8 +46,8 @@ export function ScoreProgression({
         <DeltaChart
           durationMs={durationMs}
           scoreDelta={scoreDelta}
-          team0Color={teamLines[0]?.color ?? "#8fa3b0"}
-          team1Color={teamLines[1]?.color ?? "#8fa3b0"}
+          team0Color={teamLines[0]?.color ?? TICK_FILL}
+          team1Color={teamLines[1]?.color ?? TICK_FILL}
           team0Name={teamLines[0]?.name ?? "Team 1"}
           team1Name={teamLines[1]?.name ?? "Team 2"}
         />

--- a/pages/src/components/stats/score-progression/score-progression.tsx
+++ b/pages/src/components/stats/score-progression/score-progression.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Area, AreaChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import type { ScoreDeltaData, ScoreProgressionTeamLine } from "./types";
+import { DeltaChart } from "./delta-chart/delta-chart";
+import { ProgressionChart } from "./progression-chart/progression-chart";
 import styles from "./score-progression.module.css";
 
 interface ScoreProgressionProps {
@@ -11,146 +12,6 @@ interface ScoreProgressionProps {
 }
 
 type ChartType = "progression" | "delta";
-
-const GRID_STROKE = "rgba(93, 212, 216, 0.12)";
-const AXIS_STROKE = "rgba(93, 212, 216, 0.3)";
-const TICK_FILL = "#8fa3b0";
-const TICK_FONT_SIZE = 11;
-
-function formatTime(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${String(minutes)}:${String(seconds).padStart(2, "0")}`;
-}
-
-const tooltipContentStyle = {
-  background: "var(--halo-bg-card)",
-  border: "1px solid rgba(93, 212, 216, 0.3)",
-  borderRadius: "var(--radius-base)",
-  color: "var(--halo-white)",
-  fontSize: "12px",
-};
-
-interface ProgressionChartProps {
-  readonly durationMs: number;
-  readonly teamLines: readonly ScoreProgressionTeamLine[];
-}
-
-function ProgressionChart({ durationMs, teamLines }: ProgressionChartProps): React.ReactElement {
-  return (
-    <AreaChart margin={{ top: 8, right: 16, bottom: 8, left: 8 }}>
-      <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
-      <XAxis
-        type="number"
-        dataKey="timestampMs"
-        domain={[0, durationMs]}
-        tickCount={6}
-        tickFormatter={formatTime}
-        stroke={AXIS_STROKE}
-        tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
-      />
-      <YAxis
-        allowDecimals={false}
-        width={36}
-        stroke={AXIS_STROKE}
-        tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
-      />
-      <Tooltip
-        contentStyle={tooltipContentStyle}
-        labelStyle={{ color: TICK_FILL }}
-        labelFormatter={(label) => (typeof label === "number" ? formatTime(label) : String(label ?? ""))}
-        formatter={(value, name) => [value ?? "", name]}
-      />
-      {teamLines.map((line) => (
-        <Area
-          key={line.teamId}
-          data={line.points}
-          dataKey="score"
-          name={line.name}
-          stroke={line.color}
-          strokeWidth={2}
-          fill={line.color}
-          fillOpacity={0.2}
-          dot={false}
-          type="linear"
-        />
-      ))}
-    </AreaChart>
-  );
-}
-
-interface DeltaChartProps {
-  readonly durationMs: number;
-  readonly scoreDelta: ScoreDeltaData;
-  readonly team0Color: string;
-  readonly team1Color: string;
-  readonly team0Name: string;
-  readonly team1Name: string;
-}
-
-function DeltaChart({
-  durationMs,
-  scoreDelta,
-  team0Color,
-  team1Color,
-  team0Name,
-  team1Name,
-}: DeltaChartProps): React.ReactElement {
-  const { points, minScore, maxScore, zeroFraction } = scoreDelta;
-  const zeroPercent = `${String(Math.round(zeroFraction * 100))}%`;
-
-  return (
-    <AreaChart data={points} margin={{ top: 8, right: 16, bottom: 8, left: 8 }}>
-      <defs>
-        <linearGradient id="scoreDeltaGradient" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor={team0Color} stopOpacity={0.4} />
-          <stop offset={zeroPercent} stopColor={team0Color} stopOpacity={0.4} />
-          <stop offset={zeroPercent} stopColor={team1Color} stopOpacity={0.4} />
-          <stop offset="100%" stopColor={team1Color} stopOpacity={0.4} />
-        </linearGradient>
-      </defs>
-      <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
-      <XAxis
-        type="number"
-        dataKey="timestampMs"
-        domain={[0, durationMs]}
-        tickCount={6}
-        tickFormatter={formatTime}
-        stroke={AXIS_STROKE}
-        tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
-      />
-      <YAxis
-        allowDecimals={false}
-        width={36}
-        domain={[minScore, maxScore]}
-        stroke={AXIS_STROKE}
-        tick={{ fill: TICK_FILL, fontSize: TICK_FONT_SIZE }}
-      />
-      <ReferenceLine y={0} stroke={AXIS_STROKE} strokeDasharray="3 3" />
-      <Tooltip
-        contentStyle={tooltipContentStyle}
-        labelStyle={{ color: TICK_FILL }}
-        labelFormatter={(label) => (typeof label === "number" ? formatTime(label) : String(label ?? ""))}
-        formatter={(value) => {
-          if (typeof value !== "number" || value === 0) {
-            return ["Tied", "Score Delta"];
-          }
-          const leader = value > 0 ? team0Name : team1Name;
-          return [`${leader} +${String(Math.abs(value))}`, "Score Delta"];
-        }}
-      />
-      <Area
-        dataKey="score"
-        stroke={TICK_FILL}
-        strokeWidth={2}
-        fill="url(#scoreDeltaGradient)"
-        dot={false}
-        type="linear"
-      />
-    </AreaChart>
-  );
-}
 
 export function ScoreProgression({
   durationMs,
@@ -169,7 +30,10 @@ export function ScoreProgression({
           className={styles.chartSelect}
           value={effectiveChartType}
           onChange={(e) => {
-            setChartType(e.target.value as ChartType);
+            const { value } = e.target;
+            if (value === "progression" || value === "delta") {
+              setChartType(value);
+            }
           }}
           aria-label="Chart type"
         >
@@ -177,20 +41,18 @@ export function ScoreProgression({
           {scoreDelta != null && <option value="delta">Score Delta</option>}
         </select>
       </div>
-      <ResponsiveContainer width="100%" height={260}>
-        {effectiveChartType === "delta" && scoreDelta != null ? (
-          <DeltaChart
-            durationMs={durationMs}
-            scoreDelta={scoreDelta}
-            team0Color={teamLines[0]?.color ?? TICK_FILL}
-            team1Color={teamLines[1]?.color ?? TICK_FILL}
-            team0Name={teamLines[0]?.name ?? "Team 1"}
-            team1Name={teamLines[1]?.name ?? "Team 2"}
-          />
-        ) : (
-          <ProgressionChart durationMs={durationMs} teamLines={teamLines} />
-        )}
-      </ResponsiveContainer>
+      {effectiveChartType === "delta" && scoreDelta != null ? (
+        <DeltaChart
+          durationMs={durationMs}
+          scoreDelta={scoreDelta}
+          team0Color={teamLines[0]?.color ?? "#8fa3b0"}
+          team1Color={teamLines[1]?.color ?? "#8fa3b0"}
+          team0Name={teamLines[0]?.name ?? "Team 1"}
+          team1Name={teamLines[1]?.name ?? "Team 2"}
+        />
+      ) : (
+        <ProgressionChart durationMs={durationMs} teamLines={teamLines} />
+      )}
     </div>
   );
 }

--- a/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
@@ -97,4 +97,68 @@ describe("formatScoreProgression", () => {
     const result = formatScoreProgression(aFakeScoreProgressionWith({ durationMs: 480000 }), TEAM_COLORS);
     expect(result?.durationMs).toBe(480000);
   });
+
+  describe("scoreDelta", () => {
+    it("computes step-function delta points from events", () => {
+      const result = formatScoreProgression(aFakeScoreProgressionWith(), TEAM_COLORS);
+      // t=0:0 | t=5000 pre:0 post:1 | t=12000 pre:1 post:0 | t=20000 pre:0 post:1 | t=600000:1
+      expect(result?.scoreDelta?.points).toEqual([
+        { timestampMs: 0, score: 0 },
+        { timestampMs: 5000, score: 0 },
+        { timestampMs: 5000, score: 1 },
+        { timestampMs: 12000, score: 1 },
+        { timestampMs: 12000, score: 0 },
+        { timestampMs: 20000, score: 0 },
+        { timestampMs: 20000, score: 1 },
+        { timestampMs: 600000, score: 1 },
+      ]);
+    });
+
+    it("sets minScore and maxScore from the computed delta points", () => {
+      const result = formatScoreProgression(aFakeScoreProgressionWith(), TEAM_COLORS);
+      expect(result?.scoreDelta?.minScore).toBe(0);
+      expect(result?.scoreDelta?.maxScore).toBe(1);
+    });
+
+    it("sets zeroFraction to maxScore / range for mixed positive and negative deltas", () => {
+      const data = aFakeScoreProgressionWith({
+        timeline: {
+          type: "kill-race",
+          events: [
+            { timestampMs: 5000, teamId: 1, runningScores: { "0": 0, "1": 1 } },
+            { timestampMs: 10000, teamId: 0, runningScores: { "0": 1, "1": 1 } },
+            { timestampMs: 15000, teamId: 0, runningScores: { "0": 2, "1": 1 } },
+          ],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      // minScore=-1, maxScore=1, range=2, zeroFraction=1/2=0.5
+      expect(result?.scoreDelta?.minScore).toBe(-1);
+      expect(result?.scoreDelta?.maxScore).toBe(1);
+      expect(result?.scoreDelta?.zeroFraction).toBe(0.5);
+    });
+
+    it("sets zeroFraction to 1 when team0 always leads", () => {
+      const data = aFakeScoreProgressionWith({
+        timeline: {
+          type: "kill-race",
+          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      // minScore=0, maxScore=1, range=1, zeroFraction=1/1=1
+      expect(result?.scoreDelta?.zeroFraction).toBe(1);
+    });
+
+    it("returns null scoreDelta when only one team is present", () => {
+      const data = aFakeScoreProgressionWith({
+        timeline: {
+          type: "kill-race",
+          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1 } }],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.scoreDelta).toBeNull();
+    });
+  });
 });

--- a/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
@@ -42,10 +42,10 @@ describe("formatScoreProgression", () => {
     expect(result?.teamLines[1]?.name).toBe("Cobra");
   });
 
-  it("uses fallback colors when teamColors has no entries", () => {
+  it("uses getTeamColorOrDefault fallback colors when teamColors has no entries", () => {
     const result = formatScoreProgression(aFakeScoreProgressionWith(), []);
-    expect(result?.teamLines[0]?.color).toBe("#888888");
-    expect(result?.teamLines[1]?.color).toBe("#aaaaaa");
+    expect(result?.teamLines[0]?.color).toBe("#FE3939");
+    expect(result?.teamLines[1]?.color).toBe("#3B9DFF");
   });
 
   it("starts each team line at (0, 0)", () => {
@@ -160,6 +160,20 @@ describe("formatScoreProgression", () => {
         timeline: {
           type: "kill-race",
           events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1 } }],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.scoreDelta).toBeNull();
+    });
+
+    it("returns null scoreDelta when all deltas are 0 (perfectly tied match)", () => {
+      const data = aFakeScoreProgressionWith({
+        timeline: {
+          type: "kill-race",
+          events: [
+            { timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 1 } },
+            { timestampMs: 10000, teamId: 1, runningScores: { "0": 2, "1": 2 } },
+          ],
         },
       });
       const result = formatScoreProgression(data, TEAM_COLORS);

--- a/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
@@ -101,7 +101,6 @@ describe("formatScoreProgression", () => {
   describe("scoreDelta", () => {
     it("computes step-function delta points from events", () => {
       const result = formatScoreProgression(aFakeScoreProgressionWith(), TEAM_COLORS);
-      // t=0:0 | t=5000 pre:0 post:1 | t=12000 pre:1 post:0 | t=20000 pre:0 post:1 | t=600000:1
       expect(result?.scoreDelta?.points).toEqual([
         { timestampMs: 0, score: 0 },
         { timestampMs: 5000, score: 0 },
@@ -132,7 +131,6 @@ describe("formatScoreProgression", () => {
         },
       });
       const result = formatScoreProgression(data, TEAM_COLORS);
-      // minScore=-1, maxScore=1, range=2, zeroFraction=1/2=0.5
       expect(result?.scoreDelta?.minScore).toBe(-1);
       expect(result?.scoreDelta?.maxScore).toBe(1);
       expect(result?.scoreDelta?.zeroFraction).toBe(0.5);
@@ -146,7 +144,6 @@ describe("formatScoreProgression", () => {
         },
       });
       const result = formatScoreProgression(data, TEAM_COLORS);
-      // minScore=0, maxScore=1, range=1, zeroFraction=1/1=1
       expect(result?.scoreDelta?.zeroFraction).toBe(1);
     });
 

--- a/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
@@ -99,15 +99,12 @@ describe("formatScoreProgression", () => {
   });
 
   describe("scoreDelta", () => {
-    it("computes step-function delta points from events", () => {
+    it("computes delta points from events with one point per event plus start and terminal", () => {
       const result = formatScoreProgression(aFakeScoreProgressionWith(), TEAM_COLORS);
       expect(result?.scoreDelta?.points).toEqual([
         { timestampMs: 0, score: 0 },
-        { timestampMs: 5000, score: 0 },
         { timestampMs: 5000, score: 1 },
-        { timestampMs: 12000, score: 1 },
         { timestampMs: 12000, score: 0 },
-        { timestampMs: 20000, score: 0 },
         { timestampMs: 20000, score: 1 },
         { timestampMs: 600000, score: 1 },
       ]);
@@ -134,6 +131,17 @@ describe("formatScoreProgression", () => {
       expect(result?.scoreDelta?.minScore).toBe(-1);
       expect(result?.scoreDelta?.maxScore).toBe(1);
       expect(result?.scoreDelta?.zeroFraction).toBe(0.5);
+    });
+
+    it("sets zeroFraction to 0 when team1 always leads", () => {
+      const data = aFakeScoreProgressionWith({
+        timeline: {
+          type: "kill-race",
+          events: [{ timestampMs: 5000, teamId: 1, runningScores: { "0": 0, "1": 1 } }],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.scoreDelta?.zeroFraction).toBe(0);
     });
 
     it("sets zeroFraction to 1 when team0 always leads", () => {

--- a/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
@@ -101,11 +101,18 @@ describe("ScoreProgressionPresenter", () => {
       expect(model.deltaViewModel?.tooltipFormatter(0)).toEqual(["Tied", "Score Delta"]);
     });
 
-    it("deltaViewModel.tooltipFormatter returns Tied when value is not a number", () => {
+    it("deltaViewModel.tooltipFormatter returns Tied when value is a string", () => {
       const { store, presenter } = makePresenter();
       store.update({ chartType: "delta" });
       const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
       expect(model.deltaViewModel?.tooltipFormatter("unknown")).toEqual(["Tied", "Score Delta"]);
+    });
+
+    it("deltaViewModel.tooltipFormatter returns Tied when value is NaN", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ chartType: "delta" });
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
+      expect(model.deltaViewModel?.tooltipFormatter(NaN)).toEqual(["Tied", "Score Delta"]);
     });
   });
 

--- a/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
@@ -109,23 +109,23 @@ describe("ScoreProgressionPresenter", () => {
     });
   });
 
-  describe("setChartType()", () => {
+  describe("onChartTypeChange()", () => {
     it("updates the store to delta", () => {
       const { store, presenter } = makePresenter();
-      presenter.setChartType("delta");
+      presenter.onChartTypeChange("delta");
       expect(store.getSnapshot().chartType).toBe("delta");
     });
 
     it("updates the store to progression", () => {
       const { store, presenter } = makePresenter();
       store.update({ chartType: "delta" });
-      presenter.setChartType("progression");
+      presenter.onChartTypeChange("progression");
       expect(store.getSnapshot().chartType).toBe("progression");
     });
 
     it("ignores invalid values", () => {
       const { store, presenter } = makePresenter();
-      presenter.setChartType("invalid");
+      presenter.onChartTypeChange("invalid");
       expect(store.getSnapshot().chartType).toBe("progression");
     });
   });

--- a/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { ScoreProgressionPresenter } from "../score-progression-presenter";
+import { ScoreProgressionStore } from "../score-progression-store";
+import type { ScoreDeltaData, ScoreProgressionTeamLine } from "../types";
+
+const aFakeScoreDeltaData = (): ScoreDeltaData => ({
+  points: [
+    { timestampMs: 0, score: 0 },
+    { timestampMs: 5000, score: 1 },
+    { timestampMs: 600000, score: 1 },
+  ],
+  minScore: 0,
+  maxScore: 1,
+  zeroFraction: 1,
+});
+
+const aFakeTeamLine = (name: string, color: string, teamId = 0): ScoreProgressionTeamLine => ({
+  teamId,
+  name,
+  color,
+  points: [],
+});
+
+function makePresenter(): { store: ScoreProgressionStore; presenter: ScoreProgressionPresenter } {
+  const store = new ScoreProgressionStore();
+  const presenter = new ScoreProgressionPresenter({ store });
+  return { store, presenter };
+}
+
+const BASE_INPUT = {
+  durationMs: 600000,
+  teamLines: [aFakeTeamLine("Eagle", "#f00", 0), aFakeTeamLine("Cobra", "#00f", 1)],
+  ariaLabel: "test chart",
+};
+
+describe("ScoreProgressionPresenter", () => {
+  describe("present()", () => {
+    it("returns effectiveChartType progression when chartType is progression", () => {
+      const { store, presenter } = makePresenter();
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
+      expect(model.effectiveChartType).toBe("progression");
+    });
+
+    it("returns effectiveChartType delta when chartType is delta and scoreDelta is non-null", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ chartType: "delta" });
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
+      expect(model.effectiveChartType).toBe("delta");
+    });
+
+    it("falls back to progression when chartType is delta but scoreDelta is null", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ chartType: "delta" });
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: null });
+      expect(model.effectiveChartType).toBe("progression");
+    });
+
+    it("sets hasDelta true when scoreDelta is non-null", () => {
+      const { store, presenter } = makePresenter();
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
+      expect(model.hasDelta).toBe(true);
+    });
+
+    it("sets hasDelta false when scoreDelta is null", () => {
+      const { store, presenter } = makePresenter();
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: null });
+      expect(model.hasDelta).toBe(false);
+    });
+
+    it("returns null deltaViewModel when effectiveChartType is progression", () => {
+      const { store, presenter } = makePresenter();
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
+      expect(model.deltaViewModel).toBeNull();
+    });
+
+    it("returns non-null deltaViewModel when effectiveChartType is delta", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ chartType: "delta" });
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
+      expect(model.deltaViewModel).not.toBeNull();
+    });
+
+    it("deltaViewModel.tooltipFormatter returns team0Name leading on positive delta", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ chartType: "delta" });
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
+      expect(model.deltaViewModel?.tooltipFormatter(3)).toEqual(["Eagle +3", "Score Delta"]);
+    });
+
+    it("deltaViewModel.tooltipFormatter returns team1Name leading on negative delta", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ chartType: "delta" });
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
+      expect(model.deltaViewModel?.tooltipFormatter(-2)).toEqual(["Cobra +2", "Score Delta"]);
+    });
+
+    it("deltaViewModel.tooltipFormatter returns Tied when value is 0", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ chartType: "delta" });
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
+      expect(model.deltaViewModel?.tooltipFormatter(0)).toEqual(["Tied", "Score Delta"]);
+    });
+
+    it("deltaViewModel.tooltipFormatter returns Tied when value is not a number", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ chartType: "delta" });
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
+      expect(model.deltaViewModel?.tooltipFormatter("unknown")).toEqual(["Tied", "Score Delta"]);
+    });
+  });
+
+  describe("setChartType()", () => {
+    it("updates the store to delta", () => {
+      const { store, presenter } = makePresenter();
+      presenter.setChartType("delta");
+      expect(store.getSnapshot().chartType).toBe("delta");
+    });
+
+    it("updates the store to progression", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ chartType: "delta" });
+      presenter.setChartType("progression");
+      expect(store.getSnapshot().chartType).toBe("progression");
+    });
+
+    it("ignores invalid values", () => {
+      const { store, presenter } = makePresenter();
+      presenter.setChartType("invalid");
+      expect(store.getSnapshot().chartType).toBe("progression");
+    });
+  });
+});

--- a/pages/src/components/stats/score-progression/types.ts
+++ b/pages/src/components/stats/score-progression/types.ts
@@ -22,3 +22,27 @@ export interface ScoreProgressionViewData {
   readonly teamLines: readonly ScoreProgressionTeamLine[];
   readonly scoreDelta: ScoreDeltaData | null;
 }
+
+export type ChartType = "progression" | "delta";
+
+export interface ScoreProgressionDeltaViewModel {
+  readonly durationMs: number;
+  readonly scoreDelta: ScoreDeltaData;
+  readonly team0Color: string;
+  readonly team1Color: string;
+  readonly tooltipFormatter: (value: unknown) => [string, string];
+}
+
+export interface ScoreProgressionProgressionViewModel {
+  readonly durationMs: number;
+  readonly teamLines: readonly ScoreProgressionTeamLine[];
+}
+
+export interface ScoreProgressionViewModel {
+  readonly ariaLabel: string;
+  readonly effectiveChartType: ChartType;
+  readonly hasDelta: boolean;
+  readonly onChartTypeChange: (value: string) => void;
+  readonly deltaViewModel: ScoreProgressionDeltaViewModel | null;
+  readonly progressionViewModel: ScoreProgressionProgressionViewModel;
+}

--- a/pages/src/components/stats/score-progression/types.ts
+++ b/pages/src/components/stats/score-progression/types.ts
@@ -42,7 +42,7 @@ export interface ScoreProgressionViewModel {
   readonly ariaLabel: string;
   readonly effectiveChartType: ChartType;
   readonly hasDelta: boolean;
-  readonly onChartTypeChange: (value: string) => void;
   readonly deltaViewModel: ScoreProgressionDeltaViewModel | null;
   readonly progressionViewModel: ScoreProgressionProgressionViewModel;
+  readonly onChartTypeChange: (value: string) => void;
 }

--- a/pages/src/components/stats/score-progression/types.ts
+++ b/pages/src/components/stats/score-progression/types.ts
@@ -10,7 +10,15 @@ export interface ScoreProgressionTeamLine {
   readonly points: readonly ScoreProgressionPoint[];
 }
 
+export interface ScoreDeltaData {
+  readonly points: readonly ScoreProgressionPoint[];
+  readonly minScore: number;
+  readonly maxScore: number;
+  readonly zeroFraction: number;
+}
+
 export interface ScoreProgressionViewData {
   readonly durationMs: number;
   readonly teamLines: readonly ScoreProgressionTeamLine[];
+  readonly scoreDelta: ScoreDeltaData | null;
 }

--- a/pages/src/components/stats/score-progression/types.ts
+++ b/pages/src/components/stats/score-progression/types.ts
@@ -30,7 +30,7 @@ export interface ScoreProgressionDeltaViewModel {
   readonly scoreDelta: ScoreDeltaData;
   readonly team0Color: string;
   readonly team1Color: string;
-  readonly tooltipFormatter: (value: unknown) => [string, string];
+  readonly tooltipFormatter: (value: number | string | readonly (number | string)[] | undefined) => [string, string];
 }
 
 export interface ScoreProgressionProgressionViewModel {

--- a/pages/src/components/stats/tests/match-stats.test.tsx
+++ b/pages/src/components/stats/tests/match-stats.test.tsx
@@ -220,7 +220,7 @@ describe("MatchStats", () => {
 
   it("falls back to Players tab when Timeline is active and scoreProgressionViewData becomes null", () => {
     const data = [aFakeMatchStatsDataWith({ teamId: 0 })];
-    const scoreProgressionViewData: ScoreProgressionViewData = { durationMs: 600000, teamLines: [] };
+    const scoreProgressionViewData: ScoreProgressionViewData = { durationMs: 600000, teamLines: [], scoreDelta: null };
     const baseProps = {
       data,
       id: "match-1",

--- a/pages/src/components/stats/tests/match-stats.test.tsx
+++ b/pages/src/components/stats/tests/match-stats.test.tsx
@@ -15,8 +15,8 @@ afterEach(() => {
   cleanup();
 });
 
-vi.mock("../score-progression/score-progression", () => ({
-  ScoreProgression: (): React.ReactNode => <div>Score Progression Chart</div>,
+vi.mock("../score-progression/create", () => ({
+  createScoreProgression: (): (() => React.ReactNode) => (): React.ReactNode => <div>Score Progression Chart</div>,
 }));
 
 vi.mock("../../icons/team-icon", () => ({


### PR DESCRIPTION
## Context

Part of the kill matrix improvements plan (PR 11 of 13). The Timeline tab previously showed only a Score Progression area chart. This PR adds a chart type selector so viewers can compare different views of the same match data.

## This change

- Adds a `<select>` toolbar above the chart to toggle between **Score Progression** (per-team area chart) and **Score Delta** (single area chart)
- Score Delta computes `team0Score − team1Score` at each kill event using the raw event stream, producing a correct step-function with paired pre/post-kill points — avoids the point-count mismatch that index-based subtraction from team lines would cause
- Dual-colour SVG `<linearGradient>` fill: team 0's colour above the zero line, team 1's below, with `zeroFraction` mapping the zero crossing to SVG coordinate space
- Tooltip shows `"<TeamName> +N"` or `"Tied"` for the delta view
- Selector is hidden (option removed) when the match mode produces no delta data (e.g. single-team modes)
- `safeActiveTab` guard in `MatchStats` falls back to `"players"` when switching to a match with no score progression data while Timeline is active

## Subsequent work

- PR 12: Backend augmentation — add `victimTeamId` to kill events, per-mode respawn duration constants
- PR 13: Player advantage overlay — checkbox in toolbar, formatter derives active-player-count delta, secondary y-axis overlay