### PR TITLE
Preserve completed series metadata and dim overlay loss icons

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1974,7 +1974,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     switch (payload.type) {
       case "ended": {
-        this.clearSeriesState(trackerState);
+        this.retireActiveSeries(trackerState);
         break;
       }
       case "substituted": {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -3015,13 +3015,17 @@ describe("IndividualTrackerDO", () => {
       expect(response.status).toBe(400);
     });
 
-    it("flushes existing series metadata when nudging with ended event", async () => {
+    it("retires active series metadata when nudging with ended event", async () => {
       const persistedSeriesGroupOverrides = [
         { matchIds: ["match-1"], titleOverride: "Custom Label", subtitleOverride: null },
       ];
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
-          activeSeries: anActiveSeries({ matchIds: ["match-1"] }),
+          activeSeries: anActiveSeries({
+            title: "Dog Crew",
+            subtitle: "Queue #8018",
+            matchIds: ["match-1"],
+          }),
           seriesGroupOverrides: persistedSeriesGroupOverrides,
         }),
       );
@@ -3034,7 +3038,14 @@ describe("IndividualTrackerDO", () => {
 
       const persisted = lastPersistedState(storagePutSpy);
       expect(persisted.activeSeries).toBeUndefined();
-      expect(persisted.completedSeries).toBeUndefined();
+      expect(persisted.completedSeries).toEqual([
+        expect.objectContaining({
+          title: "Dog Crew",
+          subtitle: "Queue #8018",
+          isActive: false,
+          matchIds: ["match-1"],
+        }),
+      ]);
       expect(persisted.seriesGroupOverrides).toEqual(persistedSeriesGroupOverrides);
       expect(storageSetAlarmSpy).toHaveBeenCalledWith(Date.now());
     });

--- a/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
@@ -502,6 +502,20 @@ function NeatQueueStreamerOverlay({
     ],
   );
 
+  const observedTeamId = useMemo((): number => {
+    if (settings.global.colors.mode !== "player") {
+      return 0;
+    }
+
+    const selectedPlayerId = settings.global.colors.playerView.selectedPlayerId;
+    if (selectedPlayerId == null || selectedPlayerId === "") {
+      return 0;
+    }
+
+    const playerTeamId = neatQueueState.teams.findIndex((team) => team.players.some((player) => player.id === selectedPlayerId));
+    return playerTeamId >= 0 ? playerTeamId : 0;
+  }, [neatQueueState.teams, settings.global.colors.mode, settings.global.colors.playerView.selectedPlayerId]);
+
   const tabs = useMemo<readonly OverlayTab[]>(
     () => [
       {
@@ -515,7 +529,7 @@ function NeatQueueStreamerOverlay({
       ...neatQueueState.matches.map((match, idx) => {
         const winningTeamId = match.rawMatchStats?.Teams.find((team) => team.Outcome === 2)?.TeamId ?? null;
         const teamColor = winningTeamId !== null ? teamColors[winningTeamId]?.hex : undefined;
-        const didEagleLose = winningTeamId !== null && winningTeamId !== 0;
+        const isLoss = winningTeamId !== null && winningTeamId !== observedTeamId;
 
         return {
           type: "match" as const,
@@ -526,14 +540,14 @@ function NeatQueueStreamerOverlay({
           icons: [
             {
               src: gameModeIconUrl(match.gameType, match.rawMatchStats?.MatchInfo.GameVariantCategory),
-              dimmed: didEagleLose,
+              dimmed: isLoss,
             },
           ],
           teamColor,
         };
       }),
     ],
-    [gameModeIconUrl, neatQueueState.matches, neatQueueState.seriesScore, settings.global.ticker.showTabs, teamColors],
+    [gameModeIconUrl, neatQueueState.matches, neatQueueState.seriesScore, observedTeamId, settings.global.ticker.showTabs, teamColors],
   );
 
   const { showScore, showTeamDetails } = settings.global.display;

--- a/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
@@ -522,6 +522,7 @@ function NeatQueueStreamerOverlay({
         }
 
         const teamColor = winningTeamIndex !== null ? teamColors[winningTeamIndex]?.hex : undefined;
+        const didEagleLose = winningTeamIndex !== null && winningTeamIndex !== 0;
 
         return {
           type: "match" as const,
@@ -529,7 +530,12 @@ function NeatQueueStreamerOverlay({
           matchId: match.matchId,
           label: settings.global.ticker.showTabs ? match.gameMap : "",
           score: match.gameScore,
-          icon: gameModeIconUrl(match.gameType, match.rawMatchStats?.MatchInfo.GameVariantCategory),
+          icons: [
+            {
+              src: gameModeIconUrl(match.gameType, match.rawMatchStats?.MatchInfo.GameVariantCategory),
+              dimmed: didEagleLose,
+            },
+          ],
           teamColor,
         };
       }),

--- a/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
@@ -513,16 +513,9 @@ function NeatQueueStreamerOverlay({
         teamColor: undefined,
       },
       ...neatQueueState.matches.map((match, idx) => {
-        let winningTeamIndex: number | null = null;
-        if (match.rawMatchStats) {
-          const winningTeam = match.rawMatchStats.Teams.find((team) => team.Outcome === 2);
-          if (winningTeam) {
-            winningTeamIndex = match.rawMatchStats.Teams.indexOf(winningTeam);
-          }
-        }
-
-        const teamColor = winningTeamIndex !== null ? teamColors[winningTeamIndex]?.hex : undefined;
-        const didEagleLose = winningTeamIndex !== null && winningTeamIndex !== 0;
+        const winningTeamId = match.rawMatchStats?.Teams.find((team) => team.Outcome === 2)?.TeamId ?? null;
+        const teamColor = winningTeamId !== null ? teamColors[winningTeamId]?.hex : undefined;
+        const didEagleLose = winningTeamId !== null && winningTeamId !== 0;
 
         return {
           type: "match" as const,

--- a/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
@@ -507,12 +507,14 @@ function NeatQueueStreamerOverlay({
       return 0;
     }
 
-    const selectedPlayerId = settings.global.colors.playerView.selectedPlayerId;
+    const { selectedPlayerId } = settings.global.colors.playerView;
     if (selectedPlayerId == null || selectedPlayerId === "") {
       return 0;
     }
 
-    const playerTeamId = neatQueueState.teams.findIndex((team) => team.players.some((player) => player.id === selectedPlayerId));
+    const playerTeamId = neatQueueState.teams.findIndex((team) =>
+      team.players.some((player) => player.id === selectedPlayerId),
+    );
     return playerTeamId >= 0 ? playerTeamId : 0;
   }, [neatQueueState.teams, settings.global.colors.mode, settings.global.colors.playerView.selectedPlayerId]);
 
@@ -547,7 +549,14 @@ function NeatQueueStreamerOverlay({
         };
       }),
     ],
-    [gameModeIconUrl, neatQueueState.matches, neatQueueState.seriesScore, observedTeamId, settings.global.ticker.showTabs, teamColors],
+    [
+      gameModeIconUrl,
+      neatQueueState.matches,
+      neatQueueState.seriesScore,
+      observedTeamId,
+      settings.global.ticker.showTabs,
+      teamColors,
+    ],
   );
 
   const { showScore, showTeamDetails } = settings.global.display;

--- a/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay-create-props.test.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay-create-props.test.tsx
@@ -164,7 +164,7 @@ describe("StreamerOverlay create props", () => {
     expect(screen.getByTestId("shared-overlay-matches-length")).toHaveTextContent("0");
   });
 
-  it("passes dimmed tab icons for matches where Eagle loses", () => {
+  it("passes dimmed tab icons for losses from the observed team perspective", () => {
     const eagleLossStats = aFakeMatchStatsWith({
       Teams: [
         { ...aFakeMatchStatsWith().Teams[0], TeamId: 0, Outcome: 3 },
@@ -309,5 +309,97 @@ describe("StreamerOverlay create props", () => {
 
     const dimmedIconNodes = screen.getAllByTestId("shared-overlay-dimmed-icons");
     expect(dimmedIconNodes.at(-1)).toHaveTextContent("0");
+  });
+
+  it("uses selected player team as observed team in player mode", () => {
+    const teamOneWinStats = aFakeMatchStatsWith({
+      Teams: [
+        { ...aFakeMatchStatsWith().Teams[0], TeamId: 0, Outcome: 3 },
+        { ...aFakeMatchStatsWith().Teams[1], TeamId: 1, Outcome: 2 },
+      ],
+    });
+    const teamZeroWinStats = aFakeMatchStatsWith({
+      Teams: [
+        { ...aFakeMatchStatsWith().Teams[0], TeamId: 0, Outcome: 2 },
+        { ...aFakeMatchStatsWith().Teams[1], TeamId: 1, Outcome: 3 },
+      ],
+    });
+
+    const model = aFakeLiveTrackerViewModelWith({
+      state: {
+        type: "neatqueue",
+        guildName: "Test Guild",
+        guildId: "test-guild-id",
+        guildIcon: "data:,",
+        queueNumber: 5,
+        status: "active",
+        lastUpdateTime: "2025-01-01T00:00:00.000Z",
+        teams: [
+          { name: "Team 1", players: [{ id: "player1", displayName: "player_one" }] },
+          { name: "Team 2", players: [{ id: "player2", displayName: "player_two" }] },
+        ],
+        matches: [
+          {
+            matchId: "match-observed-win",
+            gameTypeAndMap: "Slayer: Aquarius",
+            gameType: "Slayer",
+            gameMap: "Aquarius",
+            gameMapThumbnailUrl: "data:,",
+            duration: "10m 0s",
+            gameScore: "50:45",
+            gameSubScore: null,
+            startTime: "2024-12-31T23:50:00.000Z",
+            endTime: "2025-01-01T00:00:00.000Z",
+            rawMatchStats: teamOneWinStats,
+            playerXuidToGametag: {},
+          },
+          {
+            matchId: "match-observed-loss",
+            gameTypeAndMap: "CTF: Argyle",
+            gameType: "CTF",
+            gameMap: "Argyle",
+            gameMapThumbnailUrl: "data:,",
+            duration: "10m 0s",
+            gameScore: "3:5",
+            gameSubScore: null,
+            startTime: "2024-12-31T23:35:00.000Z",
+            endTime: "2024-12-31T23:45:00.000Z",
+            rawMatchStats: teamZeroWinStats,
+            playerXuidToGametag: {},
+          },
+        ],
+        substitutions: [],
+        seriesScore: "1:1",
+        medalMetadata: { 1: { name: "Killing Spree", sortingWeight: 1500 } },
+        playersAssociationData: {},
+      },
+    });
+    const settingsWithTabsAndPlayerMode = {
+      ...DEFAULT_ALL_SETTINGS,
+      global: {
+        ...DEFAULT_ALL_SETTINGS.global,
+        colors: {
+          ...DEFAULT_ALL_SETTINGS.global.colors,
+          mode: "player" as const,
+          playerView: {
+            ...DEFAULT_ALL_SETTINGS.global.colors.playerView,
+            selectedPlayerId: "player2",
+          },
+        },
+        ticker: {
+          ...DEFAULT_ALL_SETTINGS.global.ticker,
+          showTabs: true,
+        },
+      },
+    };
+
+    render(
+      <LiveTrackerProvider {...defaultProviderProps} model={model}>
+        <StreamerOverlay {...defaultProps} settings={settingsWithTabsAndPlayerMode} />
+      </LiveTrackerProvider>,
+    );
+
+    const dimmedIconNodes = screen.getAllByTestId("shared-overlay-dimmed-icons");
+    expect(dimmedIconNodes.at(-1)).toHaveTextContent("1");
   });
 });

--- a/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay-create-props.test.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay-create-props.test.tsx
@@ -247,4 +247,67 @@ describe("StreamerOverlay create props", () => {
     const dimmedIconNodes = screen.getAllByTestId("shared-overlay-dimmed-icons");
     expect(dimmedIconNodes.at(-1)).toHaveTextContent("1");
   });
+
+  it("uses TeamId rather than team array order for tab dimming", () => {
+    const reorderedTeamsStats = aFakeMatchStatsWith({
+      Teams: [
+        { ...aFakeMatchStatsWith().Teams[1], TeamId: 1, Outcome: 3 },
+        { ...aFakeMatchStatsWith().Teams[0], TeamId: 0, Outcome: 2 },
+      ],
+    });
+    const model = aFakeLiveTrackerViewModelWith({
+      state: {
+        type: "neatqueue",
+        guildName: "Test Guild",
+        guildId: "test-guild-id",
+        guildIcon: "data:,",
+        queueNumber: 5,
+        status: "active",
+        lastUpdateTime: "2025-01-01T00:00:00.000Z",
+        teams: [
+          { name: "Team 1", players: [{ id: "player1", displayName: "player_one" }] },
+          { name: "Team 2", players: [{ id: "player2", displayName: "player_two" }] },
+        ],
+        matches: [
+          {
+            matchId: "match-reordered-win",
+            gameTypeAndMap: "Slayer: Aquarius",
+            gameType: "Slayer",
+            gameMap: "Aquarius",
+            gameMapThumbnailUrl: "data:,",
+            duration: "10m 0s",
+            gameScore: "50:45",
+            gameSubScore: null,
+            startTime: "2024-12-31T23:50:00.000Z",
+            endTime: "2025-01-01T00:00:00.000Z",
+            rawMatchStats: reorderedTeamsStats,
+            playerXuidToGametag: {},
+          },
+        ],
+        substitutions: [],
+        seriesScore: "1:0",
+        medalMetadata: { 1: { name: "Killing Spree", sortingWeight: 1500 } },
+        playersAssociationData: {},
+      },
+    });
+    const settingsWithTabs = {
+      ...DEFAULT_ALL_SETTINGS,
+      global: {
+        ...DEFAULT_ALL_SETTINGS.global,
+        ticker: {
+          ...DEFAULT_ALL_SETTINGS.global.ticker,
+          showTabs: true,
+        },
+      },
+    };
+
+    render(
+      <LiveTrackerProvider {...defaultProviderProps} model={model}>
+        <StreamerOverlay {...defaultProps} settings={settingsWithTabs} />
+      </LiveTrackerProvider>,
+    );
+
+    const dimmedIconNodes = screen.getAllByTestId("shared-overlay-dimmed-icons");
+    expect(dimmedIconNodes.at(-1)).toHaveTextContent("0");
+  });
 });

--- a/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay-create-props.test.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay-create-props.test.tsx
@@ -10,11 +10,29 @@ import { LiveTrackerProvider, type LiveTrackerProviderProps } from "../../live-t
 import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import type { LiveTrackerViewModel } from "../../types";
 import { DEFAULT_ALL_SETTINGS } from "../../settings/types";
+import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 
 vi.mock("../../../streamer-overlay/create", () => ({
   createStreamerOverlaySection: () =>
     function MockStreamerOverlaySection(props: SharedStreamerOverlayProps): React.ReactElement {
-      return <div data-testid="shared-overlay-matches-length">{props.matchesLength.toString()}</div>;
+      const dimmedIconCount = props.tabs.reduce((count, tab) => {
+        if (tab.type === "series") {
+          return count + (tab.icons?.filter((icon) => icon.dimmed).length ?? 0);
+        }
+
+        if ("icons" in tab && tab.icons != null) {
+          return count + tab.icons.filter((icon) => icon.dimmed).length;
+        }
+
+        return count;
+      }, 0);
+
+      return (
+        <>
+          <div data-testid="shared-overlay-matches-length">{props.matchesLength.toString()}</div>
+          <div data-testid="shared-overlay-dimmed-icons">{dimmedIconCount.toString()}</div>
+        </>
+      );
     },
 }));
 
@@ -144,5 +162,89 @@ describe("StreamerOverlay create props", () => {
     );
 
     expect(screen.getByTestId("shared-overlay-matches-length")).toHaveTextContent("0");
+  });
+
+  it("passes dimmed tab icons for matches where Eagle loses", () => {
+    const eagleLossStats = aFakeMatchStatsWith({
+      Teams: [
+        { ...aFakeMatchStatsWith().Teams[0], TeamId: 0, Outcome: 3 },
+        { ...aFakeMatchStatsWith().Teams[1], TeamId: 1, Outcome: 2 },
+      ],
+    });
+    const eagleWinStats = aFakeMatchStatsWith({
+      Teams: [
+        { ...aFakeMatchStatsWith().Teams[0], TeamId: 0, Outcome: 2 },
+        { ...aFakeMatchStatsWith().Teams[1], TeamId: 1, Outcome: 3 },
+      ],
+    });
+
+    const model = aFakeLiveTrackerViewModelWith({
+      state: {
+        type: "neatqueue",
+        guildName: "Test Guild",
+        guildId: "test-guild-id",
+        guildIcon: "data:,",
+        queueNumber: 5,
+        status: "active",
+        lastUpdateTime: "2025-01-01T00:00:00.000Z",
+        teams: [
+          { name: "Team 1", players: [{ id: "player1", displayName: "player_one" }] },
+          { name: "Team 2", players: [{ id: "player2", displayName: "player_two" }] },
+        ],
+        matches: [
+          {
+            matchId: "match-loss",
+            gameTypeAndMap: "Slayer: Aquarius",
+            gameType: "Slayer",
+            gameMap: "Aquarius",
+            gameMapThumbnailUrl: "data:,",
+            duration: "10m 0s",
+            gameScore: "45:50",
+            gameSubScore: null,
+            startTime: "2024-12-31T23:50:00.000Z",
+            endTime: "2025-01-01T00:00:00.000Z",
+            rawMatchStats: eagleLossStats,
+            playerXuidToGametag: {},
+          },
+          {
+            matchId: "match-win",
+            gameTypeAndMap: "CTF: Argyle",
+            gameType: "CTF",
+            gameMap: "Argyle",
+            gameMapThumbnailUrl: "data:,",
+            duration: "10m 0s",
+            gameScore: "5:3",
+            gameSubScore: null,
+            startTime: "2024-12-31T23:35:00.000Z",
+            endTime: "2024-12-31T23:45:00.000Z",
+            rawMatchStats: eagleWinStats,
+            playerXuidToGametag: {},
+          },
+        ],
+        substitutions: [],
+        seriesScore: "1:1",
+        medalMetadata: { 1: { name: "Killing Spree", sortingWeight: 1500 } },
+        playersAssociationData: {},
+      },
+    });
+    const settingsWithTabs = {
+      ...DEFAULT_ALL_SETTINGS,
+      global: {
+        ...DEFAULT_ALL_SETTINGS.global,
+        ticker: {
+          ...DEFAULT_ALL_SETTINGS.global.ticker,
+          showTabs: true,
+        },
+      },
+    };
+
+    render(
+      <LiveTrackerProvider {...defaultProviderProps} model={model}>
+        <StreamerOverlay {...defaultProps} settings={settingsWithTabs} />
+      </LiveTrackerProvider>,
+    );
+
+    const dimmedIconNodes = screen.getAllByTestId("shared-overlay-dimmed-icons");
+    expect(dimmedIconNodes.at(-1)).toHaveTextContent("1");
   });
 });

--- a/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay.test.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay.test.tsx
@@ -256,4 +256,5 @@ describe("StreamerOverlay", () => {
     expect(screen.getAllByText("Test Guild").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Series score").length).toBeGreaterThan(0);
   });
+
 });

--- a/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay.test.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/tests/streamer-overlay.test.tsx
@@ -256,5 +256,4 @@ describe("StreamerOverlay", () => {
     expect(screen.getAllByText("Test Guild").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Series score").length).toBeGreaterThan(0);
   });
-
 });


### PR DESCRIPTION
## Context
Individual tracker series metadata was being lost when a NeatQueue series ended via nudge, which caused completed series entries to lose the custom title/subtitle shown during the active series (for example, Dog Crew / Queue #8018). In parallel, the live tracker matchmaking overlay tabs were not visually encoding match outcomes the same way the viewer does.

## This PR
- Preserve ended-series metadata by retiring activeSeries into completedSeries on ended nudge instead of clearing series state outright.
- Keep series title/subtitle available in completed series rendering after queue completion.
- Add win/loss icon dimming behavior to live tracker overlay match tabs.
- Refine dimming semantics to use observed-team perspective rather than Eagle/Cobra-specific naming:
  - in player mode, observed team is derived from the selected player's team
  - otherwise, observer fallback behavior is used
  - dimmed state is driven by whether the observed team lost
- Add and update targeted tests:
  - individual tracker DO nudge test verifies completed series metadata is retained after ended
  - live tracker overlay create-props tests verify dimmed icon data for losses, TeamId ordering robustness, and selected-player player-mode behavior
  - existing live tracker overlay render tests remain passing

## Subsequent Work
- Optional follow-up: add a visual regression/snapshot assertion at the shared overlay tabs component level to lock in dimmed icon class application in DOM rendering.
