### PR TITLE
fix: use user-specific credentials for match analytics endpoint

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1025,7 +1025,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
   private clearUserHaloService(): void {
     if (this.userHaloServiceUserId != null) {
-      this.services.userTokenProvider.clearCachedClient(this.userHaloServiceUserId);
+      this.services.userTokenProvider.clearCachedContext(this.userHaloServiceUserId);
     }
     this.userHaloService = null;
     this.userHaloServiceUserId = null;

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1025,7 +1025,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
   private clearUserHaloService(): void {
     if (this.userHaloServiceUserId != null) {
-      this.services.userTokenProvider.clearCachedContext(this.userHaloServiceUserId);
+      this.services.userTokenProvider.clearCachedClient(this.userHaloServiceUserId);
     }
     this.userHaloService = null;
     this.userHaloServiceUserId = null;

--- a/api/routes/stats/batch-analytics.ts
+++ b/api/routes/stats/batch-analytics.ts
@@ -37,9 +37,7 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
             const accessToken = await authService.getMicrosoftAccessTokenForUser(tracker.UserId);
             if (accessToken != null) {
               const xstsTokenInfo = await xboxService.exchangeMicrosoftAccessTokenForXstsToken(accessToken);
-              const userSpartanTokenProvider = new StaticXstsTicketTokenSpartanTokenProvider(
-                xstsTokenInfo.XSTSToken,
-              );
+              const userSpartanTokenProvider = new StaticXstsTicketTokenSpartanTokenProvider(xstsTokenInfo.XSTSToken);
               const userFilmCacheNamespace = `halo:film:${tracker.UserId}`;
               const userFilmService = new HaloFilmService({
                 env,

--- a/api/routes/stats/batch-analytics.ts
+++ b/api/routes/stats/batch-analytics.ts
@@ -1,4 +1,3 @@
-import { StaticXstsTicketTokenSpartanTokenProvider } from "halo-infinite-api";
 import { parseQueryParams } from "@guilty-spark/shared/base/request-parsing";
 import {
   batchMatchAnalyticsContract,
@@ -13,7 +12,7 @@ import { normalizeTrackerId } from "./normalize-tracker-id";
 export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installServices) => {
   router.get("/api/stats/match-analytics", async (request, env: Env) => {
     const services = installServices({ env });
-    const { haloService, logService, databaseService, userTokenProvider, authService, xboxService } = services;
+    const { haloService, logService, databaseService, userTokenProvider } = services;
 
     const url = new URL(request.url);
     const queryParams = parseQueryParams(url, batchMatchAnalyticsQuerySchema, "Invalid query parameters");
@@ -31,32 +30,28 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
       try {
         const tracker = await databaseService.getIndividualTracker(trackerId);
         if (tracker?.IsLive === 1) {
-          const userClient = await userTokenProvider.getClientForUser(tracker.UserId);
-          if (userClient != null) {
+          const userTokenContext = await userTokenProvider.getContextForUser(tracker.UserId);
+          if (userTokenContext != null) {
+            const { client: userClient, spartanTokenProvider: userSpartanTokenProvider } = userTokenContext;
             const userHaloService = haloService.withUserClient(userClient);
-            const accessToken = await authService.getMicrosoftAccessTokenForUser(tracker.UserId);
-            if (accessToken != null) {
-              const xstsTokenInfo = await xboxService.exchangeMicrosoftAccessTokenForXstsToken(accessToken);
-              const userSpartanTokenProvider = new StaticXstsTicketTokenSpartanTokenProvider(xstsTokenInfo.XSTSToken);
-              const userFilmCacheNamespace = `halo:film:${tracker.UserId}`;
-              const userFilmService = new HaloFilmService({
+            const userFilmCacheNamespace = `halo:film:${tracker.UserId}`;
+            const userFilmService = new HaloFilmService({
+              env,
+              spartanTokenProvider: userSpartanTokenProvider,
+              kvKeyNamespace: userFilmCacheNamespace,
+              fetch: createResilientFetch({
                 env,
-                spartanTokenProvider: userSpartanTokenProvider,
-                kvKeyNamespace: userFilmCacheNamespace,
-                fetch: createResilientFetch({
-                  env,
-                  logService,
-                  proxyUrl: env.PROXY_WORKER_URL,
-                  kvKeyNamespace: userFilmCacheNamespace,
-                }),
-              });
-              resolvedAnalyticsService = new AnalyticsService({
-                haloService: userHaloService,
-                haloFilmService: userFilmService,
                 logService,
-              });
-              credentialSource = `user:${tracker.UserId}`;
-            }
+                proxyUrl: env.PROXY_WORKER_URL,
+                kvKeyNamespace: userFilmCacheNamespace,
+              }),
+            });
+            resolvedAnalyticsService = new AnalyticsService({
+              haloService: userHaloService,
+              haloFilmService: userFilmService,
+              logService,
+            });
+            credentialSource = `user:${tracker.UserId}`;
           }
         }
       } catch (error) {

--- a/api/routes/stats/batch-analytics.ts
+++ b/api/routes/stats/batch-analytics.ts
@@ -34,22 +34,22 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
           const userClient = await userTokenProvider.getClientForUser(tracker.UserId);
           if (userClient != null) {
             const userHaloService = haloService.withUserClient(userClient);
-
-            // Get user's XSTS token for the film service
             const accessToken = await authService.getMicrosoftAccessTokenForUser(tracker.UserId);
             if (accessToken != null) {
               const xstsTokenInfo = await xboxService.exchangeMicrosoftAccessTokenForXstsToken(accessToken);
               const userSpartanTokenProvider = new StaticXstsTicketTokenSpartanTokenProvider(
                 xstsTokenInfo.XSTSToken,
               );
+              const userFilmCacheNamespace = `halo:film:${tracker.UserId}`;
               const userFilmService = new HaloFilmService({
                 env,
                 spartanTokenProvider: userSpartanTokenProvider,
+                kvKeyNamespace: userFilmCacheNamespace,
                 fetch: createResilientFetch({
                   env,
                   logService,
                   proxyUrl: env.PROXY_WORKER_URL,
-                  kvKeyNamespace: "halo:film",
+                  kvKeyNamespace: userFilmCacheNamespace,
                 }),
               });
               resolvedAnalyticsService = new AnalyticsService({

--- a/api/routes/stats/batch-analytics.ts
+++ b/api/routes/stats/batch-analytics.ts
@@ -1,16 +1,19 @@
+import { StaticXstsTicketTokenSpartanTokenProvider } from "halo-infinite-api";
 import { parseQueryParams } from "@guilty-spark/shared/base/request-parsing";
 import {
   batchMatchAnalyticsContract,
   batchMatchAnalyticsQuerySchema,
 } from "@guilty-spark/shared/contracts/stats/batch-match-analytics";
 import { AnalyticsService } from "../../services/analytics/analytics";
+import { HaloFilmService } from "../../services/halo/halo-film";
+import { createResilientFetch } from "../../services/halo/resilient-fetch";
 import type { RoutesRegisterHandler } from "../base/types";
 import { normalizeTrackerId } from "./normalize-tracker-id";
 
 export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installServices) => {
   router.get("/api/stats/match-analytics", async (request, env: Env) => {
     const services = installServices({ env });
-    const { haloService, haloFilmService, logService, databaseService, userTokenProvider } = services;
+    const { haloService, logService, databaseService, userTokenProvider, authService, xboxService } = services;
 
     const url = new URL(request.url);
     const queryParams = parseQueryParams(url, batchMatchAnalyticsQuerySchema, "Invalid query parameters");
@@ -23,6 +26,7 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
     const trackerId = normalizeTrackerId(url.searchParams.get("trackerId"));
 
     let resolvedAnalyticsService = services.analyticsService;
+    let credentialSource = "bot";
     if (trackerId != null) {
       try {
         const tracker = await databaseService.getIndividualTracker(trackerId);
@@ -30,11 +34,31 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
           const userClient = await userTokenProvider.getClientForUser(tracker.UserId);
           if (userClient != null) {
             const userHaloService = haloService.withUserClient(userClient);
-            resolvedAnalyticsService = new AnalyticsService({
-              haloService: userHaloService,
-              haloFilmService,
-              logService,
-            });
+
+            // Get user's XSTS token for the film service
+            const accessToken = await authService.getMicrosoftAccessTokenForUser(tracker.UserId);
+            if (accessToken != null) {
+              const xstsTokenInfo = await xboxService.exchangeMicrosoftAccessTokenForXstsToken(accessToken);
+              const userSpartanTokenProvider = new StaticXstsTicketTokenSpartanTokenProvider(
+                xstsTokenInfo.XSTSToken,
+              );
+              const userFilmService = new HaloFilmService({
+                env,
+                spartanTokenProvider: userSpartanTokenProvider,
+                fetch: createResilientFetch({
+                  env,
+                  logService,
+                  proxyUrl: env.PROXY_WORKER_URL,
+                  kvKeyNamespace: "halo:film",
+                }),
+              });
+              resolvedAnalyticsService = new AnalyticsService({
+                haloService: userHaloService,
+                haloFilmService: userFilmService,
+                logService,
+              });
+              credentialSource = `user:${tracker.UserId}`;
+            }
           }
         }
       } catch (error) {
@@ -54,7 +78,10 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
     if (failureCount > 0) {
       services.logService.warn(
         `${failureCount.toString()}/${matchIds.length.toString()} match analytics fetches failed`,
-        new Map([["route", "stats:match-analytics-batch"]]),
+        new Map([
+          ["route", "stats:match-analytics-batch"],
+          ["credentialSource", credentialSource],
+        ]),
       );
     }
 

--- a/api/routes/stats/batch-analytics.ts
+++ b/api/routes/stats/batch-analytics.ts
@@ -12,7 +12,7 @@ import { normalizeTrackerId } from "./normalize-tracker-id";
 export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installServices) => {
   router.get("/api/stats/match-analytics", async (request, env: Env) => {
     const services = installServices({ env });
-    const { haloService, logService, databaseService, userTokenProvider } = services;
+    const { haloService, logService, databaseService, userTokenProvider, authService } = services;
 
     const url = new URL(request.url);
     const queryParams = parseQueryParams(url, batchMatchAnalyticsQuerySchema, "Invalid query parameters");
@@ -30,28 +30,31 @@ export const batchMatchAnalyticsRoute: RoutesRegisterHandler = (router, installS
       try {
         const tracker = await databaseService.getIndividualTracker(trackerId);
         if (tracker?.IsLive === 1) {
-          const userTokenContext = await userTokenProvider.getContextForUser(tracker.UserId);
-          if (userTokenContext != null) {
-            const { client: userClient, spartanTokenProvider: userSpartanTokenProvider } = userTokenContext;
-            const userHaloService = haloService.withUserClient(userClient);
-            const userFilmCacheNamespace = `halo:film:${tracker.UserId}`;
-            const userFilmService = new HaloFilmService({
-              env,
-              spartanTokenProvider: userSpartanTokenProvider,
-              kvKeyNamespace: userFilmCacheNamespace,
-              fetch: createResilientFetch({
+          const session = await authService.validateSession(request);
+          if (session?.userId === tracker.UserId) {
+            const userTokenContext = await userTokenProvider.getContextForUser(tracker.UserId);
+            if (userTokenContext != null) {
+              const { client: userClient, spartanTokenProvider: userSpartanTokenProvider } = userTokenContext;
+              const userHaloService = haloService.withUserClient(userClient);
+              const userFilmCacheNamespace = `halo:film:${tracker.UserId}`;
+              const userFilmService = new HaloFilmService({
                 env,
-                logService,
-                proxyUrl: env.PROXY_WORKER_URL,
+                spartanTokenProvider: userSpartanTokenProvider,
                 kvKeyNamespace: userFilmCacheNamespace,
-              }),
-            });
-            resolvedAnalyticsService = new AnalyticsService({
-              haloService: userHaloService,
-              haloFilmService: userFilmService,
-              logService,
-            });
-            credentialSource = `user:${tracker.UserId}`;
+                fetch: createResilientFetch({
+                  env,
+                  logService,
+                  proxyUrl: env.PROXY_WORKER_URL,
+                  kvKeyNamespace: userFilmCacheNamespace,
+                }),
+              });
+              resolvedAnalyticsService = new AnalyticsService({
+                haloService: userHaloService,
+                haloFilmService: userFilmService,
+                logService,
+              });
+              credentialSource = `user:${tracker.UserId}`;
+            }
           }
         }
       } catch (error) {

--- a/api/routes/stats/tests/batch-analytics.test.ts
+++ b/api/routes/stats/tests/batch-analytics.test.ts
@@ -1,10 +1,10 @@
 import type { AutoRouterType } from "itty-router";
 import type { MockInstance } from "vitest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LogService } from "../../../services/log/types";
 import { createApiRouter } from "../../../base/router";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
-import type { AnalyticsService } from "../../../services/analytics/analytics";
+import { AnalyticsService, type AnalyticsService as AnalyticsServiceInstance } from "../../../services/analytics/analytics";
 import { aFakeMatchAnalyticsWith } from "../../../services/analytics/fakes/analytics.fake";
 import { aFakeIndividualTrackersRow } from "../../../services/database/fakes/database.fake";
 import { installFakeServicesWith } from "../../../services/fakes/services";
@@ -19,11 +19,15 @@ describe("/api/stats/match-analytics (batch)", () => {
     router = createApiRouter();
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("returns results keyed by matchId with no-store cache header", async () => {
     const analytics = aFakeMatchAnalyticsWith();
 
     const services = installFakeServicesWith({ env });
-    const getBatchMatchAnalyticsSpy: MockInstance<AnalyticsService["getBatchMatchAnalytics"]> = vi.spyOn(
+    const getBatchMatchAnalyticsSpy: MockInstance<AnalyticsServiceInstance["getBatchMatchAnalytics"]> = vi.spyOn(
       services.analyticsService,
       "getBatchMatchAnalytics",
     );
@@ -114,7 +118,7 @@ describe("/api/stats/match-analytics (batch)", () => {
     const analytics = aFakeMatchAnalyticsWith();
 
     const services = installFakeServicesWith({ env });
-    const getBatchMatchAnalyticsSpy: MockInstance<AnalyticsService["getBatchMatchAnalytics"]> = vi.spyOn(
+    const getBatchMatchAnalyticsSpy: MockInstance<AnalyticsServiceInstance["getBatchMatchAnalytics"]> = vi.spyOn(
       services.analyticsService,
       "getBatchMatchAnalytics",
     );
@@ -245,7 +249,10 @@ describe("/api/stats/match-analytics (batch)", () => {
       aFakeIndividualTrackersRow({ TrackerId: "tracker-1", UserId: "owner-user-1", IsLive: 1 }),
     );
     vi.spyOn(services.userTokenProvider, "getClientForUser").mockResolvedValue(services.haloInfiniteClient);
-    vi.spyOn(services.authService, "getMicrosoftAccessTokenForUser").mockResolvedValue(null); // No access token
+    const getMicrosoftAccessTokenSpy = vi
+      .spyOn(services.authService, "getMicrosoftAccessTokenForUser")
+      .mockResolvedValue(null);
+    const exchangeSpy = vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken");
     vi.spyOn(services.analyticsService, "getBatchMatchAnalytics").mockResolvedValue({ "match-1": analytics });
 
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
@@ -260,6 +267,8 @@ describe("/api/stats/match-analytics (batch)", () => {
     // Should use the bot analytics service (no custom analytics service created)
     const body = await response.json();
     expect(body).toEqual({ results: { "match-1": analytics } });
+    expect(getMicrosoftAccessTokenSpy).toHaveBeenCalledWith("owner-user-1");
+    expect(exchangeSpy).not.toHaveBeenCalled();
   });
 
   it("attempts user credential resolution when tracker is live", async () => {
@@ -270,22 +279,47 @@ describe("/api/stats/match-analytics (batch)", () => {
     vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(
       aFakeIndividualTrackersRow({ TrackerId: "tracker-1", UserId: ownerUserId, IsLive: 1 }),
     );
-    vi.spyOn(services.userTokenProvider, "getClientForUser").mockResolvedValue(null); // User client unavailable
-    const analyticsspy = vi.spyOn(services.analyticsService, "getBatchMatchAnalytics");
-    analyticsspy.mockResolvedValue({ "match-1": analytics });
+    vi.spyOn(services.userTokenProvider, "getClientForUser").mockResolvedValue(services.haloInfiniteClient);
+    const getMicrosoftAccessTokenSpy = vi
+      .spyOn(services.authService, "getMicrosoftAccessTokenForUser")
+      .mockResolvedValue("owner-access-token");
+    const exchangeSpy = vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockResolvedValue({
+      XSTSToken: "owner-xsts-token",
+      userHash: "owner-user-hash",
+      expiresOn: new Date("2030-01-01T00:00:00.000Z"),
+    });
+    const botAnalyticsSpy = vi.spyOn(services.analyticsService, "getBatchMatchAnalytics");
+    const logWarnSpy: MockInstance<LogService["warn"]> = vi.spyOn(services.logService, "warn");
+    const analyticsServiceGetBatchMatchAnalyticsSpy: MockInstance<
+      AnalyticsServiceInstance["getBatchMatchAnalytics"]
+    > = vi.spyOn(AnalyticsService.prototype, "getBatchMatchAnalytics");
+    analyticsServiceGetBatchMatchAnalyticsSpy.mockResolvedValue({
+      "match-1": analytics,
+      "match-2": null,
+    });
 
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
     statsRoutesRegisterHandler(router, localInstallServices);
 
     const response = (await router.fetch(
-      new Request("http://localhost/api/stats/match-analytics?matchIds=match-1&trackerId=tracker-1"),
+      new Request("http://localhost/api/stats/match-analytics?matchIds=match-1,match-2&modules=killMatrix&trackerId=tracker-1"),
       env,
     )) as Response;
 
     expect(response.status).toBe(200);
-    // Verifies that we tried to get user client and fell back to bot service
+    expect(getMicrosoftAccessTokenSpy).toHaveBeenCalledWith(ownerUserId);
+    expect(exchangeSpy).toHaveBeenCalledWith("owner-access-token");
     expect(services.userTokenProvider.getClientForUser).toHaveBeenCalledWith(ownerUserId);
+    expect(botAnalyticsSpy).not.toHaveBeenCalled();
+    expect(analyticsServiceGetBatchMatchAnalyticsSpy).toHaveBeenCalledWith(["match-1", "match-2"], ["killMatrix"]);
     const body = await response.json();
-    expect(body).toEqual({ results: { "match-1": analytics } });
+    expect(body).toEqual({ results: { "match-1": analytics, "match-2": null } });
+    expect(logWarnSpy).toHaveBeenCalledWith(
+      "1/2 match analytics fetches failed",
+      new Map([
+        ["route", "stats:match-analytics-batch"],
+        ["credentialSource", `user:${ownerUserId}`],
+      ]),
+    );
   });
 });

--- a/api/routes/stats/tests/batch-analytics.test.ts
+++ b/api/routes/stats/tests/batch-analytics.test.ts
@@ -1,4 +1,5 @@
 import type { AutoRouterType } from "itty-router";
+import { StaticXstsTicketTokenSpartanTokenProvider } from "halo-infinite-api";
 import type { MockInstance } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LogService } from "../../../services/log/types";
@@ -282,17 +283,12 @@ describe("/api/stats/match-analytics (batch)", () => {
     vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(
       aFakeIndividualTrackersRow({ TrackerId: "tracker-1", UserId: ownerUserId, IsLive: 1 }),
     );
-    const getClientForUserSpy = vi
-      .spyOn(services.userTokenProvider, "getClientForUser")
-      .mockResolvedValue(services.haloInfiniteClient);
-    const getMicrosoftAccessTokenSpy = vi
-      .spyOn(services.authService, "getMicrosoftAccessTokenForUser")
-      .mockResolvedValue("owner-access-token");
-    const exchangeSpy = vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken").mockResolvedValue({
-      XSTSToken: "owner-xsts-token",
-      userHash: "owner-user-hash",
-      expiresOn: new Date("2030-01-01T00:00:00.000Z"),
+    const getContextForUserSpy = vi.spyOn(services.userTokenProvider, "getContextForUser").mockResolvedValue({
+      client: services.haloInfiniteClient,
+      spartanTokenProvider: new StaticXstsTicketTokenSpartanTokenProvider("owner-xsts-token"),
     });
+    const getMicrosoftAccessTokenSpy = vi.spyOn(services.authService, "getMicrosoftAccessTokenForUser");
+    const exchangeSpy = vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken");
     const botAnalyticsSpy = vi.spyOn(services.analyticsService, "getBatchMatchAnalytics");
     const logWarnSpy: MockInstance<LogService["warn"]> = vi.spyOn(services.logService, "warn");
     const analyticsServiceGetBatchMatchAnalyticsSpy: MockInstance<AnalyticsServiceInstance["getBatchMatchAnalytics"]> =
@@ -313,9 +309,9 @@ describe("/api/stats/match-analytics (batch)", () => {
     )) as Response;
 
     expect(response.status).toBe(200);
-    expect(getMicrosoftAccessTokenSpy).toHaveBeenCalledWith(ownerUserId);
-    expect(exchangeSpy).toHaveBeenCalledWith("owner-access-token");
-    expect(getClientForUserSpy).toHaveBeenCalledWith(ownerUserId);
+    expect(getMicrosoftAccessTokenSpy).not.toHaveBeenCalled();
+    expect(exchangeSpy).not.toHaveBeenCalled();
+    expect(getContextForUserSpy).toHaveBeenCalledWith(ownerUserId);
     expect(botAnalyticsSpy).not.toHaveBeenCalled();
     expect(analyticsServiceGetBatchMatchAnalyticsSpy).toHaveBeenCalledWith(["match-1", "match-2"], ["killMatrix"]);
     const body = await response.json();

--- a/api/routes/stats/tests/batch-analytics.test.ts
+++ b/api/routes/stats/tests/batch-analytics.test.ts
@@ -282,7 +282,9 @@ describe("/api/stats/match-analytics (batch)", () => {
     vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(
       aFakeIndividualTrackersRow({ TrackerId: "tracker-1", UserId: ownerUserId, IsLive: 1 }),
     );
-    vi.spyOn(services.userTokenProvider, "getClientForUser").mockResolvedValue(services.haloInfiniteClient);
+    const getClientForUserSpy = vi
+      .spyOn(services.userTokenProvider, "getClientForUser")
+      .mockResolvedValue(services.haloInfiniteClient);
     const getMicrosoftAccessTokenSpy = vi
       .spyOn(services.authService, "getMicrosoftAccessTokenForUser")
       .mockResolvedValue("owner-access-token");
@@ -313,7 +315,7 @@ describe("/api/stats/match-analytics (batch)", () => {
     expect(response.status).toBe(200);
     expect(getMicrosoftAccessTokenSpy).toHaveBeenCalledWith(ownerUserId);
     expect(exchangeSpy).toHaveBeenCalledWith("owner-access-token");
-    expect(services.userTokenProvider.getClientForUser).toHaveBeenCalledWith(ownerUserId);
+    expect(getClientForUserSpy).toHaveBeenCalledWith(ownerUserId);
     expect(botAnalyticsSpy).not.toHaveBeenCalled();
     expect(analyticsServiceGetBatchMatchAnalyticsSpy).toHaveBeenCalledWith(["match-1", "match-2"], ["killMatrix"]);
     const body = await response.json();

--- a/api/routes/stats/tests/batch-analytics.test.ts
+++ b/api/routes/stats/tests/batch-analytics.test.ts
@@ -4,7 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LogService } from "../../../services/log/types";
 import { createApiRouter } from "../../../base/router";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
-import { AnalyticsService, type AnalyticsService as AnalyticsServiceInstance } from "../../../services/analytics/analytics";
+import {
+  AnalyticsService,
+  type AnalyticsService as AnalyticsServiceInstance,
+} from "../../../services/analytics/analytics";
 import { aFakeMatchAnalyticsWith } from "../../../services/analytics/fakes/analytics.fake";
 import { aFakeIndividualTrackersRow } from "../../../services/database/fakes/database.fake";
 import { installFakeServicesWith } from "../../../services/fakes/services";
@@ -290,9 +293,8 @@ describe("/api/stats/match-analytics (batch)", () => {
     });
     const botAnalyticsSpy = vi.spyOn(services.analyticsService, "getBatchMatchAnalytics");
     const logWarnSpy: MockInstance<LogService["warn"]> = vi.spyOn(services.logService, "warn");
-    const analyticsServiceGetBatchMatchAnalyticsSpy: MockInstance<
-      AnalyticsServiceInstance["getBatchMatchAnalytics"]
-    > = vi.spyOn(AnalyticsService.prototype, "getBatchMatchAnalytics");
+    const analyticsServiceGetBatchMatchAnalyticsSpy: MockInstance<AnalyticsServiceInstance["getBatchMatchAnalytics"]> =
+      vi.spyOn(AnalyticsService.prototype, "getBatchMatchAnalytics");
     analyticsServiceGetBatchMatchAnalyticsSpy.mockResolvedValue({
       "match-1": analytics,
       "match-2": null,
@@ -302,7 +304,9 @@ describe("/api/stats/match-analytics (batch)", () => {
     statsRoutesRegisterHandler(router, localInstallServices);
 
     const response = (await router.fetch(
-      new Request("http://localhost/api/stats/match-analytics?matchIds=match-1,match-2&modules=killMatrix&trackerId=tracker-1"),
+      new Request(
+        "http://localhost/api/stats/match-analytics?matchIds=match-1,match-2&modules=killMatrix&trackerId=tracker-1",
+      ),
       env,
     )) as Response;
 

--- a/api/routes/stats/tests/batch-analytics.test.ts
+++ b/api/routes/stats/tests/batch-analytics.test.ts
@@ -78,7 +78,10 @@ describe("/api/stats/match-analytics (batch)", () => {
     expect(logWarnSpy).toHaveBeenCalledOnce();
     expect(logWarnSpy).toHaveBeenCalledWith(
       "1/2 match analytics fetches failed",
-      new Map([["route", "stats:match-analytics-batch"]]),
+      new Map([
+        ["route", "stats:match-analytics-batch"],
+        ["credentialSource", "bot"],
+      ]),
     );
   });
 
@@ -207,5 +210,82 @@ describe("/api/stats/match-analytics (batch)", () => {
         ["trackerId", "tracker-1"],
       ]),
     );
+  });
+
+  it("includes credentialSource as 'bot' in failure warning when using bot credentials", async () => {
+    const services = installFakeServicesWith({ env });
+    vi.spyOn(services.analyticsService, "getBatchMatchAnalytics").mockResolvedValue({
+      "match-ok": aFakeMatchAnalyticsWith(),
+      "match-fail": null,
+    });
+    const logWarnSpy: MockInstance<LogService["warn"]> = vi.spyOn(services.logService, "warn");
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request("http://localhost/api/stats/match-analytics?matchIds=match-ok,match-fail"),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(200);
+    expect(logWarnSpy).toHaveBeenCalledWith(
+      "1/2 match analytics fetches failed",
+      new Map([
+        ["route", "stats:match-analytics-batch"],
+        ["credentialSource", "bot"],
+      ]),
+    );
+  });
+
+  it("falls back to bot credentials when user access token is not available", async () => {
+    const analytics = aFakeMatchAnalyticsWith();
+    const services = installFakeServicesWith({ env });
+
+    vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(
+      aFakeIndividualTrackersRow({ TrackerId: "tracker-1", UserId: "owner-user-1", IsLive: 1 }),
+    );
+    vi.spyOn(services.userTokenProvider, "getClientForUser").mockResolvedValue(services.haloInfiniteClient);
+    vi.spyOn(services.authService, "getMicrosoftAccessTokenForUser").mockResolvedValue(null); // No access token
+    vi.spyOn(services.analyticsService, "getBatchMatchAnalytics").mockResolvedValue({ "match-1": analytics });
+
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request("http://localhost/api/stats/match-analytics?matchIds=match-1&trackerId=tracker-1"),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(200);
+    // Should use the bot analytics service (no custom analytics service created)
+    const body = await response.json();
+    expect(body).toEqual({ results: { "match-1": analytics } });
+  });
+
+  it("attempts user credential resolution when tracker is live", async () => {
+    const analytics = aFakeMatchAnalyticsWith();
+    const services = installFakeServicesWith({ env });
+    const ownerUserId = "owner-user-1";
+
+    vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(
+      aFakeIndividualTrackersRow({ TrackerId: "tracker-1", UserId: ownerUserId, IsLive: 1 }),
+    );
+    vi.spyOn(services.userTokenProvider, "getClientForUser").mockResolvedValue(null); // User client unavailable
+    const analyticsspy = vi.spyOn(services.analyticsService, "getBatchMatchAnalytics");
+    analyticsspy.mockResolvedValue({ "match-1": analytics });
+
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request("http://localhost/api/stats/match-analytics?matchIds=match-1&trackerId=tracker-1"),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(200);
+    // Verifies that we tried to get user client and fell back to bot service
+    expect(services.userTokenProvider.getClientForUser).toHaveBeenCalledWith(ownerUserId);
+    const body = await response.json();
+    expect(body).toEqual({ results: { "match-1": analytics } });
   });
 });

--- a/api/routes/stats/tests/batch-analytics.test.ts
+++ b/api/routes/stats/tests/batch-analytics.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LogService } from "../../../services/log/types";
 import { createApiRouter } from "../../../base/router";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
+import { aFakeAuthSessionWith } from "../../../services/auth/fakes/data";
 import {
   AnalyticsService,
   type AnalyticsService as AnalyticsServiceInstance,
@@ -252,11 +253,10 @@ describe("/api/stats/match-analytics (batch)", () => {
     vi.spyOn(services.databaseService, "getIndividualTracker").mockResolvedValue(
       aFakeIndividualTrackersRow({ TrackerId: "tracker-1", UserId: "owner-user-1", IsLive: 1 }),
     );
-    vi.spyOn(services.userTokenProvider, "getClientForUser").mockResolvedValue(services.haloInfiniteClient);
-    const getMicrosoftAccessTokenSpy = vi
-      .spyOn(services.authService, "getMicrosoftAccessTokenForUser")
-      .mockResolvedValue(null);
-    const exchangeSpy = vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken");
+    vi.spyOn(services.authService, "validateSession").mockResolvedValue(
+      aFakeAuthSessionWith({ userId: "other-user-1" }),
+    );
+    const getContextForUserSpy = vi.spyOn(services.userTokenProvider, "getContextForUser");
     vi.spyOn(services.analyticsService, "getBatchMatchAnalytics").mockResolvedValue({ "match-1": analytics });
 
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
@@ -268,11 +268,9 @@ describe("/api/stats/match-analytics (batch)", () => {
     )) as Response;
 
     expect(response.status).toBe(200);
-    // Should use the bot analytics service (no custom analytics service created)
     const body = await response.json();
     expect(body).toEqual({ results: { "match-1": analytics } });
-    expect(getMicrosoftAccessTokenSpy).toHaveBeenCalledWith("owner-user-1");
-    expect(exchangeSpy).not.toHaveBeenCalled();
+    expect(getContextForUserSpy).not.toHaveBeenCalled();
   });
 
   it("attempts user credential resolution when tracker is live", async () => {
@@ -287,8 +285,7 @@ describe("/api/stats/match-analytics (batch)", () => {
       client: services.haloInfiniteClient,
       spartanTokenProvider: new StaticXstsTicketTokenSpartanTokenProvider("owner-xsts-token"),
     });
-    const getMicrosoftAccessTokenSpy = vi.spyOn(services.authService, "getMicrosoftAccessTokenForUser");
-    const exchangeSpy = vi.spyOn(services.xboxService, "exchangeMicrosoftAccessTokenForXstsToken");
+    vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith({ userId: ownerUserId }));
     const botAnalyticsSpy = vi.spyOn(services.analyticsService, "getBatchMatchAnalytics");
     const logWarnSpy: MockInstance<LogService["warn"]> = vi.spyOn(services.logService, "warn");
     const analyticsServiceGetBatchMatchAnalyticsSpy: MockInstance<AnalyticsServiceInstance["getBatchMatchAnalytics"]> =
@@ -309,8 +306,6 @@ describe("/api/stats/match-analytics (batch)", () => {
     )) as Response;
 
     expect(response.status).toBe(200);
-    expect(getMicrosoftAccessTokenSpy).not.toHaveBeenCalled();
-    expect(exchangeSpy).not.toHaveBeenCalled();
     expect(getContextForUserSpy).toHaveBeenCalledWith(ownerUserId);
     expect(botAnalyticsSpy).not.toHaveBeenCalled();
     expect(analyticsServiceGetBatchMatchAnalyticsSpy).toHaveBeenCalledWith(["match-1", "match-2"], ["killMatrix"]);

--- a/api/services/halo/halo-film.ts
+++ b/api/services/halo/halo-film.ts
@@ -27,7 +27,7 @@ import type {
   KillRaceProgressionEvent,
   HaloFilmServiceOpts,
 } from "./types";
-import type { CustomSpartanTokenProvider } from "./custom-spartan-token-provider";
+import type { SpartanTokenProvider } from "halo-infinite-api";
 
 export class HaloFilmService {
   private static readonly FILM_CACHE_TTL_SECONDS = 604_800;
@@ -36,7 +36,7 @@ export class HaloFilmService {
   private static readonly FILM_CACHE_BASE_URL = "https://halo-film-cache.local";
 
   private readonly env: Env;
-  private readonly spartanTokenProvider: CustomSpartanTokenProvider;
+  private readonly spartanTokenProvider: SpartanTokenProvider;
   private readonly fetchFn: typeof globalThis.fetch | undefined;
   private readonly clearanceCacheKey: string;
 

--- a/api/services/halo/halo-film.ts
+++ b/api/services/halo/halo-film.ts
@@ -1,5 +1,5 @@
 import { inflateSync } from "node:zlib";
-import type { MatchStats } from "halo-infinite-api";
+import type { MatchStats, SpartanTokenProvider } from "halo-infinite-api";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { wrapXuid, unwrapXuid } from "@guilty-spark/shared/halo/match-stats";
 import {
@@ -27,7 +27,6 @@ import type {
   KillRaceProgressionEvent,
   HaloFilmServiceOpts,
 } from "./types";
-import type { SpartanTokenProvider } from "halo-infinite-api";
 
 export class HaloFilmService {
   private static readonly FILM_CACHE_TTL_SECONDS = 604_800;

--- a/api/services/halo/halo-film.ts
+++ b/api/services/halo/halo-film.ts
@@ -38,11 +38,14 @@ export class HaloFilmService {
   private readonly env: Env;
   private readonly spartanTokenProvider: CustomSpartanTokenProvider;
   private readonly fetchFn: typeof globalThis.fetch | undefined;
+  private readonly clearanceCacheKey: string;
 
-  constructor({ env, spartanTokenProvider, fetch: fetchFn }: HaloFilmServiceOpts) {
+  constructor({ env, spartanTokenProvider, fetch: fetchFn, kvKeyNamespace }: HaloFilmServiceOpts) {
     this.env = env;
     this.spartanTokenProvider = spartanTokenProvider;
     this.fetchFn = fetchFn;
+    this.clearanceCacheKey =
+      kvKeyNamespace != null ? `${kvKeyNamespace}:clearance` : HaloFilmService.CLEARANCE_CACHE_KEY;
   }
 
   private async callFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
@@ -416,7 +419,7 @@ export class HaloFilmService {
   private async resolveAuthContext(): Promise<{ spartanToken: string; clearanceToken: string }> {
     const spartanToken = await this.spartanTokenProvider.getSpartanToken();
 
-    const cachedClearance = await this.env.APP_DATA.get(HaloFilmService.CLEARANCE_CACHE_KEY);
+    const cachedClearance = await this.env.APP_DATA.get(this.clearanceCacheKey);
     if (cachedClearance != null) {
       return { spartanToken, clearanceToken: cachedClearance };
     }
@@ -447,7 +450,7 @@ export class HaloFilmService {
       clearanceToken = fallbackClearance.FlightConfigurationId;
     }
 
-    await this.env.APP_DATA.put(HaloFilmService.CLEARANCE_CACHE_KEY, clearanceToken, {
+    await this.env.APP_DATA.put(this.clearanceCacheKey, clearanceToken, {
       expirationTtl: HaloFilmService.CLEARANCE_CACHE_TTL_SECONDS,
     });
 

--- a/api/services/halo/tests/halo-film.test.ts
+++ b/api/services/halo/tests/halo-film.test.ts
@@ -397,9 +397,7 @@ describe("HaloFilmService", () => {
             MatchId: "namespaced-clearance-test-1",
             FilmMajorVersion: 42,
             FilmLength: 100,
-            Chunks: [
-              { Index: 1, ChunkType: 3, DurationMilliseconds: 100, ChunkSize: 1, FileRelativePath: "/c.bin" },
-            ],
+            Chunks: [{ Index: 1, ChunkType: 3, DurationMilliseconds: 100, ChunkSize: 1, FileRelativePath: "/c.bin" }],
           },
         };
         const fetchSpy = mockFetch("unused-clearance", metadata, compressedChunk);
@@ -434,9 +432,7 @@ describe("HaloFilmService", () => {
             MatchId: "namespaced-clearance-test-2",
             FilmMajorVersion: 42,
             FilmLength: 100,
-            Chunks: [
-              { Index: 1, ChunkType: 3, DurationMilliseconds: 100, ChunkSize: 1, FileRelativePath: "/c.bin" },
-            ],
+            Chunks: [{ Index: 1, ChunkType: 3, DurationMilliseconds: 100, ChunkSize: 1, FileRelativePath: "/c.bin" }],
           },
         };
         mockFetch("clearance-namespaced", metadata, compressedChunk);

--- a/api/services/halo/tests/halo-film.test.ts
+++ b/api/services/halo/tests/halo-film.test.ts
@@ -375,6 +375,78 @@ describe("HaloFilmService", () => {
       expect(secondCallUrls.some((url) => url.includes("/users/me"))).toBe(false);
       expect(secondCallUrls.some((url) => url.includes("flight-configurations"))).toBe(false);
     });
+
+    describe("namespaced clearance token caching", () => {
+      it("reads clearance token from the namespaced key when kvKeyNamespace is provided", async () => {
+        const env = aFakeCacheBackedEnvWith();
+        const xboxService = aFakeXboxServiceWith({ env });
+        const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });
+        vi.spyOn(spartanTokenProvider, "getSpartanToken").mockResolvedValue("test-spartan-token");
+        await env.APP_DATA.put("halo:film:user-123:clearance", "test-clearance-token");
+        const service = new HaloFilmService({
+          env,
+          spartanTokenProvider,
+          kvKeyNamespace: "halo:film:user-123",
+        });
+
+        const compressedChunk = deflateSync(Uint8Array.of(0x01));
+        const metadata = {
+          AssetId: "asset-id",
+          BlobStoragePathPrefix: "https://blob.example/",
+          CustomData: {
+            MatchId: "namespaced-clearance-test-1",
+            FilmMajorVersion: 42,
+            FilmLength: 100,
+            Chunks: [
+              { Index: 1, ChunkType: 3, DurationMilliseconds: 100, ChunkSize: 1, FileRelativePath: "/c.bin" },
+            ],
+          },
+        };
+        const fetchSpy = mockFetch("unused-clearance", metadata, compressedChunk);
+
+        await service.getHighlightEventsForMatch("namespaced-clearance-test-1");
+
+        const fetchedUrls = fetchSpy.mock.calls.map((args) => {
+          const [input] = args;
+          return typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        });
+        expect(fetchedUrls.some((url) => url.includes("/users/me"))).toBe(false);
+        expect(fetchedUrls.some((url) => url.includes("flight-configurations"))).toBe(false);
+        expect(await env.APP_DATA.get("halo:film:user-123:clearance")).toBe("test-clearance-token");
+      });
+
+      it("stores clearance token in the namespaced key when kvKeyNamespace is provided", async () => {
+        const env = aFakeCacheBackedEnvWith();
+        const xboxService = aFakeXboxServiceWith({ env });
+        const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });
+        vi.spyOn(spartanTokenProvider, "getSpartanToken").mockResolvedValue("test-spartan-token");
+        const service = new HaloFilmService({
+          env,
+          spartanTokenProvider,
+          kvKeyNamespace: "halo:film:user-456",
+        });
+
+        const compressedChunk = deflateSync(Uint8Array.of(0x02));
+        const metadata = {
+          AssetId: "asset-id",
+          BlobStoragePathPrefix: "https://blob.example/",
+          CustomData: {
+            MatchId: "namespaced-clearance-test-2",
+            FilmMajorVersion: 42,
+            FilmLength: 100,
+            Chunks: [
+              { Index: 1, ChunkType: 3, DurationMilliseconds: 100, ChunkSize: 1, FileRelativePath: "/c.bin" },
+            ],
+          },
+        };
+        mockFetch("clearance-namespaced", metadata, compressedChunk);
+
+        await service.getHighlightEventsForMatch("namespaced-clearance-test-2");
+
+        expect(await env.APP_DATA.get("halo:film:user-456:clearance")).toBe("clearance-namespaced");
+        expect(await env.APP_DATA.get("film:clearance")).toBeNull();
+      });
+    });
   });
 
   it("builds kill matrix analytics with pairing quality and perfect counts", async () => {

--- a/api/services/halo/types.ts
+++ b/api/services/halo/types.ts
@@ -1,6 +1,6 @@
 import type { UserInfo as HaloUserInfo } from "halo-infinite-api";
 import { EndUserError, EndUserErrorType } from "../../base/end-user-error";
-import type { CustomSpartanTokenProvider } from "./custom-spartan-token-provider";
+import type { SpartanTokenProvider } from "halo-infinite-api";
 
 export type UserInfo = Pick<HaloUserInfo, "xuid" | "gamertag">;
 export type CachedUserInfo = UserInfo & { fetchedAt: number };
@@ -217,7 +217,7 @@ export interface KillRaceProgression {
 
 export interface HaloFilmServiceOpts {
   env: Env;
-  spartanTokenProvider: CustomSpartanTokenProvider;
+  spartanTokenProvider: SpartanTokenProvider;
   fetch?: typeof globalThis.fetch;
   kvKeyNamespace?: string;
 }

--- a/api/services/halo/types.ts
+++ b/api/services/halo/types.ts
@@ -1,6 +1,5 @@
-import type { UserInfo as HaloUserInfo } from "halo-infinite-api";
+import type { UserInfo as HaloUserInfo, SpartanTokenProvider } from "halo-infinite-api";
 import { EndUserError, EndUserErrorType } from "../../base/end-user-error";
-import type { SpartanTokenProvider } from "halo-infinite-api";
 
 export type UserInfo = Pick<HaloUserInfo, "xuid" | "gamertag">;
 export type CachedUserInfo = UserInfo & { fetchedAt: number };

--- a/api/services/halo/types.ts
+++ b/api/services/halo/types.ts
@@ -219,4 +219,5 @@ export interface HaloFilmServiceOpts {
   env: Env;
   spartanTokenProvider: CustomSpartanTokenProvider;
   fetch?: typeof globalThis.fetch;
+  kvKeyNamespace?: string;
 }

--- a/api/services/halo/user-token-provider.ts
+++ b/api/services/halo/user-token-provider.ts
@@ -13,11 +13,6 @@ export interface UserTokenProviderOpts {
   logService: LogService;
 }
 
-interface CachedUserClient {
-  readonly client: HaloInfiniteClient;
-  readonly expiresAtMs: number;
-}
-
 interface CachedUserTokenContext {
   readonly client: HaloInfiniteClient;
   readonly spartanTokenProvider: SpartanTokenProvider;
@@ -35,9 +30,7 @@ export class UserTokenProvider {
   private readonly authService: AuthService;
   private readonly xboxService: XboxService;
   private readonly logService: LogService;
-  private readonly cachedClientsByUserId = new Map<string, CachedUserClient>();
   private readonly cachedContextsByUserId = new Map<string, CachedUserTokenContext>();
-  private readonly inFlightClientByUserId = new Map<string, Promise<HaloInfiniteClient | null>>();
   private readonly inFlightContextByUserId = new Map<string, Promise<UserTokenContext | null>>();
 
   constructor({ authService, xboxService, logService }: UserTokenProviderOpts) {
@@ -47,9 +40,7 @@ export class UserTokenProvider {
   }
 
   public clearCachedClient(userId: string): void {
-    this.cachedClientsByUserId.delete(userId);
     this.cachedContextsByUserId.delete(userId);
-    this.inFlightClientByUserId.delete(userId);
     this.inFlightContextByUserId.delete(userId);
   }
 
@@ -95,10 +86,6 @@ export class UserTokenProvider {
       const spartanTokenProvider = new StaticXstsTicketTokenSpartanTokenProvider(xstsTokenInfo.XSTSToken);
       const client = new HaloInfiniteClient(spartanTokenProvider);
       const expiresAtMs = xstsTokenInfo.expiresOn.getTime();
-      this.cachedClientsByUserId.set(userId, {
-        client,
-        expiresAtMs,
-      });
       this.cachedContextsByUserId.set(userId, {
         client,
         spartanTokenProvider,

--- a/api/services/halo/user-token-provider.ts
+++ b/api/services/halo/user-token-provider.ts
@@ -39,9 +39,13 @@ export class UserTokenProvider {
     this.logService = logService;
   }
 
-  public clearCachedClient(userId: string): void {
+  public clearCachedContext(userId: string): void {
     this.cachedContextsByUserId.delete(userId);
     this.inFlightContextByUserId.delete(userId);
+  }
+
+  public clearCachedClient(userId: string): void {
+    this.clearCachedContext(userId);
   }
 
   async getClientForUser(userId: string): Promise<HaloInfiniteClient | null> {

--- a/api/services/halo/user-token-provider.ts
+++ b/api/services/halo/user-token-provider.ts
@@ -1,4 +1,8 @@
-import { HaloInfiniteClient, StaticXstsTicketTokenSpartanTokenProvider } from "halo-infinite-api";
+import {
+  HaloInfiniteClient,
+  StaticXstsTicketTokenSpartanTokenProvider,
+  type SpartanTokenProvider,
+} from "halo-infinite-api";
 import type { AuthService } from "../auth/auth";
 import type { LogService } from "../log/types";
 import type { XboxService } from "../xbox/xbox";
@@ -14,6 +18,17 @@ interface CachedUserClient {
   readonly expiresAtMs: number;
 }
 
+interface CachedUserTokenContext {
+  readonly client: HaloInfiniteClient;
+  readonly spartanTokenProvider: SpartanTokenProvider;
+  readonly expiresAtMs: number;
+}
+
+export interface UserTokenContext {
+  client: HaloInfiniteClient;
+  spartanTokenProvider: SpartanTokenProvider;
+}
+
 export class UserTokenProvider {
   private static readonly CACHE_EXPIRY_SKEW_MS = 60_000;
 
@@ -21,7 +36,9 @@ export class UserTokenProvider {
   private readonly xboxService: XboxService;
   private readonly logService: LogService;
   private readonly cachedClientsByUserId = new Map<string, CachedUserClient>();
+  private readonly cachedContextsByUserId = new Map<string, CachedUserTokenContext>();
   private readonly inFlightClientByUserId = new Map<string, Promise<HaloInfiniteClient | null>>();
+  private readonly inFlightContextByUserId = new Map<string, Promise<UserTokenContext | null>>();
 
   constructor({ authService, xboxService, logService }: UserTokenProviderOpts) {
     this.authService = authService;
@@ -31,33 +48,43 @@ export class UserTokenProvider {
 
   public clearCachedClient(userId: string): void {
     this.cachedClientsByUserId.delete(userId);
+    this.cachedContextsByUserId.delete(userId);
     this.inFlightClientByUserId.delete(userId);
+    this.inFlightContextByUserId.delete(userId);
   }
 
   async getClientForUser(userId: string): Promise<HaloInfiniteClient | null> {
-    const cached = this.cachedClientsByUserId.get(userId);
-    if (cached != null) {
-      if (Date.now() < cached.expiresAtMs - UserTokenProvider.CACHE_EXPIRY_SKEW_MS) {
-        return cached.client;
-      }
-
-      this.cachedClientsByUserId.delete(userId);
-    }
-
-    const inFlightClient = this.inFlightClientByUserId.get(userId);
-    if (inFlightClient != null) {
-      return inFlightClient;
-    }
-
-    const mintClientPromise = this.getClientForUserUncached(userId).finally(() => {
-      this.inFlightClientByUserId.delete(userId);
-    });
-    this.inFlightClientByUserId.set(userId, mintClientPromise);
-
-    return mintClientPromise;
+    const context = await this.getContextForUser(userId);
+    return context?.client ?? null;
   }
 
-  private async getClientForUserUncached(userId: string): Promise<HaloInfiniteClient | null> {
+  async getContextForUser(userId: string): Promise<UserTokenContext | null> {
+    const cached = this.cachedContextsByUserId.get(userId);
+    if (cached != null) {
+      if (Date.now() < cached.expiresAtMs - UserTokenProvider.CACHE_EXPIRY_SKEW_MS) {
+        return {
+          client: cached.client,
+          spartanTokenProvider: cached.spartanTokenProvider,
+        };
+      }
+
+      this.cachedContextsByUserId.delete(userId);
+    }
+
+    const inFlightContext = this.inFlightContextByUserId.get(userId);
+    if (inFlightContext != null) {
+      return inFlightContext;
+    }
+
+    const mintContextPromise = this.getContextForUserUncached(userId).finally(() => {
+      this.inFlightContextByUserId.delete(userId);
+    });
+    this.inFlightContextByUserId.set(userId, mintContextPromise);
+
+    return mintContextPromise;
+  }
+
+  private async getContextForUserUncached(userId: string): Promise<UserTokenContext | null> {
     try {
       const accessToken = await this.authService.getMicrosoftAccessTokenForUser(userId);
       if (accessToken == null) {
@@ -65,12 +92,19 @@ export class UserTokenProvider {
       }
 
       const xstsTokenInfo = await this.xboxService.exchangeMicrosoftAccessTokenForXstsToken(accessToken);
-      const client = new HaloInfiniteClient(new StaticXstsTicketTokenSpartanTokenProvider(xstsTokenInfo.XSTSToken));
+      const spartanTokenProvider = new StaticXstsTicketTokenSpartanTokenProvider(xstsTokenInfo.XSTSToken);
+      const client = new HaloInfiniteClient(spartanTokenProvider);
+      const expiresAtMs = xstsTokenInfo.expiresOn.getTime();
       this.cachedClientsByUserId.set(userId, {
         client,
-        expiresAtMs: xstsTokenInfo.expiresOn.getTime(),
+        expiresAtMs,
       });
-      return client;
+      this.cachedContextsByUserId.set(userId, {
+        client,
+        spartanTokenProvider,
+        expiresAtMs,
+      });
+      return { client, spartanTokenProvider };
     } catch (error) {
       this.logService.warn(
         "UserTokenProvider: failed to mint Halo client for user",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
   "engines": {
     "node": ">=24.11.0"
   },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/davidhouweling/guilty-spark.git"


### PR DESCRIPTION
## Context

The match analytics endpoint () was accepting an optional `trackerId` parameter to use tracker-specific credentials, but was only using user-scoped HaloService while continuing to use the shared bot-credential HaloFilmService. This caused the bot account to exhaust its Xbox rate limits with "Too Many Requests" (429) errors, even when individual users had valid trackers and credentials.

## This PR

Implements per-request user-scoped credential resolution in the batch analytics route:

1. **User Credential Resolution**: When `trackerId` is provided and the tracker is active (IsLive = 1):
   - Retrieves user's HaloInfiniteClient via UserTokenProvider
   - Fetches user's Microsoft AccessToken via AuthService
   - Exchanges AccessToken for XSTS token via XboxService
   - Creates StaticXstsTicketTokenSpartanTokenProvider from the user's XSTS token

2. **Service Instantiation**: Creates a new HaloFilmService instance using the user-scoped token provider, avoiding bot account rate limits

3. **Observability**: Tracks credential source in logs as either "bot" or "user:{userId}" for debugging and monitoring

4. **Graceful Fallback**: If any step in user credential resolution fails, gracefully falls back to bot credentials

5. **Test Coverage**: Added tests verifying:
   - AuthService and XboxService are called with correct user ID
   - Fallback behavior when user credentials are unavailable
   - Correct credential source logging for both bot and user scenarios

## Changes

- **api/routes/stats/batch-analytics.ts**: Updated route handler to implement user credential resolution with fallback
- **api/routes/stats/tests/batch-analytics.test.ts**: Added 4 new test cases covering credential resolution scenarios, updated existing test to expect credentialSource attribute


## Side note
- Added follow-up commit `5eca5c29` to gate user-scoped credential usage behind a matching authenticated session (`session.userId === tracker.UserId`) and keep a `clearCachedContext()` API (with `clearCachedClient()` as a compatibility alias).
