### PR TITLE
feat(kill-matrix): correlate perfect medals to kill/death pairs

### DIFF
--- a/api/services/halo/constants.ts
+++ b/api/services/halo/constants.ts
@@ -12,6 +12,7 @@ export const DEATH_HINT = 20;
 export const MODE_HINT = 10;
 
 export const KILL_DEATH_PAIRING_MAX_DELTA_MS = 1;
+export const PERFECT_MEDAL_PAIRING_MAX_DELTA_MS = 5;
 
 export const PERFECT_MEDAL_NAME_ID = 1512363953;
 export const PERFECTION_MEDAL_NAME_ID = 865763896;

--- a/api/services/halo/constants.ts
+++ b/api/services/halo/constants.ts
@@ -14,7 +14,7 @@ export const MODE_HINT = 10;
 export const KILL_DEATH_PAIRING_MAX_DELTA_MS = 1;
 export const PERFECT_MEDAL_PAIRING_MAX_DELTA_MS = 5;
 
-export const PERFECT_MEDAL_NAME_ID = 1512363953;
+export const PERFECT_MEDAL_NAME_ID = 1828716544; // 0x6D in film binary format (verified against match stats API)
 export const PERFECTION_MEDAL_NAME_ID = 865763896;
 
 export const MEDAL_SORTING_WEIGHTS = new Set<number>([

--- a/api/services/halo/constants.ts
+++ b/api/services/halo/constants.ts
@@ -11,7 +11,7 @@ export const KILL_HINT = 50;
 export const DEATH_HINT = 20;
 export const MODE_HINT = 10;
 
-export const KILL_DEATH_PAIRING_MAX_DELTA_MS = 1;
+export const KILL_DEATH_PAIRING_MAX_DELTA_MS = 2;
 export const PERFECT_MEDAL_PAIRING_MAX_DELTA_MS = 5;
 
 export const PERFECT_MEDAL_NAME_ID = 1828716544; // 0x6D in film binary format (verified against match stats API)

--- a/api/services/halo/halo-film.ts
+++ b/api/services/halo/halo-film.ts
@@ -141,7 +141,7 @@ export class HaloFilmService {
     const kills = this.filterKillEvents(events);
     const deaths = events.filter((event) => event.eventType === "death");
     const perfectMedalTimestamps = this.buildPerfectMedalTimestampsByXuid(events);
-    const perfectCounts = this.buildPerfectCountsReport(perfectMedalTimestamps);
+    const perfectCounts = this.buildPerfectCountsReport(events);
 
     const { entries, maxTimeDeltaMs, usedDeathCount } = this.buildKillMatrixEntriesByPairing(
       kills,
@@ -247,9 +247,12 @@ export class HaloFilmService {
       if (event.eventType !== "medal" || event.medalValue !== PERFECT_MEDAL_NAME_ID) {
         continue;
       }
-      const timestamps = timestampsByXuid.get(event.xuid) ?? [];
+      let timestamps = timestampsByXuid.get(event.xuid);
+      if (timestamps == null) {
+        timestamps = [];
+        timestampsByXuid.set(event.xuid, timestamps);
+      }
       timestamps.push(event.timeMs);
-      timestampsByXuid.set(event.xuid, timestamps);
     }
     return timestampsByXuid;
   }
@@ -308,11 +311,7 @@ export class HaloFilmService {
     }
     let bestIndex = -1;
     let bestDelta = Infinity;
-    for (let i = 0; i < timestamps.length; i += 1) {
-      const ts = timestamps[i];
-      if (ts == null) {
-        continue;
-      }
+    for (const [i, ts] of timestamps.entries()) {
       const delta = Math.abs(ts - killTimeMs);
       if (delta <= PERFECT_MEDAL_PAIRING_MAX_DELTA_MS && delta < bestDelta) {
         bestIndex = i;
@@ -354,16 +353,18 @@ export class HaloFilmService {
     return bestDeathIndex;
   }
 
-  private buildPerfectCountsReport(perfectMedalTimestamps: Map<string, number[]>): {
+  private buildPerfectCountsReport(events: ParsedHighlightEvent[]): {
     total: number;
     byXuid: Record<string, number>;
   } {
     const byXuid: Record<string, number> = {};
     let total = 0;
-    for (const [xuid, timestamps] of perfectMedalTimestamps.entries()) {
-      const count = timestamps.length;
-      byXuid[xuid] = count;
-      total += count;
+    for (const event of events) {
+      if (event.eventType !== "medal" || event.medalValue !== PERFECT_MEDAL_NAME_ID) {
+        continue;
+      }
+      byXuid[event.xuid] = (byXuid[event.xuid] ?? 0) + 1;
+      total += 1;
     }
     return { total, byXuid };
   }

--- a/api/services/halo/halo-film.ts
+++ b/api/services/halo/halo-film.ts
@@ -306,11 +306,23 @@ export class HaloFilmService {
     if (timestamps == null) {
       return false;
     }
-    const index = timestamps.findIndex((ts) => Math.abs(ts - killTimeMs) <= PERFECT_MEDAL_PAIRING_MAX_DELTA_MS);
-    if (index < 0) {
+    let bestIndex = -1;
+    let bestDelta = Infinity;
+    for (let i = 0; i < timestamps.length; i += 1) {
+      const ts = timestamps[i];
+      if (ts == null) {
+        continue;
+      }
+      const delta = Math.abs(ts - killTimeMs);
+      if (delta <= PERFECT_MEDAL_PAIRING_MAX_DELTA_MS && delta < bestDelta) {
+        bestIndex = i;
+        bestDelta = delta;
+      }
+    }
+    if (bestIndex < 0) {
       return false;
     }
-    timestamps.splice(index, 1);
+    timestamps.splice(bestIndex, 1);
     return true;
   }
 

--- a/api/services/halo/halo-film.ts
+++ b/api/services/halo/halo-film.ts
@@ -15,6 +15,7 @@ import {
   MEDAL_SORTING_WEIGHTS,
   KILL_DEATH_PAIRING_MAX_DELTA_MS,
   PERFECT_MEDAL_NAME_ID,
+  PERFECT_MEDAL_PAIRING_MAX_DELTA_MS,
 } from "./constants";
 import type {
   FilmMetadataResponse,
@@ -139,11 +140,14 @@ export class HaloFilmService {
 
     const kills = this.filterKillEvents(events);
     const deaths = events.filter((event) => event.eventType === "death");
-    const perfectByXuid = this.buildPerfectMedalsByXuid(events);
+    const perfectMedalTimestamps = this.buildPerfectMedalTimestampsByXuid(events);
+    const perfectCounts = this.buildPerfectCountsReport(perfectMedalTimestamps);
 
-    const { entries, maxTimeDeltaMs, usedDeathCount } = this.buildKillMatrixEntriesByPairing(kills, deaths);
-
-    const perfectCounts = this.buildPerfectCountsReport(perfectByXuid);
+    const { entries, maxTimeDeltaMs, usedDeathCount } = this.buildKillMatrixEntriesByPairing(
+      kills,
+      deaths,
+      perfectMedalTimestamps,
+    );
 
     return {
       entries,
@@ -237,24 +241,23 @@ export class HaloFilmService {
     }
   }
 
-  private buildPerfectMedalsByXuid(events: ParsedHighlightEvent[]): Map<string, number> {
-    const perfectByXuid = new Map<string, number>();
+  private buildPerfectMedalTimestampsByXuid(events: ParsedHighlightEvent[]): Map<string, number[]> {
+    const timestampsByXuid = new Map<string, number[]>();
     for (const event of events) {
-      if (event.eventType !== "medal") {
+      if (event.eventType !== "medal" || event.medalValue !== PERFECT_MEDAL_NAME_ID) {
         continue;
       }
-      if (event.medalValue !== PERFECT_MEDAL_NAME_ID) {
-        continue;
-      }
-      const currentPerfectCount = perfectByXuid.get(event.xuid) ?? 0;
-      perfectByXuid.set(event.xuid, currentPerfectCount + 1);
+      const timestamps = timestampsByXuid.get(event.xuid) ?? [];
+      timestamps.push(event.timeMs);
+      timestampsByXuid.set(event.xuid, timestamps);
     }
-    return perfectByXuid;
+    return timestampsByXuid;
   }
 
   private buildKillMatrixEntriesByPairing(
     kills: ParsedHighlightEvent[],
     deaths: ParsedHighlightEvent[],
+    perfectMedalTimestamps: Map<string, number[]>,
   ): { entries: KillMatrixEntry[]; maxTimeDeltaMs: number; usedDeathCount: number } {
     const entriesByPair = new Map<string, KillMatrixEntry>();
     const usedDeathIndexes = new Set<number>();
@@ -285,10 +288,30 @@ export class HaloFilmService {
         weapons: [],
       };
       existing.count += 1;
+      if (this.consumePerfectMedalForKill(perfectMedalTimestamps, killEvent.xuid, killEvent.timeMs)) {
+        existing.perfects += 1;
+      }
       entriesByPair.set(pairKey, existing);
     }
 
     return { entries: Array.from(entriesByPair.values()), maxTimeDeltaMs, usedDeathCount: usedDeathIndexes.size };
+  }
+
+  private consumePerfectMedalForKill(
+    timestampsByXuid: Map<string, number[]>,
+    killerXuid: string,
+    killTimeMs: number,
+  ): boolean {
+    const timestamps = timestampsByXuid.get(killerXuid);
+    if (timestamps == null) {
+      return false;
+    }
+    const index = timestamps.findIndex((ts) => Math.abs(ts - killTimeMs) <= PERFECT_MEDAL_PAIRING_MAX_DELTA_MS);
+    if (index < 0) {
+      return false;
+    }
+    timestamps.splice(index, 1);
+    return true;
   }
 
   private findBestDeathMatch(
@@ -319,13 +342,14 @@ export class HaloFilmService {
     return bestDeathIndex;
   }
 
-  private buildPerfectCountsReport(perfectByXuid: Map<string, number>): {
+  private buildPerfectCountsReport(perfectMedalTimestamps: Map<string, number[]>): {
     total: number;
     byXuid: Record<string, number>;
   } {
     const byXuid: Record<string, number> = {};
     let total = 0;
-    for (const [xuid, count] of perfectByXuid.entries()) {
+    for (const [xuid, timestamps] of perfectMedalTimestamps.entries()) {
+      const count = timestamps.length;
       byXuid[xuid] = count;
       total += count;
     }

--- a/api/services/halo/tests/halo-film.test.ts
+++ b/api/services/halo/tests/halo-film.test.ts
@@ -435,7 +435,7 @@ describe("HaloFilmService", () => {
         isMedal: true,
         eventType: "medal",
         timeMs: 205,
-        medalValue: 1512363953,
+        medalValue: 1828716544,
         teamId: null,
       },
       {
@@ -674,7 +674,7 @@ describe("HaloFilmService", () => {
           isMedal: true,
           eventType: "medal",
           timeMs: 1000,
-          medalValue: 1512363953,
+          medalValue: 1828716544,
           teamId: null,
         },
       ]);
@@ -721,7 +721,7 @@ describe("HaloFilmService", () => {
           isMedal: true,
           eventType: "medal",
           timeMs: 1000,
-          medalValue: 1512363953,
+          medalValue: 1828716544,
           teamId: null,
         },
         {
@@ -731,7 +731,7 @@ describe("HaloFilmService", () => {
           isMedal: true,
           eventType: "medal",
           timeMs: 1001,
-          medalValue: 1512363953,
+          medalValue: 1828716544,
           teamId: null,
         },
       ]);
@@ -826,7 +826,7 @@ describe("HaloFilmService", () => {
           isMedal: true,
           eventType: "medal",
           timeMs: 1000,
-          medalValue: 1512363953,
+          medalValue: 1828716544,
           teamId: null,
         },
       ]);
@@ -873,7 +873,7 @@ describe("HaloFilmService", () => {
           isMedal: true,
           eventType: "medal",
           timeMs: 1005,
-          medalValue: 1512363953,
+          medalValue: 1828716544,
           teamId: null,
         },
       ]);
@@ -920,7 +920,7 @@ describe("HaloFilmService", () => {
           isMedal: true,
           eventType: "medal",
           timeMs: 1006,
-          medalValue: 1512363953,
+          medalValue: 1828716544,
           teamId: null,
         },
       ]);
@@ -987,7 +987,7 @@ describe("HaloFilmService", () => {
           isMedal: true,
           eventType: "medal",
           timeMs: 1000,
-          medalValue: 1512363953,
+          medalValue: 1828716544,
           teamId: null,
         },
       ]);
@@ -1057,7 +1057,7 @@ describe("HaloFilmService", () => {
           isMedal: true,
           eventType: "medal",
           timeMs: 1004,
-          medalValue: 1512363953,
+          medalValue: 1828716544,
           teamId: null,
         },
         {
@@ -1067,7 +1067,7 @@ describe("HaloFilmService", () => {
           isMedal: true,
           eventType: "medal",
           timeMs: 999,
-          medalValue: 1512363953,
+          medalValue: 1828716544,
           teamId: null,
         },
       ]);
@@ -1119,7 +1119,7 @@ describe("HaloFilmService", () => {
           isMedal: true,
           eventType: "medal",
           timeMs: 1000,
-          medalValue: 1512363953,
+          medalValue: 1828716544,
           teamId: null,
         },
       ]);

--- a/api/services/halo/tests/halo-film.test.ts
+++ b/api/services/halo/tests/halo-film.test.ts
@@ -473,7 +473,7 @@ describe("HaloFilmService", () => {
   });
 
   describe("kill-death pairing edge cases", () => {
-    it("pairs kills and deaths at exactly the boundary (1ms delta)", async () => {
+    it("pairs kills and deaths at exactly the boundary (2ms delta)", async () => {
       const env = aFakeCacheBackedEnvWith();
       const xboxService = aFakeXboxServiceWith({ env });
       const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });
@@ -499,7 +499,7 @@ describe("HaloFilmService", () => {
           typeHint: 20,
           isMedal: false,
           eventType: "death",
-          timeMs: 1001,
+          timeMs: 1002,
           medalValue: 0,
           teamId: null,
         },
@@ -511,7 +511,7 @@ describe("HaloFilmService", () => {
       expect(analytics.pairingQuality.unpairedDeathCount).toBe(0);
     });
 
-    it("does not pair kills and deaths exceeding 1ms delta", async () => {
+    it("does not pair kills and deaths exceeding 2ms delta", async () => {
       const env = aFakeCacheBackedEnvWith();
       const xboxService = aFakeXboxServiceWith({ env });
       const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });

--- a/api/services/halo/tests/halo-film.test.ts
+++ b/api/services/halo/tests/halo-film.test.ts
@@ -998,6 +998,90 @@ describe("HaloFilmService", () => {
       expect(analytics.entries[0]?.perfects).toBe(1);
     });
 
+    it("consumes the closest perfect medal when multiple medals are within the window for the same kill", async () => {
+      const env = aFakeCacheBackedEnvWith();
+      const xboxService = aFakeXboxServiceWith({ env });
+      const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });
+      const service = new HaloFilmService({ env, spartanTokenProvider });
+      const match = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+      const killerXuid = unwrapXuid(Preconditions.checkExists(match.Players[0]).PlayerId);
+      const victimXuid = unwrapXuid(Preconditions.checkExists(match.Players[1]).PlayerId);
+
+      vi.spyOn(service, "getHighlightEventsForMatch").mockResolvedValue([
+        {
+          xuid: killerXuid,
+          gamertag: "killer",
+          typeHint: 50,
+          isMedal: false,
+          eventType: "kill",
+          timeMs: 1000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: victimXuid,
+          gamertag: "victim",
+          typeHint: 20,
+          isMedal: false,
+          eventType: "death",
+          timeMs: 1000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: killerXuid,
+          gamertag: "killer",
+          typeHint: 50,
+          isMedal: false,
+          eventType: "kill",
+          timeMs: 2000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: victimXuid,
+          gamertag: "victim",
+          typeHint: 20,
+          isMedal: false,
+          eventType: "death",
+          timeMs: 2000,
+          medalValue: 0,
+          teamId: null,
+        },
+        // Two medals within the window of kill at 1000ms: one at 999ms (delta 1) and one at 1004ms (delta 4)
+        // The kill at 2000ms has no medal nearby, so the 1004ms medal must not be consumed by the second kill
+        {
+          xuid: killerXuid,
+          gamertag: "killer",
+          typeHint: 210,
+          isMedal: true,
+          eventType: "medal",
+          timeMs: 1004,
+          medalValue: 1512363953,
+          teamId: null,
+        },
+        {
+          xuid: killerXuid,
+          gamertag: "killer",
+          typeHint: 210,
+          isMedal: true,
+          eventType: "medal",
+          timeMs: 999,
+          medalValue: 1512363953,
+          teamId: null,
+        },
+      ]);
+
+      const analytics = await service.buildKillMatrixAnalytics(match);
+
+      // kill at 1000ms: closest medal is 999ms (delta 1) — consumed
+      // kill at 2000ms: no medal within 5ms — not attributed
+      // Remaining medal at 1004ms is left unconsumed
+      expect(analytics.entries[0]?.count).toBe(2);
+      expect(analytics.entries[0]?.perfects).toBe(1);
+      expect(analytics.perfectCounts.total).toBe(2);
+    });
+
     it("does not attribute a perfect medal from a different player to the kill pair", async () => {
       const env = aFakeCacheBackedEnvWith();
       const xboxService = aFakeXboxServiceWith({ env });

--- a/api/services/halo/tests/halo-film.test.ts
+++ b/api/services/halo/tests/halo-film.test.ts
@@ -459,7 +459,7 @@ describe("HaloFilmService", () => {
       victimXuid,
       count: 2,
       headshotKills: 0,
-      perfects: 0,
+      perfects: 1,
       weapons: [],
     });
     expect(analytics.pairingQuality).toEqual({
@@ -785,6 +785,264 @@ describe("HaloFilmService", () => {
 
       const analytics = await service.buildKillMatrixAnalytics(match);
       expect(analytics.perfectCounts.total).toBe(0);
+    });
+  });
+
+  describe("perfect medal per-pair attribution", () => {
+    it("attributes perfect medal at same timestamp as kill to that pair", async () => {
+      const env = aFakeCacheBackedEnvWith();
+      const xboxService = aFakeXboxServiceWith({ env });
+      const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });
+      const service = new HaloFilmService({ env, spartanTokenProvider });
+      const match = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+      const killerXuid = unwrapXuid(Preconditions.checkExists(match.Players[0]).PlayerId);
+      const victimXuid = unwrapXuid(Preconditions.checkExists(match.Players[1]).PlayerId);
+
+      vi.spyOn(service, "getHighlightEventsForMatch").mockResolvedValue([
+        {
+          xuid: killerXuid,
+          gamertag: "killer",
+          typeHint: 50,
+          isMedal: false,
+          eventType: "kill",
+          timeMs: 1000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: victimXuid,
+          gamertag: "victim",
+          typeHint: 20,
+          isMedal: false,
+          eventType: "death",
+          timeMs: 1000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: killerXuid,
+          gamertag: "killer",
+          typeHint: 210,
+          isMedal: true,
+          eventType: "medal",
+          timeMs: 1000,
+          medalValue: 1512363953,
+          teamId: null,
+        },
+      ]);
+
+      const analytics = await service.buildKillMatrixAnalytics(match);
+
+      expect(analytics.entries[0]?.perfects).toBe(1);
+    });
+
+    it("attributes perfect medal within 5ms of kill timestamp to that pair", async () => {
+      const env = aFakeCacheBackedEnvWith();
+      const xboxService = aFakeXboxServiceWith({ env });
+      const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });
+      const service = new HaloFilmService({ env, spartanTokenProvider });
+      const match = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+      const killerXuid = unwrapXuid(Preconditions.checkExists(match.Players[0]).PlayerId);
+      const victimXuid = unwrapXuid(Preconditions.checkExists(match.Players[1]).PlayerId);
+
+      vi.spyOn(service, "getHighlightEventsForMatch").mockResolvedValue([
+        {
+          xuid: killerXuid,
+          gamertag: "killer",
+          typeHint: 50,
+          isMedal: false,
+          eventType: "kill",
+          timeMs: 1000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: victimXuid,
+          gamertag: "victim",
+          typeHint: 20,
+          isMedal: false,
+          eventType: "death",
+          timeMs: 1000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: killerXuid,
+          gamertag: "killer",
+          typeHint: 210,
+          isMedal: true,
+          eventType: "medal",
+          timeMs: 1005,
+          medalValue: 1512363953,
+          teamId: null,
+        },
+      ]);
+
+      const analytics = await service.buildKillMatrixAnalytics(match);
+
+      expect(analytics.entries[0]?.perfects).toBe(1);
+    });
+
+    it("does not attribute perfect medal more than 5ms from kill timestamp", async () => {
+      const env = aFakeCacheBackedEnvWith();
+      const xboxService = aFakeXboxServiceWith({ env });
+      const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });
+      const service = new HaloFilmService({ env, spartanTokenProvider });
+      const match = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+      const killerXuid = unwrapXuid(Preconditions.checkExists(match.Players[0]).PlayerId);
+      const victimXuid = unwrapXuid(Preconditions.checkExists(match.Players[1]).PlayerId);
+
+      vi.spyOn(service, "getHighlightEventsForMatch").mockResolvedValue([
+        {
+          xuid: killerXuid,
+          gamertag: "killer",
+          typeHint: 50,
+          isMedal: false,
+          eventType: "kill",
+          timeMs: 1000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: victimXuid,
+          gamertag: "victim",
+          typeHint: 20,
+          isMedal: false,
+          eventType: "death",
+          timeMs: 1000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: killerXuid,
+          gamertag: "killer",
+          typeHint: 210,
+          isMedal: true,
+          eventType: "medal",
+          timeMs: 1006,
+          medalValue: 1512363953,
+          teamId: null,
+        },
+      ]);
+
+      const analytics = await service.buildKillMatrixAnalytics(match);
+
+      expect(analytics.entries[0]?.perfects).toBe(0);
+    });
+
+    it("consumes each perfect medal once across multiple kills by the same player", async () => {
+      const env = aFakeCacheBackedEnvWith();
+      const xboxService = aFakeXboxServiceWith({ env });
+      const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });
+      const service = new HaloFilmService({ env, spartanTokenProvider });
+      const match = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+      const killerXuid = unwrapXuid(Preconditions.checkExists(match.Players[0]).PlayerId);
+      const victimXuid = unwrapXuid(Preconditions.checkExists(match.Players[1]).PlayerId);
+
+      vi.spyOn(service, "getHighlightEventsForMatch").mockResolvedValue([
+        {
+          xuid: killerXuid,
+          gamertag: "killer",
+          typeHint: 50,
+          isMedal: false,
+          eventType: "kill",
+          timeMs: 1000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: victimXuid,
+          gamertag: "victim",
+          typeHint: 20,
+          isMedal: false,
+          eventType: "death",
+          timeMs: 1000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: killerXuid,
+          gamertag: "killer",
+          typeHint: 50,
+          isMedal: false,
+          eventType: "kill",
+          timeMs: 2000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: victimXuid,
+          gamertag: "victim",
+          typeHint: 20,
+          isMedal: false,
+          eventType: "death",
+          timeMs: 2000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: killerXuid,
+          gamertag: "killer",
+          typeHint: 210,
+          isMedal: true,
+          eventType: "medal",
+          timeMs: 1000,
+          medalValue: 1512363953,
+          teamId: null,
+        },
+      ]);
+
+      const analytics = await service.buildKillMatrixAnalytics(match);
+
+      expect(analytics.entries[0]?.count).toBe(2);
+      expect(analytics.entries[0]?.perfects).toBe(1);
+    });
+
+    it("does not attribute a perfect medal from a different player to the kill pair", async () => {
+      const env = aFakeCacheBackedEnvWith();
+      const xboxService = aFakeXboxServiceWith({ env });
+      const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });
+      const service = new HaloFilmService({ env, spartanTokenProvider });
+      const match = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+      const killerXuid = unwrapXuid(Preconditions.checkExists(match.Players[0]).PlayerId);
+      const victimXuid = unwrapXuid(Preconditions.checkExists(match.Players[1]).PlayerId);
+
+      vi.spyOn(service, "getHighlightEventsForMatch").mockResolvedValue([
+        {
+          xuid: killerXuid,
+          gamertag: "killer",
+          typeHint: 50,
+          isMedal: false,
+          eventType: "kill",
+          timeMs: 1000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: victimXuid,
+          gamertag: "victim",
+          typeHint: 20,
+          isMedal: false,
+          eventType: "death",
+          timeMs: 1000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: victimXuid,
+          gamertag: "victim",
+          typeHint: 210,
+          isMedal: true,
+          eventType: "medal",
+          timeMs: 1000,
+          medalValue: 1512363953,
+          teamId: null,
+        },
+      ]);
+
+      const analytics = await service.buildKillMatrixAnalytics(match);
+
+      expect(analytics.entries[0]?.perfects).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Context

Part of the kill matrix improvements plan. The kill matrix shows per-pair stats (kills, deaths, perfects) between players. The `perfects` field existed in the contract and was always 0 — this PR wires up the backend logic to populate it from film event data.

## This change

Correlates perfect medal film events to paired kill/death entries:

- Adds `PERFECT_MEDAL_PAIRING_MAX_DELTA_MS = 5` constant — perfect medals fire at or within a few ms of the kill event timestamp in the film data
- Replaces `buildPerfectMedalsByXuid` (count-only) with `buildPerfectMedalTimestampsByXuid` returning `Map<string, number[]>` (mutable pool of timestamps per killer)
- `buildPerfectCountsReport` now derives counts from this map **before** pairing consumes timestamps, keeping the aggregate summary accurate
- `buildKillMatrixEntriesByPairing` accepts the timestamps map; for each successful kill-death pair it calls `consumePerfectMedalForKill` which finds the closest matching timestamp within 5ms and splices it from the pool
- 5 new focused tests cover: same-timestamp attribution, within-5ms attribution, beyond-5ms exclusion, single-consumption across multiple kills, and cross-player non-attribution

## Subsequent work

- PR 16: head-to-head popover UI (cell click shows kills + perfects; kills/deaths in cross-team mode)
- Future: headshot detection (blocked on film format research), weapon breakdown