### PR TITLE
feat(score-progression): Backend player activity data — deathTimeline contract extension

### DIFF
--- a/api/services/analytics/analytics.ts
+++ b/api/services/analytics/analytics.ts
@@ -5,6 +5,7 @@ import {
   type KillMatrixEntry as ContractKillMatrixEntry,
 } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { getDurationInSeconds } from "@guilty-spark/shared/halo/duration";
+import { KILL_RACE_RESPAWN_DURATION_MS } from "@guilty-spark/shared/halo/respawn-durations";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import type { HaloService } from "../halo/halo";
 import type { HaloFilmService } from "../halo/halo-film";
@@ -64,6 +65,7 @@ export class AnalyticsService {
           mode,
           durationMs: Math.round(getDurationInSeconds(matchStats.MatchInfo.Duration) * 1000),
           teamCount: progression.teamCount,
+          respawnDurationMs: KILL_RACE_RESPAWN_DURATION_MS[mode] ?? null,
           timeline: { type: "kill-race", events: progression.events, deathTimeline: progression.deathTimeline },
         };
       }

--- a/api/services/analytics/analytics.ts
+++ b/api/services/analytics/analytics.ts
@@ -64,7 +64,7 @@ export class AnalyticsService {
           mode,
           durationMs: Math.round(getDurationInSeconds(matchStats.MatchInfo.Duration) * 1000),
           teamCount: progression.teamCount,
-          timeline: { type: "kill-race", events: progression.events },
+          timeline: { type: "kill-race", events: progression.events, deathTimeline: progression.deathTimeline },
         };
       }
     }

--- a/api/services/analytics/tests/analytics.test.ts
+++ b/api/services/analytics/tests/analytics.test.ts
@@ -99,6 +99,7 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
     expect(results["match-1"]?.scoreProgression?.mode).toBe(GameVariantCategory.MultiplayerSlayer);
     expect(results["match-1"]?.scoreProgression?.durationMs).toBe(525500);
     expect(results["match-1"]?.scoreProgression?.teamCount).toBe(2);
+    expect(results["match-1"]?.scoreProgression?.respawnDurationMs).toBe(8000);
     expect(results["match-1"]?.scoreProgression?.timeline.type).toBe("kill-race");
     expect(results["match-1"]?.scoreProgression?.timeline.events).toHaveLength(1);
     expect(results["match-1"]?.scoreProgression?.timeline.deathTimeline).toEqual([{ timestampMs: 5100, teamId: 1 }]);

--- a/api/services/analytics/tests/analytics.test.ts
+++ b/api/services/analytics/tests/analytics.test.ts
@@ -87,6 +87,7 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
     });
     vi.spyOn(haloFilmService, "buildKillRaceProgression").mockResolvedValue({
       events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+      deathTimeline: [{ timestampMs: 5100, teamId: 1 }],
       teamCount: 2,
     });
 
@@ -100,6 +101,7 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
     expect(results["match-1"]?.scoreProgression?.teamCount).toBe(2);
     expect(results["match-1"]?.scoreProgression?.timeline.type).toBe("kill-race");
     expect(results["match-1"]?.scoreProgression?.timeline.events).toHaveLength(1);
+    expect(results["match-1"]?.scoreProgression?.timeline.deathTimeline).toEqual([{ timestampMs: 5100, teamId: 1 }]);
   });
 
   it("returns scoreProgression null when scoreProgression module is requested but match has no teams", async () => {
@@ -143,6 +145,7 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
     });
     vi.spyOn(haloFilmService, "buildKillRaceProgression").mockResolvedValue({
       events: [],
+      deathTimeline: [],
       teamCount: 2,
     });
 

