### PR TITLE
feat(kill-matrix): condensed 2-team cross-team view

### DIFF
--- a/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
+++ b/pages/src/components/discord-series-stats/discord-series-stats-presenter.ts
@@ -205,6 +205,8 @@ export class DiscordSeriesStatsPresenter {
     const matchDetails: DiscordSeriesMatchDetail[] = this.renderData.matches.map((match, index) => {
       const rows = matchKillMatrixRows.get(match.matchId);
       const analytics = snapshot.analyticsByMatchId.get(match.matchId) ?? null;
+      const crossTeam =
+        rows != null && orderedPlayers != null ? KillMatrixFormatter.buildCrossTeam(rows, orderedPlayers) : null;
       const base = {
         matchId: match.matchId,
         gameMapThumbnailUrl: match.gameMapThumbnailUrl,
@@ -221,6 +223,8 @@ export class DiscordSeriesStatsPresenter {
           rows != null ? KillMatrixFormatter.pivot(rows, orderedPlayers) : EMPTY_KILL_MATRIX_PIVOT_DATA,
         transposedKillMatrixPivotData:
           rows != null ? KillMatrixFormatter.transpose(rows, orderedPlayers) : EMPTY_KILL_MATRIX_PIVOT_DATA,
+        crossTeamKillMatrixData: crossTeam?.crossTeamData ?? null,
+        swappedCrossTeamKillMatrixData: crossTeam?.swappedCrossTeamData ?? null,
         killMatrixStatus: snapshot.analyticsStatus,
         scoreProgressionViewData: formatScoreProgression(
           analytics?.scoreProgression ?? null,
@@ -244,6 +248,8 @@ export class DiscordSeriesStatsPresenter {
     const aggregatedKillMatrixRows = KillMatrixFormatter.aggregate(
       [...matchKillMatrixRows.values()].flatMap((rows) => rows),
     );
+    const aggregatedCrossTeam =
+      orderedPlayers != null ? KillMatrixFormatter.buildCrossTeam(aggregatedKillMatrixRows, orderedPlayers) : null;
     const seriesStats: DiscordSeriesStatsViewModel["seriesStats"] =
       seriesData != null
         ? {
@@ -253,6 +259,8 @@ export class DiscordSeriesStatsPresenter {
             teamColors,
             killMatrixPivotData: KillMatrixFormatter.pivot(aggregatedKillMatrixRows, orderedPlayers),
             transposedKillMatrixPivotData: KillMatrixFormatter.transpose(aggregatedKillMatrixRows, orderedPlayers),
+            crossTeamKillMatrixData: aggregatedCrossTeam?.crossTeamData ?? null,
+            swappedCrossTeamKillMatrixData: aggregatedCrossTeam?.swappedCrossTeamData ?? null,
             killMatrixStatus: snapshot.analyticsStatus,
           }
         : null;

--- a/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
@@ -178,6 +178,8 @@ export class OverlayPagePresenter {
       .flatMap((teamData) => teamData.players.map((player) => playersByGamertag.get(player.name)))
       .filter((player): player is KillMatrixPlayer => player != null);
     const orderedPlayers = resolvedPlayers.length === players.length ? resolvedPlayers : players;
+    const crossTeam =
+      killMatrixRows != null ? KillMatrixFormatter.buildCrossTeam(killMatrixRows, orderedPlayers) : null;
 
     return {
       status: "loaded",
@@ -196,6 +198,8 @@ export class OverlayPagePresenter {
         killMatrixRows != null
           ? KillMatrixFormatter.transpose(killMatrixRows, orderedPlayers)
           : EMPTY_KILL_MATRIX_PIVOT_DATA,
+      crossTeamKillMatrixData: crossTeam?.crossTeamData ?? null,
+      swappedCrossTeamKillMatrixData: crossTeam?.swappedCrossTeamData ?? null,
       scoreProgressionViewData: null,
     };
   }

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
@@ -491,6 +491,8 @@ export function IndividualTrackerViewer({
                             teamColors={renderModel.teamColors}
                             killMatrixPivotData={state.state.killMatrixPivotData}
                             transposedKillMatrixPivotData={state.state.transposedKillMatrixPivotData}
+                            crossTeamData={state.state.crossTeamKillMatrixData}
+                            swappedCrossTeamData={state.state.swappedCrossTeamKillMatrixData}
                             scoreProgressionViewData={state.state.scoreProgressionViewData}
                             showHeader={false}
                           />

--- a/pages/src/components/individual-tracker/viewer/stats-panel.tsx
+++ b/pages/src/components/individual-tracker/viewer/stats-panel.tsx
@@ -48,6 +48,8 @@ export function StatsPanel({ state }: StatsPanelProps): React.ReactElement | nul
             endTime={state.endTime}
             killMatrixPivotData={state.killMatrixPivotData}
             transposedKillMatrixPivotData={state.transposedKillMatrixPivotData}
+            crossTeamData={state.crossTeamKillMatrixData}
+            swappedCrossTeamData={state.swappedCrossTeamKillMatrixData}
             scoreProgressionViewData={state.scoreProgressionViewData}
           />
         </div>

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -5,7 +5,7 @@ import type { NormalizedMatchOutcome } from "@guilty-spark/shared/halo/match-enr
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { TrackerViewConnectionStatus } from "../../../services/individual-tracker/view-types";
 import type { MatchStatsData } from "../../../controllers/stats/types";
-import type { KillMatrixPivotData } from "../../../controllers/stats/kill-matrix/types";
+import type { KillMatrixCrossTeamData, KillMatrixPivotData } from "../../../controllers/stats/kill-matrix/types";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type { ScoreProgressionViewData } from "../../stats/score-progression/types";
 import type { SeriesStatsViewModel } from "../../series-stats/types";
@@ -123,6 +123,8 @@ export type MatchDetailsState =
       readonly data: MatchStatsData[];
       readonly killMatrixPivotData: KillMatrixPivotData;
       readonly transposedKillMatrixPivotData: KillMatrixPivotData;
+      readonly crossTeamKillMatrixData: KillMatrixCrossTeamData | null;
+      readonly swappedCrossTeamKillMatrixData: KillMatrixCrossTeamData | null;
       readonly scoreProgressionViewData: ScoreProgressionViewData | null;
     }
   | { readonly status: "error"; readonly message: string };

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -114,6 +114,8 @@ function buildSeriesViewModel({
     teamColors,
     killMatrixPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
     transposedKillMatrixPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
+    crossTeamKillMatrixData: null,
+    swappedCrossTeamKillMatrixData: null,
     killMatrixStatus: ComponentLoaderStatus.LOADED,
   };
 
@@ -182,6 +184,8 @@ function buildSeriesViewModel({
       teamColors,
       killMatrixPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
       transposedKillMatrixPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
+      crossTeamKillMatrixData: null,
+      swappedCrossTeamKillMatrixData: null,
       killMatrixStatus: ComponentLoaderStatus.LOADED,
       scoreProgressionViewData: null,
     };
@@ -376,6 +380,8 @@ export class IndividualTrackerViewerPresenter {
       .flatMap((teamData) => teamData.players.map((p) => playersByGamertag.get(p.name)))
       .filter((p): p is KillMatrixPlayer => p != null);
     const orderedPlayers = resolvedPlayers.length === players.length ? resolvedPlayers : players;
+    const crossTeam =
+      killMatrixRows != null ? KillMatrixFormatter.buildCrossTeam(killMatrixRows, orderedPlayers) : null;
 
     return {
       matchId: stats.MatchId,
@@ -393,6 +399,8 @@ export class IndividualTrackerViewerPresenter {
         killMatrixRows != null
           ? KillMatrixFormatter.transpose(killMatrixRows, orderedPlayers)
           : EMPTY_KILL_MATRIX_PIVOT_DATA,
+      crossTeamKillMatrixData: crossTeam?.crossTeamData ?? null,
+      swappedCrossTeamKillMatrixData: crossTeam?.swappedCrossTeamData ?? null,
       scoreProgressionViewData: formatScoreProgression(
         analytics?.scoreProgression ?? null,
         teamColors,

--- a/pages/src/components/individual-tracker/viewer/viewer-store.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-store.ts
@@ -1,7 +1,7 @@
 import type { TrackerLiveMessageView, TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { TrackerViewConnectionStatus } from "../../../services/individual-tracker/view-types";
 import type { MatchStatsData } from "../../../controllers/stats/types";
-import type { KillMatrixPivotData } from "../../../controllers/stats/kill-matrix/types";
+import type { KillMatrixCrossTeamData, KillMatrixPivotData } from "../../../controllers/stats/kill-matrix/types";
 import { ComponentLoaderStatus } from "../../component-loader/component-loader";
 import type { SeriesStatsViewModel } from "../../series-stats/types";
 import type { ScoreProgressionViewData } from "../../stats/score-progression/types";
@@ -17,6 +17,8 @@ export interface MatchEntryLoadedState {
   readonly data: MatchStatsData[];
   readonly killMatrixPivotData: KillMatrixPivotData;
   readonly transposedKillMatrixPivotData: KillMatrixPivotData;
+  readonly crossTeamKillMatrixData: KillMatrixCrossTeamData | null;
+  readonly swappedCrossTeamKillMatrixData: KillMatrixCrossTeamData | null;
   readonly scoreProgressionViewData: ScoreProgressionViewData | null;
 }
 

--- a/pages/src/components/live-tracker/live-tracker-presenter.ts
+++ b/pages/src/components/live-tracker/live-tracker-presenter.ts
@@ -224,14 +224,19 @@ export class LiveTrackerPresenter {
           matchId: match.matchId,
           pivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
           transposedPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
+          crossTeamData: null,
+          swappedCrossTeamData: null,
         };
       }
       const rows = LiveTrackerPresenter.killMatrixFormatter.present({ analytics, playersByXuid });
       matchKillMatrixRows.set(match.matchId, rows);
+      const crossTeam = KillMatrixFormatter.buildCrossTeam(rows, seriesPlayers ?? []);
       return {
         matchId: match.matchId,
         pivotData: KillMatrixFormatter.pivot(rows, seriesPlayers),
         transposedPivotData: KillMatrixFormatter.transpose(rows, seriesPlayers),
+        crossTeamData: crossTeam?.crossTeamData ?? null,
+        swappedCrossTeamData: crossTeam?.swappedCrossTeamData ?? null,
       };
     });
 
@@ -240,12 +245,15 @@ export class LiveTrackerPresenter {
     }
 
     const aggregatedRows = KillMatrixFormatter.aggregate([...matchKillMatrixRows.values()].flatMap((rows) => rows));
+    const aggregatedCrossTeam = KillMatrixFormatter.buildCrossTeam(aggregatedRows, seriesPlayers ?? []);
 
     return {
       allMatchKillMatrix,
       seriesKillMatrix: {
         pivotData: KillMatrixFormatter.pivot(aggregatedRows, seriesPlayers),
         transposedPivotData: KillMatrixFormatter.transpose(aggregatedRows, seriesPlayers),
+        crossTeamData: aggregatedCrossTeam?.crossTeamData ?? null,
+        swappedCrossTeamData: aggregatedCrossTeam?.swappedCrossTeamData ?? null,
       },
     };
   }

--- a/pages/src/components/live-tracker/live-tracker.tsx
+++ b/pages/src/components/live-tracker/live-tracker.tsx
@@ -377,6 +377,8 @@ export function LiveTrackerView(): React.ReactElement {
                   teamColors={teamColorsArray}
                   killMatrixPivotData={seriesKillMatrix?.pivotData}
                   transposedKillMatrixPivotData={seriesKillMatrix?.transposedPivotData}
+                  crossTeamData={seriesKillMatrix?.crossTeamData}
+                  swappedCrossTeamData={seriesKillMatrix?.swappedCrossTeamData}
                   killMatrixStatus={analyticsStatus}
                 />
               </Container>
@@ -442,6 +444,8 @@ export function LiveTrackerView(): React.ReactElement {
                             teamColors={teamColorsArray}
                             killMatrixPivotData={matchKillMatrix?.pivotData}
                             transposedKillMatrixPivotData={matchKillMatrix?.transposedPivotData}
+                            crossTeamData={matchKillMatrix?.crossTeamData}
+                            swappedCrossTeamData={matchKillMatrix?.swappedCrossTeamData}
                             killMatrixStatus={analyticsStatus}
                           />
                         </Container>

--- a/pages/src/components/live-tracker/streamer-overlay/stats-panel.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/stats-panel.tsx
@@ -6,13 +6,15 @@ import { MatchStats as MatchStatsView } from "../../stats/match-stats";
 import { SeriesStats } from "../../stats/series-stats";
 import type { MatchStatsData } from "../../../controllers/stats/types";
 import type { SeriesMetadata } from "../../../controllers/stats/series-metadata";
-import type { KillMatrixPivotData } from "../../../controllers/stats/kill-matrix/types";
+import type { KillMatrixCrossTeamData, KillMatrixPivotData } from "../../../controllers/stats/kill-matrix/types";
 import { PlayerPreSeriesInfo } from "../../player-pre-series-info/player-pre-series-info";
 import type { LiveTrackerMatchRenderModel, LiveTrackerTeamRenderModel } from "../types";
 
 interface KillMatrixData {
   readonly pivotData: KillMatrixPivotData;
   readonly transposedPivotData: KillMatrixPivotData;
+  readonly crossTeamData: KillMatrixCrossTeamData | null;
+  readonly swappedCrossTeamData: KillMatrixCrossTeamData | null;
 }
 
 interface StatsPanelContentProps {
@@ -64,6 +66,8 @@ function StatsPanelContentComponent({
         teamColors={teamColors}
         killMatrixPivotData={seriesKillMatrix?.pivotData}
         transposedKillMatrixPivotData={seriesKillMatrix?.transposedPivotData}
+        crossTeamData={seriesKillMatrix?.crossTeamData}
+        swappedCrossTeamData={seriesKillMatrix?.swappedCrossTeamData}
         killMatrixStatus={analyticsStatus}
       />
     );
@@ -89,6 +93,8 @@ function StatsPanelContentComponent({
         teamColors={teamColors}
         killMatrixPivotData={matchKillMatrix?.pivotData}
         transposedKillMatrixPivotData={matchKillMatrix?.transposedPivotData}
+        crossTeamData={matchKillMatrix?.crossTeamData}
+        swappedCrossTeamData={matchKillMatrix?.swappedCrossTeamData}
         killMatrixStatus={analyticsStatus}
       />
     );

--- a/pages/src/components/live-tracker/types.ts
+++ b/pages/src/components/live-tracker/types.ts
@@ -4,7 +4,11 @@ import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
 import type { MatchStatsData } from "../../controllers/stats/types";
 import type { SeriesMetadata } from "../../controllers/stats/series-metadata";
 import type { ComponentLoaderStatus } from "../component-loader/component-loader";
-import type { KillMatrixPivotData, KillMatrixPlayer } from "../../controllers/stats/kill-matrix/types";
+import type {
+  KillMatrixCrossTeamData,
+  KillMatrixPivotData,
+  KillMatrixPlayer,
+} from "../../controllers/stats/kill-matrix/types";
 import type { LiveTrackerParams } from "./live-tracker-store";
 
 export interface LiveTrackerSeriesStatsData {
@@ -95,11 +99,15 @@ export interface MatchKillMatrix {
   readonly matchId: string;
   readonly pivotData: KillMatrixPivotData;
   readonly transposedPivotData: KillMatrixPivotData;
+  readonly crossTeamData: KillMatrixCrossTeamData | null;
+  readonly swappedCrossTeamData: KillMatrixCrossTeamData | null;
 }
 
 export interface KillMatrixResult {
   readonly pivotData: KillMatrixPivotData;
   readonly transposedPivotData: KillMatrixPivotData;
+  readonly crossTeamData: KillMatrixCrossTeamData | null;
+  readonly swappedCrossTeamData: KillMatrixCrossTeamData | null;
 }
 
 export interface LiveTrackerViewModel {

--- a/pages/src/components/series-stats/series-stats.tsx
+++ b/pages/src/components/series-stats/series-stats.tsx
@@ -78,6 +78,8 @@ function MatchDetailSection({ detail, noGutter }: MatchDetailSectionProps): Reac
           teamColors={detail.teamColors}
           killMatrixPivotData={detail.killMatrixPivotData}
           transposedKillMatrixPivotData={detail.transposedKillMatrixPivotData}
+          crossTeamData={detail.crossTeamKillMatrixData}
+          swappedCrossTeamData={detail.swappedCrossTeamKillMatrixData}
           killMatrixStatus={detail.killMatrixStatus}
           scoreProgressionViewData={detail.scoreProgressionViewData}
         />
@@ -130,6 +132,8 @@ export function SeriesStatsView({
             teamColors={seriesStats.teamColors}
             killMatrixPivotData={seriesStats.killMatrixPivotData}
             transposedKillMatrixPivotData={seriesStats.transposedKillMatrixPivotData}
+            crossTeamData={seriesStats.crossTeamKillMatrixData}
+            swappedCrossTeamData={seriesStats.swappedCrossTeamKillMatrixData}
             killMatrixStatus={seriesStats.killMatrixStatus}
           />
         </Container>

--- a/pages/src/components/series-stats/types.ts
+++ b/pages/src/components/series-stats/types.ts
@@ -1,5 +1,5 @@
 import type { ComponentLoaderStatus } from "../component-loader/component-loader";
-import type { KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
+import type { KillMatrixCrossTeamData, KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
 import type { MatchStatsData } from "../../controllers/stats/types";
 import type { TeamColor } from "../team-colors/team-colors";
 import type { ScoreProgressionViewData } from "../stats/score-progression/types";
@@ -36,6 +36,8 @@ export interface SeriesMatchDetail {
   readonly teamColors: readonly TeamColor[];
   readonly killMatrixPivotData: KillMatrixPivotData;
   readonly transposedKillMatrixPivotData: KillMatrixPivotData;
+  readonly crossTeamKillMatrixData: KillMatrixCrossTeamData | null;
+  readonly swappedCrossTeamKillMatrixData: KillMatrixCrossTeamData | null;
   readonly killMatrixStatus: ComponentLoaderStatus;
   readonly scoreProgressionViewData: ScoreProgressionViewData | null;
 }
@@ -52,6 +54,8 @@ export interface SeriesStatsSummary {
   readonly teamColors: readonly TeamColor[];
   readonly killMatrixPivotData: KillMatrixPivotData;
   readonly transposedKillMatrixPivotData: KillMatrixPivotData;
+  readonly crossTeamKillMatrixData: KillMatrixCrossTeamData | null;
+  readonly swappedCrossTeamKillMatrixData: KillMatrixCrossTeamData | null;
   readonly killMatrixStatus: ComponentLoaderStatus;
 }
 

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.module.css
@@ -62,6 +62,23 @@
   width: 2ch;
 }
 
+.crossTeamCell {
+  display: inline-flex;
+  font-variant-numeric: tabular-nums;
+  gap: 1px;
+}
+
+.crossTeamSeparator {
+  color: var(--color-text-muted);
+}
+
+.footnote {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  margin-top: var(--space-2);
+  padding: 0 var(--space-2);
+}
+
 @keyframes shimmer {
   0% {
     background-position: 200% center;

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -221,10 +221,13 @@ export function KillMatrixTable({
         sortingFn: "alphanumeric",
         cellClassName: classNames(tableStyles.labelCell, styles.killerCell),
         cellStyle:
-          teamColors != null ? (row): React.CSSProperties => rowTeamStyle(rowHeaders[row.index].teamId) : undefined,
+          teamColors != null
+            ? (row): React.CSSProperties =>
+                rowTeamStyle(row.index < rowHeaders.length ? rowHeaders[row.index].teamId : null)
+            : undefined,
         cell: (_value, row): React.ReactNode => {
-          const ph = rowHeaders[row.index];
-          return renderPlayerHeader(ph.gamertag, ph.teamId);
+          const ph = row.index < rowHeaders.length ? rowHeaders[row.index] : null;
+          return renderPlayerHeader(ph?.gamertag ?? "", ph?.teamId ?? null);
         },
       },
     ];
@@ -242,7 +245,8 @@ export function KillMatrixTable({
         cellClassName: styles.killCell,
         cellStyle:
           teamColors != null
-            ? (row): React.CSSProperties => cellTeamStyle(rowHeaders[row.index].teamId, colTeamId)
+            ? (row): React.CSSProperties =>
+                cellTeamStyle(row.index < rowHeaders.length ? rowHeaders[row.index].teamId : null, colTeamId)
             : undefined,
         cell: (): React.ReactNode => (
           <span className={styles.shimmerContainer}>
@@ -253,7 +257,7 @@ export function KillMatrixTable({
     }
 
     return cols;
-  }, [yAxisLabel, crossTeamRowHeaders, crossTeamColHeaders, isTransposed, teamColors]);
+  }, [xAxisLabel, yAxisLabel, crossTeamRowHeaders, crossTeamColHeaders, isTransposed, teamColors]);
 
   const activeRowCount = crossTeamData != null ? (isTransposed ? crossTeamColCount : crossTeamRowCount) : undefined;
   const crossTeamShimmerRows = React.useMemo(

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -7,7 +7,12 @@ import { TeamIcon } from "../../icons/team-icon";
 import { SortableTable, type SortableTableColumn } from "../../table/sortable-table";
 import tableStyles from "../../table/table.module.css";
 import type { TeamColor } from "../../team-colors/team-colors";
-import type { KillMatrixPivotData, KillMatrixPivotRow } from "../../../controllers/stats/kill-matrix/types";
+import type {
+  KillMatrixCrossTeamData,
+  KillMatrixCrossTeamRow,
+  KillMatrixPivotData,
+  KillMatrixPivotRow,
+} from "../../../controllers/stats/kill-matrix/types";
 import styles from "./kill-matrix-table.module.css";
 
 interface PlayerHeader {
@@ -26,6 +31,8 @@ interface KillMatrixTableProps {
   readonly playerHeaders?: readonly PlayerHeader[];
   readonly transposedPivotData?: KillMatrixPivotData;
   readonly teamColors?: readonly TeamColor[];
+  readonly crossTeamData?: KillMatrixCrossTeamData;
+  readonly swappedCrossTeamData?: KillMatrixCrossTeamData;
 }
 
 export function KillMatrixTable({
@@ -39,6 +46,8 @@ export function KillMatrixTable({
   playerHeaders,
   transposedPivotData,
   teamColors,
+  crossTeamData,
+  swappedCrossTeamData,
 }: KillMatrixTableProps): React.ReactElement {
   const effectiveStatus = status ?? ComponentLoaderStatus.LOADED;
 
@@ -94,6 +103,66 @@ export function KillMatrixTable({
   const cellTeamStyle = (rowTeamId: number | null, colTeamId: number | null): React.CSSProperties =>
     ({ "--row-team-color": teamColorOf(rowTeamId), "--col-team-color": teamColorOf(colTeamId) }) as React.CSSProperties;
 
+  const activeCrossTeamData =
+    crossTeamData != null
+      ? isTransposed && swappedCrossTeamData != null
+        ? swappedCrossTeamData
+        : crossTeamData
+      : null;
+
+  const renderCrossTeamCell = (kills: number, deaths: number): React.ReactNode => (
+    <span className={styles.crossTeamCell}>
+      {kills}
+      <span className={styles.crossTeamSeparator}>:</span>
+      {deaths}
+    </span>
+  );
+
+  const crossTeamColumns = React.useMemo<SortableTableColumn<KillMatrixCrossTeamRow>[]>(() => {
+    if (effectiveStatus !== ComponentLoaderStatus.LOADED || activeCrossTeamData == null) {
+      return [];
+    }
+
+    const cols: SortableTableColumn<KillMatrixCrossTeamRow>[] = [
+      {
+        id: "xyHeader",
+        header: xyHeader,
+        accessorFn: (row: KillMatrixCrossTeamRow): string => row.playerGamertag,
+        sortingFn: "alphanumeric",
+        cellClassName: classNames(tableStyles.labelCell, styles.killerCell),
+        cellStyle:
+          teamColors != null
+            ? (row: KillMatrixCrossTeamRow): React.CSSProperties => rowTeamStyle(row.playerTeamId)
+            : undefined,
+        cell: (_value: unknown, row: KillMatrixCrossTeamRow): React.ReactNode =>
+          renderPlayerHeader(row.playerGamertag, row.playerTeamId),
+      },
+    ];
+
+    for (const { gamertag, teamId } of activeCrossTeamData.columnHeaders) {
+      const colTeamId: number | null = teamId;
+      cols.push({
+        id: gamertag,
+        header: renderPlayerHeader(gamertag, colTeamId),
+        headerClassName: styles.colHeader,
+        headerStyle: teamColors != null ? colTeamStyle(colTeamId) : undefined,
+        accessorFn: (row: KillMatrixCrossTeamRow): number => row.cells.get(gamertag)?.kills ?? 0,
+        sortingFn: "basic",
+        cellClassName: styles.killCell,
+        cellStyle:
+          teamColors != null
+            ? (row: KillMatrixCrossTeamRow): React.CSSProperties => cellTeamStyle(row.playerTeamId, colTeamId)
+            : undefined,
+        cell: (_value: unknown, row: KillMatrixCrossTeamRow): React.ReactNode => {
+          const cell = row.cells.get(gamertag);
+          return renderCrossTeamCell(cell?.kills ?? 0, cell?.deaths ?? 0);
+        },
+      });
+    }
+
+    return cols;
+  }, [effectiveStatus, xyHeader, activeCrossTeamData, teamColors]);
+
   const columns = React.useMemo<SortableTableColumn<KillMatrixPivotRow>[]>(() => {
     if (effectiveStatus !== ComponentLoaderStatus.LOADED) {
       return [];
@@ -134,6 +203,74 @@ export function KillMatrixTable({
 
     return cols;
   }, [effectiveStatus, yAxisLabel, activePivotData.columnHeaders, teamColors]);
+
+  const firstTeamId = playerHeaders?.[0]?.teamId ?? null;
+  const crossTeamRowHeaders = playerHeaders?.filter((h) => h.teamId === firstTeamId) ?? [];
+  const crossTeamColHeaders = playerHeaders?.filter((h) => h.teamId !== firstTeamId) ?? [];
+  const crossTeamRowCount = crossTeamRowHeaders.length > 0 ? crossTeamRowHeaders.length : 4;
+  const crossTeamColCount = crossTeamColHeaders.length > 0 ? crossTeamColHeaders.length : 4;
+
+  const crossTeamShimmerColumns = React.useMemo<SortableTableColumn<{ index: number }>[]>(() => {
+    const rowHeaders = isTransposed ? crossTeamColHeaders : crossTeamRowHeaders;
+    const colHeaders = isTransposed ? crossTeamRowHeaders : crossTeamColHeaders;
+    const cols: SortableTableColumn<{ index: number }>[] = [
+      {
+        id: "xyHeader",
+        header: xyHeader,
+        accessorFn: (row): number => row.index,
+        sortingFn: "alphanumeric",
+        cellClassName: classNames(tableStyles.labelCell, styles.killerCell),
+        cellStyle:
+          teamColors != null ? (row): React.CSSProperties => rowTeamStyle(rowHeaders[row.index].teamId) : undefined,
+        cell: (_value, row): React.ReactNode => {
+          const ph = rowHeaders[row.index];
+          return renderPlayerHeader(ph.gamertag, ph.teamId);
+        },
+      },
+    ];
+
+    for (let i = 0; i < colHeaders.length; i++) {
+      const header = colHeaders[i];
+      const colTeamId = header.teamId;
+      cols.push({
+        id: `col-${i.toString()}`,
+        header: renderPlayerHeader(header.gamertag, colTeamId),
+        headerClassName: styles.colHeader,
+        headerStyle: teamColors != null ? colTeamStyle(colTeamId) : undefined,
+        accessorFn: (): number => 0,
+        enableSorting: false,
+        cellClassName: styles.killCell,
+        cellStyle:
+          teamColors != null
+            ? (row): React.CSSProperties => cellTeamStyle(rowHeaders[row.index].teamId, colTeamId)
+            : undefined,
+        cell: (): React.ReactNode => (
+          <span className={styles.shimmerContainer}>
+            <span className={styles.shimmerCell} />
+          </span>
+        ),
+      });
+    }
+
+    return cols;
+  }, [yAxisLabel, crossTeamRowHeaders, crossTeamColHeaders, isTransposed, teamColors]);
+
+  const activeRowCount = crossTeamData != null ? (isTransposed ? crossTeamColCount : crossTeamRowCount) : undefined;
+  const crossTeamShimmerRows = React.useMemo(
+    () => Array.from({ length: activeRowCount ?? crossTeamRowCount }, (_, i) => ({ index: i })),
+    [activeRowCount, crossTeamRowCount],
+  );
+
+  const buildFootnoteText = (footnote: { betrayals: number; suicides: number }): string => {
+    const parts: string[] = [];
+    if (footnote.betrayals > 0) {
+      parts.push(`${footnote.betrayals.toString()} betrayal${footnote.betrayals !== 1 ? "s" : ""}`);
+    }
+    if (footnote.suicides > 0) {
+      parts.push(`${footnote.suicides.toString()} suicide${footnote.suicides !== 1 ? "s" : ""}`);
+    }
+    return `* Excluded from table: ${parts.join(", ")}`;
+  };
 
   const playerCount = playerHeaders !== undefined && playerHeaders.length > 0 ? playerHeaders.length : 8;
 
@@ -195,6 +332,34 @@ export function KillMatrixTable({
     </div>
   );
 
+  const footnoteText = activeCrossTeamData?.footnote != null ? buildFootnoteText(activeCrossTeamData.footnote) : null;
+
+  const crossTeamLoaded =
+    activeCrossTeamData == null || activeCrossTeamData.tableRows.length === 0 ? (
+      <Alert variant="info">{emptyMessage}</Alert>
+    ) : (
+      <>
+        <SortableTable
+          data={activeCrossTeamData.tableRows}
+          columns={crossTeamColumns}
+          getRowKey={(row): string => row.playerId}
+          ariaLabel={ariaLabel}
+        />
+        {footnoteText != null && <p className={styles.footnote}>{footnoteText}</p>}
+      </>
+    );
+
+  const crossTeamShimmer = (
+    <div role="region" aria-busy="true" aria-label={ariaLabel}>
+      <SortableTable
+        data={crossTeamShimmerRows}
+        columns={crossTeamShimmerColumns}
+        getRowKey={(row): string => row.index.toString()}
+        ariaLabel={ariaLabel}
+      />
+    </div>
+  );
+
   const loaded =
     activePivotData.tableRows.length === 0 ? (
       <Alert variant="info">{emptyMessage}</Alert>
@@ -207,12 +372,14 @@ export function KillMatrixTable({
       />
     );
 
+  const isCrossTeam = crossTeamData != null;
+
   return (
     <ComponentLoader
       status={effectiveStatus}
-      loading={shimmer}
+      loading={isCrossTeam ? crossTeamShimmer : shimmer}
       error={<Alert variant="warning">{errorMessage ?? emptyMessage}</Alert>}
-      loaded={loaded}
+      loaded={isCrossTeam ? crossTeamLoaded : loaded}
     />
   );
 }

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -161,7 +161,7 @@ export function KillMatrixTable({
     }
 
     return cols;
-  }, [effectiveStatus, xyHeader, activeCrossTeamData, teamColors]);
+  }, [effectiveStatus, xAxisLabel, yAxisLabel, activeCrossTeamData, teamColors]);
 
   const columns = React.useMemo<SortableTableColumn<KillMatrixPivotRow>[]>(() => {
     if (effectiveStatus !== ComponentLoaderStatus.LOADED) {

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -232,12 +232,14 @@ export function KillMatrixTable({
       },
     ];
 
-    for (let i = 0; i < colHeaders.length; i++) {
-      const header = colHeaders[i];
-      const colTeamId = header.teamId;
+    const shimmerColCount =
+      colHeaders.length > 0 ? colHeaders.length : isTransposed ? crossTeamRowCount : crossTeamColCount;
+    for (let i = 0; i < shimmerColCount; i++) {
+      const header = i < colHeaders.length ? colHeaders[i] : null;
+      const colTeamId = header?.teamId ?? null;
       cols.push({
         id: `col-${i.toString()}`,
-        header: renderPlayerHeader(header.gamertag, colTeamId),
+        header: header != null ? renderPlayerHeader(header.gamertag, colTeamId) : null,
         headerClassName: styles.colHeader,
         headerStyle: teamColors != null ? colTeamStyle(colTeamId) : undefined,
         accessorFn: (): number => 0,
@@ -257,7 +259,16 @@ export function KillMatrixTable({
     }
 
     return cols;
-  }, [xAxisLabel, yAxisLabel, crossTeamRowHeaders, crossTeamColHeaders, isTransposed, teamColors]);
+  }, [
+    xAxisLabel,
+    yAxisLabel,
+    crossTeamRowHeaders,
+    crossTeamColHeaders,
+    crossTeamRowCount,
+    crossTeamColCount,
+    isTransposed,
+    teamColors,
+  ]);
 
   const activeRowCount = crossTeamData != null ? (isTransposed ? crossTeamColCount : crossTeamRowCount) : undefined;
   const crossTeamShimmerRows = React.useMemo(

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -103,12 +103,10 @@ export function KillMatrixTable({
   const cellTeamStyle = (rowTeamId: number | null, colTeamId: number | null): React.CSSProperties =>
     ({ "--row-team-color": teamColorOf(rowTeamId), "--col-team-color": teamColorOf(colTeamId) }) as React.CSSProperties;
 
+  const isCrossTeamTransposedActive = isTransposed && swappedCrossTeamData != null;
+
   const activeCrossTeamData =
-    crossTeamData != null
-      ? isTransposed && swappedCrossTeamData != null
-        ? swappedCrossTeamData
-        : crossTeamData
-      : null;
+    crossTeamData != null ? (isCrossTeamTransposedActive ? swappedCrossTeamData : crossTeamData) : null;
 
   const renderCrossTeamCell = (kills: number, deaths: number): React.ReactNode => (
     <span className={styles.crossTeamCell}>
@@ -211,8 +209,8 @@ export function KillMatrixTable({
   const crossTeamColCount = crossTeamColHeaders.length > 0 ? crossTeamColHeaders.length : 4;
 
   const crossTeamShimmerColumns = React.useMemo<SortableTableColumn<{ index: number }>[]>(() => {
-    const rowHeaders = isTransposed ? crossTeamColHeaders : crossTeamRowHeaders;
-    const colHeaders = isTransposed ? crossTeamRowHeaders : crossTeamColHeaders;
+    const rowHeaders = isCrossTeamTransposedActive ? crossTeamColHeaders : crossTeamRowHeaders;
+    const colHeaders = isCrossTeamTransposedActive ? crossTeamRowHeaders : crossTeamColHeaders;
     const cols: SortableTableColumn<{ index: number }>[] = [
       {
         id: "xyHeader",
@@ -233,7 +231,7 @@ export function KillMatrixTable({
     ];
 
     const shimmerColCount =
-      colHeaders.length > 0 ? colHeaders.length : isTransposed ? crossTeamRowCount : crossTeamColCount;
+      colHeaders.length > 0 ? colHeaders.length : isCrossTeamTransposedActive ? crossTeamRowCount : crossTeamColCount;
     for (let i = 0; i < shimmerColCount; i++) {
       const header = i < colHeaders.length ? colHeaders[i] : null;
       const colTeamId = header?.teamId ?? null;
@@ -266,11 +264,13 @@ export function KillMatrixTable({
     crossTeamColHeaders,
     crossTeamRowCount,
     crossTeamColCount,
-    isTransposed,
+    isCrossTeamTransposedActive,
     teamColors,
+    swappedCrossTeamData,
   ]);
 
-  const activeRowCount = crossTeamData != null ? (isTransposed ? crossTeamColCount : crossTeamRowCount) : undefined;
+  const activeRowCount =
+    crossTeamData != null ? (isCrossTeamTransposedActive ? crossTeamColCount : crossTeamRowCount) : undefined;
   const crossTeamShimmerRows = React.useMemo(
     () => Array.from({ length: activeRowCount ?? crossTeamRowCount }, (_, i) => ({ index: i })),
     [activeRowCount, crossTeamRowCount],

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -61,10 +61,10 @@ export function KillMatrixTable({
   const teamColorOf = (teamId: number | null): string =>
     (teamId != null ? teamColors?.[teamId]?.hex : undefined) ?? "transparent";
 
-  const xyHeader = (
+  const renderXyHeader = (labels = true): React.ReactNode => (
     <>
-      <span className={styles.xAxisLabel}>{xAxisLabel}</span>
-      <span className={styles.yAxisLabel}>{yAxisLabel}</span>
+      {labels && <span className={styles.xAxisLabel}>{xAxisLabel}</span>}
+      {labels && <span className={styles.yAxisLabel}>{yAxisLabel}</span>}
       <Button
         variant="secondary"
         className={styles.swap}
@@ -124,7 +124,7 @@ export function KillMatrixTable({
     const cols: SortableTableColumn<KillMatrixCrossTeamRow>[] = [
       {
         id: "xyHeader",
-        header: xyHeader,
+        header: renderXyHeader(false),
         accessorFn: (row: KillMatrixCrossTeamRow): string => row.playerGamertag,
         sortingFn: "alphanumeric",
         cellClassName: classNames(tableStyles.labelCell, styles.killerCell),
@@ -169,7 +169,7 @@ export function KillMatrixTable({
     const cols: SortableTableColumn<KillMatrixPivotRow>[] = [
       {
         id: "xyHeader",
-        header: xyHeader,
+        header: renderXyHeader(),
         accessorFn: (row: KillMatrixPivotRow): string => row.killerGamertag,
         sortingFn: "alphanumeric",
         cellClassName: classNames(tableStyles.labelCell, styles.killerCell),
@@ -214,7 +214,7 @@ export function KillMatrixTable({
     const cols: SortableTableColumn<{ index: number }>[] = [
       {
         id: "xyHeader",
-        header: xyHeader,
+        header: renderXyHeader(false),
         accessorFn: (row): number => row.index,
         sortingFn: "alphanumeric",
         cellClassName: classNames(tableStyles.labelCell, styles.killerCell),
@@ -293,7 +293,7 @@ export function KillMatrixTable({
     const cols: SortableTableColumn<{ index: number }>[] = [
       {
         id: "xyHeader",
-        header: xyHeader,
+        header: renderXyHeader(),
         accessorFn: (row): number => row.index,
         sortingFn: "alphanumeric",
         cellClassName: classNames(tableStyles.labelCell, styles.killerCell),

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -391,6 +391,23 @@ describe("KillMatrixTable", () => {
 
       expect(screen.queryByText(/Excluded from table/)).not.toBeInTheDocument();
     });
+
+    it("shows 4 placeholder data columns in cross-team shimmer when playerHeaders is not provided", () => {
+      render(
+        <KillMatrixTable
+          pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
+          ariaLabel="Kill matrix"
+          emptyMessage="No kill matrix data."
+          status={ComponentLoaderStatus.LOADING}
+          crossTeamData={crossTeamData}
+        />,
+      );
+
+      const shimmer = screen.getByRole("region", { name: "Kill matrix" });
+      expect(shimmer).toHaveAttribute("aria-busy", "true");
+      // 1 xyHeader col + 4 fallback data cols = 5 cols; 4 fallback rows → 5 + 4×5 = 25 cells
+      expect(shimmer.querySelectorAll("th, td")).toHaveLength(25);
+    });
   });
 
   it("toggles between kills and deaths view when toggle button is clicked", async () => {

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -12,7 +12,10 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import { KillMatrixFormatter } from "../../../../controllers/stats/kill-matrix/kill-matrix-formatter";
-import { EMPTY_KILL_MATRIX_PIVOT_DATA } from "../../../../controllers/stats/kill-matrix/types";
+import {
+  EMPTY_KILL_MATRIX_PIVOT_DATA,
+  type KillMatrixCrossTeamData,
+} from "../../../../controllers/stats/kill-matrix/types";
 import { KillMatrixTable } from "../kill-matrix-table";
 
 describe("KillMatrixTable", () => {
@@ -289,6 +292,105 @@ describe("KillMatrixTable", () => {
 
     expect(headerLabelAfter).toBe(headerLabelBefore);
     expect(rowLabelAfter).toBe(rowLabelBefore);
+  });
+
+  describe("cross-team mode", () => {
+    const crossTeamData: KillMatrixCrossTeamData = {
+      tableRows: [
+        {
+          playerId: "111",
+          playerGamertag: "Alpha",
+          playerTeamId: 0,
+          cells: new Map([["Bravo", { kills: 3, deaths: 1 }]]),
+        },
+      ],
+      columnHeaders: [{ gamertag: "Bravo", teamId: 1 }],
+      footnote: { betrayals: 2, suicides: 1 },
+    };
+    const swappedCrossTeamData: KillMatrixCrossTeamData = {
+      tableRows: [
+        {
+          playerId: "222",
+          playerGamertag: "Bravo",
+          playerTeamId: 1,
+          cells: new Map([["Alpha", { kills: 1, deaths: 3 }]]),
+        },
+      ],
+      columnHeaders: [{ gamertag: "Alpha", teamId: 0 }],
+      footnote: { betrayals: 2, suicides: 1 },
+    };
+
+    it("renders kills:deaths in each cell", () => {
+      render(
+        <KillMatrixTable
+          pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
+          ariaLabel="Kill matrix"
+          emptyMessage="No kill matrix data."
+          crossTeamData={crossTeamData}
+          swappedCrossTeamData={swappedCrossTeamData}
+        />,
+      );
+
+      const table = screen.getByRole("table", { name: "Kill matrix" });
+      const firstDataCell = table.querySelector("tbody tr td:nth-child(2)");
+      expect(firstDataCell).toBeInTheDocument();
+      expect(firstDataCell?.textContent).toBe("3:1");
+    });
+
+    it("swap button switches which team is on rows vs columns", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <KillMatrixTable
+          pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
+          ariaLabel="Kill matrix"
+          emptyMessage="No kill matrix data."
+          crossTeamData={crossTeamData}
+          swappedCrossTeamData={swappedCrossTeamData}
+        />,
+      );
+
+      const table = screen.getByRole("table", { name: "Kill matrix" });
+      const getFirstRowLabel = (): string => (table.querySelector("tbody tr td:first-child")?.textContent ?? "").trim();
+
+      expect(getFirstRowLabel()).toContain("Alpha");
+
+      const toggleButton = table.querySelector("thead th button");
+      expect(toggleButton).toBeInTheDocument();
+      await user.click(toggleButton as HTMLElement);
+
+      expect(getFirstRowLabel()).toContain("Bravo");
+    });
+
+    it("shows footnote listing excluded betrayals and suicides", () => {
+      render(
+        <KillMatrixTable
+          pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
+          ariaLabel="Kill matrix"
+          emptyMessage="No kill matrix data."
+          crossTeamData={crossTeamData}
+          swappedCrossTeamData={swappedCrossTeamData}
+        />,
+      );
+
+      expect(screen.getByText(/Excluded from table/)).toBeInTheDocument();
+    });
+
+    it("does not show footnote when there are no betrayals or suicides", () => {
+      const cleanCrossTeamData: KillMatrixCrossTeamData = { ...crossTeamData, footnote: null };
+
+      render(
+        <KillMatrixTable
+          pivotData={EMPTY_KILL_MATRIX_PIVOT_DATA}
+          ariaLabel="Kill matrix"
+          emptyMessage="No kill matrix data."
+          crossTeamData={cleanCrossTeamData}
+          swappedCrossTeamData={swappedCrossTeamData}
+        />,
+      );
+
+      expect(screen.queryByText(/Excluded from table/)).not.toBeInTheDocument();
+    });
   });
 
   it("toggles between kills and deaths view when toggle button is clicked", async () => {

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -9,7 +9,11 @@ import { TeamIcon } from "../icons/team-icon";
 import { MedalIcon } from "../icons/medal-icon";
 import type { TeamColor } from "../team-colors/team-colors";
 import { Container } from "../container/container";
-import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
+import {
+  EMPTY_KILL_MATRIX_PIVOT_DATA,
+  type KillMatrixCrossTeamData,
+  type KillMatrixPivotData,
+} from "../../controllers/stats/kill-matrix/types";
 import type { MatchStatsData, MatchStatsPlayerData } from "../../controllers/stats/types";
 import { sortByMedals, getTeamMedalsMap, getPlayerMedalsMap } from "../../controllers/stats/medals-sorting";
 import { KillMatrixTable } from "./kill-matrix/kill-matrix-table";
@@ -33,6 +37,8 @@ interface MatchStatsProps {
   readonly teamColors?: readonly TeamColor[];
   readonly killMatrixPivotData?: KillMatrixPivotData;
   readonly transposedKillMatrixPivotData?: KillMatrixPivotData;
+  readonly crossTeamData?: KillMatrixCrossTeamData | null;
+  readonly swappedCrossTeamData?: KillMatrixCrossTeamData | null;
   readonly killMatrixStatus?: ComponentLoaderStatus;
   readonly scoreProgressionViewData?: ScoreProgressionViewData | null;
   readonly showHeader?: boolean;
@@ -55,6 +61,8 @@ export function MatchStats({
   teamColors,
   killMatrixPivotData,
   transposedKillMatrixPivotData,
+  crossTeamData,
+  swappedCrossTeamData,
   killMatrixStatus,
   scoreProgressionViewData,
   showHeader = true,
@@ -290,6 +298,8 @@ export function MatchStats({
               <KillMatrixTable
                 pivotData={killMatrixPivotData ?? EMPTY_KILL_MATRIX_PIVOT_DATA}
                 transposedPivotData={transposedKillMatrixPivotData}
+                crossTeamData={crossTeamData ?? undefined}
+                swappedCrossTeamData={swappedCrossTeamData ?? undefined}
                 ariaLabel="Match kill matrix"
                 emptyMessage="Kill matrix data is not available for this match yet."
                 errorMessage="Failed to load kill matrix data for this match."

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -8,7 +8,11 @@ import { TeamIcon } from "../icons/team-icon";
 import { MedalIcon } from "../icons/medal-icon";
 import type { TeamColor } from "../team-colors/team-colors";
 import { Container } from "../container/container";
-import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPivotData } from "../../controllers/stats/kill-matrix/types";
+import {
+  EMPTY_KILL_MATRIX_PIVOT_DATA,
+  type KillMatrixCrossTeamData,
+  type KillMatrixPivotData,
+} from "../../controllers/stats/kill-matrix/types";
 import type { MatchStatsData, MatchStatsPlayerData } from "../../controllers/stats/types";
 import type { SeriesMetadata } from "../../controllers/stats/series-metadata";
 import { sortByMedals, getTeamMedalsMap, getPlayerMedalsMap } from "../../controllers/stats/medals-sorting";
@@ -24,6 +28,8 @@ interface SeriesStatsProps {
   readonly teamColors?: readonly TeamColor[];
   readonly killMatrixPivotData?: KillMatrixPivotData;
   readonly transposedKillMatrixPivotData?: KillMatrixPivotData;
+  readonly crossTeamData?: KillMatrixCrossTeamData | null;
+  readonly swappedCrossTeamData?: KillMatrixCrossTeamData | null;
   readonly killMatrixStatus?: ComponentLoaderStatus;
   readonly showHeader?: boolean;
 }
@@ -38,6 +44,8 @@ export function SeriesStats({
   teamColors,
   killMatrixPivotData,
   transposedKillMatrixPivotData,
+  crossTeamData,
+  swappedCrossTeamData,
   killMatrixStatus,
   showHeader = true,
 }: SeriesStatsProps): React.ReactElement {
@@ -260,6 +268,8 @@ export function SeriesStats({
                 <KillMatrixTable
                   pivotData={killMatrixPivotData ?? EMPTY_KILL_MATRIX_PIVOT_DATA}
                   transposedPivotData={transposedKillMatrixPivotData}
+                  crossTeamData={crossTeamData ?? undefined}
+                  swappedCrossTeamData={swappedCrossTeamData ?? undefined}
                   ariaLabel="Series kill matrix"
                   emptyMessage="Kill matrix data is not available for this series yet."
                   errorMessage="Failed to load kill matrix data for this series."

--- a/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
+++ b/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
@@ -238,12 +238,12 @@ export class KillMatrixFormatter {
     if (teamIds.length !== 2) {
       return null;
     }
-    const [team0Id, team1Id] = teamIds;
-    const team0Players = orderedPlayers.filter((p) => p.teamId === team0Id);
-    const team1Players = orderedPlayers.filter((p) => p.teamId === team1Id);
+    const [firstTeamId, secondTeamId] = teamIds;
+    const firstTeamPlayers = orderedPlayers.filter((p) => p.teamId === firstTeamId);
+    const secondTeamPlayers = orderedPlayers.filter((p) => p.teamId === secondTeamId);
     return {
-      crossTeamData: KillMatrixFormatter.pivotCrossTeam(rows, team0Players, team1Players),
-      swappedCrossTeamData: KillMatrixFormatter.pivotCrossTeam(rows, team1Players, team0Players),
+      crossTeamData: KillMatrixFormatter.pivotCrossTeam(rows, firstTeamPlayers, secondTeamPlayers),
+      swappedCrossTeamData: KillMatrixFormatter.pivotCrossTeam(rows, secondTeamPlayers, firstTeamPlayers),
     };
   }
 

--- a/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
+++ b/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
@@ -10,7 +10,7 @@ import type {
   KillMatrixViewRow,
 } from "./types";
 
-export interface CrossTeamPair {
+interface CrossTeamPair {
   readonly crossTeamData: KillMatrixCrossTeamData;
   readonly swappedCrossTeamData: KillMatrixCrossTeamData;
 }
@@ -177,8 +177,8 @@ export class KillMatrixFormatter {
 
   public static pivotCrossTeam(
     rows: readonly KillMatrixViewRow[],
-    team0Players: readonly KillMatrixPlayer[],
-    team1Players: readonly KillMatrixPlayer[],
+    rowTeamPlayers: readonly KillMatrixPlayer[],
+    colTeamPlayers: readonly KillMatrixPlayer[],
   ): KillMatrixCrossTeamData {
     const killCounts = new Map<string, Map<string, number>>();
     let betrayals = 0;
@@ -199,9 +199,9 @@ export class KillMatrixFormatter {
       Preconditions.checkExists(killCounts.get(row.killer.xuid)).set(row.victim.xuid, row.count);
     }
 
-    const tableRows = team0Players.map((rowPlayer) => {
+    const tableRows = rowTeamPlayers.map((rowPlayer) => {
       const cells = new Map(
-        team1Players.map((colPlayer) => [
+        colTeamPlayers.map((colPlayer) => [
           colPlayer.gamertag,
           {
             kills: killCounts.get(rowPlayer.xuid)?.get(colPlayer.xuid) ?? 0,
@@ -217,7 +217,7 @@ export class KillMatrixFormatter {
       };
     });
 
-    const columnHeaders: KillMatrixColumnHeader[] = team1Players.map((p) => ({
+    const columnHeaders: KillMatrixColumnHeader[] = colTeamPlayers.map((p) => ({
       gamertag: p.gamertag,
       teamId: p.teamId,
     }));

--- a/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
+++ b/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
@@ -186,11 +186,11 @@ export class KillMatrixFormatter {
 
     for (const row of rows) {
       if (row.classification === "betrayal") {
-        betrayals++;
+        betrayals += row.count;
         continue;
       }
       if (row.classification === "suicide") {
-        suicides++;
+        suicides += row.count;
         continue;
       }
       if (!killCounts.has(row.killer.xuid)) {

--- a/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
+++ b/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
@@ -3,10 +3,17 @@ import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import type {
   KillMatrixClassification,
   KillMatrixColumnHeader,
+  KillMatrixCrossTeamData,
+  KillMatrixCrossTeamFootnote,
   KillMatrixPivotData,
   KillMatrixPlayer,
   KillMatrixViewRow,
 } from "./types";
+
+export interface CrossTeamPair {
+  readonly crossTeamData: KillMatrixCrossTeamData;
+  readonly swappedCrossTeamData: KillMatrixCrossTeamData;
+}
 
 export const GAMES_SUFFIX_RE = /\s+\(\d+\/\d+ games\)$/;
 
@@ -166,6 +173,75 @@ export class KillMatrixFormatter {
       rows.map((row) => ({ ...row, killer: row.victim, victim: row.killer })),
       orderedPlayers,
     );
+  }
+
+  public static pivotCrossTeam(
+    rows: readonly KillMatrixViewRow[],
+    team0Players: readonly KillMatrixPlayer[],
+    team1Players: readonly KillMatrixPlayer[],
+  ): KillMatrixCrossTeamData {
+    const killCounts = new Map<string, Map<string, number>>();
+    let betrayals = 0;
+    let suicides = 0;
+
+    for (const row of rows) {
+      if (row.classification === "betrayal") {
+        betrayals++;
+        continue;
+      }
+      if (row.classification === "suicide") {
+        suicides++;
+        continue;
+      }
+      if (!killCounts.has(row.killer.xuid)) {
+        killCounts.set(row.killer.xuid, new Map());
+      }
+      Preconditions.checkExists(killCounts.get(row.killer.xuid)).set(row.victim.xuid, row.count);
+    }
+
+    const tableRows = team0Players.map((rowPlayer) => {
+      const cells = new Map(
+        team1Players.map((colPlayer) => [
+          colPlayer.gamertag,
+          {
+            kills: killCounts.get(rowPlayer.xuid)?.get(colPlayer.xuid) ?? 0,
+            deaths: killCounts.get(colPlayer.xuid)?.get(rowPlayer.xuid) ?? 0,
+          },
+        ]),
+      );
+      return {
+        playerId: rowPlayer.xuid,
+        playerGamertag: rowPlayer.gamertag,
+        playerTeamId: rowPlayer.teamId,
+        cells,
+      };
+    });
+
+    const columnHeaders: KillMatrixColumnHeader[] = team1Players.map((p) => ({
+      gamertag: p.gamertag,
+      teamId: p.teamId,
+    }));
+
+    const footnote: KillMatrixCrossTeamFootnote | null = betrayals > 0 || suicides > 0 ? { betrayals, suicides } : null;
+
+    return { tableRows, columnHeaders, footnote };
+  }
+
+  public static buildCrossTeam(
+    rows: readonly KillMatrixViewRow[],
+    orderedPlayers: readonly KillMatrixPlayer[],
+  ): CrossTeamPair | null {
+    const teamIds = [...new Set(orderedPlayers.map((p) => p.teamId).filter((id): id is number => id != null))];
+    if (teamIds.length !== 2) {
+      return null;
+    }
+    const [team0Id, team1Id] = teamIds;
+    const team0Players = orderedPlayers.filter((p) => p.teamId === team0Id);
+    const team1Players = orderedPlayers.filter((p) => p.teamId === team1Id);
+    return {
+      crossTeamData: KillMatrixFormatter.pivotCrossTeam(rows, team0Players, team1Players),
+      swappedCrossTeamData: KillMatrixFormatter.pivotCrossTeam(rows, team1Players, team0Players),
+    };
   }
 
   public static aggregate(rows: readonly KillMatrixViewRow[]): KillMatrixViewRow[] {

--- a/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
+++ b/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
@@ -231,6 +231,9 @@ export class KillMatrixFormatter {
     rows: readonly KillMatrixViewRow[],
     orderedPlayers: readonly KillMatrixPlayer[],
   ): CrossTeamPair | null {
+    if (orderedPlayers.some((p) => p.teamId == null)) {
+      return null;
+    }
     const teamIds = [...new Set(orderedPlayers.map((p) => p.teamId).filter((id): id is number => id != null))];
     if (teamIds.length !== 2) {
       return null;

--- a/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
+++ b/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
@@ -302,4 +302,156 @@ describe("KillMatrixFormatter", () => {
       expect(result.tableRows[0].kills.get("Alpha")).toBe(5);
     });
   });
+
+  describe("pivotCrossTeam", () => {
+    const team0Players = [
+      { xuid: "111", gamertag: "Alpha", teamId: 0 },
+      { xuid: "333", gamertag: "Charlie", teamId: 0 },
+    ];
+    const team1Players = [
+      { xuid: "222", gamertag: "Bravo", teamId: 1 },
+      { xuid: "444", gamertag: "Delta", teamId: 1 },
+    ];
+
+    const rows: KillMatrixViewRow[] = [
+      {
+        key: "111:222",
+        killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+        victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+        count: 3,
+        headshotKills: 0,
+        perfects: 0,
+        classification: "enemy-kill",
+      },
+      {
+        key: "222:111",
+        killer: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+        victim: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+        count: 1,
+        headshotKills: 0,
+        perfects: 0,
+        classification: "enemy-kill",
+      },
+      {
+        key: "333:333",
+        killer: { xuid: "333", gamertag: "Charlie", teamId: 0 },
+        victim: { xuid: "333", gamertag: "Charlie", teamId: 0 },
+        count: 1,
+        headshotKills: 0,
+        perfects: 0,
+        classification: "suicide",
+      },
+      {
+        key: "111:333",
+        killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+        victim: { xuid: "333", gamertag: "Charlie", teamId: 0 },
+        count: 2,
+        headshotKills: 0,
+        perfects: 0,
+        classification: "betrayal",
+      },
+    ];
+
+    it("builds a row per team-0 player with kills:deaths per team-1 column", () => {
+      const result = KillMatrixFormatter.pivotCrossTeam(rows, team0Players, team1Players);
+
+      expect(result.tableRows).toHaveLength(2);
+      expect(result.columnHeaders.map((h) => h.gamertag)).toEqual(["Bravo", "Delta"]);
+      expect(result.tableRows[0]).toMatchObject({ playerId: "111", playerGamertag: "Alpha", playerTeamId: 0 });
+      expect(result.tableRows[0].cells.get("Bravo")).toEqual({ kills: 3, deaths: 1 });
+      expect(result.tableRows[0].cells.get("Delta")).toEqual({ kills: 0, deaths: 0 });
+      expect(result.tableRows[1]).toMatchObject({ playerId: "333", playerGamertag: "Charlie", playerTeamId: 0 });
+      expect(result.tableRows[1].cells.get("Bravo")).toEqual({ kills: 0, deaths: 0 });
+    });
+
+    it("excludes betrayals and suicides from cells and reports them in the footnote", () => {
+      const result = KillMatrixFormatter.pivotCrossTeam(rows, team0Players, team1Players);
+
+      expect(result.footnote).toEqual({ betrayals: 1, suicides: 1 });
+    });
+
+    it("returns null footnote when there are no betrayals or suicides", () => {
+      const enemyRows = rows.filter((r) => r.classification === "enemy-kill");
+      const result = KillMatrixFormatter.pivotCrossTeam(enemyRows, team0Players, team1Players);
+
+      expect(result.footnote).toBeNull();
+    });
+
+    it("returns empty tableRows when no team-0 players are provided", () => {
+      const result = KillMatrixFormatter.pivotCrossTeam(rows, [], team1Players);
+
+      expect(result.tableRows).toHaveLength(0);
+      expect(result.columnHeaders.map((h) => h.gamertag)).toEqual(["Bravo", "Delta"]);
+    });
+  });
+
+  describe("buildCrossTeam", () => {
+    const team0 = [
+      { xuid: "111", gamertag: "Alpha", teamId: 0 },
+      { xuid: "333", gamertag: "Charlie", teamId: 0 },
+    ];
+    const team1 = [
+      { xuid: "222", gamertag: "Bravo", teamId: 1 },
+      { xuid: "444", gamertag: "Delta", teamId: 1 },
+    ];
+    const orderedPlayers = [...team0, ...team1];
+
+    const rows: KillMatrixViewRow[] = [
+      {
+        key: "111:222",
+        killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+        victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+        count: 4,
+        headshotKills: 0,
+        perfects: 0,
+        classification: "enemy-kill",
+      },
+      {
+        key: "222:111",
+        killer: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+        victim: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+        count: 2,
+        headshotKills: 0,
+        perfects: 0,
+        classification: "enemy-kill",
+      },
+    ];
+
+    it("returns crossTeamData with team-0 rows and swappedCrossTeamData with team-1 rows when exactly 2 teams", () => {
+      const result = KillMatrixFormatter.buildCrossTeam(rows, orderedPlayers);
+
+      expect(result).not.toBeNull();
+      expect(result?.crossTeamData.tableRows.map((r) => r.playerGamertag)).toEqual(["Alpha", "Charlie"]);
+      expect(result?.swappedCrossTeamData.tableRows.map((r) => r.playerGamertag)).toEqual(["Bravo", "Delta"]);
+    });
+
+    it("swappedCrossTeamData has kills and deaths mirrored from crossTeamData", () => {
+      const result = KillMatrixFormatter.buildCrossTeam(rows, orderedPlayers);
+
+      const alphaVsBravo = result?.crossTeamData.tableRows[0]?.cells.get("Bravo");
+      const bravoVsAlpha = result?.swappedCrossTeamData.tableRows[0]?.cells.get("Alpha");
+
+      expect(alphaVsBravo).toEqual({ kills: 4, deaths: 2 });
+      expect(bravoVsAlpha).toEqual({ kills: 2, deaths: 4 });
+    });
+
+    it("returns null when all players have no teamId", () => {
+      const noTeamPlayers = orderedPlayers.map((p) => ({ ...p, teamId: null }));
+      expect(KillMatrixFormatter.buildCrossTeam(rows, noTeamPlayers)).toBeNull();
+    });
+
+    it("returns null when there is only 1 distinct teamId", () => {
+      const singleTeamPlayers = orderedPlayers.map((p) => ({ ...p, teamId: 0 }));
+      expect(KillMatrixFormatter.buildCrossTeam(rows, singleTeamPlayers)).toBeNull();
+    });
+
+    it("returns null when there are 3 or more distinct teamIds", () => {
+      const threeTeamPlayers = [
+        { xuid: "111", gamertag: "Alpha", teamId: 0 },
+        { xuid: "222", gamertag: "Bravo", teamId: 1 },
+        { xuid: "333", gamertag: "Charlie", teamId: 2 },
+      ];
+      expect(KillMatrixFormatter.buildCrossTeam(rows, threeTeamPlayers)).toBeNull();
+    });
+  });
 });

--- a/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
+++ b/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
@@ -367,7 +367,7 @@ describe("KillMatrixFormatter", () => {
     it("excludes betrayals and suicides from cells and reports them in the footnote", () => {
       const result = KillMatrixFormatter.pivotCrossTeam(rows, team0Players, team1Players);
 
-      expect(result.footnote).toEqual({ betrayals: 1, suicides: 1 });
+      expect(result.footnote).toEqual({ betrayals: 2, suicides: 1 });
     });
 
     it("returns null footnote when there are no betrayals or suicides", () => {

--- a/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
+++ b/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
@@ -453,5 +453,10 @@ describe("KillMatrixFormatter", () => {
       ];
       expect(KillMatrixFormatter.buildCrossTeam(rows, threeTeamPlayers)).toBeNull();
     });
+
+    it("returns null when any orderedPlayer has a null teamId alongside non-null teamIds", () => {
+      const mixedPlayers = [...orderedPlayers, { xuid: "555", gamertag: "Echo", teamId: null }];
+      expect(KillMatrixFormatter.buildCrossTeam(rows, mixedPlayers)).toBeNull();
+    });
   });
 });

--- a/pages/src/controllers/stats/kill-matrix/types.ts
+++ b/pages/src/controllers/stats/kill-matrix/types.ts
@@ -21,6 +21,35 @@ export interface KillMatrixPivotData {
 
 export const EMPTY_KILL_MATRIX_PIVOT_DATA: KillMatrixPivotData = { tableRows: [], columnHeaders: [] };
 
+export interface KillMatrixCrossTeamCell {
+  readonly kills: number;
+  readonly deaths: number;
+}
+
+export interface KillMatrixCrossTeamRow {
+  readonly playerId: string;
+  readonly playerGamertag: string;
+  readonly playerTeamId: number | null;
+  readonly cells: ReadonlyMap<string, KillMatrixCrossTeamCell>;
+}
+
+export interface KillMatrixCrossTeamFootnote {
+  readonly betrayals: number;
+  readonly suicides: number;
+}
+
+export interface KillMatrixCrossTeamData {
+  readonly tableRows: readonly KillMatrixCrossTeamRow[];
+  readonly columnHeaders: readonly KillMatrixColumnHeader[];
+  readonly footnote: KillMatrixCrossTeamFootnote | null;
+}
+
+export const EMPTY_KILL_MATRIX_CROSS_TEAM_DATA: KillMatrixCrossTeamData = {
+  tableRows: [],
+  columnHeaders: [],
+  footnote: null,
+};
+
 export interface KillMatrixPlayer {
   readonly xuid: string;
   readonly gamertag: string;


### PR DESCRIPTION
## Context

Part of the kill matrix improvements plan (5-PR series). The existing kill matrix shows all players as both rows and columns (NxN), which creates a sparse table in team-vs-team matches since players can't kill their own team. This PR introduces a condensed 2-team view.

## This change

- **KillMatrixTable**: Detects when `crossTeamData` is provided and renders a condensed NxM table (team A rows × team B columns). Each cell shows `kills:deaths` (e.g., `3:1`) — the row player's kills against the column player and vice versa. The swap button flips which team is on rows vs columns, enabling sorting from both perspectives. Betrayals/suicides are excluded from the table and shown as a footnote below.
- **KillMatrixFormatter**: Adds `pivotCrossTeam(rows, team0Players, team1Players)` to build the cross-team data and `buildCrossTeam(rows, orderedPlayers)` to detect 2-team matches and produce both orientations in one call.
- **Presenters**: All four presenter layers (discord-series-stats, viewer, live-tracker, overlay) now call `buildCrossTeam` when computing kill matrix data, and thread the result through types and call sites to `KillMatrixTable`.
- FFA (1 team) and multi-team (3+) matches continue to render the existing NxN layout unchanged.

## Subsequent work

- Click-to-expand cell dialog for head-to-head depth (kills, headshots, perfects, assists)
- Backend film data extraction (headshot kills, perfects, assist attribution)
- Enrich the dialog with extracted film data