### PR TITLE
Add legal pages and footer privacy/terms discoverability

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Copy API environment file
         run: cp api/.example.dev.vars api/.dev.vars
 
+      - name: Sync legal markdown
+        run: npm run sync:legal-markdown --workspace=pages
+
       - name: Run format
         run: npm run format
 

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ test-results
 .claude/*
 !.claude/commands/
 .playwright-mcp
+pages/src/pages/_generated/legal/

--- a/pages/package.json
+++ b/pages/package.json
@@ -7,13 +7,14 @@
     "node": ">=24.11.0"
   },
   "scripts": {
-    "start": "astro dev",
-    "dev": "astro dev",
-    "build": "astro build",
+    "sync:legal-markdown": "node ./scripts/sync-legal-markdown.mjs",
+    "start": "npm run sync:legal-markdown && astro dev",
+    "dev": "npm run sync:legal-markdown && astro dev",
+    "build": "npm run sync:legal-markdown && astro build",
     "preview": "npm run build && wrangler dev",
-    "astro": "astro",
+    "astro": "npm run sync:legal-markdown && astro",
     "deploy": "npm run build && wrangler deploy",
-    "typecheck": "astro check",
+    "typecheck": "npm run sync:legal-markdown && astro check",
     "cf-typegen": "wrangler types",
     "stylelint": "stylelint 'src/**/*.css' 'src/**/*.astro'",
     "stylelint:fix": "stylelint 'src/**/*.css' 'src/**/*.astro' --fix"