--- a/api/services/halo/halo-film.ts
+++ b/api/services/halo/halo-film.ts
@@ -21,6 +21,7 @@ import type {
   ParsedHighlightEvent,
   KillMatrixEntry,
   KillMatrixAnalytics,
+  KillRaceDeathEvent,
   KillRaceProgression,
   KillRaceProgressionEvent,
   HaloFilmServiceOpts,
@@ -100,9 +101,8 @@ export class HaloFilmService {
   async buildKillRaceProgression(matchStats: MatchStats): Promise<KillRaceProgression> {
     const events = await this.loadEnrichedEventsForMatch(matchStats);
     const kills = this.filterKillEvents(events);
-    const runningScores = new Map<number, number>(
-      [...new Set(matchStats.Teams.map((team) => team.TeamId))].map((id) => [id, 0]),
-    );
+    const knownTeamIds = new Set<number>(matchStats.Teams.map((team) => team.TeamId));
+    const runningScores = new Map<number, number>([...knownTeamIds].map((id) => [id, 0]));
     const progressionEvents: KillRaceProgressionEvent[] = [];
 
     for (const kill of kills) {
@@ -117,7 +117,21 @@ export class HaloFilmService {
       });
     }
 
-    return { events: progressionEvents, teamCount: runningScores.size };
+    return {
+      events: progressionEvents,
+      deathTimeline: this.buildDeathTimeline(events, knownTeamIds),
+      teamCount: runningScores.size,
+    };
+  }
+
+  private buildDeathTimeline(events: ParsedHighlightEvent[], knownTeamIds: ReadonlySet<number>): KillRaceDeathEvent[] {
+    const timeline: KillRaceDeathEvent[] = [];
+    for (const event of events) {
+      if (event.eventType === "death" && event.teamId != null && knownTeamIds.has(event.teamId)) {
+        timeline.push({ timestampMs: event.timeMs, teamId: event.teamId });
+      }
+    }
+    return timeline;
   }
 
   async buildKillMatrixAnalytics(matchStats: MatchStats): Promise<KillMatrixAnalytics> {

--- a/api/services/halo/tests/halo-film.test.ts
+++ b/api/services/halo/tests/halo-film.test.ts
@@ -918,6 +918,54 @@ describe("HaloFilmService", () => {
       expect(result.events[0]).toEqual({ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } });
       expect(result.events[1]).toEqual({ timestampMs: 12000, teamId: 1, runningScores: { "0": 1, "1": 1 } });
       expect(result.events[2]).toEqual({ timestampMs: 18000, teamId: 0, runningScores: { "0": 2, "1": 1 } });
+      expect(result.deathTimeline).toEqual([]);
+    });
+
+    it("collects deathTimeline from death events belonging to known teams", async () => {
+      const env = aFakeCacheBackedEnvWith();
+      const xboxService = aFakeXboxServiceWith({ env });
+      const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });
+      const service = new HaloFilmService({ env, spartanTokenProvider });
+      const match = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+      const team0PlayerXuid = unwrapXuid(Preconditions.checkExists(match.Players[0]).PlayerId);
+      const team1PlayerXuid = unwrapXuid(Preconditions.checkExists(match.Players[3]).PlayerId);
+
+      vi.spyOn(service, "getHighlightEventsForMatch").mockResolvedValue([
+        {
+          xuid: team0PlayerXuid,
+          gamertag: "p0",
+          typeHint: 50,
+          isMedal: false,
+          eventType: "kill",
+          timeMs: 5000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: team1PlayerXuid,
+          gamertag: "p2",
+          typeHint: 20,
+          isMedal: false,
+          eventType: "death",
+          timeMs: 5001,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: "9999999999",
+          gamertag: "unknown",
+          typeHint: 20,
+          isMedal: false,
+          eventType: "death",
+          timeMs: 6000,
+          medalValue: 0,
+          teamId: null,
+        },
+      ]);
+
+      const result = await service.buildKillRaceProgression(match);
+
+      expect(result.deathTimeline).toEqual([{ timestampMs: 5001, teamId: 1 }]);
     });
 
     it("skips kill events whose xuid is not mapped to any team in matchStats", async () => {
@@ -982,6 +1030,7 @@ describe("HaloFilmService", () => {
 
       expect(result.teamCount).toBe(2);
       expect(result.events).toHaveLength(0);
+      expect(result.deathTimeline).toEqual([]);
     });
   });
 

