### PR TITLE
feat(score-progression): player advantage overlay on timeline charts

### DIFF
--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -222,7 +222,11 @@ export class DiscordSeriesStatsPresenter {
         transposedKillMatrixPivotData:
           rows != null ? KillMatrixFormatter.transpose(rows, orderedPlayers) : EMPTY_KILL_MATRIX_PIVOT_DATA,
         killMatrixStatus: snapshot.analyticsStatus,
-        scoreProgressionViewData: formatScoreProgression(analytics?.scoreProgression ?? null, teamColors),
+        scoreProgressionViewData: formatScoreProgression(
+          analytics?.scoreProgression ?? null,
+          teamColors,
+          seriesData?.teamData[0]?.players.length ?? null,
+        ),
       };
       if (!isMatchStats(match.rawMatch)) {
         return { ...base, data: null };

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -393,7 +393,11 @@ export class IndividualTrackerViewerPresenter {
         killMatrixRows != null
           ? KillMatrixFormatter.transpose(killMatrixRows, orderedPlayers)
           : EMPTY_KILL_MATRIX_PIVOT_DATA,
-      scoreProgressionViewData: formatScoreProgression(analytics?.scoreProgression ?? null, teamColors),
+      scoreProgressionViewData: formatScoreProgression(
+        analytics?.scoreProgression ?? null,
+        teamColors,
+        matchStats[0]?.players.length ?? null,
+      ),
     };
   }
 

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -276,6 +276,7 @@ export function MatchStats({
                       durationMs={scoreProgressionViewData.durationMs}
                       teamLines={scoreProgressionViewData.teamLines}
                       scoreDelta={scoreProgressionViewData.scoreDelta}
+                      playerAdvantage={scoreProgressionViewData.playerAdvantage}
                       ariaLabel="Match score progression timeline"
                     />
                   ),

--- a/pages/src/components/stats/score-progression/chart-constants.ts
+++ b/pages/src/components/stats/score-progression/chart-constants.ts
@@ -36,6 +36,7 @@ export const TICK_STYLE = { fill: TICK_FILL, fontSize: TICK_FONT_SIZE };
 
 export const CHART_MARGIN = { top: 8, right: 16, bottom: 8, left: 8 };
 export const CHART_HEIGHT = 260;
+export const CHART_PLOT_HEIGHT = CHART_HEIGHT - CHART_MARGIN.top - CHART_MARGIN.bottom;
 
 export function formatAdvantage(value: number): string {
   return value > 0 ? `+${String(value)}` : String(value);

--- a/pages/src/components/stats/score-progression/chart-constants.ts
+++ b/pages/src/components/stats/score-progression/chart-constants.ts
@@ -35,6 +35,7 @@ export const tooltipLabelStyle = { color: TICK_FILL };
 export const TICK_STYLE = { fill: TICK_FILL, fontSize: TICK_FONT_SIZE };
 
 export const CHART_MARGIN = { top: 8, right: 16, bottom: 8, left: 8 };
+export const CHART_HEIGHT = 260;
 
 export function formatAdvantage(value: number): string {
   return value > 0 ? `+${String(value)}` : String(value);

--- a/pages/src/components/stats/score-progression/chart-constants.ts
+++ b/pages/src/components/stats/score-progression/chart-constants.ts
@@ -36,7 +36,8 @@ export const TICK_STYLE = { fill: TICK_FILL, fontSize: TICK_FONT_SIZE };
 
 export const CHART_MARGIN = { top: 8, right: 16, bottom: 8, left: 8 };
 export const CHART_HEIGHT = 260;
-export const CHART_PLOT_HEIGHT = CHART_HEIGHT - CHART_MARGIN.top - CHART_MARGIN.bottom;
+export const X_AXIS_HEIGHT = 30;
+export const CHART_PLOT_HEIGHT = CHART_HEIGHT - CHART_MARGIN.top - CHART_MARGIN.bottom - X_AXIS_HEIGHT;
 
 export function formatAdvantage(value: number): string {
   return value > 0 ? `+${String(value)}` : String(value);

--- a/pages/src/components/stats/score-progression/chart-constants.ts
+++ b/pages/src/components/stats/score-progression/chart-constants.ts
@@ -36,8 +36,6 @@ export const TICK_STYLE = { fill: TICK_FILL, fontSize: TICK_FONT_SIZE };
 
 export const CHART_MARGIN = { top: 8, right: 16, bottom: 8, left: 8 };
 export const CHART_HEIGHT = 260;
-export const X_AXIS_HEIGHT = 30;
-export const CHART_PLOT_HEIGHT = CHART_HEIGHT - CHART_MARGIN.top - CHART_MARGIN.bottom - X_AXIS_HEIGHT;
 
 export function formatAdvantage(value: number): string {
   return value > 0 ? `+${String(value)}` : String(value);

--- a/pages/src/components/stats/score-progression/chart-constants.ts
+++ b/pages/src/components/stats/score-progression/chart-constants.ts
@@ -36,6 +36,10 @@ export const TICK_STYLE = { fill: TICK_FILL, fontSize: TICK_FONT_SIZE };
 
 export const CHART_MARGIN = { top: 8, right: 16, bottom: 8, left: 8 };
 
+export function formatAdvantage(value: number): string {
+  return value > 0 ? `+${String(value)}` : String(value);
+}
+
 export function timeAxisProps(durationMs: number): {
   type: "number";
   dataKey: string;

--- a/pages/src/components/stats/score-progression/create.tsx
+++ b/pages/src/components/stats/score-progression/create.tsx
@@ -2,12 +2,13 @@ import React, { useMemo, useSyncExternalStore } from "react";
 import { ScoreProgressionPresenter } from "./score-progression-presenter";
 import { ScoreProgressionStore } from "./score-progression-store";
 import { ScoreProgression } from "./score-progression";
-import type { ScoreDeltaData, ScoreProgressionTeamLine } from "./types";
+import type { PlayerAdvantageData, ScoreDeltaData, ScoreProgressionTeamLine } from "./types";
 
 export interface ScoreProgressionProps {
   readonly durationMs: number;
   readonly teamLines: readonly ScoreProgressionTeamLine[];
   readonly scoreDelta: ScoreDeltaData | null;
+  readonly playerAdvantage: PlayerAdvantageData | null;
   readonly ariaLabel: string;
 }
 
@@ -15,6 +16,7 @@ function ScoreProgressionInternal({
   durationMs,
   teamLines,
   scoreDelta,
+  playerAdvantage,
   ariaLabel,
 }: ScoreProgressionProps): React.ReactElement {
   const store = useMemo(() => new ScoreProgressionStore(), []);
@@ -23,8 +25,8 @@ function ScoreProgressionInternal({
   const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
 
   const model = useMemo(
-    () => presenter.present(snapshot, { durationMs, teamLines, scoreDelta, ariaLabel }),
-    [presenter, snapshot, durationMs, teamLines, scoreDelta, ariaLabel],
+    () => presenter.present(snapshot, { durationMs, teamLines, scoreDelta, playerAdvantage, ariaLabel }),
+    [presenter, snapshot, durationMs, teamLines, scoreDelta, playerAdvantage, ariaLabel],
   );
 
   return <ScoreProgression {...model} />;

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -12,21 +12,28 @@ import {
 } from "../chart-constants";
 import type { ScoreProgressionDeltaViewModel } from "../types";
 
+function formatAdvantage(value: number): string {
+  return value > 0 ? `+${String(value)}` : String(value);
+}
+
 export function DeltaChart({
   durationMs,
   scoreDelta,
   team0Color,
   team1Color,
+  playerAdvantage,
   tooltipFormatter,
 }: ScoreProgressionDeltaViewModel): React.ReactElement {
   const { points, minScore, maxScore, zeroFraction } = scoreDelta;
   const gradientId = React.useId();
   const strokeGradientId = `${gradientId}-stroke`;
+  const advantageGradientId = `${gradientId}-advantage`;
   const zeroPercent = `${(zeroFraction * 100).toFixed(2)}%`;
+  const margin = playerAdvantage != null ? { ...CHART_MARGIN, right: 36 } : CHART_MARGIN;
 
   return (
     <ResponsiveContainer width="100%" height={260}>
-      <AreaChart data={points} margin={CHART_MARGIN}>
+      <AreaChart data={points} margin={margin}>
         <defs>
           <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
             <stop offset={zeroPercent} stopColor={team0Color} stopOpacity={0.4} />
@@ -37,10 +44,28 @@ export function DeltaChart({
             <stop offset={zeroPercent} stopColor={team0Color} />
             <stop offset={zeroPercent} stopColor={team1Color} />
           </linearGradient>
+          {playerAdvantage != null && (
+            <linearGradient id={advantageGradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset={`${(playerAdvantage.zeroFraction * 100).toFixed(2)}%`} stopColor={team0Color} />
+              <stop offset={`${(playerAdvantage.zeroFraction * 100).toFixed(2)}%`} stopColor={team1Color} />
+            </linearGradient>
+          )}
         </defs>
         <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
         <XAxis {...timeAxisProps(durationMs)} />
         <YAxis allowDecimals={false} width={36} domain={[minScore, maxScore]} stroke={AXIS_STROKE} tick={TICK_STYLE} />
+        {playerAdvantage != null && (
+          <YAxis
+            yAxisId="advantage"
+            orientation="right"
+            allowDecimals={false}
+            width={28}
+            domain={[playerAdvantage.minScore, playerAdvantage.maxScore]}
+            stroke={AXIS_STROKE}
+            tick={TICK_STYLE}
+            tickFormatter={formatAdvantage}
+          />
+        )}
         <ReferenceLine y={0} stroke={AXIS_STROKE} strokeDasharray="3 3" />
         <Tooltip
           contentStyle={tooltipContentStyle}
@@ -57,6 +82,24 @@ export function DeltaChart({
           dot={false}
           type="stepAfter"
         />
+        {playerAdvantage != null && (
+          <>
+            <ReferenceLine y={0} yAxisId="advantage" stroke={AXIS_STROKE} strokeDasharray="3 3" />
+            <Area
+              yAxisId="advantage"
+              data={playerAdvantage.points}
+              dataKey="score"
+              name="Player Advantage"
+              fill="none"
+              stroke={`url(#${advantageGradientId})`}
+              strokeWidth={1.5}
+              strokeDasharray="3 3"
+              dot={false}
+              type="stepAfter"
+              baseValue={0}
+            />
+          </>
+        )}
       </AreaChart>
     </ResponsiveContainer>
   );

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -48,7 +48,7 @@ function DeltaChartGradients({
   if (deltaScale == null || plotArea == null) {
     return null;
   }
-  const {height} = plotArea;
+  const { height } = plotArea;
   const deltaZeroY = deltaScale(0);
   if (deltaZeroY == null) {
     return null;

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Area, AreaChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
   AXIS_STROKE,
+  CHART_HEIGHT,
   CHART_MARGIN,
   GRID_STROKE,
   TICK_STYLE,
@@ -27,6 +28,8 @@ export function DeltaChart({
   const advantageGradientId = `${gradientId}-advantage`;
   const zeroPercent = `${(zeroFraction * 100).toFixed(2)}%`;
   const margin = playerAdvantage != null ? { ...CHART_MARGIN, right: 36 } : CHART_MARGIN;
+  const plotTop = CHART_MARGIN.top;
+  const plotBottom = CHART_HEIGHT - CHART_MARGIN.bottom;
   const wrappedTooltipFormatter = (
     value: number | string | readonly (number | string)[] | undefined,
     name: string | number | undefined,
@@ -38,20 +41,34 @@ export function DeltaChart({
   };
 
   return (
-    <ResponsiveContainer width="100%" height={260}>
+    <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
       <AreaChart data={points} margin={margin}>
         <defs>
-          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+          <linearGradient id={gradientId} x1="0" y1={plotTop} x2="0" y2={plotBottom} gradientUnits="userSpaceOnUse">
             <stop offset={zeroPercent} stopColor={team0Color} stopOpacity={0.4} />
             <stop offset={zeroPercent} stopColor={team1Color} stopOpacity={0.4} />
             <stop offset="100%" stopColor={team1Color} stopOpacity={0.4} />
           </linearGradient>
-          <linearGradient id={strokeGradientId} x1="0" y1="0" x2="0" y2="1">
+          <linearGradient
+            id={strokeGradientId}
+            x1="0"
+            y1={plotTop}
+            x2="0"
+            y2={plotBottom}
+            gradientUnits="userSpaceOnUse"
+          >
             <stop offset={zeroPercent} stopColor={team0Color} />
             <stop offset={zeroPercent} stopColor={team1Color} />
           </linearGradient>
           {playerAdvantage != null && (
-            <linearGradient id={advantageGradientId} x1="0" y1="0" x2="0" y2="1">
+            <linearGradient
+              id={advantageGradientId}
+              x1="0"
+              y1={plotTop}
+              x2="0"
+              y2={plotBottom}
+              gradientUnits="userSpaceOnUse"
+            >
               <stop offset={`${(playerAdvantage.zeroFraction * 100).toFixed(2)}%`} stopColor={team0Color} />
               <stop offset={`${(playerAdvantage.zeroFraction * 100).toFixed(2)}%`} stopColor={team1Color} />
             </linearGradient>

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -4,6 +4,7 @@ import {
   AXIS_STROKE,
   CHART_HEIGHT,
   CHART_MARGIN,
+  CHART_PLOT_HEIGHT,
   GRID_STROKE,
   TICK_STYLE,
   formatAdvantage,
@@ -29,8 +30,6 @@ export function DeltaChart({
   const advantageGradientId = `${gradientId}-advantage`;
   const zeroPercent = `${(zeroFraction * 100).toFixed(2)}%`;
   const margin = playerAdvantage != null ? { ...CHART_MARGIN, right: 36 } : CHART_MARGIN;
-  const plotTop = CHART_MARGIN.top;
-  const plotBottom = CHART_HEIGHT - CHART_MARGIN.bottom;
   const wrappedTooltipFormatter = (
     value: number | string | readonly (number | string)[] | undefined,
     name: string | number | undefined,
@@ -43,9 +42,9 @@ export function DeltaChart({
 
   return (
     <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
-      <AreaChart margin={margin}>
+      <AreaChart data={points} margin={margin}>
         <defs>
-          <linearGradient id={gradientId} x1="0" y1={plotTop} x2="0" y2={plotBottom} gradientUnits="userSpaceOnUse">
+          <linearGradient id={gradientId} x1="0" y1={0} x2="0" y2={CHART_PLOT_HEIGHT} gradientUnits="userSpaceOnUse">
             <stop offset={zeroPercent} stopColor={team0Color} stopOpacity={0.4} />
             <stop offset={zeroPercent} stopColor={team1Color} stopOpacity={0.4} />
             <stop offset="100%" stopColor={team1Color} stopOpacity={0.4} />
@@ -53,9 +52,9 @@ export function DeltaChart({
           <linearGradient
             id={strokeGradientId}
             x1="0"
-            y1={plotTop}
+            y1={0}
             x2="0"
-            y2={plotBottom}
+            y2={CHART_PLOT_HEIGHT}
             gradientUnits="userSpaceOnUse"
           >
             <stop offset={zeroPercent} stopColor={team0Color} />
@@ -65,9 +64,9 @@ export function DeltaChart({
             <linearGradient
               id={advantageGradientId}
               x1="0"
-              y1={plotTop}
+              y1={0}
               x2="0"
-              y2={plotBottom}
+              y2={CHART_PLOT_HEIGHT}
               gradientUnits="userSpaceOnUse"
             >
               <stop offset={`${(playerAdvantage.zeroFraction * 100).toFixed(2)}%`} stopColor={team0Color} />
@@ -98,7 +97,6 @@ export function DeltaChart({
           formatter={wrappedTooltipFormatter}
         />
         <Area
-          data={points}
           dataKey="score"
           baseValue={0}
           stroke={`url(#${strokeGradientId})`}

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -21,6 +21,7 @@ export function DeltaChart({
   team1Color,
   playerAdvantage,
   tooltipFormatter,
+  advantageTooltipFormatter,
 }: ScoreProgressionDeltaViewModel): React.ReactElement {
   const { points, minScore, maxScore, zeroFraction } = scoreDelta;
   const gradientId = React.useId();
@@ -35,7 +36,7 @@ export function DeltaChart({
     name: string | number | undefined,
   ): [string, string] => {
     if (name === "Player Advantage") {
-      return [typeof value === "number" ? formatAdvantage(value) : String(value), "Player Advantage"];
+      return advantageTooltipFormatter(value);
     }
     return tooltipFormatter(value);
   };

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -42,7 +42,7 @@ export function DeltaChart({
 
   return (
     <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
-      <AreaChart data={points} margin={margin}>
+      <AreaChart margin={margin}>
         <defs>
           <linearGradient id={gradientId} x1="0" y1={plotTop} x2="0" y2={plotBottom} gradientUnits="userSpaceOnUse">
             <stop offset={zeroPercent} stopColor={team0Color} stopOpacity={0.4} />
@@ -97,6 +97,7 @@ export function DeltaChart({
           formatter={wrappedTooltipFormatter}
         />
         <Area
+          data={points}
           dataKey="score"
           baseValue={0}
           stroke={`url(#${strokeGradientId})`}

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -5,16 +5,13 @@ import {
   CHART_MARGIN,
   GRID_STROKE,
   TICK_STYLE,
+  formatAdvantage,
   timeAxisProps,
   tooltipContentStyle,
   tooltipLabelStyle,
   formatTooltipLabel,
 } from "../chart-constants";
 import type { ScoreProgressionDeltaViewModel } from "../types";
-
-function formatAdvantage(value: number): string {
-  return value > 0 ? `+${String(value)}` : String(value);
-}
 
 export function DeltaChart({
   durationMs,
@@ -30,6 +27,15 @@ export function DeltaChart({
   const advantageGradientId = `${gradientId}-advantage`;
   const zeroPercent = `${(zeroFraction * 100).toFixed(2)}%`;
   const margin = playerAdvantage != null ? { ...CHART_MARGIN, right: 36 } : CHART_MARGIN;
+  const wrappedTooltipFormatter = (
+    value: number | string | readonly (number | string)[] | undefined,
+    name: string | number | undefined,
+  ): [string, string] => {
+    if (name === "Player Advantage") {
+      return [typeof value === "number" ? formatAdvantage(value) : String(value), "Player Advantage"];
+    }
+    return tooltipFormatter(value);
+  };
 
   return (
     <ResponsiveContainer width="100%" height={260}>
@@ -71,7 +77,7 @@ export function DeltaChart({
           contentStyle={tooltipContentStyle}
           labelStyle={tooltipLabelStyle}
           labelFormatter={formatTooltipLabel}
-          formatter={tooltipFormatter}
+          formatter={wrappedTooltipFormatter}
         />
         <Area
           dataKey="score"

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -1,13 +1,22 @@
 import React from "react";
-import { Area, AreaChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+  usePlotArea,
+  useYAxisScale,
+} from "recharts";
 import {
   AXIS_STROKE,
   CHART_HEIGHT,
   CHART_MARGIN,
-  CHART_PLOT_HEIGHT,
   GRID_STROKE,
   TICK_STYLE,
-  X_AXIS_HEIGHT,
   formatAdvantage,
   timeAxisProps,
   tooltipContentStyle,
@@ -15,6 +24,59 @@ import {
   formatTooltipLabel,
 } from "../chart-constants";
 import type { ScoreProgressionDeltaViewModel } from "../types";
+
+interface DeltaChartGradientsProps {
+  readonly fillGradientId: string;
+  readonly strokeGradientId: string;
+  readonly advantageGradientId: string;
+  readonly team0Color: string;
+  readonly team1Color: string;
+  readonly hasPlayerAdvantage: boolean;
+}
+
+function DeltaChartGradients({
+  fillGradientId,
+  strokeGradientId,
+  advantageGradientId,
+  team0Color,
+  team1Color,
+  hasPlayerAdvantage,
+}: DeltaChartGradientsProps): React.ReactElement | null {
+  const deltaScale = useYAxisScale(0);
+  const advantageScale = useYAxisScale("advantage");
+  const plotArea = usePlotArea();
+  if (deltaScale == null || plotArea == null) {
+    return null;
+  }
+  const {height} = plotArea;
+  const deltaZeroY = deltaScale(0);
+  if (deltaZeroY == null) {
+    return null;
+  }
+  const deltaOffset = `${((deltaZeroY / height) * 100).toFixed(2)}%`;
+  const advantageZeroY = advantageScale?.(0);
+  const advantageOffset = advantageZeroY != null ? `${((advantageZeroY / height) * 100).toFixed(2)}%` : "50%";
+
+  return (
+    <defs>
+      <linearGradient id={fillGradientId} x1="0" y1={0} x2="0" y2={height} gradientUnits="userSpaceOnUse">
+        <stop offset={deltaOffset} stopColor={team0Color} stopOpacity={0.4} />
+        <stop offset={deltaOffset} stopColor={team1Color} stopOpacity={0.4} />
+        <stop offset="100%" stopColor={team1Color} stopOpacity={0.4} />
+      </linearGradient>
+      <linearGradient id={strokeGradientId} x1="0" y1={0} x2="0" y2={height} gradientUnits="userSpaceOnUse">
+        <stop offset={deltaOffset} stopColor={team0Color} />
+        <stop offset={deltaOffset} stopColor={team1Color} />
+      </linearGradient>
+      {hasPlayerAdvantage && (
+        <linearGradient id={advantageGradientId} x1="0" y1={0} x2="0" y2={height} gradientUnits="userSpaceOnUse">
+          <stop offset={advantageOffset} stopColor={team0Color} />
+          <stop offset={advantageOffset} stopColor={team1Color} />
+        </linearGradient>
+      )}
+    </defs>
+  );
+}
 
 export function DeltaChart({
   durationMs,
@@ -25,11 +87,10 @@ export function DeltaChart({
   tooltipFormatter,
   advantageTooltipFormatter,
 }: ScoreProgressionDeltaViewModel): React.ReactElement {
-  const { points, minScore, maxScore, zeroFraction } = scoreDelta;
+  const { points, minScore, maxScore } = scoreDelta;
   const gradientId = React.useId();
   const strokeGradientId = `${gradientId}-stroke`;
   const advantageGradientId = `${gradientId}-advantage`;
-  const zeroPercent = `${(zeroFraction * 100).toFixed(2)}%`;
   const margin = playerAdvantage != null ? { ...CHART_MARGIN, right: 36 } : CHART_MARGIN;
   const wrappedTooltipFormatter = (
     value: number | string | readonly (number | string)[] | undefined,
@@ -44,39 +105,16 @@ export function DeltaChart({
   return (
     <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
       <AreaChart data={points} margin={margin}>
-        <defs>
-          <linearGradient id={gradientId} x1="0" y1={0} x2="0" y2={CHART_PLOT_HEIGHT} gradientUnits="userSpaceOnUse">
-            <stop offset={zeroPercent} stopColor={team0Color} stopOpacity={0.4} />
-            <stop offset={zeroPercent} stopColor={team1Color} stopOpacity={0.4} />
-            <stop offset="100%" stopColor={team1Color} stopOpacity={0.4} />
-          </linearGradient>
-          <linearGradient
-            id={strokeGradientId}
-            x1="0"
-            y1={0}
-            x2="0"
-            y2={CHART_PLOT_HEIGHT}
-            gradientUnits="userSpaceOnUse"
-          >
-            <stop offset={zeroPercent} stopColor={team0Color} />
-            <stop offset={zeroPercent} stopColor={team1Color} />
-          </linearGradient>
-          {playerAdvantage != null && (
-            <linearGradient
-              id={advantageGradientId}
-              x1="0"
-              y1={0}
-              x2="0"
-              y2={CHART_PLOT_HEIGHT}
-              gradientUnits="userSpaceOnUse"
-            >
-              <stop offset={`${(playerAdvantage.zeroFraction * 100).toFixed(2)}%`} stopColor={team0Color} />
-              <stop offset={`${(playerAdvantage.zeroFraction * 100).toFixed(2)}%`} stopColor={team1Color} />
-            </linearGradient>
-          )}
-        </defs>
+        <DeltaChartGradients
+          fillGradientId={gradientId}
+          strokeGradientId={strokeGradientId}
+          advantageGradientId={advantageGradientId}
+          team0Color={team0Color}
+          team1Color={team1Color}
+          hasPlayerAdvantage={playerAdvantage != null}
+        />
         <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
-        <XAxis height={X_AXIS_HEIGHT} {...timeAxisProps(durationMs)} />
+        <XAxis {...timeAxisProps(durationMs)} />
         <YAxis allowDecimals={false} width={36} domain={[minScore, maxScore]} stroke={AXIS_STROKE} tick={TICK_STYLE} />
         {playerAdvantage != null && (
           <YAxis

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -7,6 +7,7 @@ import {
   CHART_PLOT_HEIGHT,
   GRID_STROKE,
   TICK_STYLE,
+  X_AXIS_HEIGHT,
   formatAdvantage,
   timeAxisProps,
   tooltipContentStyle,
@@ -75,7 +76,7 @@ export function DeltaChart({
           )}
         </defs>
         <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
-        <XAxis {...timeAxisProps(durationMs)} />
+        <XAxis height={X_AXIS_HEIGHT} {...timeAxisProps(durationMs)} />
         <YAxis allowDecimals={false} width={36} domain={[minScore, maxScore]} stroke={AXIS_STROKE} tick={TICK_STYLE} />
         {playerAdvantage != null && (
           <YAxis

--- a/pages/src/components/stats/score-progression/delta-chart/tests/delta-chart.test.ts
+++ b/pages/src/components/stats/score-progression/delta-chart/tests/delta-chart.test.ts
@@ -9,7 +9,6 @@ describe("ScoreProgressionDeltaViewModel", () => {
         points: [{ timestampMs: 0, score: 0 }],
         minScore: 0,
         maxScore: 1,
-        zeroFraction: 1,
       },
       team0Color: "#ff0000",
       team1Color: "#0000ff",

--- a/pages/src/components/stats/score-progression/delta-chart/tests/delta-chart.test.ts
+++ b/pages/src/components/stats/score-progression/delta-chart/tests/delta-chart.test.ts
@@ -13,6 +13,7 @@ describe("ScoreProgressionDeltaViewModel", () => {
       },
       team0Color: "#ff0000",
       team1Color: "#0000ff",
+      playerAdvantage: null,
       tooltipFormatter: (value: unknown): [string, string] => [String(value), "Delta"],
     };
     expect(props.tooltipFormatter(3)).toEqual(["3", "Delta"]);

--- a/pages/src/components/stats/score-progression/delta-chart/tests/delta-chart.test.ts
+++ b/pages/src/components/stats/score-progression/delta-chart/tests/delta-chart.test.ts
@@ -15,6 +15,7 @@ describe("ScoreProgressionDeltaViewModel", () => {
       team1Color: "#0000ff",
       playerAdvantage: null,
       tooltipFormatter: (value: unknown): [string, string] => [String(value), "Delta"],
+      advantageTooltipFormatter: (value: unknown): [string, string] => [String(value), "Player Advantage"],
     };
     expect(props.tooltipFormatter(3)).toEqual(["3", "Delta"]);
   });

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -1,14 +1,23 @@
 import React from "react";
-import { Area, AreaChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+  usePlotArea,
+  useYAxisScale,
+} from "recharts";
 import {
   AXIS_STROKE,
   CHART_HEIGHT,
   CHART_MARGIN,
-  CHART_PLOT_HEIGHT,
   GRID_STROKE,
   TICK_FILL,
   TICK_STYLE,
-  X_AXIS_HEIGHT,
   formatAdvantage,
   timeAxisProps,
   tooltipContentStyle,
@@ -16,6 +25,35 @@ import {
   formatTooltipLabel,
 } from "../chart-constants";
 import type { ScoreProgressionProgressionViewModel } from "../types";
+
+interface AdvantageGradientProps {
+  readonly id: string;
+  readonly team0Color: string;
+  readonly team1Color: string;
+}
+
+function AdvantageGradient({ id, team0Color, team1Color }: AdvantageGradientProps): React.ReactElement | null {
+  const advantageScale = useYAxisScale("advantage");
+  const plotArea = usePlotArea();
+  if (advantageScale == null || plotArea == null) {
+    return null;
+  }
+  const {height} = plotArea;
+  const zeroY = advantageScale(0);
+  if (zeroY == null) {
+    return null;
+  }
+  const offset = `${((zeroY / height) * 100).toFixed(2)}%`;
+
+  return (
+    <defs>
+      <linearGradient id={id} x1="0" y1={0} x2="0" y2={height} gradientUnits="userSpaceOnUse">
+        <stop offset={offset} stopColor={team0Color} />
+        <stop offset={offset} stopColor={team1Color} />
+      </linearGradient>
+    </defs>
+  );
+}
 
 export function ProgressionChart({
   durationMs,
@@ -32,22 +70,10 @@ export function ProgressionChart({
     <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
       <AreaChart margin={margin}>
         {playerAdvantage != null && (
-          <defs>
-            <linearGradient
-              id={advantageGradientId}
-              x1="0"
-              y1={0}
-              x2="0"
-              y2={CHART_PLOT_HEIGHT}
-              gradientUnits="userSpaceOnUse"
-            >
-              <stop offset={`${(playerAdvantage.zeroFraction * 100).toFixed(2)}%`} stopColor={team0Color} />
-              <stop offset={`${(playerAdvantage.zeroFraction * 100).toFixed(2)}%`} stopColor={team1Color} />
-            </linearGradient>
-          </defs>
+          <AdvantageGradient id={advantageGradientId} team0Color={team0Color} team1Color={team1Color} />
         )}
         <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
-        <XAxis height={X_AXIS_HEIGHT} {...timeAxisProps(durationMs)} />
+        <XAxis {...timeAxisProps(durationMs)} />
         <YAxis allowDecimals={false} width={36} stroke={AXIS_STROKE} tick={TICK_STYLE} />
         {playerAdvantage != null && (
           <YAxis

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -6,16 +6,13 @@ import {
   GRID_STROKE,
   TICK_FILL,
   TICK_STYLE,
+  formatAdvantage,
   timeAxisProps,
   tooltipContentStyle,
   tooltipLabelStyle,
   formatTooltipLabel,
 } from "../chart-constants";
 import type { ScoreProgressionProgressionViewModel } from "../types";
-
-function formatAdvantage(value: number): string {
-  return value > 0 ? `+${String(value)}` : String(value);
-}
 
 export function ProgressionChart({
   durationMs,

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -4,6 +4,7 @@ import {
   AXIS_STROKE,
   CHART_HEIGHT,
   CHART_MARGIN,
+  CHART_PLOT_HEIGHT,
   GRID_STROKE,
   TICK_FILL,
   TICK_STYLE,
@@ -19,13 +20,12 @@ export function ProgressionChart({
   durationMs,
   teamLines,
   playerAdvantage,
+  tooltipFormatter,
 }: ScoreProgressionProgressionViewModel): React.ReactElement {
   const advantageGradientId = React.useId();
   const team0Color = teamLines[0]?.color ?? TICK_FILL;
   const team1Color = teamLines[1]?.color ?? TICK_FILL;
   const margin = playerAdvantage != null ? { ...CHART_MARGIN, right: 36 } : CHART_MARGIN;
-  const plotTop = CHART_MARGIN.top;
-  const plotBottom = CHART_HEIGHT - CHART_MARGIN.bottom;
 
   return (
     <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
@@ -35,9 +35,9 @@ export function ProgressionChart({
             <linearGradient
               id={advantageGradientId}
               x1="0"
-              y1={plotTop}
+              y1={0}
               x2="0"
-              y2={plotBottom}
+              y2={CHART_PLOT_HEIGHT}
               gradientUnits="userSpaceOnUse"
             >
               <stop offset={`${(playerAdvantage.zeroFraction * 100).toFixed(2)}%`} stopColor={team0Color} />
@@ -64,6 +64,7 @@ export function ProgressionChart({
           contentStyle={tooltipContentStyle}
           labelStyle={tooltipLabelStyle}
           labelFormatter={formatTooltipLabel}
+          formatter={tooltipFormatter}
         />
         {teamLines.map((line) => (
           <Area

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -38,7 +38,7 @@ function AdvantageGradient({ id, team0Color, team1Color }: AdvantageGradientProp
   if (advantageScale == null || plotArea == null) {
     return null;
   }
-  const {height} = plotArea;
+  const { height } = plotArea;
   const zeroY = advantageScale(0);
   if (zeroY == null) {
     return null;

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { Area, AreaChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
   AXIS_STROKE,
   CHART_MARGIN,
   GRID_STROKE,
+  TICK_FILL,
   TICK_STYLE,
   timeAxisProps,
   tooltipContentStyle,
@@ -12,13 +13,46 @@ import {
 } from "../chart-constants";
 import type { ScoreProgressionProgressionViewModel } from "../types";
 
-export function ProgressionChart({ durationMs, teamLines }: ScoreProgressionProgressionViewModel): React.ReactElement {
+function formatAdvantage(value: number): string {
+  return value > 0 ? `+${String(value)}` : String(value);
+}
+
+export function ProgressionChart({
+  durationMs,
+  teamLines,
+  playerAdvantage,
+}: ScoreProgressionProgressionViewModel): React.ReactElement {
+  const advantageGradientId = React.useId();
+  const team0Color = teamLines[0]?.color ?? TICK_FILL;
+  const team1Color = teamLines[1]?.color ?? TICK_FILL;
+  const margin = playerAdvantage != null ? { ...CHART_MARGIN, right: 36 } : CHART_MARGIN;
+
   return (
     <ResponsiveContainer width="100%" height={260}>
-      <AreaChart margin={CHART_MARGIN}>
+      <AreaChart margin={margin}>
+        {playerAdvantage != null && (
+          <defs>
+            <linearGradient id={advantageGradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset={`${(playerAdvantage.zeroFraction * 100).toFixed(2)}%`} stopColor={team0Color} />
+              <stop offset={`${(playerAdvantage.zeroFraction * 100).toFixed(2)}%`} stopColor={team1Color} />
+            </linearGradient>
+          </defs>
+        )}
         <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
         <XAxis {...timeAxisProps(durationMs)} />
         <YAxis allowDecimals={false} width={36} stroke={AXIS_STROKE} tick={TICK_STYLE} />
+        {playerAdvantage != null && (
+          <YAxis
+            yAxisId="advantage"
+            orientation="right"
+            allowDecimals={false}
+            width={28}
+            domain={[playerAdvantage.minScore, playerAdvantage.maxScore]}
+            stroke={AXIS_STROKE}
+            tick={TICK_STYLE}
+            tickFormatter={formatAdvantage}
+          />
+        )}
         <Tooltip
           contentStyle={tooltipContentStyle}
           labelStyle={tooltipLabelStyle}
@@ -38,6 +72,24 @@ export function ProgressionChart({ durationMs, teamLines }: ScoreProgressionProg
             type="linear"
           />
         ))}
+        {playerAdvantage != null && (
+          <>
+            <ReferenceLine y={0} yAxisId="advantage" stroke={AXIS_STROKE} strokeDasharray="3 3" />
+            <Area
+              yAxisId="advantage"
+              data={playerAdvantage.points}
+              dataKey="score"
+              name="Player Advantage"
+              fill="none"
+              stroke={`url(#${advantageGradientId})`}
+              strokeWidth={1.5}
+              strokeDasharray="3 3"
+              dot={false}
+              type="stepAfter"
+              baseValue={0}
+            />
+          </>
+        )}
       </AreaChart>
     </ResponsiveContainer>
   );

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Area, AreaChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
   AXIS_STROKE,
+  CHART_HEIGHT,
   CHART_MARGIN,
   GRID_STROKE,
   TICK_FILL,
@@ -23,13 +24,22 @@ export function ProgressionChart({
   const team0Color = teamLines[0]?.color ?? TICK_FILL;
   const team1Color = teamLines[1]?.color ?? TICK_FILL;
   const margin = playerAdvantage != null ? { ...CHART_MARGIN, right: 36 } : CHART_MARGIN;
+  const plotTop = CHART_MARGIN.top;
+  const plotBottom = CHART_HEIGHT - CHART_MARGIN.bottom;
 
   return (
-    <ResponsiveContainer width="100%" height={260}>
+    <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
       <AreaChart margin={margin}>
         {playerAdvantage != null && (
           <defs>
-            <linearGradient id={advantageGradientId} x1="0" y1="0" x2="0" y2="1">
+            <linearGradient
+              id={advantageGradientId}
+              x1="0"
+              y1={plotTop}
+              x2="0"
+              y2={plotBottom}
+              gradientUnits="userSpaceOnUse"
+            >
               <stop offset={`${(playerAdvantage.zeroFraction * 100).toFixed(2)}%`} stopColor={team0Color} />
               <stop offset={`${(playerAdvantage.zeroFraction * 100).toFixed(2)}%`} stopColor={team1Color} />
             </linearGradient>

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -8,6 +8,7 @@ import {
   GRID_STROKE,
   TICK_FILL,
   TICK_STYLE,
+  X_AXIS_HEIGHT,
   formatAdvantage,
   timeAxisProps,
   tooltipContentStyle,
@@ -46,7 +47,7 @@ export function ProgressionChart({
           </defs>
         )}
         <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
-        <XAxis {...timeAxisProps(durationMs)} />
+        <XAxis height={X_AXIS_HEIGHT} {...timeAxisProps(durationMs)} />
         <YAxis allowDecimals={false} width={36} stroke={AXIS_STROKE} tick={TICK_STYLE} />
         {playerAdvantage != null && (
           <YAxis

--- a/pages/src/components/stats/score-progression/progression-chart/tests/progression-chart.test.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/tests/progression-chart.test.tsx
@@ -22,7 +22,7 @@ describe("ProgressionChart", () => {
       { teamId: 1, name: "Cobra", color: "#ff0000", points: [] },
     ] as const;
 
-    render(<ProgressionChart durationMs={600000} teamLines={teamLines} />);
+    render(<ProgressionChart durationMs={600000} teamLines={teamLines} playerAdvantage={null} />);
 
     const areas = screen.getAllByTestId("area");
     expect(areas).toHaveLength(2);

--- a/pages/src/components/stats/score-progression/progression-chart/tests/progression-chart.test.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/tests/progression-chart.test.tsx
@@ -22,7 +22,15 @@ describe("ProgressionChart", () => {
       { teamId: 1, name: "Cobra", color: "#ff0000", points: [] },
     ] as const;
 
-    render(<ProgressionChart durationMs={600000} teamLines={teamLines} playerAdvantage={null} />);
+    const tooltipFormatter = (value: unknown): [string, string] => [String(value), ""];
+    render(
+      <ProgressionChart
+        durationMs={600000}
+        teamLines={teamLines}
+        playerAdvantage={null}
+        tooltipFormatter={tooltipFormatter}
+      />,
+    );
 
     const areas = screen.getAllByTestId("area");
     expect(areas).toHaveLength(2);

--- a/pages/src/components/stats/score-progression/score-progression-formatter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-formatter.ts
@@ -48,9 +48,8 @@ function buildScoreDelta(
   if (range === 0) {
     return null;
   }
-  const zeroFraction = maxScore / range;
 
-  return { points, minScore, maxScore, zeroFraction };
+  return { points, minScore, maxScore };
 }
 
 function buildPlayerAdvantage(
@@ -115,9 +114,9 @@ function buildPlayerAdvantage(
   }
 
   if (teamSize != null) {
-    return { points, minScore: -teamSize, maxScore: teamSize, zeroFraction: 0.5 };
+    return { points, minScore: -teamSize, maxScore: teamSize };
   }
-  return { points, minScore, maxScore, zeroFraction: maxScore / range };
+  return { points, minScore, maxScore };
 }
 
 export function formatScoreProgression(

--- a/pages/src/components/stats/score-progression/score-progression-formatter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-formatter.ts
@@ -65,7 +65,11 @@ function buildPlayerAdvantage(
 
   const [teamId0, teamId1] = teamIds;
 
-  interface AdvantageEvent { timestampMs: number; teamId: number; delta: 1 | -1 }
+  interface AdvantageEvent {
+    timestampMs: number;
+    teamId: number;
+    delta: 1 | -1;
+  }
   const events: AdvantageEvent[] = [];
   for (const death of deathTimeline) {
     events.push({ timestampMs: death.timestampMs, teamId: death.teamId, delta: 1 });

--- a/pages/src/components/stats/score-progression/score-progression-formatter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-formatter.ts
@@ -1,4 +1,8 @@
-import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import type {
+  KillRaceDeathEvent,
+  KillRaceEvent,
+  MatchAnalytics,
+} from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { getTeamName } from "@guilty-spark/shared/halo/team";
 import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { TeamColor } from "../../team-colors/team-colors";
@@ -9,9 +13,6 @@ import type {
   ScoreProgressionTeamLine,
   ScoreProgressionViewData,
 } from "./types";
-
-type KillRaceEvent = NonNullable<MatchAnalytics["scoreProgression"]>["timeline"]["events"][number];
-type KillRaceDeathEvent = NonNullable<MatchAnalytics["scoreProgression"]>["timeline"]["deathTimeline"][number];
 
 function buildScoreDelta(
   teamIds: readonly number[],

--- a/pages/src/components/stats/score-progression/score-progression-formatter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-formatter.ts
@@ -58,6 +58,7 @@ function buildPlayerAdvantage(
   deathTimeline: readonly KillRaceDeathEvent[],
   respawnDurationMs: number,
   durationMs: number,
+  teamSize: number | null,
 ): PlayerAdvantageData | null {
   if (teamIds.length < 2 || deathTimeline.length === 0) {
     return null;
@@ -113,12 +114,16 @@ function buildPlayerAdvantage(
     return null;
   }
 
+  if (teamSize != null) {
+    return { points, minScore: -teamSize, maxScore: teamSize, zeroFraction: 0.5 };
+  }
   return { points, minScore, maxScore, zeroFraction: maxScore / range };
 }
 
 export function formatScoreProgression(
   scoreProgression: MatchAnalytics["scoreProgression"],
   teamColors: readonly TeamColor[],
+  teamSize: number | null = null,
 ): ScoreProgressionViewData | null {
   if (scoreProgression === null || scoreProgression.timeline.events.length === 0) {
     return null;
@@ -166,7 +171,7 @@ export function formatScoreProgression(
 
   const playerAdvantage =
     respawnDurationMs != null
-      ? buildPlayerAdvantage(teamIds, timeline.deathTimeline, respawnDurationMs, durationMs)
+      ? buildPlayerAdvantage(teamIds, timeline.deathTimeline, respawnDurationMs, durationMs, teamSize)
       : null;
 
   return {

--- a/pages/src/components/stats/score-progression/score-progression-formatter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-formatter.ts
@@ -70,7 +70,7 @@ function buildPlayerAdvantage(
   for (const death of deathTimeline) {
     events.push({ timestampMs: death.timestampMs, teamId: death.teamId, delta: 1 });
     const respawnTs = death.timestampMs + respawnDurationMs;
-    if (respawnTs <= durationMs) {
+    if (respawnTs < durationMs) {
       events.push({ timestampMs: respawnTs, teamId: death.teamId, delta: -1 });
     }
   }
@@ -92,7 +92,6 @@ function buildPlayerAdvantage(
       respawning.set(teamId, (respawning.get(teamId) ?? 0) + delta);
       i++;
     }
-    // positive = team 0 has more active players (consistent with score delta sign)
     const score = (respawning.get(teamId1) ?? 0) - (respawning.get(teamId0) ?? 0);
     points.push({ timestampMs: ts, score });
     if (score < minScore) {

--- a/pages/src/components/stats/score-progression/score-progression-formatter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-formatter.ts
@@ -3,6 +3,7 @@ import { getTeamName } from "@guilty-spark/shared/halo/team";
 import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type {
+  PlayerAdvantageData,
   ScoreDeltaData,
   ScoreProgressionPoint,
   ScoreProgressionTeamLine,
@@ -10,6 +11,7 @@ import type {
 } from "./types";
 
 type KillRaceEvent = NonNullable<MatchAnalytics["scoreProgression"]>["timeline"]["events"][number];
+type KillRaceDeathEvent = NonNullable<MatchAnalytics["scoreProgression"]>["timeline"]["deathTimeline"][number];
 
 function buildScoreDelta(
   teamIds: readonly number[],
@@ -51,6 +53,66 @@ function buildScoreDelta(
   return { points, minScore, maxScore, zeroFraction };
 }
 
+function buildPlayerAdvantage(
+  teamIds: readonly number[],
+  deathTimeline: readonly KillRaceDeathEvent[],
+  respawnDurationMs: number,
+  durationMs: number,
+): PlayerAdvantageData | null {
+  if (teamIds.length < 2 || deathTimeline.length === 0) {
+    return null;
+  }
+
+  const [teamId0, teamId1] = teamIds;
+
+  interface AdvantageEvent { timestampMs: number; teamId: number; delta: 1 | -1 }
+  const events: AdvantageEvent[] = [];
+  for (const death of deathTimeline) {
+    events.push({ timestampMs: death.timestampMs, teamId: death.teamId, delta: 1 });
+    const respawnTs = death.timestampMs + respawnDurationMs;
+    if (respawnTs <= durationMs) {
+      events.push({ timestampMs: respawnTs, teamId: death.teamId, delta: -1 });
+    }
+  }
+  events.sort((a, b) => a.timestampMs - b.timestampMs);
+
+  const respawning = new Map<number, number>([
+    [teamId0, 0],
+    [teamId1, 0],
+  ]);
+  const points: ScoreProgressionPoint[] = [{ timestampMs: 0, score: 0 }];
+  let minScore = 0;
+  let maxScore = 0;
+  let i = 0;
+
+  while (i < events.length) {
+    const ts = events[i].timestampMs;
+    while (i < events.length && events[i].timestampMs === ts) {
+      const { teamId, delta } = events[i];
+      respawning.set(teamId, (respawning.get(teamId) ?? 0) + delta);
+      i++;
+    }
+    // positive = team 0 has more active players (consistent with score delta sign)
+    const score = (respawning.get(teamId1) ?? 0) - (respawning.get(teamId0) ?? 0);
+    points.push({ timestampMs: ts, score });
+    if (score < minScore) {
+      minScore = score;
+    }
+    if (score > maxScore) {
+      maxScore = score;
+    }
+  }
+
+  points.push({ timestampMs: durationMs, score: points.at(-1)?.score ?? 0 });
+
+  const range = maxScore - minScore;
+  if (range === 0) {
+    return null;
+  }
+
+  return { points, minScore, maxScore, zeroFraction: maxScore / range };
+}
+
 export function formatScoreProgression(
   scoreProgression: MatchAnalytics["scoreProgression"],
   teamColors: readonly TeamColor[],
@@ -59,7 +121,7 @@ export function formatScoreProgression(
     return null;
   }
 
-  const { durationMs, timeline } = scoreProgression;
+  const { durationMs, timeline, respawnDurationMs } = scoreProgression;
   const { events } = timeline;
 
   const [firstEvent] = events;
@@ -99,5 +161,15 @@ export function formatScoreProgression(
     teamLines.push({ teamId, name: state.name, color: state.color, points: state.points });
   }
 
-  return { durationMs, teamLines, scoreDelta: buildScoreDelta(teamIds, events, durationMs) };
+  const playerAdvantage =
+    respawnDurationMs != null
+      ? buildPlayerAdvantage(teamIds, timeline.deathTimeline, respawnDurationMs, durationMs)
+      : null;
+
+  return {
+    durationMs,
+    teamLines,
+    scoreDelta: buildScoreDelta(teamIds, events, durationMs),
+    playerAdvantage,
+  };
 }

--- a/pages/src/components/stats/score-progression/score-progression-formatter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-formatter.ts
@@ -18,7 +18,7 @@ function buildScoreDelta(
   events: readonly KillRaceEvent[],
   durationMs: number,
 ): ScoreDeltaData | null {
-  if (teamIds.length < 2) {
+  if (teamIds.length !== 2) {
     return null;
   }
 
@@ -59,7 +59,7 @@ function buildPlayerAdvantage(
   durationMs: number,
   teamSize: number | null,
 ): PlayerAdvantageData | null {
-  if (teamIds.length < 2 || deathTimeline.length === 0) {
+  if (teamIds.length !== 2 || deathTimeline.length === 0) {
     return null;
   }
 

--- a/pages/src/components/stats/score-progression/score-progression-presenter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-presenter.ts
@@ -57,12 +57,16 @@ export class ScoreProgressionPresenter {
           }
         : null;
 
+    const hasDelta = input.scoreDelta != null;
+    const hasPlayerAdvantage = input.playerAdvantage != null;
+
     return {
       ariaLabel: input.ariaLabel,
       effectiveChartType,
-      hasDelta: input.scoreDelta != null,
-      hasPlayerAdvantage: input.playerAdvantage != null,
+      hasDelta,
+      hasPlayerAdvantage,
       showPlayerAdvantage,
+      showToolbar: hasDelta || hasPlayerAdvantage,
       deltaViewModel,
       progressionViewModel: {
         durationMs: input.durationMs,

--- a/pages/src/components/stats/score-progression/score-progression-presenter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-presenter.ts
@@ -44,11 +44,14 @@ export class ScoreProgressionPresenter {
     const team0Name = input.teamLines[0]?.name ?? "Team 1";
     const team1Name = input.teamLines[1]?.name ?? "Team 2";
 
+    const syncedScoreDelta =
+      input.scoreDelta != null ? this.synchronizeDeltaDomain(input.scoreDelta, effectivePlayerAdvantage) : null;
+
     const deltaViewModel: ScoreProgressionDeltaViewModel | null =
-      effectiveChartType === "delta" && input.scoreDelta != null
+      effectiveChartType === "delta" && syncedScoreDelta != null
         ? {
             durationMs: input.durationMs,
-            scoreDelta: input.scoreDelta,
+            scoreDelta: syncedScoreDelta,
             team0Color: input.teamLines[0]?.color ?? TICK_FILL,
             team1Color: input.teamLines[1]?.color ?? TICK_FILL,
             playerAdvantage: effectivePlayerAdvantage,
@@ -76,6 +79,14 @@ export class ScoreProgressionPresenter {
       onChartTypeChange: this.onChartTypeChange,
       onPlayerAdvantageChange: this.onPlayerAdvantageChange,
     };
+  }
+
+  private synchronizeDeltaDomain(scoreDelta: ScoreDeltaData, advantage: PlayerAdvantageData | null): ScoreDeltaData {
+    if (advantage == null) {
+      return scoreDelta;
+    }
+    const maxAbsDelta = Math.max(Math.abs(scoreDelta.minScore), Math.abs(scoreDelta.maxScore));
+    return { ...scoreDelta, minScore: -maxAbsDelta, maxScore: maxAbsDelta, zeroFraction: 0.5 };
   }
 
   private setChartType(value: string): void {

--- a/pages/src/components/stats/score-progression/score-progression-presenter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-presenter.ts
@@ -78,6 +78,10 @@ export class ScoreProgressionPresenter {
         durationMs: input.durationMs,
         teamLines: input.teamLines,
         playerAdvantage: effectivePlayerAdvantage,
+        tooltipFormatter: (
+          value: number | string | readonly (number | string)[] | undefined,
+          name: string | number | undefined,
+        ): [string, string] => this.formatProgressionTooltip(value, name, team0Name, team1Name),
       },
       onChartTypeChange: this.onChartTypeChange,
       onPlayerAdvantageChange: this.onPlayerAdvantageChange,
@@ -100,6 +104,18 @@ export class ScoreProgressionPresenter {
 
   private setPlayerAdvantage(checked: boolean): void {
     this.config.store.update({ showPlayerAdvantage: checked });
+  }
+
+  private formatProgressionTooltip(
+    value: number | string | readonly (number | string)[] | undefined,
+    name: string | number | undefined,
+    team0Name: string,
+    team1Name: string,
+  ): [string, string] {
+    if (name === "Player Advantage") {
+      return this.formatAdvantageTooltip(value, team0Name, team1Name);
+    }
+    return [String(value ?? ""), typeof name === "string" ? name : String(name ?? "")];
   }
 
   private formatAdvantageTooltip(

--- a/pages/src/components/stats/score-progression/score-progression-presenter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-presenter.ts
@@ -2,6 +2,7 @@ import { TICK_FILL } from "./chart-constants";
 import type { ScoreProgressionSnapshot, ScoreProgressionStore } from "./score-progression-store";
 import type {
   ChartType,
+  PlayerAdvantageData,
   ScoreDeltaData,
   ScoreProgressionDeltaViewModel,
   ScoreProgressionTeamLine,
@@ -16,6 +17,7 @@ export interface ScoreProgressionInput {
   readonly durationMs: number;
   readonly teamLines: readonly ScoreProgressionTeamLine[];
   readonly scoreDelta: ScoreDeltaData | null;
+  readonly playerAdvantage: PlayerAdvantageData | null;
   readonly ariaLabel: string;
 }
 
@@ -23,16 +25,21 @@ const DELTA_LABEL = "Score Delta";
 
 export class ScoreProgressionPresenter {
   readonly onChartTypeChange: (value: string) => void;
+  readonly onPlayerAdvantageToggle: () => void;
 
   constructor(private readonly config: ScoreProgressionPresenterConfig) {
     this.onChartTypeChange = (value: string): void => {
       this.setChartType(value);
     };
+    this.onPlayerAdvantageToggle = (): void => {
+      this.togglePlayerAdvantage();
+    };
   }
 
   present(snapshot: ScoreProgressionSnapshot, input: ScoreProgressionInput): ScoreProgressionViewModel {
-    const { chartType } = snapshot;
+    const { chartType, showPlayerAdvantage } = snapshot;
     const effectiveChartType: ChartType = chartType === "delta" && input.scoreDelta == null ? "progression" : chartType;
+    const effectivePlayerAdvantage = showPlayerAdvantage ? input.playerAdvantage : null;
 
     const team0Name = input.teamLines[0]?.name ?? "Team 1";
     const team1Name = input.teamLines[1]?.name ?? "Team 2";
@@ -44,6 +51,7 @@ export class ScoreProgressionPresenter {
             scoreDelta: input.scoreDelta,
             team0Color: input.teamLines[0]?.color ?? TICK_FILL,
             team1Color: input.teamLines[1]?.color ?? TICK_FILL,
+            playerAdvantage: effectivePlayerAdvantage,
             tooltipFormatter: (value: number | string | readonly (number | string)[] | undefined): [string, string] =>
               this.formatDeltaTooltip(value, team0Name, team1Name),
           }
@@ -53,12 +61,16 @@ export class ScoreProgressionPresenter {
       ariaLabel: input.ariaLabel,
       effectiveChartType,
       hasDelta: input.scoreDelta != null,
+      hasPlayerAdvantage: input.playerAdvantage != null,
+      showPlayerAdvantage,
       deltaViewModel,
       progressionViewModel: {
         durationMs: input.durationMs,
         teamLines: input.teamLines,
+        playerAdvantage: effectivePlayerAdvantage,
       },
       onChartTypeChange: this.onChartTypeChange,
+      onPlayerAdvantageToggle: this.onPlayerAdvantageToggle,
     };
   }
 
@@ -66,6 +78,10 @@ export class ScoreProgressionPresenter {
     if (value === "progression" || value === "delta") {
       this.config.store.update({ chartType: value });
     }
+  }
+
+  private togglePlayerAdvantage(): void {
+    this.config.store.update({ showPlayerAdvantage: !this.config.store.getSnapshot().showPlayerAdvantage });
   }
 
   private formatDeltaTooltip(

--- a/pages/src/components/stats/score-progression/score-progression-presenter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-presenter.ts
@@ -25,14 +25,14 @@ const DELTA_LABEL = "Score Delta";
 
 export class ScoreProgressionPresenter {
   readonly onChartTypeChange: (value: string) => void;
-  readonly onPlayerAdvantageToggle: () => void;
+  readonly onPlayerAdvantageChange: (checked: boolean) => void;
 
   constructor(private readonly config: ScoreProgressionPresenterConfig) {
     this.onChartTypeChange = (value: string): void => {
       this.setChartType(value);
     };
-    this.onPlayerAdvantageToggle = (): void => {
-      this.togglePlayerAdvantage();
+    this.onPlayerAdvantageChange = (checked: boolean): void => {
+      this.setPlayerAdvantage(checked);
     };
   }
 
@@ -74,7 +74,7 @@ export class ScoreProgressionPresenter {
         playerAdvantage: effectivePlayerAdvantage,
       },
       onChartTypeChange: this.onChartTypeChange,
-      onPlayerAdvantageToggle: this.onPlayerAdvantageToggle,
+      onPlayerAdvantageChange: this.onPlayerAdvantageChange,
     };
   }
 
@@ -84,8 +84,8 @@ export class ScoreProgressionPresenter {
     }
   }
 
-  private togglePlayerAdvantage(): void {
-    this.config.store.update({ showPlayerAdvantage: !this.config.store.getSnapshot().showPlayerAdvantage });
+  private setPlayerAdvantage(checked: boolean): void {
+    this.config.store.update({ showPlayerAdvantage: checked });
   }
 
   private formatDeltaTooltip(

--- a/pages/src/components/stats/score-progression/score-progression-presenter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-presenter.ts
@@ -93,7 +93,7 @@ export class ScoreProgressionPresenter {
       return scoreDelta;
     }
     const maxAbsDelta = Math.max(Math.abs(scoreDelta.minScore), Math.abs(scoreDelta.maxScore));
-    return { ...scoreDelta, minScore: -maxAbsDelta, maxScore: maxAbsDelta, zeroFraction: 0.5 };
+    return { ...scoreDelta, minScore: -maxAbsDelta, maxScore: maxAbsDelta };
   }
 
   private setChartType(value: string): void {

--- a/pages/src/components/stats/score-progression/score-progression-presenter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-presenter.ts
@@ -57,6 +57,9 @@ export class ScoreProgressionPresenter {
             playerAdvantage: effectivePlayerAdvantage,
             tooltipFormatter: (value: number | string | readonly (number | string)[] | undefined): [string, string] =>
               this.formatDeltaTooltip(value, team0Name, team1Name),
+            advantageTooltipFormatter: (
+              value: number | string | readonly (number | string)[] | undefined,
+            ): [string, string] => this.formatAdvantageTooltip(value, team0Name, team1Name),
           }
         : null;
 
@@ -97,6 +100,18 @@ export class ScoreProgressionPresenter {
 
   private setPlayerAdvantage(checked: boolean): void {
     this.config.store.update({ showPlayerAdvantage: checked });
+  }
+
+  private formatAdvantageTooltip(
+    value: number | string | readonly (number | string)[] | undefined,
+    team0Name: string,
+    team1Name: string,
+  ): [string, string] {
+    if (typeof value !== "number" || value === 0 || Number.isNaN(value)) {
+      return ["Even", "Player Advantage"];
+    }
+    const leader = value > 0 ? team0Name : team1Name;
+    return [`${leader} +${String(Math.abs(value))}`, "Player Advantage"];
   }
 
   private formatDeltaTooltip(

--- a/pages/src/components/stats/score-progression/score-progression-store.ts
+++ b/pages/src/components/stats/score-progression/score-progression-store.ts
@@ -2,10 +2,11 @@ import type { ChartType } from "./types";
 
 export interface ScoreProgressionSnapshot {
   readonly chartType: ChartType;
+  readonly showPlayerAdvantage: boolean;
 }
 
 export class ScoreProgressionStore {
-  private _snapshot: ScoreProgressionSnapshot = { chartType: "progression" };
+  private _snapshot: ScoreProgressionSnapshot = { chartType: "progression", showPlayerAdvantage: false };
   private readonly listeners = new Set<() => void>();
 
   getSnapshot = (): ScoreProgressionSnapshot => this._snapshot;

--- a/pages/src/components/stats/score-progression/score-progression.module.css
+++ b/pages/src/components/stats/score-progression/score-progression.module.css
@@ -18,3 +18,19 @@
 .toolbarSelect {
   width: fit-content;
 }
+
+.toolbarCheckboxLabel {
+  align-items: center;
+  color: var(--halo-white);
+  cursor: pointer;
+  display: flex;
+  font-size: 12px;
+  gap: 6px;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.toolbarCheckbox {
+  accent-color: var(--halo-teal, #5dd4d8);
+  cursor: pointer;
+}

--- a/pages/src/components/stats/score-progression/score-progression.module.css
+++ b/pages/src/components/stats/score-progression/score-progression.module.css
@@ -19,18 +19,6 @@
   width: fit-content;
 }
 
-.toolbarCheckboxLabel {
-  align-items: center;
-  color: var(--halo-white);
-  cursor: pointer;
-  display: flex;
-  font-size: 12px;
-  gap: 6px;
-  margin-left: auto;
-  white-space: nowrap;
-}
-
 .toolbarCheckbox {
-  accent-color: var(--halo-teal, #5dd4d8);
-  cursor: pointer;
+  margin-left: auto;
 }

--- a/pages/src/components/stats/score-progression/score-progression.tsx
+++ b/pages/src/components/stats/score-progression/score-progression.tsx
@@ -11,13 +11,12 @@ export function ScoreProgression({
   hasDelta,
   hasPlayerAdvantage,
   showPlayerAdvantage,
+  showToolbar,
   deltaViewModel,
   progressionViewModel,
   onChartTypeChange,
   onPlayerAdvantageToggle,
 }: ScoreProgressionViewModel): React.ReactElement {
-  const showToolbar = hasDelta || hasPlayerAdvantage;
-
   return (
     <div className={styles.container}>
       {showToolbar && (

--- a/pages/src/components/stats/score-progression/score-progression.tsx
+++ b/pages/src/components/stats/score-progression/score-progression.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Checkbox } from "../../checkbox/checkbox";
 import { Select } from "../../select/select";
 import { DeltaChart } from "./delta-chart/delta-chart";
 import { ProgressionChart } from "./progression-chart/progression-chart";
@@ -15,7 +16,7 @@ export function ScoreProgression({
   deltaViewModel,
   progressionViewModel,
   onChartTypeChange,
-  onPlayerAdvantageToggle,
+  onPlayerAdvantageChange,
 }: ScoreProgressionViewModel): React.ReactElement {
   return (
     <div className={styles.container}>
@@ -40,15 +41,12 @@ export function ScoreProgression({
             </>
           )}
           {hasPlayerAdvantage && (
-            <label className={styles.toolbarCheckboxLabel}>
-              <input
-                type="checkbox"
-                checked={showPlayerAdvantage}
-                onChange={onPlayerAdvantageToggle}
-                className={styles.toolbarCheckbox}
-              />
-              Player Advantage
-            </label>
+            <Checkbox
+              checked={showPlayerAdvantage}
+              onChange={onPlayerAdvantageChange}
+              label="Player Advantage"
+              className={styles.toolbarCheckbox}
+            />
           )}
         </div>
       )}

--- a/pages/src/components/stats/score-progression/score-progression.tsx
+++ b/pages/src/components/stats/score-progression/score-progression.tsx
@@ -9,28 +9,48 @@ export function ScoreProgression({
   ariaLabel,
   effectiveChartType,
   hasDelta,
+  hasPlayerAdvantage,
+  showPlayerAdvantage,
   deltaViewModel,
   progressionViewModel,
   onChartTypeChange,
+  onPlayerAdvantageToggle,
 }: ScoreProgressionViewModel): React.ReactElement {
+  const showToolbar = hasDelta || hasPlayerAdvantage;
+
   return (
     <div className={styles.container}>
-      {hasDelta && (
+      {showToolbar && (
         <div className={styles.toolbar}>
-          <label htmlFor="chart-type-select" className={styles.toolbarLabel}>
-            Chart type
-          </label>
-          <Select
-            id="chart-type-select"
-            containerClassName={styles.toolbarSelect}
-            value={effectiveChartType}
-            onChange={(e) => {
-              onChartTypeChange(e.target.value);
-            }}
-          >
-            <option value="progression">Score Progression</option>
-            <option value="delta">Score Delta</option>
-          </Select>
+          {hasDelta && (
+            <>
+              <label htmlFor="chart-type-select" className={styles.toolbarLabel}>
+                Chart type
+              </label>
+              <Select
+                id="chart-type-select"
+                containerClassName={styles.toolbarSelect}
+                value={effectiveChartType}
+                onChange={(e) => {
+                  onChartTypeChange(e.target.value);
+                }}
+              >
+                <option value="progression">Score Progression</option>
+                <option value="delta">Score Delta</option>
+              </Select>
+            </>
+          )}
+          {hasPlayerAdvantage && (
+            <label className={styles.toolbarCheckboxLabel}>
+              <input
+                type="checkbox"
+                checked={showPlayerAdvantage}
+                onChange={onPlayerAdvantageToggle}
+                className={styles.toolbarCheckbox}
+              />
+              Player Advantage
+            </label>
+          )}
         </div>
       )}
       <div role="img" aria-label={ariaLabel}>

--- a/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
@@ -316,5 +316,21 @@ describe("formatScoreProgression", () => {
       expect(result?.playerAdvantage?.maxScore).toBe(1);
       expect(result?.playerAdvantage?.zeroFraction).toBe(0.5);
     });
+
+    it("bounds minScore and maxScore to ±teamSize when teamSize is provided", () => {
+      const data = aFakeScoreProgressionWith({
+        respawnDurationMs: 8000,
+        durationMs: 30000,
+        timeline: {
+          type: "kill-race",
+          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+          deathTimeline: [{ timestampMs: 5001, teamId: 1 }],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS, 4);
+      expect(result?.playerAdvantage?.minScore).toBe(-4);
+      expect(result?.playerAdvantage?.maxScore).toBe(4);
+      expect(result?.playerAdvantage?.zeroFraction).toBe(0.5);
+    });
   });
 });

--- a/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
@@ -273,11 +273,28 @@ describe("formatScoreProgression", () => {
         },
       });
       const result = formatScoreProgression(data, TEAM_COLORS);
-      // respawn at 5001 + 8000 = 13001 is past durationMs=10000 — no completion event
       expect(result?.playerAdvantage?.points).toEqual([
         { timestampMs: 0, score: 0 },
         { timestampMs: 5001, score: 1 },
         { timestampMs: 10000, score: 1 },
+      ]);
+    });
+
+    it("omits respawn completion when respawnTs equals durationMs, avoiding duplicate terminal point", () => {
+      const data = aFakeScoreProgressionWith({
+        respawnDurationMs: 8000,
+        durationMs: 13001,
+        timeline: {
+          type: "kill-race",
+          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+          deathTimeline: [{ timestampMs: 5001, teamId: 1 }],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.playerAdvantage?.points).toEqual([
+        { timestampMs: 0, score: 0 },
+        { timestampMs: 5001, score: 1 },
+        { timestampMs: 13001, score: 1 },
       ]);
     });
 

--- a/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
@@ -186,4 +186,118 @@ describe("formatScoreProgression", () => {
       expect(result?.scoreDelta).toBeNull();
     });
   });
+
+  describe("playerAdvantage", () => {
+    it("returns null playerAdvantage when respawnDurationMs is null", () => {
+      const data = aFakeScoreProgressionWith({ respawnDurationMs: null });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.playerAdvantage).toBeNull();
+    });
+
+    it("returns null playerAdvantage when deathTimeline is empty", () => {
+      const data = aFakeScoreProgressionWith({
+        respawnDurationMs: 8000,
+        timeline: {
+          type: "kill-race",
+          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+          deathTimeline: [],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.playerAdvantage).toBeNull();
+    });
+
+    it("returns null playerAdvantage when advantage never changes from 0", () => {
+      const data = aFakeScoreProgressionWith({
+        respawnDurationMs: 8000,
+        durationMs: 30000,
+        timeline: {
+          type: "kill-race",
+          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+          deathTimeline: [
+            { timestampMs: 5000, teamId: 0 },
+            { timestampMs: 5000, teamId: 1 },
+          ],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.playerAdvantage).toBeNull();
+    });
+
+    it("computes positive advantage when team 1 has a player respawning", () => {
+      const data = aFakeScoreProgressionWith({
+        respawnDurationMs: 8000,
+        durationMs: 30000,
+        timeline: {
+          type: "kill-race",
+          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+          deathTimeline: [{ timestampMs: 5001, teamId: 1 }],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.playerAdvantage?.points).toEqual([
+        { timestampMs: 0, score: 0 },
+        { timestampMs: 5001, score: 1 },
+        { timestampMs: 13001, score: 0 },
+        { timestampMs: 30000, score: 0 },
+      ]);
+    });
+
+    it("computes negative advantage when team 0 has a player respawning", () => {
+      const data = aFakeScoreProgressionWith({
+        respawnDurationMs: 8000,
+        durationMs: 30000,
+        timeline: {
+          type: "kill-race",
+          events: [{ timestampMs: 12000, teamId: 1, runningScores: { "0": 0, "1": 1 } }],
+          deathTimeline: [{ timestampMs: 12001, teamId: 0 }],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.playerAdvantage?.points).toEqual([
+        { timestampMs: 0, score: 0 },
+        { timestampMs: 12001, score: -1 },
+        { timestampMs: 20001, score: 0 },
+        { timestampMs: 30000, score: 0 },
+      ]);
+    });
+
+    it("omits respawn completion points past durationMs", () => {
+      const data = aFakeScoreProgressionWith({
+        respawnDurationMs: 8000,
+        durationMs: 10000,
+        timeline: {
+          type: "kill-race",
+          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+          deathTimeline: [{ timestampMs: 5001, teamId: 1 }],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      // respawn at 5001 + 8000 = 13001 is past durationMs=10000 — no completion event
+      expect(result?.playerAdvantage?.points).toEqual([
+        { timestampMs: 0, score: 0 },
+        { timestampMs: 5001, score: 1 },
+        { timestampMs: 10000, score: 1 },
+      ]);
+    });
+
+    it("sets minScore, maxScore and zeroFraction from computed points", () => {
+      const data = aFakeScoreProgressionWith({
+        respawnDurationMs: 8000,
+        durationMs: 30000,
+        timeline: {
+          type: "kill-race",
+          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+          deathTimeline: [
+            { timestampMs: 5001, teamId: 1 },
+            { timestampMs: 12001, teamId: 0 },
+          ],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.playerAdvantage?.minScore).toBe(-1);
+      expect(result?.playerAdvantage?.maxScore).toBe(1);
+      expect(result?.playerAdvantage?.zeroFraction).toBe(0.5);
+    });
+  });
 });

--- a/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
@@ -117,7 +117,7 @@ describe("formatScoreProgression", () => {
       expect(result?.scoreDelta?.maxScore).toBe(1);
     });
 
-    it("sets zeroFraction to maxScore / range for mixed positive and negative deltas", () => {
+    it("sets minScore and maxScore for mixed positive and negative deltas", () => {
       const data = aFakeScoreProgressionWith({
         timeline: {
           type: "kill-race",
@@ -132,31 +132,6 @@ describe("formatScoreProgression", () => {
       const result = formatScoreProgression(data, TEAM_COLORS);
       expect(result?.scoreDelta?.minScore).toBe(-1);
       expect(result?.scoreDelta?.maxScore).toBe(1);
-      expect(result?.scoreDelta?.zeroFraction).toBe(0.5);
-    });
-
-    it("sets zeroFraction to 0 when team1 always leads", () => {
-      const data = aFakeScoreProgressionWith({
-        timeline: {
-          type: "kill-race",
-          events: [{ timestampMs: 5000, teamId: 1, runningScores: { "0": 0, "1": 1 } }],
-          deathTimeline: [],
-        },
-      });
-      const result = formatScoreProgression(data, TEAM_COLORS);
-      expect(result?.scoreDelta?.zeroFraction).toBe(0);
-    });
-
-    it("sets zeroFraction to 1 when team0 always leads", () => {
-      const data = aFakeScoreProgressionWith({
-        timeline: {
-          type: "kill-race",
-          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
-          deathTimeline: [],
-        },
-      });
-      const result = formatScoreProgression(data, TEAM_COLORS);
-      expect(result?.scoreDelta?.zeroFraction).toBe(1);
     });
 
     it("returns null scoreDelta when only one team is present", () => {
@@ -298,7 +273,7 @@ describe("formatScoreProgression", () => {
       ]);
     });
 
-    it("sets minScore, maxScore and zeroFraction from computed points", () => {
+    it("sets minScore and maxScore from computed points", () => {
       const data = aFakeScoreProgressionWith({
         respawnDurationMs: 8000,
         durationMs: 30000,
@@ -314,7 +289,6 @@ describe("formatScoreProgression", () => {
       const result = formatScoreProgression(data, TEAM_COLORS);
       expect(result?.playerAdvantage?.minScore).toBe(-1);
       expect(result?.playerAdvantage?.maxScore).toBe(1);
-      expect(result?.playerAdvantage?.zeroFraction).toBe(0.5);
     });
 
     it("bounds minScore and maxScore to ±teamSize when teamSize is provided", () => {
@@ -330,7 +304,6 @@ describe("formatScoreProgression", () => {
       const result = formatScoreProgression(data, TEAM_COLORS, 4);
       expect(result?.playerAdvantage?.minScore).toBe(-4);
       expect(result?.playerAdvantage?.maxScore).toBe(4);
-      expect(result?.playerAdvantage?.zeroFraction).toBe(0.5);
     });
   });
 });

--- a/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
@@ -146,6 +146,18 @@ describe("formatScoreProgression", () => {
       expect(result?.scoreDelta).toBeNull();
     });
 
+    it("returns null scoreDelta when more than 2 teams are present", () => {
+      const data = aFakeScoreProgressionWith({
+        timeline: {
+          type: "kill-race",
+          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0, "2": 0 } }],
+          deathTimeline: [],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.scoreDelta).toBeNull();
+    });
+
     it("returns null scoreDelta when all deltas are 0 (perfectly tied match)", () => {
       const data = aFakeScoreProgressionWith({
         timeline: {
@@ -163,6 +175,19 @@ describe("formatScoreProgression", () => {
   });
 
   describe("playerAdvantage", () => {
+    it("returns null playerAdvantage when more than 2 teams are present", () => {
+      const data = aFakeScoreProgressionWith({
+        respawnDurationMs: 8000,
+        timeline: {
+          type: "kill-race",
+          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0, "2": 0 } }],
+          deathTimeline: [{ timestampMs: 5001, teamId: 1 }],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.playerAdvantage).toBeNull();
+    });
+
     it("returns null playerAdvantage when respawnDurationMs is null", () => {
       const data = aFakeScoreProgressionWith({ respawnDurationMs: null });
       const result = formatScoreProgression(data, TEAM_COLORS);

--- a/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
@@ -128,6 +128,30 @@ describe("ScoreProgressionPresenter", () => {
     });
   });
 
+  describe("showToolbar", () => {
+    it("sets showToolbar true when scoreDelta is non-null", () => {
+      const { store, presenter } = makePresenter();
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
+      expect(model.showToolbar).toBe(true);
+    });
+
+    it("sets showToolbar true when playerAdvantage is non-null", () => {
+      const { store, presenter } = makePresenter();
+      const model = presenter.present(store.getSnapshot(), {
+        ...BASE_INPUT,
+        scoreDelta: null,
+        playerAdvantage: aFakePlayerAdvantageData(),
+      });
+      expect(model.showToolbar).toBe(true);
+    });
+
+    it("sets showToolbar false when both scoreDelta and playerAdvantage are null", () => {
+      const { store, presenter } = makePresenter();
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: null });
+      expect(model.showToolbar).toBe(false);
+    });
+  });
+
   describe("player advantage", () => {
     it("sets hasPlayerAdvantage true when playerAdvantage is non-null", () => {
       const { store, presenter } = makePresenter();

--- a/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
@@ -190,6 +190,32 @@ describe("ScoreProgressionPresenter", () => {
       });
       expect(model.progressionViewModel.playerAdvantage).toBe(advantage);
     });
+
+    it("symmetrizes scoreDelta domain when playerAdvantage is shown", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ showPlayerAdvantage: true, chartType: "delta" });
+      const model = presenter.present(store.getSnapshot(), {
+        ...BASE_INPUT,
+        scoreDelta: { ...aFakeScoreDeltaData(), minScore: -1, maxScore: 3, zeroFraction: 0.75 },
+        playerAdvantage: aFakePlayerAdvantageData(),
+      });
+      expect(model.deltaViewModel?.scoreDelta.minScore).toBe(-3);
+      expect(model.deltaViewModel?.scoreDelta.maxScore).toBe(3);
+      expect(model.deltaViewModel?.scoreDelta.zeroFraction).toBe(0.5);
+    });
+
+    it("preserves original scoreDelta domain when playerAdvantage is hidden", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ chartType: "delta" });
+      const model = presenter.present(store.getSnapshot(), {
+        ...BASE_INPUT,
+        scoreDelta: { ...aFakeScoreDeltaData(), minScore: -1, maxScore: 3, zeroFraction: 0.75 },
+        playerAdvantage: aFakePlayerAdvantageData(),
+      });
+      expect(model.deltaViewModel?.scoreDelta.minScore).toBe(-1);
+      expect(model.deltaViewModel?.scoreDelta.maxScore).toBe(3);
+      expect(model.deltaViewModel?.scoreDelta.zeroFraction).toBe(0.75);
+    });
   });
 
   describe("onChartTypeChange()", () => {

--- a/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
@@ -126,6 +126,27 @@ describe("ScoreProgressionPresenter", () => {
       const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
       expect(model.deltaViewModel?.tooltipFormatter(NaN)).toEqual(["Tied", "Score Delta"]);
     });
+
+    it("deltaViewModel.advantageTooltipFormatter returns team0Name leading on positive advantage", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ chartType: "delta" });
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
+      expect(model.deltaViewModel?.advantageTooltipFormatter(2)).toEqual(["Eagle +2", "Player Advantage"]);
+    });
+
+    it("deltaViewModel.advantageTooltipFormatter returns team1Name leading on negative advantage", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ chartType: "delta" });
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
+      expect(model.deltaViewModel?.advantageTooltipFormatter(-1)).toEqual(["Cobra +1", "Player Advantage"]);
+    });
+
+    it("deltaViewModel.advantageTooltipFormatter returns Even when value is 0", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ chartType: "delta" });
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
+      expect(model.deltaViewModel?.advantageTooltipFormatter(0)).toEqual(["Even", "Player Advantage"]);
+    });
   });
 
   describe("showToolbar", () => {

--- a/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { ScoreProgressionPresenter } from "../score-progression-presenter";
 import { ScoreProgressionStore } from "../score-progression-store";
-import type { ScoreDeltaData, ScoreProgressionTeamLine } from "../types";
+import type { PlayerAdvantageData, ScoreDeltaData, ScoreProgressionTeamLine } from "../types";
 
 const aFakeScoreDeltaData = (): ScoreDeltaData => ({
   points: [
@@ -27,9 +27,21 @@ function makePresenter(): { store: ScoreProgressionStore; presenter: ScoreProgre
   return { store, presenter };
 }
 
+const aFakePlayerAdvantageData = (): PlayerAdvantageData => ({
+  points: [
+    { timestampMs: 0, score: 0 },
+    { timestampMs: 5100, score: 1 },
+    { timestampMs: 600000, score: 1 },
+  ],
+  minScore: 0,
+  maxScore: 1,
+  zeroFraction: 1,
+});
+
 const BASE_INPUT = {
   durationMs: 600000,
   teamLines: [aFakeTeamLine("Eagle", "#f00", 0), aFakeTeamLine("Cobra", "#00f", 1)],
+  playerAdvantage: null,
   ariaLabel: "test chart",
 };
 
@@ -113,6 +125,46 @@ describe("ScoreProgressionPresenter", () => {
       store.update({ chartType: "delta" });
       const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: aFakeScoreDeltaData() });
       expect(model.deltaViewModel?.tooltipFormatter(NaN)).toEqual(["Tied", "Score Delta"]);
+    });
+  });
+
+  describe("player advantage", () => {
+    it("sets hasPlayerAdvantage true when playerAdvantage is non-null", () => {
+      const { store, presenter } = makePresenter();
+      const model = presenter.present(store.getSnapshot(), {
+        ...BASE_INPUT,
+        scoreDelta: null,
+        playerAdvantage: aFakePlayerAdvantageData(),
+      });
+      expect(model.hasPlayerAdvantage).toBe(true);
+    });
+
+    it("sets hasPlayerAdvantage false when playerAdvantage is null", () => {
+      const { store, presenter } = makePresenter();
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: null });
+      expect(model.hasPlayerAdvantage).toBe(false);
+    });
+
+    it("passes null playerAdvantage to progressionViewModel when showPlayerAdvantage is false", () => {
+      const { store, presenter } = makePresenter();
+      const model = presenter.present(store.getSnapshot(), {
+        ...BASE_INPUT,
+        scoreDelta: null,
+        playerAdvantage: aFakePlayerAdvantageData(),
+      });
+      expect(model.progressionViewModel.playerAdvantage).toBeNull();
+    });
+
+    it("passes playerAdvantage to progressionViewModel when showPlayerAdvantage is true", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ showPlayerAdvantage: true });
+      const advantage = aFakePlayerAdvantageData();
+      const model = presenter.present(store.getSnapshot(), {
+        ...BASE_INPUT,
+        scoreDelta: null,
+        playerAdvantage: advantage,
+      });
+      expect(model.progressionViewModel.playerAdvantage).toBe(advantage);
     });
   });
 

--- a/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
@@ -239,6 +239,34 @@ describe("ScoreProgressionPresenter", () => {
     });
   });
 
+  describe("progressionViewModel.tooltipFormatter", () => {
+    it("formats Player Advantage series with leading team name", () => {
+      const { store, presenter } = makePresenter();
+      store.update({ showPlayerAdvantage: true });
+      const model = presenter.present(store.getSnapshot(), {
+        ...BASE_INPUT,
+        scoreDelta: null,
+        playerAdvantage: aFakePlayerAdvantageData(),
+      });
+      expect(model.progressionViewModel.tooltipFormatter(2, "Player Advantage")).toEqual([
+        "Eagle +2",
+        "Player Advantage",
+      ]);
+      expect(model.progressionViewModel.tooltipFormatter(-1, "Player Advantage")).toEqual([
+        "Cobra +1",
+        "Player Advantage",
+      ]);
+      expect(model.progressionViewModel.tooltipFormatter(0, "Player Advantage")).toEqual(["Even", "Player Advantage"]);
+    });
+
+    it("passes through team line series unchanged", () => {
+      const { store, presenter } = makePresenter();
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: null });
+      expect(model.progressionViewModel.tooltipFormatter(5, "Eagle")).toEqual(["5", "Eagle"]);
+      expect(model.progressionViewModel.tooltipFormatter(3, "Cobra")).toEqual(["3", "Cobra"]);
+    });
+  });
+
   describe("onChartTypeChange()", () => {
     it("updates the store to delta", () => {
       const { store, presenter } = makePresenter();

--- a/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
@@ -11,7 +11,6 @@ const aFakeScoreDeltaData = (): ScoreDeltaData => ({
   ],
   minScore: 0,
   maxScore: 1,
-  zeroFraction: 1,
 });
 
 const aFakeTeamLine = (name: string, color: string, teamId = 0): ScoreProgressionTeamLine => ({
@@ -35,7 +34,6 @@ const aFakePlayerAdvantageData = (): PlayerAdvantageData => ({
   ],
   minScore: 0,
   maxScore: 1,
-  zeroFraction: 1,
 });
 
 const BASE_INPUT = {
@@ -217,12 +215,11 @@ describe("ScoreProgressionPresenter", () => {
       store.update({ showPlayerAdvantage: true, chartType: "delta" });
       const model = presenter.present(store.getSnapshot(), {
         ...BASE_INPUT,
-        scoreDelta: { ...aFakeScoreDeltaData(), minScore: -1, maxScore: 3, zeroFraction: 0.75 },
+        scoreDelta: { ...aFakeScoreDeltaData(), minScore: -1, maxScore: 3 },
         playerAdvantage: aFakePlayerAdvantageData(),
       });
       expect(model.deltaViewModel?.scoreDelta.minScore).toBe(-3);
       expect(model.deltaViewModel?.scoreDelta.maxScore).toBe(3);
-      expect(model.deltaViewModel?.scoreDelta.zeroFraction).toBe(0.5);
     });
 
     it("preserves original scoreDelta domain when playerAdvantage is hidden", () => {
@@ -230,12 +227,11 @@ describe("ScoreProgressionPresenter", () => {
       store.update({ chartType: "delta" });
       const model = presenter.present(store.getSnapshot(), {
         ...BASE_INPUT,
-        scoreDelta: { ...aFakeScoreDeltaData(), minScore: -1, maxScore: 3, zeroFraction: 0.75 },
+        scoreDelta: { ...aFakeScoreDeltaData(), minScore: -1, maxScore: 3 },
         playerAdvantage: aFakePlayerAdvantageData(),
       });
       expect(model.deltaViewModel?.scoreDelta.minScore).toBe(-1);
       expect(model.deltaViewModel?.scoreDelta.maxScore).toBe(3);
-      expect(model.deltaViewModel?.scoreDelta.zeroFraction).toBe(0.75);
     });
   });
 

--- a/pages/src/components/stats/score-progression/types.ts
+++ b/pages/src/components/stats/score-progression/types.ts
@@ -49,6 +49,10 @@ export interface ScoreProgressionProgressionViewModel {
   readonly durationMs: number;
   readonly teamLines: readonly ScoreProgressionTeamLine[];
   readonly playerAdvantage: PlayerAdvantageData | null;
+  readonly tooltipFormatter: (
+    value: number | string | readonly (number | string)[] | undefined,
+    name: string | number | undefined,
+  ) => [string, string];
 }
 
 export interface ScoreProgressionViewModel {

--- a/pages/src/components/stats/score-progression/types.ts
+++ b/pages/src/components/stats/score-progression/types.ts
@@ -17,10 +17,18 @@ export interface ScoreDeltaData {
   readonly zeroFraction: number;
 }
 
+export interface PlayerAdvantageData {
+  readonly points: readonly ScoreProgressionPoint[];
+  readonly minScore: number;
+  readonly maxScore: number;
+  readonly zeroFraction: number;
+}
+
 export interface ScoreProgressionViewData {
   readonly durationMs: number;
   readonly teamLines: readonly ScoreProgressionTeamLine[];
   readonly scoreDelta: ScoreDeltaData | null;
+  readonly playerAdvantage: PlayerAdvantageData | null;
 }
 
 export type ChartType = "progression" | "delta";
@@ -30,19 +38,24 @@ export interface ScoreProgressionDeltaViewModel {
   readonly scoreDelta: ScoreDeltaData;
   readonly team0Color: string;
   readonly team1Color: string;
+  readonly playerAdvantage: PlayerAdvantageData | null;
   readonly tooltipFormatter: (value: number | string | readonly (number | string)[] | undefined) => [string, string];
 }
 
 export interface ScoreProgressionProgressionViewModel {
   readonly durationMs: number;
   readonly teamLines: readonly ScoreProgressionTeamLine[];
+  readonly playerAdvantage: PlayerAdvantageData | null;
 }
 
 export interface ScoreProgressionViewModel {
   readonly ariaLabel: string;
   readonly effectiveChartType: ChartType;
   readonly hasDelta: boolean;
+  readonly hasPlayerAdvantage: boolean;
+  readonly showPlayerAdvantage: boolean;
   readonly deltaViewModel: ScoreProgressionDeltaViewModel | null;
   readonly progressionViewModel: ScoreProgressionProgressionViewModel;
   readonly onChartTypeChange: (value: string) => void;
+  readonly onPlayerAdvantageToggle: () => void;
 }

--- a/pages/src/components/stats/score-progression/types.ts
+++ b/pages/src/components/stats/score-progression/types.ts
@@ -58,5 +58,5 @@ export interface ScoreProgressionViewModel {
   readonly deltaViewModel: ScoreProgressionDeltaViewModel | null;
   readonly progressionViewModel: ScoreProgressionProgressionViewModel;
   readonly onChartTypeChange: (value: string) => void;
-  readonly onPlayerAdvantageToggle: () => void;
+  readonly onPlayerAdvantageChange: (checked: boolean) => void;
 }

--- a/pages/src/components/stats/score-progression/types.ts
+++ b/pages/src/components/stats/score-progression/types.ts
@@ -54,6 +54,7 @@ export interface ScoreProgressionViewModel {
   readonly hasDelta: boolean;
   readonly hasPlayerAdvantage: boolean;
   readonly showPlayerAdvantage: boolean;
+  readonly showToolbar: boolean;
   readonly deltaViewModel: ScoreProgressionDeltaViewModel | null;
   readonly progressionViewModel: ScoreProgressionProgressionViewModel;
   readonly onChartTypeChange: (value: string) => void;

--- a/pages/src/components/stats/score-progression/types.ts
+++ b/pages/src/components/stats/score-progression/types.ts
@@ -40,6 +40,9 @@ export interface ScoreProgressionDeltaViewModel {
   readonly team1Color: string;
   readonly playerAdvantage: PlayerAdvantageData | null;
   readonly tooltipFormatter: (value: number | string | readonly (number | string)[] | undefined) => [string, string];
+  readonly advantageTooltipFormatter: (
+    value: number | string | readonly (number | string)[] | undefined,
+  ) => [string, string];
 }
 
 export interface ScoreProgressionProgressionViewModel {

--- a/pages/src/components/stats/score-progression/types.ts
+++ b/pages/src/components/stats/score-progression/types.ts
@@ -14,14 +14,12 @@ export interface ScoreDeltaData {
   readonly points: readonly ScoreProgressionPoint[];
   readonly minScore: number;
   readonly maxScore: number;
-  readonly zeroFraction: number;
 }
 
 export interface PlayerAdvantageData {
   readonly points: readonly ScoreProgressionPoint[];
   readonly minScore: number;
   readonly maxScore: number;
-  readonly zeroFraction: number;
 }
 
 export interface ScoreProgressionViewData {

--- a/pages/src/components/stats/tests/match-stats.test.tsx
+++ b/pages/src/components/stats/tests/match-stats.test.tsx
@@ -220,7 +220,12 @@ describe("MatchStats", () => {
 
   it("falls back to Players tab when Timeline is active and scoreProgressionViewData becomes null", () => {
     const data = [aFakeMatchStatsDataWith({ teamId: 0 })];
-    const scoreProgressionViewData: ScoreProgressionViewData = { durationMs: 600000, teamLines: [], scoreDelta: null };
+    const scoreProgressionViewData: ScoreProgressionViewData = {
+      durationMs: 600000,
+      teamLines: [],
+      scoreDelta: null,
+      playerAdvantage: null,
+    };
     const baseProps = {
       data,
       id: "match-1",

--- a/shared/src/contracts/stats/match-analytics.ts
+++ b/shared/src/contracts/stats/match-analytics.ts
@@ -11,6 +11,9 @@ const killRaceDeathEventSchema = z.object({
   teamId: z.number().int().nonnegative(),
 });
 
+export type KillRaceEvent = z.infer<typeof killRaceEventSchema>;
+export type KillRaceDeathEvent = z.infer<typeof killRaceDeathEventSchema>;
+
 const killRaceTimelineSchema = z.object({
   type: z.literal("kill-race"),
   events: z.array(killRaceEventSchema),


### PR DESCRIPTION
## Context

This is PR 13 of 13 in the kill matrix improvements plan. The plan has progressively enhanced the match analytics Timeline tab — from the basic score progression chart through score delta, respawn duration data, and now a player advantage overlay that shows how many more active players one team had at any given moment during a match.

Player advantage is computed from the `deathTimeline` and backend-supplied `respawnDurationMs` field added in PR 12. A death event adds +1 respawning for that team; a respawn completion (death timestamp + respawn duration, if before match end) subtracts 1. The sign convention matches the score delta: positive = team 0 (Eagle) has more active players.

## This change

- **`buildPlayerAdvantage` formatter**: Computes advantage points from the `deathTimeline` using respawn windows. Returns `null` when `respawnDurationMs` is null (Attrition) or when advantage is flat-zero throughout (no useful signal).
- **Overlay rendering**: A dotted step-line with no fill rendered as a secondary right-hand Y-axis in both the progression and delta charts. The stroke uses the same dual-color `linearGradient` pattern as the delta chart — team 0 color above zero, team 1 color below.
- **Toolbar checkbox**: "Player Advantage" checkbox pushed to the far right of the toolbar via `margin-left: auto`. Only shown when `playerAdvantage` data is non-null. The toolbar itself now appears when either the chart-type selector or the checkbox is relevant.
- **Store/presenter pattern**: `showPlayerAdvantage: boolean` added to the store snapshot (default `false`). `ScoreProgressionPresenter.present()` gates the effective advantage value through this toggle and computes `showToolbar` as a pre-derived prop.