--- a/pages/scripts/sync-legal-markdown.mjs
+++ b/pages/scripts/sync-legal-markdown.mjs
@@ -1,0 +1,21 @@
+import { cp, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptFilePath = fileURLToPath(import.meta.url);
+const scriptsDirectoryPath = path.dirname(scriptFilePath);
+const pagesWorkspaceRootPath = path.resolve(scriptsDirectoryPath, "..");
+const repositoryRootPath = path.resolve(pagesWorkspaceRootPath, "..");
+const generatedLegalDirectoryPath = path.join(pagesWorkspaceRootPath, "src/pages/_generated/legal");
+
+const legalMarkdownSyncTargets = [
+  { sourcePath: path.join(repositoryRootPath, "PRIVACY_POLICY.md"), destinationFileName: "privacy-policy.md" },
+  { sourcePath: path.join(repositoryRootPath, "TERMS_OF_SERVICE.md"), destinationFileName: "terms-of-service.md" },
+];
+
+await mkdir(generatedLegalDirectoryPath, { recursive: true });
+
+for (const target of legalMarkdownSyncTargets) {
+  const destinationPath = path.join(generatedLegalDirectoryPath, target.destinationFileName);
+  await cp(target.sourcePath, destinationPath);
+}

--- a/pages/src/components/footer/footer-minimal.astro
+++ b/pages/src/components/footer/footer-minimal.astro
@@ -1,0 +1,17 @@
+---
+// Minimal footer component
+import Container from "../container/container.astro";
+import styles from "./footer-minimal.module.css";
+---
+
+<footer class={styles.footer}>
+  <Container>
+    <div class={styles.inner}>
+      <span class={styles.legal}>© David Houweling · Not affiliated with Microsoft or 343 Industries.</span>
+      <nav class={styles.links} aria-label="Footer">
+        <a href="/privacy-policy" class={styles.link}>Privacy</a>
+        <a href="/terms-of-service" class={styles.link}>Terms</a>
+      </nav>
+    </div>
+  </Container>
+</footer>

--- a/pages/src/components/footer/footer-minimal.astro
+++ b/pages/src/components/footer/footer-minimal.astro
@@ -7,8 +7,8 @@ import styles from "./footer-minimal.module.css";
 <footer class={styles.footer}>
   <Container>
     <div class={styles.inner}>
-      <span class={styles.legal}>© David Houweling · Not affiliated with Microsoft or 343 Industries.</span>
-      <nav class={styles.links} aria-label="Footer">
+      <span class={styles.legal}>© David Houweling. Not affiliated with Microsoft or 343 Industries.</span>
+      <nav class={styles.links} aria-label="Legal">
         <a href="/privacy-policy" class={styles.link}>Privacy</a>
         <a href="/terms-of-service" class={styles.link}>Terms</a>
       </nav>

--- a/pages/src/components/footer/footer-minimal.module.css
+++ b/pages/src/components/footer/footer-minimal.module.css
@@ -1,0 +1,44 @@
+.footer {
+  background: var(--halo-bg-primary);
+  border-top: 1px solid var(--halo-teal-darker);
+  padding: var(--space-4) 0;
+}
+
+.inner {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  text-align: center;
+}
+
+.legal {
+  color: var(--halo-gray);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+}
+
+.links {
+  display: flex;
+  gap: var(--space-4);
+}
+
+.link {
+  color: var(--halo-teal-dark);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  text-decoration: none;
+  transition: color var(--transition-base) ease;
+}
+
+.link:hover {
+  color: var(--halo-teal-primary);
+}
+
+@media (--tablet-viewport) {
+  .inner {
+    flex-direction: row;
+    justify-content: space-between;
+    text-align: left;
+  }
+}

--- a/pages/src/components/footer/footer.astro
+++ b/pages/src/components/footer/footer.astro
@@ -9,15 +9,17 @@ const footerSections = [
   {
     heading: "Resources",
     links: [
-      { href: GITHUB_URL, label: "GitHub Repository" },
-      { href: `${GITHUB_URL}/issues`, label: "Report Issues" },
+      { href: GITHUB_URL, label: "GitHub Repository", external: true },
+      { href: `${GITHUB_URL}/issues`, label: "Report Issues", external: true },
+      { href: "/privacy-policy", label: "Privacy Policy", external: false },
+      { href: "/terms-of-service", label: "Terms of Service", external: false },
     ],
   },
   {
     heading: "Community",
     links: [
-      { href: SUPPORT_SERVER_URL, label: "Discord Server" },
-      { href: `https://github.com/${GITHUB_REPO_OWNER}`, label: "Developer" },
+      { href: SUPPORT_SERVER_URL, label: "Discord Server", external: true },
+      { href: `https://github.com/${GITHUB_REPO_OWNER}`, label: "Developer", external: true },
     ],
   },
 ];
@@ -36,7 +38,12 @@ const footerSections = [
           <div class={styles.footerSection}>
             <h4 class={styles.footerHeading}>{section.heading}</h4>
             {section.links.map((link) => (
-              <a class={styles.footerLink} href={link.href} target="_blank" rel="noopener noreferrer">
+              <a
+                class={styles.footerLink}
+                href={link.href}
+                target={link.external ? "_blank" : undefined}
+                rel={link.external ? "noopener noreferrer" : undefined}
+              >
                 {link.label}
               </a>
             ))}

--- a/pages/src/components/footer/footer.module.css
+++ b/pages/src/components/footer/footer.module.css
@@ -7,7 +7,6 @@
 .haloFooter {
   background: var(--halo-bg-primary);
   border-top: 1px solid var(--halo-teal-dark);
-  margin-top: var(--space-4);
   padding-bottom: var(--space-6);
   padding-top: var(--space-12);
 }

--- a/pages/src/components/heading/heading.astro
+++ b/pages/src/components/heading/heading.astro
@@ -1,0 +1,17 @@
+---
+import styles from "./heading.module.css";
+
+type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+interface Props {
+  tagName: HeadingTag;
+  class?: string;
+}
+
+const { tagName, class: className } = Astro.props;
+const Tag = tagName;
+---
+
+<Tag class:list={[styles.heading, styles[tagName], className]}>
+  <slot />
+</Tag>

--- a/pages/src/components/heading/heading.module.css
+++ b/pages/src/components/heading/heading.module.css
@@ -1,0 +1,38 @@
+.heading {
+  color: var(--halo-white);
+  font-family: var(--font-heading);
+  letter-spacing: 0.06em;
+  line-height: 1.15;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.h1 {
+  font-size: clamp(2rem, 5.5vw, 3rem);
+  font-weight: 800;
+}
+
+.h2 {
+  font-size: clamp(1.55rem, 4vw, 2.1rem);
+  font-weight: 700;
+}
+
+.h3 {
+  font-size: clamp(1.2rem, 3.2vw, 1.55rem);
+  font-weight: 700;
+}
+
+.h4 {
+  font-size: clamp(1.05rem, 2.5vw, 1.3rem);
+  font-weight: 700;
+}
+
+.h5 {
+  font-size: var(--text-base);
+  font-weight: 700;
+}
+
+.h6 {
+  font-size: var(--text-sm);
+  font-weight: 700;
+}

--- a/pages/src/layouts/layout.astro
+++ b/pages/src/layouts/layout.astro
@@ -2,15 +2,18 @@
 import GuiltySparkIcon from "../assets/guilty-spark-icon.png";
 import Header from "../components/header/header.astro";
 import Footer from "../components/footer/footer.astro";
+import FooterMinimal from "../components/footer/footer-minimal.astro";
 
 interface Props {
   title?: string;
   description?: string;
+  fullFooter?: boolean;
 }
 
 const {
   title = "Guilty Spark - Halo Infinite Stats for Discord",
   description = "A powerful Discord bot that brings Halo Infinite match statistics to your server. Track custom games, generate HCS maps, and analyze player performance.",
+  fullFooter = false,
 } = Astro.props;
 ---
 
@@ -33,6 +36,7 @@ const {
 
     <!-- Open Graph / Discord -->
     <meta property="og:type" content="website" />
+    <meta property="og:url" content={new URL(Astro.url.pathname, "https://guilty-spark.app").href} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:image" content={`https://guilty-spark.app/${GuiltySparkIcon.src}`} />
@@ -89,7 +93,7 @@ const {
     <main>
       <slot />
     </main>
-    <Footer />
+    {fullFooter ? <Footer /> : <FooterMinimal />}
   </body>
 </html>
 <style is:global>

--- a/pages/src/pages/_styles/legal-page.module.css
+++ b/pages/src/pages/_styles/legal-page.module.css
@@ -1,0 +1,94 @@
+.legalPage {
+  min-height: 100vh;
+  padding: 92px 0 var(--space-20);
+}
+
+.heroBlock {
+  margin-bottom: var(--space-8);
+  text-align: center;
+}
+
+.eyebrow {
+  color: var(--halo-teal-primary);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  margin-bottom: var(--space-3);
+  text-transform: uppercase;
+}
+
+.title {
+  margin-bottom: var(--space-4);
+}
+
+.markdownContent {
+  background: color-mix(in srgb, var(--halo-bg-secondary) 93%, black 7%);
+  border: 1px solid color-mix(in srgb, var(--halo-teal-primary) 30%, transparent);
+  border-radius: var(--radius-lg);
+  color: var(--halo-gray);
+  font-family: var(--font-body);
+  line-height: 1.75;
+  margin: 0 auto;
+  max-width: 980px;
+  padding: var(--space-7);
+}
+
+.policyText {
+  font-family: var(--font-body);
+  margin: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.markdownContent :global(h1),
+.markdownContent :global(h2),
+.markdownContent :global(h3),
+.markdownContent :global(h4) {
+  color: var(--halo-white);
+  font-family: var(--font-heading);
+  letter-spacing: 0.04em;
+  margin-top: var(--space-8);
+  text-transform: uppercase;
+}
+
+.markdownContent :global(h1) {
+  font-size: clamp(1.55rem, 4vw, 2rem);
+  margin-top: 0;
+}
+
+.markdownContent :global(h2) {
+  font-size: clamp(1.35rem, 3.2vw, 1.7rem);
+}
+
+.markdownContent :global(h3) {
+  font-size: clamp(1.15rem, 2.7vw, 1.45rem);
+}
+
+.markdownContent :global(p),
+.markdownContent :global(li) {
+  color: var(--halo-gray);
+}
+
+.markdownContent :global(a) {
+  color: var(--halo-cyan);
+}
+
+.markdownContent :global(code) {
+  background: rgb(0 212 255 / 8%);
+}
+
+.markdownContent :global(ul),
+.markdownContent :global(ol) {
+  padding-left: var(--space-6);
+}
+
+@media (--tablet-viewport) {
+  .legalPage {
+    padding-top: 104px;
+  }
+
+  .markdownContent {
+    padding: var(--space-10);
+  }
+}

--- a/pages/src/pages/_styles/legal-page.module.css
+++ b/pages/src/pages/_styles/legal-page.module.css
@@ -34,13 +34,6 @@
   padding: var(--space-7);
 }
 
-.policyText {
-  font-family: var(--font-body);
-  margin: 0;
-  overflow-wrap: anywhere;
-  white-space: pre-wrap;
-}
-
 .markdownContent :global(h1),
 .markdownContent :global(h2),
 .markdownContent :global(h3),

--- a/pages/src/pages/_styles/legal-page.module.css
+++ b/pages/src/pages/_styles/legal-page.module.css
@@ -50,6 +50,10 @@
   margin-top: 0;
 }
 
+.markdownContent :global(h1:first-child) {
+  display: none;
+}
+
 .markdownContent :global(h2) {
   font-size: clamp(1.35rem, 3.2vw, 1.7rem);
 }

--- a/pages/src/pages/index.astro
+++ b/pages/src/pages/index.astro
@@ -130,7 +130,7 @@ const testimonialItems: CommunityTestimonial[] = [
 ];
 ---
 
-<Layout>
+<Layout fullFooter={true}>
   <!-- Hero Section -->
   <section class={styles.heroSection}>
     <Container class={styles.heroContent}>

--- a/pages/src/pages/privacy-policy.astro
+++ b/pages/src/pages/privacy-policy.astro
@@ -3,7 +3,7 @@ import Layout from "../layouts/layout.astro";
 import Container from "../components/container/container.astro";
 import Heading from "../components/heading/heading.astro";
 import styles from "./_styles/legal-page.module.css";
-import PrivacyPolicyMarkdown from "../../../PRIVACY_POLICY.md";
+import PrivacyPolicyMarkdown from "./_generated/legal/privacy-policy.md";
 ---
 
 <Layout title="Privacy Policy - Guilty Spark" description="Privacy policy for Guilty Spark services and website tools.">

--- a/pages/src/pages/privacy-policy.astro
+++ b/pages/src/pages/privacy-policy.astro
@@ -3,8 +3,7 @@ import Layout from "../layouts/layout.astro";
 import Container from "../components/container/container.astro";
 import Heading from "../components/heading/heading.astro";
 import styles from "./_styles/legal-page.module.css";
-// eslint-disable-next-line import/no-unresolved
-import policyMarkdown from "../../../PRIVACY_POLICY.md?raw";
+import PrivacyPolicyMarkdown from "../../../PRIVACY_POLICY.md";
 ---
 
 <Layout title="Privacy Policy - Guilty Spark" description="Privacy policy for Guilty Spark services and website tools.">
@@ -16,7 +15,7 @@ import policyMarkdown from "../../../PRIVACY_POLICY.md?raw";
       </header>
 
       <article class={styles.markdownContent}>
-        <pre class={styles.policyText}>{policyMarkdown}</pre>
+        <PrivacyPolicyMarkdown />
       </article>
     </Container>
   </section>

--- a/pages/src/pages/privacy-policy.astro
+++ b/pages/src/pages/privacy-policy.astro
@@ -1,0 +1,23 @@
+---
+import Layout from "../layouts/layout.astro";
+import Container from "../components/container/container.astro";
+import Heading from "../components/heading/heading.astro";
+import styles from "./_styles/legal-page.module.css";
+// eslint-disable-next-line import/no-unresolved
+import policyMarkdown from "../../../PRIVACY_POLICY.md?raw";
+---
+
+<Layout title="Privacy Policy - Guilty Spark" description="Privacy policy for Guilty Spark services and website tools.">
+  <section class={styles.legalPage}>
+    <Container>
+      <header class={styles.heroBlock}>
+        <p class={styles.eyebrow}>Legal Transmission</p>
+        <Heading tagName="h1" class={styles.title}>Privacy Policy</Heading>
+      </header>
+
+      <article class={styles.markdownContent}>
+        <pre class={styles.policyText}>{policyMarkdown}</pre>
+      </article>
+    </Container>
+  </section>
+</Layout>

--- a/pages/src/pages/terms-of-service.astro
+++ b/pages/src/pages/terms-of-service.astro
@@ -3,7 +3,7 @@ import Layout from "../layouts/layout.astro";
 import Container from "../components/container/container.astro";
 import Heading from "../components/heading/heading.astro";
 import styles from "./_styles/legal-page.module.css";
-import TermsOfServiceMarkdown from "../../../TERMS_OF_SERVICE.md";
+import TermsOfServiceMarkdown from "./_generated/legal/terms-of-service.md";
 ---
 
 <Layout

--- a/pages/src/pages/terms-of-service.astro
+++ b/pages/src/pages/terms-of-service.astro
@@ -7,7 +7,10 @@ import styles from "./_styles/legal-page.module.css";
 import termsMarkdown from "../../../TERMS_OF_SERVICE.md?raw";
 ---
 
-<Layout title="Terms of Service - Guilty Spark" description="Terms of service for Guilty Spark services and website tools.">
+<Layout
+  title="Terms of Service - Guilty Spark"
+  description="Terms of service for Guilty Spark services and website tools."
+>
   <section class={styles.legalPage}>
     <Container>
       <header class={styles.heroBlock}>

--- a/pages/src/pages/terms-of-service.astro
+++ b/pages/src/pages/terms-of-service.astro
@@ -1,0 +1,23 @@
+---
+import Layout from "../layouts/layout.astro";
+import Container from "../components/container/container.astro";
+import Heading from "../components/heading/heading.astro";
+import styles from "./_styles/legal-page.module.css";
+// eslint-disable-next-line import/no-unresolved
+import termsMarkdown from "../../../TERMS_OF_SERVICE.md?raw";
+---
+
+<Layout title="Terms of Service - Guilty Spark" description="Terms of service for Guilty Spark services and website tools.">
+  <section class={styles.legalPage}>
+    <Container>
+      <header class={styles.heroBlock}>
+        <p class={styles.eyebrow}>Legal Transmission</p>
+        <Heading tagName="h1" class={styles.title}>Terms of Service</Heading>
+      </header>
+
+      <article class={styles.markdownContent}>
+        <pre class={styles.policyText}>{termsMarkdown}</pre>
+      </article>
+    </Container>
+  </section>
+</Layout>

--- a/pages/src/pages/terms-of-service.astro
+++ b/pages/src/pages/terms-of-service.astro
@@ -3,8 +3,7 @@ import Layout from "../layouts/layout.astro";
 import Container from "../components/container/container.astro";
 import Heading from "../components/heading/heading.astro";
 import styles from "./_styles/legal-page.module.css";
-// eslint-disable-next-line import/no-unresolved
-import termsMarkdown from "../../../TERMS_OF_SERVICE.md?raw";
+import TermsOfServiceMarkdown from "../../../TERMS_OF_SERVICE.md";
 ---
 
 <Layout
@@ -19,7 +18,7 @@ import termsMarkdown from "../../../TERMS_OF_SERVICE.md?raw";
       </header>
 
       <article class={styles.markdownContent}>
-        <pre class={styles.policyText}>{termsMarkdown}</pre>
+        <TermsOfServiceMarkdown />
       </article>
     </Container>
   </section>


### PR DESCRIPTION
## Context
For the Discord Message Content intent resubmission, the form asks "Where is your Privacy Policy available?" with examples including bot bio, help commands, and website links. The merged policy (PR #687) lives in the repo but was not linked from the website footer or discoverable at a stable URL. This PR closes that gap.

## This PR
- Adds `/privacy-policy` and `/terms-of-service` pages to the website, rendering the repo markdown files at stable `guilty-spark.app` URLs.
- Adds Privacy Policy and Terms of Service links to the full footer (`Resources` section).
- Introduces a minimal footer component (legal line + Privacy/Terms links) used on most pages by default; the full footer is opt-in via `fullFooter={true}` on the homepage.
- Adds a reusable `Heading` component used by the legal pages.
- Updates `index.astro` to use the full footer on the homepage.

## Subsequent Work
- Update the Discord Developer Portal Privacy Policy URL to point to `https://guilty-spark.app/privacy-policy`.
- Update the FAQ data-collection answer to reference the privacy policy page.
- Include the stable URL in the evidence pack form draft.