--- a/api/services/halo/types.ts
+++ b/api/services/halo/types.ts
@@ -204,8 +204,14 @@ export interface KillRaceProgressionEvent {
   runningScores: Record<string, number>;
 }
 
+export interface KillRaceDeathEvent {
+  timestampMs: number;
+  teamId: number;
+}
+
 export interface KillRaceProgression {
   events: KillRaceProgressionEvent[];
+  deathTimeline: KillRaceDeathEvent[];
   teamCount: number;
 }
 

--- a/pages/src/components/stats/score-progression/fakes/aFakeScoreProgressionWith.ts
+++ b/pages/src/components/stats/score-progression/fakes/aFakeScoreProgressionWith.ts
@@ -7,6 +7,7 @@ export function aFakeScoreProgressionWith(
     mode: 9,
     durationMs: 600000,
     teamCount: 2,
+    respawnDurationMs: 8000,
     timeline: {
       type: "kill-race",
       events: [

--- a/pages/src/components/stats/score-progression/fakes/aFakeScoreProgressionWith.ts
+++ b/pages/src/components/stats/score-progression/fakes/aFakeScoreProgressionWith.ts
@@ -14,6 +14,11 @@ export function aFakeScoreProgressionWith(
         { timestampMs: 12000, teamId: 1, runningScores: { "0": 1, "1": 1 } },
         { timestampMs: 20000, teamId: 0, runningScores: { "0": 2, "1": 1 } },
       ],
+      deathTimeline: [
+        { timestampMs: 5001, teamId: 1 },
+        { timestampMs: 12001, teamId: 0 },
+        { timestampMs: 20001, teamId: 1 },
+      ],
     },
     ...overrides,
   };

--- a/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
@@ -13,7 +13,7 @@ describe("formatScoreProgression", () => {
   });
 
   it("returns null when timeline has no events", () => {
-    const data = aFakeScoreProgressionWith({ timeline: { type: "kill-race", events: [] } });
+    const data = aFakeScoreProgressionWith({ timeline: { type: "kill-race", events: [], deathTimeline: [] } });
     expect(formatScoreProgression(data, TEAM_COLORS)).toBeNull();
   });
 
@@ -82,6 +82,7 @@ describe("formatScoreProgression", () => {
       timeline: {
         type: "kill-race",
         events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+        deathTimeline: [],
       },
     });
     const result = formatScoreProgression(data, TEAM_COLORS);
@@ -125,6 +126,7 @@ describe("formatScoreProgression", () => {
             { timestampMs: 10000, teamId: 0, runningScores: { "0": 1, "1": 1 } },
             { timestampMs: 15000, teamId: 0, runningScores: { "0": 2, "1": 1 } },
           ],
+          deathTimeline: [],
         },
       });
       const result = formatScoreProgression(data, TEAM_COLORS);
@@ -138,6 +140,7 @@ describe("formatScoreProgression", () => {
         timeline: {
           type: "kill-race",
           events: [{ timestampMs: 5000, teamId: 1, runningScores: { "0": 0, "1": 1 } }],
+          deathTimeline: [],
         },
       });
       const result = formatScoreProgression(data, TEAM_COLORS);
@@ -149,6 +152,7 @@ describe("formatScoreProgression", () => {
         timeline: {
           type: "kill-race",
           events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+          deathTimeline: [],
         },
       });
       const result = formatScoreProgression(data, TEAM_COLORS);
@@ -160,6 +164,7 @@ describe("formatScoreProgression", () => {
         timeline: {
           type: "kill-race",
           events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1 } }],
+          deathTimeline: [],
         },
       });
       const result = formatScoreProgression(data, TEAM_COLORS);
@@ -174,6 +179,7 @@ describe("formatScoreProgression", () => {
             { timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 1 } },
             { timestampMs: 10000, teamId: 1, runningScores: { "0": 2, "1": 2 } },
           ],
+          deathTimeline: [],
         },
       });
       const result = formatScoreProgression(data, TEAM_COLORS);

