### PR TITLE
Normalize tracker series mapping boundary

### DIFF
--- a/api/individual-tracker/mapper.ts
+++ b/api/individual-tracker/mapper.ts
@@ -171,10 +171,7 @@ export function toTrackerView(
             damageDealtTakenRatio: match.damageDealtTakenRatio,
             isMatchmaking: match.isMatchmaking,
           })),
-    series:
-      doState == null
-        ? []
-        : doState.series.map(toTrackerSeriesGroup),
+    series: doState == null ? [] : doState.series.map(toTrackerSeriesGroup),
     lastUpdateTime: doState == null ? "" : doState.lastUpdateTime,
     lastMatchDiscoveredAt: doState == null ? null : doState.lastMatchDiscoveredAt,
     hasActiveSeries: doState?.hasActiveSeries ?? false,

--- a/api/individual-tracker/mapper.ts
+++ b/api/individual-tracker/mapper.ts
@@ -1,6 +1,12 @@
 import type { TrackerProfile } from "@guilty-spark/shared/contracts/individual-tracker/profile";
 import type { Tracker, TrackerState } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
-import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
+import type {
+  TrackerActiveSeriesContext,
+  TrackerSeriesGroup,
+  TrackerSeriesPlayer,
+  TrackerSeriesTeam,
+  TrackerViewState,
+} from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { IndividualTrackerDoState } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/lifecycle";
 import {
@@ -75,6 +81,55 @@ function toTrackerState(state: IndividualTrackerDoState): TrackerState {
   };
 }
 
