### PR TITLE
Fix streamer settings propagation and canonicalize follow defaults

### DIFF
--- a/api/durable-objects/user-tracker/fakes/user-tracker-do.fake.ts
+++ b/api/durable-objects/user-tracker/fakes/user-tracker-do.fake.ts
@@ -63,6 +63,9 @@ export function aFakeUserTrackerDOWith(opts: FakeUserTrackerDOOpts = {}): FakeUs
           }),
         );
       }
+      case "/settings-changed": {
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
       case "/websocket": {
         return Promise.resolve(new Response(null, { status: 200, headers: { "x-fake-upgrade": "websocket" } }));
       }

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -5,6 +5,7 @@ import {
   userTrackerViewStateContract,
 } from "@guilty-spark/shared/contracts/durable-objects/user-tracker/management";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import { withStreamerViewSettingsDefaults } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { UserTrackerDO } from "../user-tracker-do";
 import {
   aFakeDurableObjectNamespaceWith,
@@ -1028,6 +1029,130 @@ describe("UserTrackerDO", () => {
 
     expect(response.status).toBe(405);
     await expect(response.text()).resolves.toBe("Method Not Allowed");
+  });
+
+  it("returns 204 for a settings-changed POST and queues a directory push", async () => {
+    const persistedStorage = new Map<string, unknown>();
+    persistedStorage.set("userTrackerState", {
+      state: { userId: "user-1", lastUpdateTime: "2026-07-16T00:00:00.000Z" },
+      viewState: null,
+    });
+
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        if (typeof key !== "string") {
+          const values = new Map<string, unknown>();
+          for (const currentKey of key) {
+            const value = persistedStorage.get(currentKey);
+            if (value !== undefined) {
+              values.set(currentKey, value);
+            }
+          }
+          return await Promise.resolve(values);
+        }
+        return await Promise.resolve(persistedStorage.get(key));
+      }) as DurableObjectStorage["get"],
+      put: (async (key: string, value: unknown) => {
+        persistedStorage.set(key, value);
+        await Promise.resolve();
+      }) as DurableObjectStorage["put"],
+    });
+
+    const trackerDo = aFakeIndividualTrackerDOWith({
+      viewStateResponse: {
+        state: aFakeIndividualTrackerViewStateWith({ trackerId: "t1", gamertag: "G", matches: [] }),
+      },
+    });
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const services = installFakeServicesWith({ env: localEnv });
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([
+      aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1", Gamertag: "G", Status: "active", IsLive: 1 }),
+    ]);
+    vi.spyOn(services.individualTrackerService, "getSettingsForView").mockResolvedValue({
+      styleFlags: { playerTeamColor: "cerulean", playerEnemyColor: "salmon" },
+    });
+
+    const state = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const localUserTrackerDO = new UserTrackerDO(state, localEnv, () => services, webSocketAdapter);
+
+    const response = await localUserTrackerDO.fetch(new Request("http://do/settings-changed", { method: "POST" }));
+
+    expect(response.status).toBe(204);
+
+    await vi.waitFor(() => {
+      const stored = persistedStorage.get("userTrackerState") as { viewState: { directory: unknown } } | undefined;
+      expect(stored?.viewState.directory).toBeDefined();
+    });
+  });
+
+  it("returns 405 when settings-changed is called with a non-POST method", async () => {
+    const response = await userTrackerDO.fetch(new Request("http://do/settings-changed", { method: "GET" }));
+
+    expect(response.status).toBe(405);
+    await expect(response.text()).resolves.toBe("Method Not Allowed");
+  });
+
+  it("handles legacy stored directories without streamerSettings during settings-changed refresh", async () => {
+    const persistedStorage = new Map<string, unknown>();
+    persistedStorage.set("userTrackerState", {
+      state: { userId: "user-1", lastUpdateTime: "2026-07-16T00:00:00.000Z" },
+      viewState: {
+        userId: "user-1",
+        lastUpdateTime: "2026-07-16T00:00:00.000Z",
+        directory: {
+          trackers: [],
+          liveTrackerId: null,
+        },
+      },
+    });
+
+    const sharedStorage = aFakeDurableObjectStorageWith({
+      get: (async (key: string | string[]) => {
+        if (typeof key !== "string") {
+          const values = new Map<string, unknown>();
+          for (const currentKey of key) {
+            const value = persistedStorage.get(currentKey);
+            if (value !== undefined) {
+              values.set(currentKey, value);
+            }
+          }
+          return await Promise.resolve(values);
+        }
+
+        return await Promise.resolve(persistedStorage.get(key));
+      }) as DurableObjectStorage["get"],
+      put: (async (key: string, value: unknown) => {
+        persistedStorage.set(key, value);
+        await Promise.resolve();
+      }) as DurableObjectStorage["put"],
+    });
+
+    const localEnv = aFakeEnvWith({
+      INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(aFakeIndividualTrackerDOWith()),
+    });
+    const services = installFakeServicesWith({ env: localEnv });
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([]);
+    vi.spyOn(services.individualTrackerService, "getSettingsForView").mockResolvedValue({});
+
+    const state = aFakeDurableObjectStateWith({ storage: sharedStorage });
+    const localUserTrackerDO = new UserTrackerDO(state, localEnv, () => services, webSocketAdapter);
+
+    const response = await localUserTrackerDO.fetch(new Request("http://do/settings-changed", { method: "POST" }));
+
+    expect(response.status).toBe(204);
+
+    await vi.waitFor(() => {
+      const stored = persistedStorage.get("userTrackerState") as
+        | {
+            viewState: {
+              directory: {
+                streamerSettings: Record<string, unknown>;
+              };
+            };
+          }
+        | undefined;
+      expect(stored?.viewState.directory.streamerSettings).toEqual(withStreamerViewSettingsDefaults({}));
+    });
   });
 
   it("rejects websocket endpoint when request is not an upgrade", async () => {

--- a/api/durable-objects/user-tracker/types.ts
+++ b/api/durable-objects/user-tracker/types.ts
@@ -1,6 +1,7 @@
 import type { TrackerDirectory } from "@guilty-spark/shared/contracts/individual-tracker/follow";
 import type { UserTrackerViewState } from "@guilty-spark/shared/contracts/durable-objects/user-tracker/management";
 import type { UserTrackerState } from "@guilty-spark/shared/contracts/durable-objects/user-tracker/lifecycle";
+import { withStreamerViewSettingsDefaults } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 
 export interface UserTrackerInternalState {
   state: UserTrackerState | null;
@@ -10,4 +11,5 @@ export interface UserTrackerInternalState {
 export const emptyTrackerDirectory: TrackerDirectory = {
   trackers: [],
   liveTrackerId: null,
+  streamerSettings: withStreamerViewSettingsDefaults({}),
 };

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -16,6 +16,7 @@ import {
 import {
   DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS,
   INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT,
+  withStreamerViewSettingsDefaults,
 } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import {
   CloudflareWebSocketHibernationAdapter,
@@ -76,6 +77,15 @@ function statsHighlightSlotsAreEqual(left: readonly string[], right: readonly st
   }
 
   return true;
+}
+
+function normalizeTrackerDirectory(
+  directory: Omit<TrackerDirectory, "streamerSettings"> & { streamerSettings?: TrackerDirectory["streamerSettings"] },
+): TrackerDirectory {
+  return {
+    ...directory,
+    streamerSettings: withStreamerViewSettingsDefaults(directory.streamerSettings),
+  };
 }
 
 export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
@@ -146,6 +156,12 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
               return new Response("Method Not Allowed", { status: 405 });
             }
             return await this.handleNudge(request);
+          }
+          case "settings-changed": {
+            if (request.method !== "POST") {
+              return new Response("Method Not Allowed", { status: 405 });
+            }
+            return this.handleSettingsChanged();
           }
           case "websocket": {
             if (request.method !== "GET") {
@@ -246,6 +262,16 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   private async loadState(): Promise<UserTrackerInternalState> {
     const stored = await this.state.storage.get<UserTrackerInternalState>(USER_TRACKER_STATE_KEY);
     if (stored != null) {
+      if (stored.viewState != null) {
+        return {
+          ...stored,
+          viewState: {
+            ...stored.viewState,
+            directory: normalizeTrackerDirectory({ ...stored.viewState.directory }),
+          },
+        };
+      }
+
       return stored;
     }
 
@@ -296,6 +322,11 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     return userTrackerNudgeContract.toResponse({ success: true }, { noStore: true });
   }
 
+  private handleSettingsChanged(): Response {
+    void this.queueDirectoryPush();
+    return new Response(null, { status: 204 });
+  }
+
   private async handleWebSocket(request: Request): Promise<Response> {
     if (request.headers.get("Upgrade") !== "websocket") {
       return new Response("Expected WebSocket upgrade", { status: 426 });
@@ -344,10 +375,11 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   }
 
   private async buildDirectory(userId: string): Promise<TrackerDirectory> {
-    const [allTrackers, streamerSettings] = await Promise.all([
+    const [allTrackers, rawStreamerSettings] = await Promise.all([
       this.databaseService.findIndividualTrackersByUserId(userId),
       this.individualTrackerService.getSettingsForView(userId),
     ]);
+    const streamerSettings = withStreamerViewSettingsDefaults(rawStreamerSettings);
 
     const nonStopped = allTrackers.filter(isNonStopped);
     const statsHighlightSlots =
@@ -368,7 +400,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     return {
       trackers: entries,
       liveTrackerId,
-      streamerSettings: Object.keys(streamerSettings).length > 0 ? streamerSettings : undefined,
+      streamerSettings,
     };
   }
 
@@ -673,10 +705,11 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     previousDirectory: TrackerDirectory,
     dirtyTrackerIds: Set<string>,
   ): Promise<TrackerDirectory> {
-    const [allTrackers, streamerSettings] = await Promise.all([
+    const [allTrackers, rawStreamerSettings] = await Promise.all([
       this.databaseService.findIndividualTrackersByUserId(userId),
       this.individualTrackerService.getSettingsForView(userId),
     ]);
+    const streamerSettings = withStreamerViewSettingsDefaults(rawStreamerSettings);
 
     const nonStoppedRows = allTrackers.filter(isNonStopped);
     const rowsByTrackerId = new Map(nonStoppedRows.map((row) => [row.TrackerId, row]));
@@ -696,7 +729,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     }
 
     const previousStatsHighlightSlots = normalizeStatsHighlightSlots(
-      previousDirectory.streamerSettings?.visibleSections?.statsHighlightSlots,
+      previousDirectory.streamerSettings.visibleSections?.statsHighlightSlots,
     );
     const nextStatsHighlightSlots = normalizeStatsHighlightSlots(streamerSettings.visibleSections?.statsHighlightSlots);
     if (!statsHighlightSlotsAreEqual(previousStatsHighlightSlots, nextStatsHighlightSlots)) {
@@ -734,7 +767,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     return {
       trackers: entries,
       liveTrackerId,
-      streamerSettings: Object.keys(streamerSettings).length > 0 ? streamerSettings : undefined,
+      streamerSettings,
     };
   }
 

--- a/api/routes/individual-tracker/settings.ts
+++ b/api/routes/individual-tracker/settings.ts
@@ -3,15 +3,26 @@ import { settingsBodySchema, settingsContract } from "@guilty-spark/shared/contr
 import { parseJsonBody } from "@guilty-spark/shared/base/request-parsing";
 import type { RoutesRegisterHandler } from "../base/types";
 import { requireSession } from "../base/require-session";
+import type { LogService } from "../../services/log/types";
 
 function getUserTrackerSettingsChangedUrl(): string {
   return "http://do/settings-changed";
 }
 
-async function notifyUserTrackerSettingsChanged(env: Env, userId: string): Promise<void> {
-  const doId = env.USER_TRACKER_DO.idFromName(userId);
-  const stub = env.USER_TRACKER_DO.get(doId);
-  await stub.fetch(new Request(getUserTrackerSettingsChangedUrl(), { method: "POST" }));
+async function notifyUserTrackerSettingsChanged(env: Env, userId: string, logService: LogService): Promise<void> {
+  try {
+    const doId = env.USER_TRACKER_DO.idFromName(userId);
+    const stub = env.USER_TRACKER_DO.get(doId);
+    await stub.fetch(new Request(getUserTrackerSettingsChangedUrl(), { method: "POST" }));
+  } catch (error) {
+    logService.warn(
+      error,
+      new Map([
+        ["context", "User tracker settings changed notification error"],
+        ["userId", userId],
+      ]),
+    );
+  }
 }
 
 export const trackerSettingsRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
@@ -51,7 +62,7 @@ export const trackerSettingsRoutesRegisterHandler: RoutesRegisterHandler = (rout
 
       const settings = await individualTrackerService.updateSettings(auth.session.userId, parsed.data.settings);
 
-      void notifyUserTrackerSettingsChanged(env, auth.session.userId);
+      void notifyUserTrackerSettingsChanged(env, auth.session.userId, logService);
 
       return settingsContract.toResponse({ settings }, { noStore: true });
     } catch (error) {

--- a/api/routes/individual-tracker/settings.ts
+++ b/api/routes/individual-tracker/settings.ts
@@ -4,6 +4,16 @@ import { parseJsonBody } from "@guilty-spark/shared/base/request-parsing";
 import type { RoutesRegisterHandler } from "../base/types";
 import { requireSession } from "../base/require-session";
 
+function getUserTrackerSettingsChangedUrl(): string {
+  return "http://do/settings-changed";
+}
+
+async function notifyUserTrackerSettingsChanged(env: Env, userId: string): Promise<void> {
+  const doId = env.USER_TRACKER_DO.idFromName(userId);
+  const stub = env.USER_TRACKER_DO.get(doId);
+  await stub.fetch(new Request(getUserTrackerSettingsChangedUrl(), { method: "POST" }));
+}
+
 export const trackerSettingsRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
   router.get("/api/individual-tracker/settings", async (request, env: Env) => {
     const services = installServices({ env });
@@ -40,6 +50,8 @@ export const trackerSettingsRoutesRegisterHandler: RoutesRegisterHandler = (rout
       }
 
       const settings = await individualTrackerService.updateSettings(auth.session.userId, parsed.data.settings);
+
+      void notifyUserTrackerSettingsChanged(env, auth.session.userId);
 
       return settingsContract.toResponse({ settings }, { noStore: true });
     } catch (error) {

--- a/api/routes/individual-tracker/tests/settings.test.ts
+++ b/api/routes/individual-tracker/tests/settings.test.ts
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SettingsResponse } from "@guilty-spark/shared/contracts/individual-tracker/settings";
 import { createApiRouter } from "../../../base/router";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
+import { aFakeDurableObjectNamespaceWith } from "../../../base/fakes/do.fake";
 import { aFakeAuthSessionWith } from "../../../services/auth/fakes/data";
 import { installFakeServicesWith } from "../../../services/fakes/services";
+import { aFakeUserTrackerDOWith } from "../../../durable-objects/user-tracker/fakes/user-tracker-do.fake";
 import { individualTrackerRoutesRegisterHandler } from "../individual-tracker";
 
 const SESSION_USER_ID = "user-123";
@@ -123,6 +125,44 @@ describe("/api/individual-tracker/settings", () => {
       expect(res.status).toBe(200);
       const body = await res.json<SettingsResponse>();
       expect(body.settings).toEqual(newSettings);
+    });
+
+    it("notifies the UserTrackerDO after saving settings", async () => {
+      const newSettings = { styleFlags: { playerTeamColor: "cerulean" } };
+      const fakeUserTrackerDO = aFakeUserTrackerDOWith();
+      const fetchSpy = vi.spyOn(fakeUserTrackerDO, "fetch");
+      const localEnv = aFakeEnvWith({
+        USER_TRACKER_DO: aFakeDurableObjectNamespaceWith(fakeUserTrackerDO),
+      });
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = withAuth(installFakeServicesWith)({ env: localEnv });
+        vi.spyOn(services.individualTrackerService, "updateSettings").mockResolvedValue(newSettings);
+        return services;
+      });
+      individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const req = new Request("http://localhost/api/individual-tracker/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ settings: newSettings }),
+      });
+      const maybeResponse: unknown = await router.fetch(req, localEnv);
+      if (!(maybeResponse instanceof Response)) {
+        throw new Error("Expected Response");
+      }
+      const res = maybeResponse;
+
+      expect(res.status).toBe(200);
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalled();
+      });
+
+      const firstCallRequest = fetchSpy.mock.calls[0]?.[0];
+      if (!(firstCallRequest instanceof Request)) {
+        throw new Error("Expected Request");
+      }
+
+      expect(firstCallRequest.url).toContain("/settings-changed");
     });
   });
 });

--- a/api/routes/user-tracker/tests/follow.test.ts
+++ b/api/routes/user-tracker/tests/follow.test.ts
@@ -1,6 +1,7 @@
 import type { AutoRouterType } from "itty-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TrackerDirectoryResponse } from "@guilty-spark/shared/contracts/individual-tracker/follow";
+import { withStreamerViewSettingsDefaults } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { createApiRouter } from "../../../base/router";
 import { aFakeDurableObjectNamespaceWith } from "../../../base/fakes/do.fake";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
@@ -87,6 +88,7 @@ describe("/u/:gamertag follow routes", () => {
                 },
               ],
               liveTrackerId: "t1",
+              streamerSettings: withStreamerViewSettingsDefaults({}),
             },
           },
         },