--- a/shared/src/contracts/stats/match-analytics.ts
+++ b/shared/src/contracts/stats/match-analytics.ts
@@ -6,9 +6,15 @@ const killRaceEventSchema = z.object({
   runningScores: z.record(z.string().regex(/^\d+$/), z.number().int().nonnegative()),
 });
 
+const killRaceDeathEventSchema = z.object({
+  timestampMs: z.number().int().nonnegative(),
+  teamId: z.number().int().nonnegative(),
+});
+
 const killRaceTimelineSchema = z.object({
   type: z.literal("kill-race"),
   events: z.array(killRaceEventSchema),
+  deathTimeline: z.array(killRaceDeathEventSchema),
 });
 
 export const killMatrixEntrySchema = z.object({

--- a/shared/src/contracts/stats/match-analytics.ts
+++ b/shared/src/contracts/stats/match-analytics.ts
@@ -74,6 +74,7 @@ export const matchAnalyticsSchema = z.object({
       mode: z.number().int().nonnegative(),
       durationMs: z.number().int().nonnegative(),
       teamCount: z.number().int().positive(),
+      respawnDurationMs: z.number().int().positive().nullable(),
       timeline: killRaceTimelineSchema,
     })
     .nullable(),

--- a/shared/src/halo/respawn-durations.ts
+++ b/shared/src/halo/respawn-durations.ts
@@ -1,0 +1,7 @@
+import { GameVariantCategory } from "halo-infinite-api";
+
+export const KILL_RACE_RESPAWN_DURATION_MS: Partial<Record<number, number>> = {
+  [GameVariantCategory.MultiplayerSlayer]: 5000,
+  [GameVariantCategory.MultiplayerFiesta]: 5000,
+  // Attrition uses a lives-pool mechanic with teammate revival; respawn duration TBD
+};

--- a/shared/src/halo/respawn-durations.ts
+++ b/shared/src/halo/respawn-durations.ts
@@ -1,7 +1,7 @@
 import { GameVariantCategory } from "halo-infinite-api";
 
 export const KILL_RACE_RESPAWN_DURATION_MS: Partial<Record<number, number>> = {
-  [GameVariantCategory.MultiplayerSlayer]: 5000,
-  [GameVariantCategory.MultiplayerFiesta]: 5000,
+  [GameVariantCategory.MultiplayerSlayer]: 8000,
+  [GameVariantCategory.MultiplayerFiesta]: 8000,
   // Attrition uses a lives-pool mechanic with teammate revival; respawn duration TBD
 };


### PR DESCRIPTION
## Context

Part of the kill matrix improvements plan (PR 12 of 13). The score progression chart will gain a player advantage overlay (PR 13) showing active player counts per team over time. To drive that overlay, the frontend needs raw death timing data and respawn duration from the API.

## This change

- Adds `deathTimeline: KillRaceDeathEvent[]` to `killRaceTimelineSchema` in the shared contract — each event is `{ timestampMs, teamId }` sourced directly from film death events (which already carry `teamId` after `assignTeamIdsToEvents` runs)
- Adds `respawnDurationMs: number | null` to the `scoreProgression` contract — backend-supplied so the frontend never needs to know respawn durations directly. Derived from `KILL_RACE_RESPAWN_DURATION_MS` (Slayer/Fiesta = 8000ms per the January 2023 ranked update; Attrition = `null` pending lives-pool mechanic clarification). When the exact value becomes derivable from film data, only the backend changes
- Extends `KillRaceProgression` in the API type layer and wires it through `buildKillRaceProgression` via a new `buildDeathTimeline` private method
- Adds `KILL_RACE_RESPAWN_DURATION_MS: Partial<Record<number, number>>` keyed by `GameVariantCategory` in `shared/src/halo/respawn-durations.ts`
- Propagates both fields through `AnalyticsService` into the contract response
- Updates all test fixtures (`aFakeScoreProgressionWith`, inline overrides in formatter tests) and adds a dedicated `halo-film.test.ts` case verifying that unmapped team deaths are excluded

## Subsequent work

- PR 13: Frontend player advantage overlay — consumes `deathTimeline` + `respawnDurationMs` to render active-player-count timelines on the score progression chart