+function toTrackerSeriesPlayer(player: TrackerSeriesPlayer): TrackerSeriesPlayer {
+  return {
+    discordId: player.discordId,
+    discordName: player.discordName,
+    gamertag: player.gamertag,
+    xboxId: player.xboxId,
+    currentRank: player.currentRank,
+    currentRankTier: player.currentRankTier,
+    currentRankSubTier: player.currentRankSubTier,
+    currentRankMeasurementMatchesRemaining: player.currentRankMeasurementMatchesRemaining,
+    currentRankInitialMeasurementMatches: player.currentRankInitialMeasurementMatches,
+    allTimePeakRank: player.allTimePeakRank,
+    esra: player.esra,
+    lastRankedGamePlayed: player.lastRankedGamePlayed,
+  };
+}
+
+function toTrackerSeriesTeam(team: TrackerSeriesTeam): TrackerSeriesTeam {
+  return {
+    id: team.id,
+    name: team.name,
+    players: team.players.map(toTrackerSeriesPlayer),
+  };
+}
+
+function toTrackerSeriesGroup(group: TrackerSeriesGroup): TrackerSeriesGroup {
+  return {
+    id: group.id,
+    matchIds: group.matchIds,
+    matchBackgroundUrls: group.matchBackgroundUrls,
+    score: group.score,
+    killsDeathsAssistsKda: group.killsDeathsAssistsKda,
+    damageDealtTakenRatio: group.damageDealtTakenRatio,
+    title: group.title,
+    subtitle: group.subtitle,
+    guildIconUrl: group.guildIconUrl,
+    ...(group.teams != null ? { teams: group.teams.map(toTrackerSeriesTeam) } : {}),
+  };
+}
+
+function toTrackerActiveSeriesContext(context: TrackerActiveSeriesContext): TrackerActiveSeriesContext {
+  return {
+    title: context.title,
+    subtitle: context.subtitle,
+    guildIconUrl: context.guildIconUrl,
+    teams: context.teams.map(toTrackerSeriesTeam),
+  };
+}
+
 export function toTracker(row: IndividualTrackersRow, state: IndividualTrackerDoState | null): Tracker {
   return {
     trackerId: row.TrackerId,
@@ -119,23 +174,14 @@ export function toTrackerView(
     series:
       doState == null
         ? []
-        : doState.series.map((group) => ({
-            id: group.id,
-            matchIds: group.matchIds,
-            matchBackgroundUrls: group.matchBackgroundUrls,
-            score: group.score,
-            killsDeathsAssistsKda: group.killsDeathsAssistsKda,
-            damageDealtTakenRatio: group.damageDealtTakenRatio,
-            title: group.title,
-            subtitle: group.subtitle,
-            guildIconUrl: group.guildIconUrl,
-            teams: group.teams,
-          })),
+        : doState.series.map(toTrackerSeriesGroup),
     lastUpdateTime: doState == null ? "" : doState.lastUpdateTime,
     lastMatchDiscoveredAt: doState == null ? null : doState.lastMatchDiscoveredAt,
     hasActiveSeries: doState?.hasActiveSeries ?? false,
     hasRecentCompletedSeries: doState?.hasRecentCompletedSeries ?? false,
-    ...(doState?.activeSeriesContext !== undefined ? { activeSeriesContext: doState.activeSeriesContext } : {}),
+    ...(doState?.activeSeriesContext !== undefined
+      ? { activeSeriesContext: toTrackerActiveSeriesContext(doState.activeSeriesContext) }
+      : {}),
     ...(doState?.statsHighlights != null ? { statsHighlights: [...doState.statsHighlights] } : {}),
     ...(doState?.preSeriesPlayerInfo != null ? { preSeriesPlayerInfo: doState.preSeriesPlayerInfo } : {}),
   };

--- a/shared/src/contracts/individual-tracker/view.ts
+++ b/shared/src/contracts/individual-tracker/view.ts
@@ -61,6 +61,14 @@ export const trackerSeriesGroupSchema = z.object({
 });
 export type TrackerSeriesGroup = z.infer<typeof trackerSeriesGroupSchema>;
 
+export const trackerActiveSeriesContextSchema = z.object({
+  title: z.string(),
+  subtitle: z.string().nullable(),
+  guildIconUrl: z.string().nullable().optional(),
+  teams: z.array(trackerSeriesTeamSchema),
+});
+export type TrackerActiveSeriesContext = z.infer<typeof trackerActiveSeriesContextSchema>;
+
 export const trackerLiveViewSchema = z.object({
   trackerId: z.string(),
   gamertag: z.string(),
@@ -73,14 +81,7 @@ export const trackerLiveViewSchema = z.object({
   hasActiveSeries: z.boolean(),
   hasRecentCompletedSeries: z.boolean(),
   searchStartTime: z.string().optional(),
-  activeSeriesContext: z
-    .object({
-      title: z.string(),
-      subtitle: z.string().nullable(),
-      guildIconUrl: z.string().nullable().optional(),
-      teams: z.array(trackerSeriesTeamSchema),
-    })
-    .optional(),
+  activeSeriesContext: trackerActiveSeriesContextSchema.optional(),
 });
 export type TrackerLiveView = z.infer<typeof trackerLiveViewSchema>;
 


### PR DESCRIPTION
## Context
The individual/user series parity work was merged in PR #706, and this follow-up starts the first convergence slice to reduce model-shaping duplication without changing behavior. This slice focuses only on normalization boundaries and schema reuse so future convergence can happen in smaller, safer steps.

## This PR
1. Extracts a canonical active-series context schema/type in shared contracts and reuses it in tracker live view state.
2. Centralizes series and active-series context normalization in the API mapper (player, team, series group, active context), replacing repeated inline mapping.
3. Keeps payload behavior unchanged while making mapper boundaries explicit and easier to evolve.
4. Validates no-regression with focused API/pages typechecks and parity-sensitive regression suites.

## Subsequent Work
1. Continue convergence Slice 2 by moving any remaining transitional mapper glue to a single canonical normalization boundary.
2. Extend the compatibility matrix to confirm follow-directory projections and no-match pending-row behavior remain unchanged through additional convergence steps.
3. Optionally add diagnostics counters around enrichment completeness to support faster parity triage post-deploy.