### PR TITLE
Refine pre-series behavior and active-series linking

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -338,12 +338,12 @@ function isEligibleForActiveSeries(
     return false;
   }
 
+  if (summary.isMatchmaking) {
+    return false;
+  }
+
   const expectedTeamCounts = getExpectedSeriesTeamCounts(activeSeries.teams);
   if (expectedTeamCounts == null) {
-    if (summary.isMatchmaking) {
-      return false;
-    }
-
     return true;
   }
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -151,6 +151,7 @@ const DEFAULT_WEBSOCKET_STATS_HIGHLIGHT_SLOTS = DEFAULT_INDIVIDUAL_STATS_HIGHLIG
 
 const UNKNOWN_KDA_DISPLAY = "-:-:- (-)";
 const UNKNOWN_DAMAGE_RATIO_DISPLAY = "-:- (-)";
+const UNKNOWN_SERIES_SUMMARY_DISPLAY = "N/A";
 const STATS_DISPLAY_LOCALE = "en-US";
 
 function computeTrackedPlayerSummaryStats(
@@ -196,6 +197,13 @@ function computeSeriesSummaryStats(summaries: readonly IndividualTrackerMatchSum
   killsDeathsAssistsKda: string;
   damageDealtTakenRatio: string;
 } {
+  if (summaries.length === 0) {
+    return {
+      killsDeathsAssistsKda: UNKNOWN_SERIES_SUMMARY_DISPLAY,
+      damageDealtTakenRatio: UNKNOWN_SERIES_SUMMARY_DISPLAY,
+    };
+  }
+
   let kills = 0;
   let deaths = 0;
   let assists = 0;
@@ -211,8 +219,8 @@ function computeSeriesSummaryStats(summaries: readonly IndividualTrackerMatchSum
       summary.damageTaken == null
     ) {
       return {
-        killsDeathsAssistsKda: UNKNOWN_KDA_DISPLAY,
-        damageDealtTakenRatio: UNKNOWN_DAMAGE_RATIO_DISPLAY,
+        killsDeathsAssistsKda: UNKNOWN_SERIES_SUMMARY_DISPLAY,
+        damageDealtTakenRatio: UNKNOWN_SERIES_SUMMARY_DISPLAY,
       };
     }
 
@@ -319,6 +327,27 @@ function getSeriesSummariesForView(
       : groupSummaries.filter((summary) => hasExpectedSeriesTeamCounts(summary, expectedTeamCounts));
 
   return collapseSequentialSeriesEntries(summariesWithExpectedTeams);
+}
+
+function isEligibleForActiveSeries(
+  summary: IndividualTrackerMatchSummary,
+  matchDurationSeconds: number,
+  activeSeries: ActiveSeries,
+): boolean {
+  if (matchDurationSeconds < 120) {
+    return false;
+  }
+
+  const expectedTeamCounts = getExpectedSeriesTeamCounts(activeSeries.teams);
+  if (expectedTeamCounts == null) {
+    if (summary.isMatchmaking) {
+      return false;
+    }
+
+    return true;
+  }
+
+  return hasExpectedSeriesTeamCounts(summary, expectedTeamCounts);
 }
 
 function normalizeRankTier(rankTier: string | null | undefined): string | null {
@@ -582,17 +611,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       }
 
       const isMatchmakingMatch = match.MatchInfo.Playlist != null;
-      if (trackerState.activeSeries != null && isMatchmakingMatch) {
-        this.clearSeriesState(trackerState);
-        this.logService.info(
-          "IndividualTracker: series ended after matchmaking match was discovered",
-          new Map([
-            ["trackerId", trackerState.trackerId],
-            ["gamertag", trackerState.gamertag],
-            ["matchId", matchId],
-          ]),
-        );
-      }
 
       const outcome = getMatchOutcomeLabel(match.Outcome);
       const mapName = await this.resolveMapName(
@@ -629,9 +647,22 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       if (durationSeconds >= 120) {
         trackerState.selectedMatchIds.push(matchId);
       }
-      if (trackerState.activeSeries != null && !isMatchmakingMatch && !existingActiveSeriesMatchIds.has(matchId)) {
-        trackerState.activeSeries.matchIds.push(matchId);
-        existingActiveSeriesMatchIds.add(matchId);
+      if (trackerState.activeSeries != null && !existingActiveSeriesMatchIds.has(matchId)) {
+        const isSeriesEligible = isEligibleForActiveSeries(summary, durationSeconds, trackerState.activeSeries);
+        if (isSeriesEligible) {
+          trackerState.activeSeries.matchIds.push(matchId);
+          existingActiveSeriesMatchIds.add(matchId);
+        } else if (isMatchmakingMatch) {
+          this.clearSeriesState(trackerState);
+          this.logService.info(
+            "IndividualTracker: series ended after matchmaking match was discovered",
+            new Map([
+              ["trackerId", trackerState.trackerId],
+              ["gamertag", trackerState.gamertag],
+              ["matchId", matchId],
+            ]),
+          );
+        }
       }
       newlyDiscovered.add(matchId);
       discoveredNewMatch = true;
@@ -2016,13 +2047,14 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       }
       case "started": {
         this.clearSeriesState(trackerState);
+        const startedAt = payload.startedAt ?? new Date().toISOString();
         trackerState.activeSeries = {
           title: payload.title,
           subtitle: payload.subtitle,
           guildIconUrl: payload.guildIconUrl,
           teams: payload.teams,
           matchIds: [],
-          startedAt: new Date().toISOString(),
+          startedAt,
           isActive: true,
         };
 
@@ -2368,7 +2400,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     const activeSeriesMatchIds = state.activeSeries?.matchIds ?? [];
     const activeSeriesMatchIdSet = new Set(activeSeriesMatchIds);
     const groupings =
-      activeSeriesMatchIds.length >= 2
+      activeSeriesMatchIds.length > 0
         ? [activeSeriesMatchIds, ...autoGroupings.filter((g) => !g.some((id) => activeSeriesMatchIdSet.has(id)))]
         : autoGroupings;
 
@@ -2472,6 +2504,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
               title: state.activeSeries.title,
               subtitle: state.activeSeries.subtitle,
               guildIconUrl: state.activeSeries.guildIconUrl,
+              startedAt: state.activeSeries.startedAt,
               teams: state.activeSeries.teams,
             },
           }

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -3299,6 +3299,47 @@ describe("IndividualTrackerDO", () => {
       expect(group?.teams).toEqual(teams);
     });
 
+    it("surfaces an active series group when only one active-series match is currently linked", async () => {
+      const ids = ["match-active-1"];
+      const activeSeries: ActiveSeries = {
+        title: "Queue Live",
+        subtitle: "Queue #8",
+        guildIconUrl: null,
+        matchIds: ids,
+        teams: [],
+        startedAt: "2026-07-17T09:23:30.659Z",
+        isActive: true,
+      };
+
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          ...makeSeriesMatches(ids),
+          activeSeries,
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
+
+      expect(response.status).toBe(200);
+      const body = await response.json<{
+        state: {
+          hasActiveSeries: boolean;
+          activeSeriesContext?: { startedAt?: string };
+          series: { title: string; subtitle: string; matchIds: string[]; score: string }[];
+        };
+      }>();
+
+      expect(body.state.hasActiveSeries).toBe(true);
+      expect(body.state.activeSeriesContext?.startedAt).toBe("2026-07-17T09:23:30.659Z");
+      expect(body.state.series).toHaveLength(1);
+      expect(body.state.series[0]).toMatchObject({
+        title: "Queue Live",
+        subtitle: "Queue #8",
+        matchIds: ["match-active-1"],
+        score: "0:0",
+      });
+    });
+
     it("applies completedSeries metadata to a matching group after the series ends", async () => {
       const ids = ["match-c-1", "match-c-2"];
       const completedSeries: ActiveSeries = {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1779,7 +1779,24 @@ describe("IndividualTrackerDO", () => {
             title: "Active Series",
             subtitle: "Customs",
             guildIconUrl: null,
-            teams: [],
+            teams: [
+              {
+                id: 0,
+                name: "Eagle",
+                players: [
+                  { discordId: null, discordName: null, gamertag: "Alpha", xboxId: "1111111111" },
+                  { discordId: null, discordName: null, gamertag: "Bravo", xboxId: "2222222222" },
+                ],
+              },
+              {
+                id: 1,
+                name: "Cobra",
+                players: [
+                  { discordId: null, discordName: null, gamertag: "Charlie", xboxId: "3333333333" },
+                  { discordId: null, discordName: null, gamertag: "Delta", xboxId: "4444444444" },
+                ],
+              },
+            ],
             matchIds: ["series-custom-match"],
             startedAt: "2024-11-26T11:00:00.000Z",
             isActive: true,

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -240,6 +240,7 @@ export interface ActiveSeriesContext {
   title: string;
   subtitle: string | null;
   guildIconUrl: string | null;
+  startedAt?: string;
   teams: SeriesTeam[];
 }
 

--- a/api/individual-tracker/mapper.ts
+++ b/api/individual-tracker/mapper.ts
@@ -126,6 +126,7 @@ function toTrackerActiveSeriesContext(context: TrackerActiveSeriesContext): Trac
     title: context.title,
     subtitle: context.subtitle,
     guildIconUrl: context.guildIconUrl,
+    startedAt: context.startedAt,
     teams: context.teams.map(toTrackerSeriesTeam),
   };
 }

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -703,14 +703,15 @@ export class NeatQueueService {
   }
 
   private resolveSeriesStartedAt(request: NeatQueueTeamsCreatedRequest): string {
-    const candidateTimestamp = request.teams
+    const validTimestamps = request.teams
       .flatMap((team) => team.map((player) => player.timestamp))
-      .find((value) => {
-        return value.trim() !== "";
-      });
+      .map((value) => value.trim())
+      .filter((value) => value !== "")
+      .map((value) => Date.parse(value))
+      .filter((value) => !Number.isNaN(value));
 
-    if (candidateTimestamp != null && !Number.isNaN(Date.parse(candidateTimestamp))) {
-      return new Date(candidateTimestamp).toISOString();
+    if (validTimestamps.length > 0) {
+      return new Date(Math.min(...validTimestamps)).toISOString();
     }
 
     return new Date().toISOString();

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -683,6 +683,7 @@ export class NeatQueueService {
         title,
         subtitle: `Queue #${request.match_number.toString()}`,
         guildIconUrl,
+        startedAt: this.resolveSeriesStartedAt(request),
         teams: seriesTeams,
       };
       queueState.seriesContext = seriesContext;
@@ -699,6 +700,20 @@ export class NeatQueueService {
         ]),
       );
     }
+  }
+
+  private resolveSeriesStartedAt(request: NeatQueueTeamsCreatedRequest): string {
+    const candidateTimestamp = request.teams
+      .flatMap((team) => team.map((player) => player.timestamp))
+      .find((value) => {
+        return value.trim() !== "";
+      });
+
+    if (candidateTimestamp != null && !Number.isNaN(Date.parse(candidateTimestamp))) {
+      return new Date(candidateTimestamp).toISOString();
+    }
+
+    return new Date().toISOString();
   }
 
   private async fetchGuildDisplayInfo(guildId: string): Promise<{ title: string; guildIconUrl: string | null }> {

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -2262,6 +2262,38 @@ describe("NeatQueueService", () => {
         expect(payload.startedAt).toBe(expectedStartedAt);
       });
 
+      it("uses earliest valid player timestamp when earlier entries are invalid", async () => {
+        vi.setSystemTime(new Date("2026-07-17T10:00:00.000Z"));
+
+        const teamsCreatedRequest = getFakeNeatQueueData("teamsCreated");
+        const [firstTeam, secondTeam] = teamsCreatedRequest.teams;
+        if (firstTeam?.[0] == null || secondTeam?.[0] == null) {
+          throw new Error("Expected fake teamsCreated payload to include at least 2 players");
+        }
+
+        firstTeam[0].timestamp = "not-a-date";
+        secondTeam[0].timestamp = "2026-07-17T09:58:00.000Z";
+
+        (vi.spyOn(env.APP_DATA, "get") as MockInstance).mockResolvedValue(aFakeNeatQueueStateWith());
+        vi.spyOn(env.APP_DATA, "put").mockResolvedValue();
+        vi.spyOn(discordService, "getGuild").mockResolvedValue({
+          ...guild,
+          id: "guild-1",
+          name: "Test Server",
+          icon: null,
+        });
+        vi.spyOn(databaseService, "getGuildConfig").mockResolvedValue(
+          aFakeGuildConfigRow({ NeatQueueInformerLiveTracking: "N" }),
+        );
+
+        const { jobToComplete } = neatQueueService.handleRequest(teamsCreatedRequest, neatQueueConfig);
+        await jobToComplete?.();
+
+        expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
+        const [, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], SeriesStartedPayload];
+        expect(payload.startedAt).toBe("2026-07-17T09:58:00.000Z");
+      });
+
       it("uses guild ID as title fallback when getGuild fails and team names are unavailable", async () => {
         const teamsCreatedRequest = getFakeNeatQueueData("teamsCreated");
         teamsCreatedRequest.teams = [];

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -2230,6 +2230,9 @@ describe("NeatQueueService", () => {
 
       it("uses guild display name for title even when explicit team names are set", async () => {
         const teamsCreatedRequest = getFakeNeatQueueData("teamsCreated");
+        const expectedStartedAt = new Date(
+          teamsCreatedRequest.teams[0]?.[0]?.timestamp ?? "2026-01-01T00:00:00.000Z",
+        ).toISOString();
         const team0Player = teamsCreatedRequest.teams[0]?.[0];
         const team1Player = teamsCreatedRequest.teams[1]?.[0];
         if (team0Player != null) {
@@ -2256,6 +2259,7 @@ describe("NeatQueueService", () => {
         expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
         const [, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], SeriesStartedPayload];
         expect(payload.title).toBe("Test Server");
+        expect(payload.startedAt).toBe(expectedStartedAt);
       });
 
       it("uses guild ID as title fallback when getGuild fails and team names are unavailable", async () => {

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
@@ -311,6 +311,7 @@ describe("buildViewerRenderModel", () => {
         title: "Alpha vs Beta",
         subtitle: "Bo5",
         guildIconUrl: "https://cdn.example.com/icon.png",
+        startedAt: "2026-07-17T09:23:30.659Z",
         teams: [
           {
             id: 0,
@@ -336,6 +337,11 @@ describe("buildViewerRenderModel", () => {
       expect(first.series.title).toBe("Alpha vs Beta");
       expect(first.series.subtitle).toBe("Bo5");
       expect(first.series.guildIconUrl).toBe("https://cdn.example.com/icon.png");
+      expect(first.series.score).toBe("0:0");
+      expect(first.series.duration).toBe("-");
+      expect(first.series.killsDeathsAssistsKda).toBe("N/A");
+      expect(first.series.damageDealtTakenRatio).toBe("N/A");
+      expect(first.series.startTime).toBe("2026-07-17T09:23:30.659Z");
       expect(first.series.matches).toHaveLength(0);
       expect(first.series.teams[0]?.players[0]?.discordName).toBe("AlphaOne");
       expect(first.series.teams[1]?.players[0]?.gamertag).toBe("BetaTag");

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
@@ -422,6 +422,46 @@ describe("buildViewerRenderModel", () => {
     }
   });
 
+  it("renders active series row once the first linked match is available", () => {
+    const view = aFakeTrackerViewStateWith({
+      matches: [aFakeTrackerMatchSummaryWith({ matchId: "m1" })],
+      series: [
+        aFakeTrackerSeriesGroupWith({
+          id: "series-live",
+          title: "Alpha vs Beta",
+          subtitle: "Bo3",
+          matchIds: ["m1"],
+        }),
+      ],
+      hasActiveSeries: true,
+      activeSeriesContext: {
+        title: "Alpha vs Beta",
+        subtitle: "Bo3",
+        teams: [
+          {
+            id: 0,
+            name: "Alpha",
+            players: [{ discordId: null, discordName: "AlphaOne", gamertag: "AlphaTag", xboxId: null }],
+          },
+          {
+            id: 1,
+            name: "Beta",
+            players: [{ discordId: null, discordName: "BetaOne", gamertag: "BetaTag", xboxId: null }],
+          },
+        ],
+      },
+    });
+
+    const model = buildViewerRenderModel({ view });
+    expect(model.timeline).toHaveLength(1);
+    expect(model.timeline[0]?.type).toBe("series");
+    if (model.timeline[0]?.type === "series") {
+      expect(model.timeline[0].series.id).toBe("series-live");
+      expect(model.timeline[0].series.matches.map((match) => match.matchId)).toEqual(["m1"]);
+      expect(model.timeline[0].series.isActive).toBe(true);
+    }
+  });
+
   it("maps active series context teams onto the active series tab", () => {
     const view = aFakeTrackerViewStateWith({
       matches: [aFakeTrackerMatchSummaryWith({ matchId: "m1" }), aFakeTrackerMatchSummaryWith({ matchId: "m2" })],

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -81,6 +81,7 @@ export interface ViewerActiveSeriesContext {
   readonly title: string;
   readonly subtitle: string | null;
   readonly guildIconUrl?: string | null;
+  readonly startedAt?: string;
   readonly teams: readonly ViewerSeriesTeam[];
 }
 

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -284,7 +284,8 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
   let fallbackActiveSeriesId: string | null = null;
   for (const series of view.series) {
     const knownIds = series.matchIds.filter((id) => matchesById.has(id));
-    if (knownIds.length < 2) {
+    const isCurrentActiveSeries = activeSeriesId != null && series.id === activeSeriesId;
+    if (knownIds.length < 2 && !(isCurrentActiveSeries && knownIds.length > 0)) {
       continue;
     }
     const [anchorId] = series.matchIds;

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -30,6 +30,7 @@ export interface BuildViewerRenderModelOptions {
 const UNKNOWN_KDA_DISPLAY = "-:-:- (-)";
 const UNKNOWN_DAMAGE_RATIO_DISPLAY = "-:- (-)";
 const PENDING_ACTIVE_SERIES_ID_PREFIX = "pending-active-series";
+const PENDING_SERIES_SUMMARY_DISPLAY = "N/A";
 
 type ActiveSeriesContext = NonNullable<TrackerViewState["activeSeriesContext"]>;
 type ActiveSeriesTeam = ActiveSeriesContext["teams"][number];
@@ -103,6 +104,7 @@ function toViewerActiveSeriesContext(view: TrackerViewState): ViewerActiveSeries
     title: view.activeSeriesContext.title,
     subtitle: view.activeSeriesContext.subtitle,
     guildIconUrl: view.activeSeriesContext.guildIconUrl ?? null,
+    startedAt: view.activeSeriesContext.startedAt,
     teams: view.activeSeriesContext.teams.map(toViewerSeriesTeam),
   };
 }
@@ -179,11 +181,11 @@ function toPendingActiveSeriesTab(view: TrackerViewState): ViewerSeriesTab {
     teams,
     preSeriesTableData: toPreSeriesTableData(teams),
     matchBackgroundUrls: [],
-    score: "-",
-    duration: "unknown",
-    killsDeathsAssistsKda: UNKNOWN_KDA_DISPLAY,
-    damageDealtTakenRatio: UNKNOWN_DAMAGE_RATIO_DISPLAY,
-    startTime: "",
+    score: "0:0",
+    duration: "-",
+    killsDeathsAssistsKda: PENDING_SERIES_SUMMARY_DISPLAY,
+    damageDealtTakenRatio: PENDING_SERIES_SUMMARY_DISPLAY,
+    startTime: activeSeriesContext.startedAt ?? view.lastUpdateTime,
     endTime: "",
     matches: [],
     colorHex: undefined,
@@ -306,11 +308,13 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
         }
       }
 
-      let seriesDuration = "unknown";
+      let seriesDuration = "-";
       let seriesStartTime = "";
       let seriesEndTime = "";
+      const isCurrentActiveSeries = activeSeriesId != null && anchoredSeries.id === activeSeriesId;
 
       if (seriesSummaries.length > 0) {
+        seriesDuration = "unknown";
         let totalSeconds = 0;
         let hasInvalidDurationBounds = false;
         for (const summary of seriesSummaries) {
@@ -339,6 +343,8 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
         const endTimes = seriesSummaries.map((summary) => summary.endTime);
         seriesStartTime = startTimes.reduce((earliest, current) => (current < earliest ? current : earliest));
         seriesEndTime = endTimes.reduce((latest, current) => (current > latest ? current : latest));
+      } else if (isCurrentActiveSeries && view.activeSeriesContext?.startedAt != null) {
+        seriesStartTime = view.activeSeriesContext.startedAt;
       }
 
       const series: ViewerSeriesTab = {

--- a/pages/src/components/live-tracker/state-render-model.ts
+++ b/pages/src/components/live-tracker/state-render-model.ts
@@ -12,6 +12,14 @@ import type {
   LiveTrackerSubstitutionRenderModel,
 } from "./types";
 
+function normalizeSeriesScore(score: string): string {
+  if (/^\d+:\d+$/.test(score)) {
+    return score;
+  }
+
+  return "0:0";
+}
+
 function toMatchRenderModel(
   summary: LiveTrackerMatchSummary,
   rawMatches: Record<string, unknown>,
@@ -112,7 +120,7 @@ export function toLiveTrackerStateRenderModel(
     teams,
     matches,
     substitutions,
-    seriesScore: message.data.seriesScore,
+    seriesScore: normalizeSeriesScore(message.data.seriesScore),
     medalMetadata,
     playersAssociationData: message.data.playersAssociationData,
     seriesData:
@@ -120,7 +128,7 @@ export function toLiveTrackerStateRenderModel(
         ? {
             seriesId: message.data.seriesData.seriesId,
             teams: message.data.seriesData.teams,
-            seriesScore: message.data.seriesData.seriesScore,
+            seriesScore: normalizeSeriesScore(message.data.seriesData.seriesScore),
             matchIds: message.data.seriesData.matchIds,
             startTime: message.data.seriesData.startTime,
             lastUpdateTime: message.data.seriesData.lastUpdateTime,

--- a/pages/src/components/live-tracker/streamer-overlay/stats-panel.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/stats-panel.tsx
@@ -21,7 +21,7 @@ interface StatsPanelContentProps {
   readonly selectedTab: number;
   readonly teams: readonly LiveTrackerTeamRenderModel[];
   readonly playersAssociationData: Record<string, PlayerAssociationData> | null;
-  readonly matchesLength: number;
+  readonly seriesMatchCount: number;
   readonly seriesStats: {
     teamData: MatchStatsData[];
     playerData: MatchStatsData[];
@@ -40,7 +40,7 @@ function StatsPanelContentComponent({
   selectedTab,
   teams,
   playersAssociationData,
-  matchesLength,
+  seriesMatchCount,
   seriesStats,
   selectedMatchStats,
   selectedMatch,
@@ -50,13 +50,13 @@ function StatsPanelContentComponent({
   seriesKillMatrix,
   analyticsStatus,
 }: StatsPanelContentProps): React.ReactElement | null {
-  if (selectedTab === -1 && matchesLength === 0 && playersAssociationData != null) {
+  if (selectedTab === -1 && seriesMatchCount === 0 && playersAssociationData != null) {
     return (
       <PlayerPreSeriesInfo teams={teams} playersAssociationData={playersAssociationData} teamColors={teamColors} />
     );
   }
 
-  if (selectedTab === -1 && seriesStats != null && matchesLength > 0) {
+  if (selectedTab === -1 && seriesStats != null && seriesMatchCount > 0) {
     return (
       <SeriesStats
         teamData={seriesStats.teamData}

--- a/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
@@ -583,7 +583,7 @@ function NeatQueueStreamerOverlay({
       tickerMatchGroups={tickerMatchGroups}
       showTabs={showTabs}
       showTicker={showTicker}
-      matchesLength={neatQueueState.matches.length}
+      matchesLength={seriesMatchCount}
       showPreview={settings.global.viewPreview}
       previewMode={settings.global.colors.mode}
       fontSizeStyles={fontSizeStyles}

--- a/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
@@ -76,6 +76,8 @@ function NeatQueueStreamerOverlay({
   settingsUi,
 }: NeatQueueStreamerOverlayProps): React.ReactElement {
   const SharedStreamerOverlay = useMemo(() => createStreamerOverlaySection(), []);
+  const seriesMatchCount = neatQueueState.seriesData?.matchIds.length ?? neatQueueState.matches.length;
+  const isPreSeriesMode = seriesMatchCount === 0;
 
   const allMatchStats = useAllMatchStats();
   const seriesStats = useSeriesStats();
@@ -131,11 +133,7 @@ function NeatQueueStreamerOverlay({
       });
     };
 
-    if (
-      settings.global.ticker.showPreSeriesInfo &&
-      neatQueueState.matches.length === 0 &&
-      neatQueueState.playersAssociationData
-    ) {
+    if (settings.global.ticker.showPreSeriesInfo && isPreSeriesMode && neatQueueState.playersAssociationData) {
       const playersAssociationData = new Map(Object.entries(neatQueueState.playersAssociationData));
       const rows: TickerStatRow[] = [];
 
@@ -353,6 +351,7 @@ function NeatQueueStreamerOverlay({
     neatQueueState,
     seriesStats,
     allMatchStats,
+    isPreSeriesMode,
     settings.global.ticker.selectedSlayerStats,
     settings.global.ticker.showObjectiveStats,
     settings.global.ticker.medalRarityFilter,
@@ -362,14 +361,14 @@ function NeatQueueStreamerOverlay({
   const hasPanelContent = useCallback(
     (tabIndex: number): boolean => {
       if (tabIndex === -1) {
-        if (neatQueueState.matches.length === 0 && neatQueueState.playersAssociationData != null) {
+        if (isPreSeriesMode && neatQueueState.playersAssociationData != null) {
           return true;
         }
-        return seriesStats != null && neatQueueState.matches.length > 0;
+        return seriesStats != null && seriesMatchCount > 0;
       }
       return allMatchStats[tabIndex]?.data != null && Boolean(neatQueueState.matches[tabIndex]);
     },
-    [allMatchStats, neatQueueState, seriesStats],
+    [allMatchStats, isPreSeriesMode, neatQueueState, seriesMatchCount, seriesStats],
   );
 
   const renderPanelContent = useCallback(
@@ -382,7 +381,7 @@ function NeatQueueStreamerOverlay({
           selectedTab={tabIndex}
           teams={neatQueueState.teams}
           playersAssociationData={neatQueueState.playersAssociationData}
-          matchesLength={neatQueueState.matches.length}
+          seriesMatchCount={seriesMatchCount}
           seriesStats={seriesStats}
           selectedMatchStats={selectedMatchStats}
           selectedMatch={selectedMatch}
@@ -400,6 +399,7 @@ function NeatQueueStreamerOverlay({
       analyticsStatus,
       gameModeIconUrl,
       neatQueueState,
+      seriesMatchCount,
       seriesKillMatrix,
       seriesStats,
       teamColors,

--- a/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay-create-props.test.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay-create-props.test.tsx
@@ -1,0 +1,148 @@
+import "@testing-library/jest-dom/vitest";
+
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { TeamColor } from "../../../team-colors/team-colors";
+import type { StreamerOverlayProps } from "../streamer-overlay";
+import type { StreamerOverlayProps as SharedStreamerOverlayProps } from "../../../streamer-overlay/create";
+import { LiveTrackerProvider, type LiveTrackerProviderProps } from "../../live-tracker-context";
+import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
+import type { LiveTrackerViewModel } from "../../types";
+import { DEFAULT_ALL_SETTINGS } from "../../settings/types";
+
+vi.mock("../../../streamer-overlay/create", () => ({
+  createStreamerOverlaySection: () =>
+    function MockStreamerOverlaySection(props: SharedStreamerOverlayProps): React.ReactElement {
+      return <div data-testid="shared-overlay-matches-length">{props.matchesLength.toString()}</div>;
+    },
+}));
+
+const { StreamerOverlay } = await import("../streamer-overlay");
+
+const defaultParams = { type: "team" as const, server: "test-server", queue: "5" };
+
+function aFakeLiveTrackerViewModelWith(overrides?: Partial<LiveTrackerViewModel>): LiveTrackerViewModel {
+  return {
+    title: "Test Guild",
+    subtitle: "Queue 5",
+    iconUrl: "data:,",
+    statusText: "active",
+    statusClassName: "status-active",
+    sortedSubstitutions: [],
+    availablePlayers: [],
+    params: defaultParams,
+    allMatchStats: [],
+    seriesStats: null,
+    analyticsStatus: ComponentLoaderStatus.LOADED,
+    allMatchKillMatrix: [],
+    seriesKillMatrix: null,
+    state: {
+      type: "neatqueue",
+      guildName: "Test Guild",
+      guildId: "test-guild-id",
+      guildIcon: "data:,",
+      queueNumber: 5,
+      status: "active",
+      lastUpdateTime: "2025-01-01T00:00:00.000Z",
+      teams: [
+        {
+          name: "Team 1",
+          players: [{ id: "player1", displayName: "player_one" }],
+        },
+        {
+          name: "Team 2",
+          players: [{ id: "player2", displayName: "player_two" }],
+        },
+      ],
+      matches: [],
+      substitutions: [],
+      seriesScore: "0:0",
+      medalMetadata: { 1: { name: "Killing Spree", sortingWeight: 1500 } },
+      playersAssociationData: {},
+    },
+    ...overrides,
+  };
+}
+
+const defaultProviderProps: Omit<LiveTrackerProviderProps, "children"> = {
+  params: defaultParams,
+  model: aFakeLiveTrackerViewModelWith(),
+  allMatchStats: [] as { matchId: string; data: never[] }[],
+  seriesStats: null,
+  analyticsStatus: ComponentLoaderStatus.LOADED,
+  allMatchKillMatrix: [],
+  seriesKillMatrix: null,
+};
+
+describe("StreamerOverlay create props", () => {
+  const teamColors: TeamColor[] = [
+    { id: "eagle", name: "Eagle", hex: "#0066CC" },
+    { id: "cobra", name: "Cobra", hex: "#CC0000" },
+  ];
+  const gameModeIconUrl = (gameMode: string): string => `https://example.com/icons/${gameMode}.png`;
+
+  const defaultProps: StreamerOverlayProps = {
+    teamColors,
+    gameModeIconUrl,
+    settings: DEFAULT_ALL_SETTINGS,
+    settingsUi: <div>Settings UI</div>,
+  };
+
+  it("passes seriesData match count to shared overlay when seriesData exists", () => {
+    const model = aFakeLiveTrackerViewModelWith({
+      state: {
+        type: "neatqueue",
+        guildName: "Test Guild",
+        guildId: "test-guild-id",
+        guildIcon: "data:,",
+        queueNumber: 5,
+        status: "active",
+        lastUpdateTime: "2025-01-01T00:00:00.000Z",
+        teams: [
+          { name: "Team 1", players: [{ id: "player1", displayName: "player_one" }] },
+          { name: "Team 2", players: [{ id: "player2", displayName: "player_two" }] },
+        ],
+        matches: [
+          {
+            matchId: "match1",
+            gameTypeAndMap: "Slayer: Aquarius",
+            gameType: "Slayer",
+            gameMap: "Aquarius",
+            gameMapThumbnailUrl: "data:,",
+            duration: "10m 0s",
+            gameScore: "50:49",
+            gameSubScore: null,
+            startTime: "2024-12-31T23:50:00.000Z",
+            endTime: "2025-01-01T00:00:00.000Z",
+            rawMatchStats: null,
+            playerXuidToGametag: {},
+          },
+        ],
+        substitutions: [],
+        seriesScore: "0:0",
+        medalMetadata: { 1: { name: "Killing Spree", sortingWeight: 1500 } },
+        playersAssociationData: {},
+        seriesData: {
+          seriesId: { guildId: "test-guild-id", queueNumber: 5 },
+          teams: [
+            { name: "Team 1", playerIds: ["player1"] },
+            { name: "Team 2", playerIds: ["player2"] },
+          ],
+          seriesScore: "0:0",
+          matchIds: [],
+          startTime: "2025-01-01T00:00:00.000Z",
+          lastUpdateTime: "2025-01-01T00:00:00.000Z",
+        },
+      },
+    });
+
+    render(
+      <LiveTrackerProvider {...defaultProviderProps} model={model}>
+        <StreamerOverlay {...defaultProps} />
+      </LiveTrackerProvider>,
+    );
+
+    expect(screen.getByTestId("shared-overlay-matches-length")).toHaveTextContent("0");
+  });
+});

--- a/pages/src/components/live-tracker/tests/state-render-model.test.ts
+++ b/pages/src/components/live-tracker/tests/state-render-model.test.ts
@@ -26,4 +26,35 @@ describe("toLiveTrackerStateRenderModel", () => {
     expect(model.matches[0]?.matchId).toBe("3d203681-2950-46a9-b6ae-d9da82d3d0d5");
     expect(model.matches[model.matches.length - 1]?.endTime).toBe("2026-03-28T11:07:51.805Z");
   });
+
+  it("normalizes invalid series score values to 0:0", () => {
+    const fallbackSeriesData = {
+      seriesId: {
+        guildId: sampleLiveTrackerStateMessage.data.guildId,
+        queueNumber: sampleLiveTrackerStateMessage.data.queueNumber,
+      },
+      teams: [],
+      seriesScore: "-",
+      matchIds: [],
+      startTime: sampleLiveTrackerStateMessage.data.lastUpdateTime,
+      lastUpdateTime: sampleLiveTrackerStateMessage.data.lastUpdateTime,
+    };
+
+    const message = {
+      ...sampleLiveTrackerStateMessage,
+      data: {
+        ...sampleLiveTrackerStateMessage.data,
+        seriesScore: "-",
+        seriesData: {
+          ...(sampleLiveTrackerStateMessage.data.seriesData ?? fallbackSeriesData),
+          seriesScore: "-",
+        },
+      },
+    };
+
+    const model = toLiveTrackerStateRenderModel(message, {});
+
+    expect(model.seriesScore).toBe("0:0");
+    expect(model.seriesData?.seriesScore).toBe("0:0");
+  });
 });

--- a/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
@@ -15,6 +15,7 @@ export const seriesStartedPayloadSchema = z.object({
   title: z.string(),
   subtitle: z.string(),
   guildIconUrl: z.string().nullable(),
+  startedAt: z.string().optional(),
   teams: z.array(seriesTeamSchema),
 });
 export type SeriesStartedPayload = z.infer<typeof seriesStartedPayloadSchema>;

--- a/shared/src/contracts/individual-tracker/view.ts
+++ b/shared/src/contracts/individual-tracker/view.ts
@@ -65,6 +65,7 @@ export const trackerActiveSeriesContextSchema = z.object({
   title: z.string(),
   subtitle: z.string().nullable(),
   guildIconUrl: z.string().nullable().optional(),
+  startedAt: z.string().optional(),
   teams: z.array(trackerSeriesTeamSchema),
 });
 export type TrackerActiveSeriesContext = z.infer<typeof trackerActiveSeriesContextSchema>;


### PR DESCRIPTION
## Context
Streamer settings now flow correctly in production, and this PR focuses on pre-series correctness for both the individual viewer and stream overlays. The main goals were to improve initial series display values, carry forward NeatQueue start-time context, and ensure active series match-linking behaves correctly when the first eligible game appears.

## This PR

| Issue | Where the gap was | How this PR fixes it | Tests added/updated |
|---|---|---|---|
| Viewer series score should start at 0:0, not - | Pending active-series row used placeholder score values in the viewer render model | Pending active-series row now renders score as 0:0 with pre-series defaults | Updated assertions in `pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts` |
| Viewer missing-data formatting should be clean (- or N/A) | Series summary fallback formatting could show dense unknown templates | Added series-summary-specific fallback display as N/A for pre-series style summaries | Covered by updated viewer pending-row assertions and existing DO series tests |
| Pre-series start time should come from NeatQueue trigger | Started-at timestamp was not propagated through nudge/contract/view context | Added optional `startedAt` through nudge + view contracts, DO state/view context, mapper, and viewer model | Added startedAt assertion in `api/services/neatqueue/tests/neatqueue.test.ts` and active-series view assertion in `api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts` |
| Active series should include first eligible match without waiting for auto-detection threshold | Active-series grouping only surfaced when linked matches reached 2 | Added explicit active-series eligibility logic and changed active-series grouping threshold from 2+ to 1+ while preserving auto-detection behavior when no active series exists | Added regression test: `surfaces an active series group when only one active-series match is currently linked` in `api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts` |
| Stream overlay top team score should start at 0, not - | Overlay score display depended on raw upstream score strings | Added score normalization so invalid score values map to 0:0 in state render model | Added regression test in `pages/src/components/live-tracker/tests/state-render-model.test.ts` |
| Stream overlay Series score tab should read 0:0, not - | Same upstream score dependency as top score | Same normalization fix now feeds Series score tab values | Covered by the new state-render-model normalization test and existing overlay render tests |
| Information ticker should show pre-series info when series is pre-game | Pre-series mode used raw matches length, which could miss series pre-game state | Switched pre-series gating to `seriesData.matchIds` count and aligned panel/ticker conditions | Existing overlay suite remains passing (`pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay.test.tsx`) |

### Notes on active-series rule behavior
- Auto-detection behavior remains unchanged when there is no active series (existing grouping heuristics remain in place).
- When an active series exists, the “two consecutive custom games” requirement is intentionally bypassed so the first eligible match can be linked immediately.

### Validation
- Targeted suites passed:
  - `api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts`
  - `api/services/neatqueue/tests/neatqueue.test.ts`
  - `pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts`
  - `pages/src/components/live-tracker/tests/state-render-model.test.ts`
  - `pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay.test.tsx`
- `npm run typecheck` passed.
- Full `npm run done` reached green format/typecheck/lint and then hit the existing `test:changed` script edge case (`vitest related` with no related files), while explicit targeted suites above passed.

## Subsequent Work
- Add a focused overlay regression test that explicitly validates pre-series ticker behavior when `seriesData.matchIds` is empty while raw matches may still be present.