@@ -120,6 +122,7 @@ describe("/u/:gamertag follow routes", () => {
           },
         ],
         liveTrackerId: "t1",
+        streamerSettings: withStreamerViewSettingsDefaults({}),
       });
 
       const rawUrl = getRawUrl(userTrackerFetchSpy.mock.calls[0]?.[0] ?? "http://do/view-state");
@@ -143,7 +146,11 @@ describe("/u/:gamertag follow routes", () => {
       const res = (await router.fetch(getRequest("/u/EmptyTag"), localEnv)) as Response;
 
       expect(res.status).toBe(200);
-      await expect(res.json<TrackerDirectoryResponse>()).resolves.toEqual({ trackers: [], liveTrackerId: null });
+      await expect(res.json<TrackerDirectoryResponse>()).resolves.toEqual({
+        trackers: [],
+        liveTrackerId: null,
+        streamerSettings: withStreamerViewSettingsDefaults({}),
+      });
     });
   });
 

--- a/pages/src/components/follow/follow-tracker-tabs/tests/follow-tracker-tabs.test.tsx
+++ b/pages/src/components/follow/follow-tracker-tabs/tests/follow-tracker-tabs.test.tsx
@@ -85,6 +85,7 @@ describe("FollowTrackerTabs", () => {
         }),
       ],
       liveTrackerId: null,
