### PR TITLE
feat(score-progression): use neutral color for player advantage line

### DIFF
--- a/pages/src/components/stats/score-progression/chart-constants.ts
+++ b/pages/src/components/stats/score-progression/chart-constants.ts
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 export const GRID_STROKE = "rgba(93, 212, 216, 0.12)";
 export const AXIS_STROKE = "rgba(93, 212, 216, 0.3)";
 export const TICK_FILL = "#8fa3b0";
+export const ADVANTAGE_STROKE = "#e8f4f8";
 export const TICK_FONT_SIZE = 11;
 
 export const tooltipContentStyle = {

--- a/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
+++ b/pages/src/components/stats/score-progression/delta-chart/delta-chart.tsx
@@ -12,6 +12,7 @@ import {
   useYAxisScale,
 } from "recharts";
 import {
+  ADVANTAGE_STROKE,
   AXIS_STROKE,
   CHART_HEIGHT,
   CHART_MARGIN,
@@ -28,22 +29,17 @@ import type { ScoreProgressionDeltaViewModel } from "../types";
 interface DeltaChartGradientsProps {
   readonly fillGradientId: string;
   readonly strokeGradientId: string;
-  readonly advantageGradientId: string;
   readonly team0Color: string;
   readonly team1Color: string;
-  readonly hasPlayerAdvantage: boolean;
 }
 
 function DeltaChartGradients({
   fillGradientId,
   strokeGradientId,
-  advantageGradientId,
   team0Color,
   team1Color,
-  hasPlayerAdvantage,
 }: DeltaChartGradientsProps): React.ReactElement | null {
   const deltaScale = useYAxisScale(0);
-  const advantageScale = useYAxisScale("advantage");
   const plotArea = usePlotArea();
   if (deltaScale == null || plotArea == null) {
     return null;
@@ -54,8 +50,6 @@ function DeltaChartGradients({
     return null;
   }
   const deltaOffset = `${((deltaZeroY / height) * 100).toFixed(2)}%`;
-  const advantageZeroY = advantageScale?.(0);
-  const advantageOffset = advantageZeroY != null ? `${((advantageZeroY / height) * 100).toFixed(2)}%` : "50%";
 
   return (
     <defs>
@@ -68,12 +62,6 @@ function DeltaChartGradients({
         <stop offset={deltaOffset} stopColor={team0Color} />
         <stop offset={deltaOffset} stopColor={team1Color} />
       </linearGradient>
-      {hasPlayerAdvantage && (
-        <linearGradient id={advantageGradientId} x1="0" y1={0} x2="0" y2={height} gradientUnits="userSpaceOnUse">
-          <stop offset={advantageOffset} stopColor={team0Color} />
-          <stop offset={advantageOffset} stopColor={team1Color} />
-        </linearGradient>
-      )}
     </defs>
   );
 }
@@ -90,7 +78,6 @@ export function DeltaChart({
   const { points, minScore, maxScore } = scoreDelta;
   const gradientId = React.useId();
   const strokeGradientId = `${gradientId}-stroke`;
-  const advantageGradientId = `${gradientId}-advantage`;
   const margin = playerAdvantage != null ? { ...CHART_MARGIN, right: 36 } : CHART_MARGIN;
   const wrappedTooltipFormatter = (
     value: number | string | readonly (number | string)[] | undefined,
@@ -108,10 +95,8 @@ export function DeltaChart({
         <DeltaChartGradients
           fillGradientId={gradientId}
           strokeGradientId={strokeGradientId}
-          advantageGradientId={advantageGradientId}
           team0Color={team0Color}
           team1Color={team1Color}
-          hasPlayerAdvantage={playerAdvantage != null}
         />
         <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
         <XAxis {...timeAxisProps(durationMs)} />
@@ -153,7 +138,7 @@ export function DeltaChart({
               dataKey="score"
               name="Player Advantage"
               fill="none"
-              stroke={`url(#${advantageGradientId})`}
+              stroke={ADVANTAGE_STROKE}
               strokeWidth={1.5}
               strokeDasharray="3 3"
               dot={false}

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -1,22 +1,11 @@
 import React from "react";
+import { Area, AreaChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
-  Area,
-  AreaChart,
-  CartesianGrid,
-  ReferenceLine,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-  usePlotArea,
-  useYAxisScale,
-} from "recharts";
-import {
+  ADVANTAGE_STROKE,
   AXIS_STROKE,
   CHART_HEIGHT,
   CHART_MARGIN,
   GRID_STROKE,
-  TICK_FILL,
   TICK_STYLE,
   formatAdvantage,
   timeAxisProps,
@@ -26,52 +15,17 @@ import {
 } from "../chart-constants";
 import type { ScoreProgressionProgressionViewModel } from "../types";
 
-interface AdvantageGradientProps {
-  readonly id: string;
-  readonly team0Color: string;
-  readonly team1Color: string;
-}
-
-function AdvantageGradient({ id, team0Color, team1Color }: AdvantageGradientProps): React.ReactElement | null {
-  const advantageScale = useYAxisScale("advantage");
-  const plotArea = usePlotArea();
-  if (advantageScale == null || plotArea == null) {
-    return null;
-  }
-  const { height } = plotArea;
-  const zeroY = advantageScale(0);
-  if (zeroY == null) {
-    return null;
-  }
-  const offset = `${((zeroY / height) * 100).toFixed(2)}%`;
-
-  return (
-    <defs>
-      <linearGradient id={id} x1="0" y1={0} x2="0" y2={height} gradientUnits="userSpaceOnUse">
-        <stop offset={offset} stopColor={team0Color} />
-        <stop offset={offset} stopColor={team1Color} />
-      </linearGradient>
-    </defs>
-  );
-}
-
 export function ProgressionChart({
   durationMs,
   teamLines,
   playerAdvantage,
   tooltipFormatter,
 }: ScoreProgressionProgressionViewModel): React.ReactElement {
-  const advantageGradientId = React.useId();
-  const team0Color = teamLines[0]?.color ?? TICK_FILL;
-  const team1Color = teamLines[1]?.color ?? TICK_FILL;
   const margin = playerAdvantage != null ? { ...CHART_MARGIN, right: 36 } : CHART_MARGIN;
 
   return (
     <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
       <AreaChart margin={margin}>
-        {playerAdvantage != null && (
-          <AdvantageGradient id={advantageGradientId} team0Color={team0Color} team1Color={team1Color} />
-        )}
         <CartesianGrid strokeDasharray="4 4" stroke={GRID_STROKE} />
         <XAxis {...timeAxisProps(durationMs)} />
         <YAxis allowDecimals={false} width={36} stroke={AXIS_STROKE} tick={TICK_STYLE} />
@@ -116,7 +70,7 @@ export function ProgressionChart({
               dataKey="score"
               name="Player Advantage"
               fill="none"
-              stroke={`url(#${advantageGradientId})`}
+              stroke={ADVANTAGE_STROKE}
               strokeWidth={1.5}
               strokeDasharray="3 3"
               dot={false}


### PR DESCRIPTION
## Context

The player advantage overlay is a secondary chart series showing the active-player-count delta (team 0 minus team 1 respawning players). Previously it used a dual-color gradient that matched team colors, making it visually indistinguishable from the score lines it overlays.

## This change

- Replaces the dual-color advantage gradient with a single neutral stroke color (`--halo-white` / `#e8f4f8`) defined as `ADVANTAGE_STROKE` in `chart-constants.ts`
- Removes the `AdvantageGradient` sub-component from `ProgressionChart` entirely (and the associated `usePlotArea`/`useYAxisScale` hook usage it required)
- Removes the advantage gradient branch from `DeltaChartGradients` in `DeltaChart`, simplifying the props interface
- Net result: ~60 lines removed, 1 constant added — the advantage line is now visually distinct as "a different kind of data" rather than a third team score line

🤖 Generated with [Claude Code](https://claude.com/claude-code)