+      streamerSettings: {},
     };
 
     render(
@@ -120,6 +121,7 @@ describe("FollowTrackerTabs", () => {
     const emptyDirectory: TrackerDirectory = {
       trackers: [],
       liveTrackerId: null,
+      streamerSettings: {},
     };
 
     render(

--- a/pages/src/components/follow/tests/use-follow-live-directory.test.ts
+++ b/pages/src/components/follow/tests/use-follow-live-directory.test.ts
@@ -30,6 +30,7 @@ describe("useFollowLiveDirectory", () => {
     const dir: TrackerDirectory = {
       trackers: [aTrackerWith({ trackerId: "tracker-1", isLive: false, status: "active" })],
       liveTrackerId: null,
+      streamerSettings: {},
     };
     const service = aFakeFollowLiveServiceWith({ directory: dir });
     const { result } = renderHook(() =>
@@ -62,6 +63,7 @@ describe("useFollowLiveDirectory", () => {
         aTrackerWith({ trackerId: "tracker-2", gamertag: "Spartan Two" }),
       ],
       liveTrackerId: "tracker-1",
+      streamerSettings: {},
     };
 
     act(() => {
@@ -87,6 +89,7 @@ describe("useFollowLiveDirectory", () => {
         aTrackerWith({ trackerId: "tracker-2", gamertag: "Spartan Two", isLive: true }),
       ],
       liveTrackerId: "tracker-2",
+      streamerSettings: {},
     };
 
     act(() => {
@@ -119,6 +122,7 @@ describe("useFollowLiveDirectory", () => {
         aTrackerWith({ trackerId: "tracker-3", gamertag: "Spartan Three", isLive: true }),
       ],
       liveTrackerId: "tracker-3",
+      streamerSettings: {},
     };
 
     act(() => {
@@ -150,6 +154,7 @@ describe("useFollowLiveDirectory", () => {
         aTrackerWith({ trackerId: "tracker-3", gamertag: "Spartan Three", isLive: true, status: "active" }),
       ],
       liveTrackerId: "tracker-3",
+      streamerSettings: {},
     };
 
     act(() => {
@@ -180,6 +185,7 @@ describe("useFollowLiveDirectory", () => {
         aTrackerWith({ trackerId: "tracker-3", gamertag: "Spartan Three", isLive: false, status: "paused" }),
       ],
       liveTrackerId: null,
+      streamerSettings: {},
     };
 
     act(() => {

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-store.ts
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings-store.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_STREAMER_VIEW_SETTINGS,
   DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS,
   INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT,
 } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
@@ -33,34 +34,38 @@ export interface StreamerSettingsSnapshot {
   readonly saveErrorMessage: string | null;
 }
 
+const DEFAULT_STYLE_FLAGS = DEFAULT_STREAMER_VIEW_SETTINGS.styleFlags;
+const DEFAULT_VISIBLE_SECTIONS = DEFAULT_STREAMER_VIEW_SETTINGS.visibleSections;
+const DEFAULT_FONT_SIZES = DEFAULT_STREAMER_VIEW_SETTINGS.layoutOptions?.fontSizes;
+
 const DEFAULT_DISPLAY_SETTINGS: DisplaySettings = {
-  showTeamDetails: true,
-  showDiscordNames: false,
-  showXboxNames: true,
-  showServerIcon: true,
-  showTitle: true,
-  showSubtitle: true,
-  showScore: true,
+  showTeamDetails: DEFAULT_VISIBLE_SECTIONS?.showTeamDetails ?? true,
+  showDiscordNames: DEFAULT_VISIBLE_SECTIONS?.showDiscordNames ?? false,
+  showXboxNames: DEFAULT_VISIBLE_SECTIONS?.showXboxNames ?? true,
+  showServerIcon: DEFAULT_VISIBLE_SECTIONS?.showServerIcon ?? true,
+  showTitle: DEFAULT_VISIBLE_SECTIONS?.showTitle ?? true,
+  showSubtitle: DEFAULT_VISIBLE_SECTIONS?.showSubtitle ?? true,
+  showScore: DEFAULT_VISIBLE_SECTIONS?.showScore ?? true,
 };
 
 const DEFAULT_STATS_HIGHLIGHT_SLOTS: readonly IndividualStatsHighlightOption[] =
   DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS.slice(0, INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT);
 
 const DEFAULT_TICKER_SETTINGS: TickerSettings = {
-  showTicker: true,
-  showTabs: true,
-  showPreSeriesInfo: true,
-  selectedSlayerStats: ["Score", "Kills", "Deaths", "Assists", "KDA", "Damage dealt", "Damage taken", "Damage ratio"],
-  showObjectiveStats: false,
-  medalRarityFilter: [2, 3],
+  showTicker: DEFAULT_VISIBLE_SECTIONS?.showTicker ?? true,
+  showTabs: DEFAULT_VISIBLE_SECTIONS?.showTabs ?? true,
+  showPreSeriesInfo: DEFAULT_STYLE_FLAGS?.showPreSeriesInfo ?? true,
+  selectedSlayerStats: DEFAULT_STYLE_FLAGS?.selectedSlayerStats ?? [],
+  showObjectiveStats: DEFAULT_STYLE_FLAGS?.showObjectiveStats ?? false,
+  medalRarityFilter: DEFAULT_STYLE_FLAGS?.medalRarityFilter ?? [],
 };
 
 const DEFAULT_FONT_SIZE_SETTINGS: FontSizeSettings = {
-  queueInfo: 100,
-  score: 100,
-  teams: 100,
-  tabs: 100,
-  ticker: 100,
+  queueInfo: DEFAULT_FONT_SIZES?.queueInfo ?? 100,
+  score: DEFAULT_FONT_SIZES?.score ?? 100,
+  teams: DEFAULT_FONT_SIZES?.teams ?? 100,
+  tabs: DEFAULT_FONT_SIZES?.tabs ?? 100,
+  ticker: DEFAULT_FONT_SIZES?.ticker ?? 100,
 };
 
 export class StreamerSettingsStore {
@@ -70,21 +75,21 @@ export class StreamerSettingsStore {
   public constructor() {
     this.snapshot = {
       gamertag: null,
-      defaultColorMode: "player",
-      playerTeamColor: "cerulean",
-      playerEnemyColor: "salmon",
-      observerTeamColor: "salmon",
-      observerEnemyColor: "cerulean",
+      defaultColorMode: DEFAULT_STYLE_FLAGS?.colorMode ?? "player",
+      playerTeamColor: DEFAULT_STYLE_FLAGS?.playerTeamColor ?? "cerulean",
+      playerEnemyColor: DEFAULT_STYLE_FLAGS?.playerEnemyColor ?? "salmon",
+      observerTeamColor: DEFAULT_STYLE_FLAGS?.observerTeamColor ?? "salmon",
+      observerEnemyColor: DEFAULT_STYLE_FLAGS?.observerEnemyColor ?? "cerulean",
       displaySettings: DEFAULT_DISPLAY_SETTINGS,
       tickerSettings: DEFAULT_TICKER_SETTINGS,
-      inSeriesShowSeriesTab: true,
-      matchmakingShowSummaryTab: true,
-      disableTeamPlayerNames: false,
-      inSeriesShowTicker: true,
-      matchmakingShowTicker: true,
-      matchmakingShowStatsHighlights: true,
-      inSeriesMyStatsOnly: false,
-      matchmakingMyStatsOnly: false,
+      inSeriesShowSeriesTab: DEFAULT_STYLE_FLAGS?.inSeriesShowSeriesTab ?? true,
+      matchmakingShowSummaryTab: DEFAULT_STYLE_FLAGS?.matchmakingShowSummaryTab ?? true,
+      disableTeamPlayerNames: DEFAULT_STYLE_FLAGS?.disableTeamPlayerNames ?? false,
+      inSeriesShowTicker: DEFAULT_STYLE_FLAGS?.inSeriesShowTicker ?? true,
+      matchmakingShowTicker: DEFAULT_STYLE_FLAGS?.matchmakingShowTicker ?? true,
+      matchmakingShowStatsHighlights: DEFAULT_STYLE_FLAGS?.matchmakingShowStatsHighlights ?? true,
+      inSeriesMyStatsOnly: DEFAULT_STYLE_FLAGS?.inSeriesMyStatsOnly ?? false,
+      matchmakingMyStatsOnly: DEFAULT_STYLE_FLAGS?.matchmakingMyStatsOnly ?? false,
       fontSizeSettings: DEFAULT_FONT_SIZE_SETTINGS,
       statsHighlightSlots: DEFAULT_STATS_HIGHLIGHT_SLOTS,
       saveStatus: "idle",

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -6,6 +6,7 @@ import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-
 import type { SeriesMatchesResponse } from "@guilty-spark/shared/contracts/stats/series-matches";
 import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import { withStreamerViewSettingsDefaults } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { SeriesMatchesService } from "../../../services/stats/series-matches-types";
@@ -228,8 +229,8 @@ export class IndividualTrackerViewerPresenter {
   }
 
   public static present(snapshot: IndividualTrackerViewerSnapshot): IndividualTrackerViewerViewModel {
-    const streamerSettings = snapshot.view?.streamerSettings;
-    const styleFlags = streamerSettings?.styleFlags;
+    const streamerSettings = withStreamerViewSettingsDefaults(snapshot.view?.streamerSettings);
+    const { styleFlags } = streamerSettings;
     return {
       renderModel:
         snapshot.view == null

--- a/pages/src/services/follow/fakes/follow.fake.ts
+++ b/pages/src/services/follow/fakes/follow.fake.ts
@@ -53,7 +53,7 @@ export class FakeFollowLiveService implements FollowLiveService {
   public lastConnection: FakeDirectoryConnection | null = null;
 
   public constructor(options?: { readonly directory?: TrackerDirectory }) {
-    this.directory = options?.directory ?? { trackers: [], liveTrackerId: null };
+    this.directory = options?.directory ?? { trackers: [], liveTrackerId: null, streamerSettings: {} };
   }
 
   public async getDirectory(): Promise<TrackerDirectory> {

--- a/pages/src/services/follow/tests/follow.test.ts
+++ b/pages/src/services/follow/tests/follow.test.ts
@@ -28,10 +28,13 @@ class MockWebSocket {
 }
 
 function aFakeDirectory(overrides: Partial<TrackerDirectory> = {}): TrackerDirectory {
+  const { streamerSettings, ...otherOverrides } = overrides;
+
   return {
     trackers: [],
     liveTrackerId: null,
-    ...overrides,
+    streamerSettings: streamerSettings ?? {},
+    ...otherOverrides,
   };
 }
 

--- a/shared/src/contracts/durable-objects/user-tracker/tests/user-tracker.test.ts
+++ b/shared/src/contracts/durable-objects/user-tracker/tests/user-tracker.test.ts
@@ -23,6 +23,7 @@ describe("userTracker contracts", () => {
   const directory = trackerDirectorySchema.parse({
     trackers: [],
     liveTrackerId: null,
+    streamerSettings: {},
   });
 
   it("round-trips status response", async () => {

--- a/shared/src/contracts/individual-tracker/fakes/follow.fake.ts
+++ b/shared/src/contracts/individual-tracker/fakes/follow.fake.ts
@@ -45,6 +45,7 @@ export function aDirectoryWith(overrides: Partial<TrackerDirectory> = {}): Track
       aTrackerWith({ trackerId: "tracker-2", gamertag: "Spartan Two", isLive: false, status: "active" }),
     ],
     liveTrackerId: "tracker-1",
+    streamerSettings: {},
     ...overrides,
   };
 }

--- a/shared/src/contracts/individual-tracker/follow.ts
+++ b/shared/src/contracts/individual-tracker/follow.ts
@@ -9,7 +9,7 @@ export type TrackerDirectoryEntry = z.infer<typeof trackerDirectoryEntrySchema>;
 export const trackerDirectorySchema = z.object({
   trackers: z.array(trackerDirectoryEntrySchema),
   liveTrackerId: z.string().nullable(),
-  streamerSettings: streamerViewSettingsSchema.optional(),
+  streamerSettings: streamerViewSettingsSchema,
 });
 export type TrackerDirectory = z.infer<typeof trackerDirectorySchema>;
 

--- a/shared/src/contracts/individual-tracker/tests/follow.test.ts
+++ b/shared/src/contracts/individual-tracker/tests/follow.test.ts
@@ -33,6 +33,7 @@ const validEntry = {
 const validDirectory: TrackerDirectoryResponse = {
   trackers: [validEntry],
   liveTrackerId: "t1",
+  streamerSettings: {},
 };
 
 describe("trackerDirectoryContract", () => {
@@ -43,7 +44,7 @@ describe("trackerDirectoryContract", () => {
   });
 
   it("parses a directory with no trackers", () => {
-    const result = trackerDirectoryContract.parse({ trackers: [], liveTrackerId: null });
+    const result = trackerDirectoryContract.parse({ trackers: [], liveTrackerId: null, streamerSettings: {} });
     expect(result.trackers).toEqual([]);
   });
 
@@ -53,7 +54,7 @@ describe("trackerDirectoryContract", () => {
       liveTrackerId: null,
       streamerSettings: { styleFlags: { colorMode: "observer" } },
     });
-    expect(result.streamerSettings?.styleFlags?.colorMode).toBe("observer");
+    expect(result.streamerSettings.styleFlags?.colorMode).toBe("observer");
   });
 
   it("serialises to and from a Response", async () => {
@@ -70,6 +71,7 @@ describe("trackerDirectoryContract", () => {
     expect(() =>
       trackerDirectoryContract.parse({
         liveTrackerId: null,
+        streamerSettings: {},
         trackers: [{ ...validEntry, status: "invalid" }],
       }),
     ).toThrow();
@@ -80,7 +82,7 @@ describe("trackerDirectoryMessageContract", () => {
   it("serialises and parses a directory message", () => {
     const msg = trackerDirectoryMessageContract.serialize({
       type: "directory",
-      directory: { trackers: [validEntry], liveTrackerId: "t1" },
+      directory: { trackers: [validEntry], liveTrackerId: "t1", streamerSettings: {} },
     });
     expect(typeof msg).toBe("string");
 
@@ -92,7 +94,7 @@ describe("trackerDirectoryMessageContract", () => {
   it("rejects a message with the wrong type", () => {
     expect(() =>
       trackerDirectoryMessageContract.parse(
-        JSON.stringify({ type: "wrong", directory: { trackers: [], liveTrackerId: null } }),
+        JSON.stringify({ type: "wrong", directory: { trackers: [], liveTrackerId: null, streamerSettings: {} } }),
       ),
     ).toThrow();
   });

--- a/shared/src/individual-tracker/streamer-view-settings.ts
+++ b/shared/src/individual-tracker/streamer-view-settings.ts
@@ -188,7 +188,10 @@ export const DEFAULT_STREAMER_VIEW_SETTINGS: StreamerViewSettings = {
     showScore: true,
     showTicker: true,
     showTabs: true,
-    statsHighlightSlots: [...DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS],
+    statsHighlightSlots: DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS.slice(
+      0,
+      INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT,
+    ),
   },
   layoutOptions: {
     defaultColorMode: "player",

--- a/shared/src/individual-tracker/streamer-view-settings.ts
+++ b/shared/src/individual-tracker/streamer-view-settings.ts
@@ -158,6 +158,71 @@ export const streamerViewSettingsSchema = z.object({
 });
 export type StreamerViewSettings = z.infer<typeof streamerViewSettingsSchema>;
 
+export const DEFAULT_STREAMER_VIEW_SETTINGS: StreamerViewSettings = {
+  styleFlags: {
+    colorMode: "player",
+    playerTeamColor: "cerulean",
+    playerEnemyColor: "salmon",
+    observerTeamColor: "salmon",
+    observerEnemyColor: "cerulean",
+    showPreSeriesInfo: true,
+    selectedSlayerStats: ["Score", "Kills", "Deaths", "Assists", "KDA", "Damage dealt", "Damage taken", "Damage ratio"],
+    showObjectiveStats: false,
+    medalRarityFilter: [2, 3],
+    inSeriesShowSeriesTab: true,
+    matchmakingShowSummaryTab: true,
+    disableTeamPlayerNames: false,
+    inSeriesShowTicker: true,
+    matchmakingShowTicker: true,
+    matchmakingShowStatsHighlights: true,
+    inSeriesMyStatsOnly: false,
+    matchmakingMyStatsOnly: false,
+  },
+  visibleSections: {
+    showTeamDetails: true,
+    showDiscordNames: false,
+    showXboxNames: true,
+    showServerIcon: true,
+    showTitle: true,
+    showSubtitle: true,
+    showScore: true,
+    showTicker: true,
+    showTabs: true,
+    statsHighlightSlots: [...DEFAULT_INDIVIDUAL_STATS_HIGHLIGHTS_STAT_SLOTS],
+  },
+  layoutOptions: {
+    defaultColorMode: "player",
+    fontSizes: {
+      queueInfo: 100,
+      score: 100,
+      teams: 100,
+      tabs: 100,
+      ticker: 100,
+    },
+  },
+};
+
+export function withStreamerViewSettingsDefaults(settings: StreamerViewSettings | undefined): StreamerViewSettings {
+  return {
+    styleFlags: {
+      ...DEFAULT_STREAMER_VIEW_SETTINGS.styleFlags,
+      ...settings?.styleFlags,
+    },
+    visibleSections: {
+      ...DEFAULT_STREAMER_VIEW_SETTINGS.visibleSections,
+      ...settings?.visibleSections,
+    },
+    layoutOptions: {
+      ...DEFAULT_STREAMER_VIEW_SETTINGS.layoutOptions,
+      ...settings?.layoutOptions,
+      fontSizes: {
+        ...DEFAULT_STREAMER_VIEW_SETTINGS.layoutOptions?.fontSizes,
+        ...settings?.layoutOptions?.fontSizes,
+      },
+    },
+  };
+}
+
 export type StreamerViewColorMode = z.infer<typeof streamerViewColorModeSchema>;
 export type StreamerViewObserverColorOverride = z.infer<typeof streamerViewObserverColorOverrideSchema>;
 export type StreamerViewObserverColorOverrides = z.infer<typeof streamerViewObserverColorOverridesSchema>;

--- a/shared/src/individual-tracker/tests/streamer-view-settings.test.ts
+++ b/shared/src/individual-tracker/tests/streamer-view-settings.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_STREAMER_VIEW_SETTINGS,
+  INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT,
+  withStreamerViewSettingsDefaults,
+} from "../streamer-view-settings";
+
+describe("DEFAULT_STREAMER_VIEW_SETTINGS", () => {
+  it("uses the default stats highlight slot count", () => {
+    expect(DEFAULT_STREAMER_VIEW_SETTINGS.visibleSections?.statsHighlightSlots).toHaveLength(
+      INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT,
+    );
+  });
+});
+
+describe("withStreamerViewSettingsDefaults()", () => {
+  it("fills missing stats highlight slots using the default slot count", () => {
+    const settings = withStreamerViewSettingsDefaults({});
+
+    expect(settings.visibleSections?.statsHighlightSlots).toHaveLength(INDIVIDUAL_STATS_HIGHLIGHTS_DEFAULT_SLOT_COUNT);
+  });
+});


### PR DESCRIPTION
## Context
Streamer settings in follow/overlay flows were inconsistent in two ways: updates were not pushed immediately through UserTrackerDO, and default values could diverge between UI/runtime layers (or break serialization when legacy state lacked streamerSettings).

## This PR
- Adds POST /settings-changed handling in UserTrackerDO and triggers it from PATCH /api/individual-tracker/settings so settings changes fan out immediately.
- Makes follow directory streamerSettings required in the shared contract and updates producers/fakes/tests accordingly.
- Introduces canonical streamer-setting defaults in shared (DEFAULT_STREAMER_VIEW_SETTINGS + withStreamerViewSettingsDefaults) and applies them upstream in UserTrackerDO plus viewer/store consumers.
- Adds/updates regression coverage, including legacy stored directory state missing streamerSettings, to prevent repeat serialization failures.
- Keeps full validation green (npm run done).

## Subsequent Work
- Optional cleanup: remove now-redundant downstream nullish fallbacks where defaulted settings are guaranteed by source contracts.
- Monitor production logs for any residual legacy state shape edge cases around durable object storage hydration.
