### PR TITLE
Split stats and analytics loading for tracker stats views

### DIFF
--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -8,6 +8,7 @@ import type { MedalEntry, MedalMetadata } from "@guilty-spark/shared/halo/medals
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { summarizeSeriesOutcome } from "@guilty-spark/shared/halo/match-enrichment";
+import type { ComponentLoaderStatus } from "../../component-loader/component-loader";
 import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type { TickerMatchGroup, TickerStatRow } from "../../information-ticker/information-ticker";
@@ -79,6 +80,7 @@ export type MatchStatsState =
       readonly playerMap: Map<string, string>;
       readonly medalMetadata: MedalMetadata;
       readonly analytics: MatchAnalytics | null;
+      readonly analyticsStatus: ComponentLoaderStatus;
     }
   | { readonly status: "error"; readonly message: string };
 

--- a/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
@@ -4,17 +4,25 @@ import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-
 import { StatsController } from "../../../controllers/stats/stats-controller";
 import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPlayer } from "../../../controllers/stats/kill-matrix/types";
+import { ComponentLoaderStatus } from "../../component-loader/component-loader";
+import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { MatchDetailsState, ViewerTimelineItem } from "../viewer/types";
 import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
 import type { OverlayPageSnapshot, OverlayPageStore } from "./overlay-page-store";
+import { formatScoreProgression } from "../../stats/score-progression/score-progression-formatter";
 
 interface OverlayPagePresenterConfig {
   readonly store: OverlayPageStore;
   readonly haloClient: HaloInfiniteClient;
   readonly medalMetadataResolver: HaloMedalMetadataResolver;
   readonly matchAnalyticsService: MatchAnalyticsService;
+}
+
+interface OverlayAnalyticsLoadResult {
+  readonly status: ComponentLoaderStatus;
+  readonly analyticsByMatchId: Readonly<Record<string, MatchAnalytics | null>>;
 }
 
 export interface OverlayPageViewModel {
@@ -109,11 +117,23 @@ export class OverlayPagePresenter {
 
       const xuids = stats.Players.filter((player) => player.PlayerType === 1).map((player) => getPlayerXuid(player));
 
-      const [users, analyticsByMatchId, medalMetadata] = await Promise.all([
+      const analyticsPromise = this.config.matchAnalyticsService
+        .getBatchMatchAnalytics([matchId], ["killMatrix", "scoreProgression"])
+        .then(
+          (analyticsByMatchId): OverlayAnalyticsLoadResult => ({
+            status: ComponentLoaderStatus.LOADED,
+            analyticsByMatchId,
+          }),
+        )
+        .catch(
+          (): OverlayAnalyticsLoadResult => ({
+            status: ComponentLoaderStatus.ERROR,
+            analyticsByMatchId: {},
+          }),
+        );
+
+      const [users, medalMetadata] = await Promise.all([
         this.config.haloClient.getUsers(xuids).catch(() => []),
-        this.config.matchAnalyticsService
-          .getBatchMatchAnalytics([matchId])
-          .catch((): Record<string, MatchAnalytics | null> => ({})),
         this.config.medalMetadataResolver.getMedalMetadataForMatch(stats),
       ]);
 
@@ -133,7 +153,22 @@ export class OverlayPagePresenter {
         stats,
         playerMap,
         medalMetadata,
-        analytics: analyticsByMatchId[matchId] ?? null,
+        analytics: null,
+        analyticsStatus: ComponentLoaderStatus.LOADING,
+      });
+
+      const analyticsResult = await analyticsPromise;
+      if (this.shouldAbort()) {
+        return;
+      }
+
+      this.config.store.setMatchStatsState(matchId, {
+        status: "loaded",
+        stats,
+        playerMap,
+        medalMetadata,
+        analytics: analyticsResult.analyticsByMatchId[matchId] ?? null,
+        analyticsStatus: analyticsResult.status,
       });
     } catch {
       if (this.shouldAbort()) {
@@ -163,7 +198,7 @@ export class OverlayPagePresenter {
       return { status: "error", message: matchStatsState.message };
     }
 
-    const { stats, playerMap, medalMetadata, analytics } = matchStatsState;
+    const { stats, playerMap, medalMetadata, analytics, analyticsStatus } = matchStatsState;
     const controller = new StatsController();
     controller.loadMatch(stats, playerMap, medalMetadata);
     if (analytics != null) {
@@ -200,7 +235,12 @@ export class OverlayPagePresenter {
           : EMPTY_KILL_MATRIX_PIVOT_DATA,
       crossTeamKillMatrixData: crossTeam?.crossTeamData ?? null,
       swappedCrossTeamKillMatrixData: crossTeam?.swappedCrossTeamData ?? null,
-      scoreProgressionViewData: null,
+      killMatrixStatus: analyticsStatus,
+      scoreProgressionViewData: formatScoreProgression(
+        analytics?.scoreProgression ?? null,
+        [getTeamColorOrDefault(undefined, 0), getTeamColorOrDefault(undefined, 1)],
+        data[0]?.players.length ?? null,
+      ),
     };
   }
 

--- a/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
@@ -119,18 +119,14 @@ export class OverlayPagePresenter {
 
       const analyticsPromise = this.config.matchAnalyticsService
         .getBatchMatchAnalytics([matchId], ["killMatrix", "scoreProgression"])
-        .then(
-          (analyticsByMatchId): OverlayAnalyticsLoadResult => ({
-            status: ComponentLoaderStatus.LOADED,
-            analyticsByMatchId,
-          }),
-        )
-        .catch(
-          (): OverlayAnalyticsLoadResult => ({
-            status: ComponentLoaderStatus.ERROR,
-            analyticsByMatchId: {},
-          }),
-        );
+        .then((analyticsByMatchId): OverlayAnalyticsLoadResult => ({
+          status: ComponentLoaderStatus.LOADED,
+          analyticsByMatchId,
+        }))
+        .catch((): OverlayAnalyticsLoadResult => ({
+          status: ComponentLoaderStatus.ERROR,
+          analyticsByMatchId: {},
+        }));
 
       const [users, medalMetadata] = await Promise.all([
         this.config.haloClient.getUsers(xuids).catch(() => []),

--- a/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
@@ -9,9 +9,9 @@ import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
 import type { MatchDetailsState, ViewerTimelineItem } from "../viewer/types";
+import { formatScoreProgression } from "../../stats/score-progression/score-progression-formatter";
 import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
 import type { OverlayPageSnapshot, OverlayPageStore } from "./overlay-page-store";
-import { formatScoreProgression } from "../../stats/score-progression/score-progression-formatter";
 
 interface OverlayPagePresenterConfig {
   readonly store: OverlayPageStore;
@@ -117,16 +117,7 @@ export class OverlayPagePresenter {
 
       const xuids = stats.Players.filter((player) => player.PlayerType === 1).map((player) => getPlayerXuid(player));
 
-      const analyticsPromise = this.config.matchAnalyticsService
-        .getBatchMatchAnalytics([matchId], ["killMatrix", "scoreProgression"])
-        .then((analyticsByMatchId): OverlayAnalyticsLoadResult => ({
-          status: ComponentLoaderStatus.LOADED,
-          analyticsByMatchId,
-        }))
-        .catch((): OverlayAnalyticsLoadResult => ({
-          status: ComponentLoaderStatus.ERROR,
-          analyticsByMatchId: {},
-        }));
+      const analyticsPromise = this.loadMatchAnalyticsAsync(matchId);
 
       const [users, medalMetadata] = await Promise.all([
         this.config.haloClient.getUsers(xuids).catch(() => []),
@@ -175,6 +166,25 @@ export class OverlayPagePresenter {
         status: "error",
         message: "Failed to load match stats",
       });
+    }
+  }
+
+  private async loadMatchAnalyticsAsync(matchId: string): Promise<OverlayAnalyticsLoadResult> {
+    try {
+      const analyticsByMatchId = await this.config.matchAnalyticsService.getBatchMatchAnalytics(
+        [matchId],
+        ["killMatrix", "scoreProgression"],
+      );
+
+      return {
+        status: ComponentLoaderStatus.LOADED,
+        analyticsByMatchId,
+      };
+    } catch {
+      return {
+        status: ComponentLoaderStatus.ERROR,
+        analyticsByMatchId: {},
+      };
     }
   }
 

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import { aFakeMatchStatsWith, aFakeMedalMetadata } from "../../../../controllers/stats/fakes/data";
 import { gameModeIconSrc } from "../../game-mode-icon";
 import type {
@@ -975,6 +976,7 @@ describe("individual-tracker-overlay-presenter", () => {
             ]),
             medalMetadata: aFakeMedalMetadata(),
             analytics: null,
+            analyticsStatus: ComponentLoaderStatus.LOADED,
           },
         ],
       ]),
@@ -1018,6 +1020,7 @@ describe("individual-tracker-overlay-presenter", () => {
             ]),
             medalMetadata: aFakeMedalMetadata(),
             analytics: null,
+            analyticsStatus: ComponentLoaderStatus.LOADED,
           },
         ],
       ]),
@@ -1062,6 +1065,7 @@ describe("individual-tracker-overlay-presenter", () => {
             ]),
             medalMetadata: aFakeMedalMetadata(),
             analytics: null,
+            analyticsStatus: ComponentLoaderStatus.LOADED,
           },
         ],
       ]),
@@ -1101,6 +1105,7 @@ describe("individual-tracker-overlay-presenter", () => {
             ]),
             medalMetadata: aFakeMedalMetadata(),
             analytics: null,
+            analyticsStatus: ComponentLoaderStatus.LOADED,
           },
         ],
         [
@@ -1116,6 +1121,7 @@ describe("individual-tracker-overlay-presenter", () => {
             ]),
             medalMetadata: aFakeMedalMetadata(),
             analytics: null,
+            analyticsStatus: ComponentLoaderStatus.LOADED,
           },
         ],
       ]),
@@ -1160,6 +1166,7 @@ describe("individual-tracker-overlay-presenter", () => {
             ]),
             medalMetadata: aFakeMedalMetadata(),
             analytics: null,
+            analyticsStatus: ComponentLoaderStatus.LOADED,
           },
         ],
       ]),

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -18,6 +18,7 @@ import {
   aFakeTrackerSeriesGroupWith,
   aFakeTrackerViewStateWith,
 } from "../../../../services/individual-tracker/fakes/view.fake";
+import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 import { buildViewerRenderModel } from "../../viewer/viewer-render-model";
 import { IndividualTrackerOverlayPresenter, type MatchStatsState } from "../individual-tracker-overlay-presenter";
@@ -159,6 +160,7 @@ describe("IndividualTrackerOverlay", () => {
             ]),
             medalMetadata: {},
             analytics: null,
+            analyticsStatus: ComponentLoaderStatus.LOADED,
           },
           selectedMatchId: "m-1",
         })}
@@ -239,6 +241,7 @@ describe("IndividualTrackerOverlay", () => {
             ]),
             medalMetadata: {},
             analytics: null,
+            analyticsStatus: ComponentLoaderStatus.LOADED,
           },
           selectedMatchId: "m-1",
           onDeselect,

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
@@ -1,6 +1,7 @@
 import type { HaloInfiniteClient } from "halo-infinite-api";
 import { describe, expect, it, vi } from "vitest";
 import { waitFor } from "@testing-library/react";
+import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 import { aFakeHaloClientWith } from "../../../../services/fakes/halo-client.fake";
 import { HaloMedalMetadataResolver } from "../../../../services/halo/medal-metadata-resolver";
@@ -136,6 +137,48 @@ describe("OverlayPagePresenter", () => {
     const model = presenter.present(store.getSnapshot());
     expect(model.matchStatsState?.status).toBe("loaded");
     expect(model.matchStatsPanelState?.status).toBe("loaded");
+  });
+
+  it("loads overlay stats before analytics resolves", async () => {
+    const store = new OverlayPageStore();
+    const haloClient = aFakeHaloClientWith({
+      getMatchStats: vi.fn(async () => Promise.resolve(aFakeMatchStatsWith({ MatchId: "match-1" }))),
+      getUsers: vi.fn(async (xuids: string[]) => Promise.resolve(aUsersFor(xuids))),
+    });
+
+    const matchAnalyticsService = aFakeMatchAnalyticsServiceWith();
+    let resolveAnalytics: ((value: Record<string, null>) => void) | undefined;
+    const analyticsPromise = new Promise<Record<string, null>>((resolve) => {
+      resolveAnalytics = resolve;
+    });
+    vi.spyOn(matchAnalyticsService, "getBatchMatchAnalytics").mockImplementation(async () => analyticsPromise);
+
+    const presenter = new OverlayPagePresenter({
+      store,
+      haloClient,
+      medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
+      matchAnalyticsService,
+    });
+
+    presenter.selectMatch("match-1");
+
+    await waitFor(() => {
+      const state = store.getSnapshot().matchStatsByMatchId.get("match-1");
+      expect(state?.status).toBe("loaded");
+      if (state?.status === "loaded") {
+        expect(state.analyticsStatus).toBe(ComponentLoaderStatus.LOADING);
+      }
+    });
+
+    resolveAnalytics?.({ "match-1": null });
+
+    await waitFor(() => {
+      const state = store.getSnapshot().matchStatsByMatchId.get("match-1");
+      expect(state?.status).toBe("loaded");
+      if (state?.status === "loaded") {
+        expect(state.analyticsStatus).toBe(ComponentLoaderStatus.LOADED);
+      }
+    });
   });
 
   it("resolves medal metadata from the proxied medals file and caches it across loads", async () => {

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-page-store.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-page-store.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { ComponentLoaderStatus } from "../../../component-loader/component-loader";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 import { OverlayPageStore } from "../overlay-page-store";
 
@@ -13,6 +14,7 @@ describe("OverlayPageStore", () => {
       playerMap: new Map([["xuid-1", "Spartan"]]),
       medalMetadata: {},
       analytics: null,
+      analyticsStatus: ComponentLoaderStatus.LOADED,
     });
 
     const snapshot = store.getSnapshot();

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
@@ -493,6 +493,7 @@ export function IndividualTrackerViewer({
                             transposedKillMatrixPivotData={state.state.transposedKillMatrixPivotData}
                             crossTeamData={state.state.crossTeamKillMatrixData}
                             swappedCrossTeamData={state.state.swappedCrossTeamKillMatrixData}
+                            killMatrixStatus={state.state.killMatrixStatus}
                             scoreProgressionViewData={state.state.scoreProgressionViewData}
                             showHeader={false}
                           />

--- a/pages/src/components/individual-tracker/viewer/stats-panel.tsx
+++ b/pages/src/components/individual-tracker/viewer/stats-panel.tsx
@@ -50,6 +50,7 @@ export function StatsPanel({ state }: StatsPanelProps): React.ReactElement | nul
             transposedKillMatrixPivotData={state.transposedKillMatrixPivotData}
             crossTeamData={state.crossTeamKillMatrixData}
             swappedCrossTeamData={state.swappedCrossTeamKillMatrixData}
+            killMatrixStatus={state.killMatrixStatus}
             scoreProgressionViewData={state.scoreProgressionViewData}
           />
         </div>

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -811,7 +811,7 @@ describe("useIndividualTrackerViewer", () => {
       })),
     });
     vi.spyOn(matchAnalyticsService, "getBatchMatchAnalytics").mockImplementation(async (ids) =>
-      Object.fromEntries(ids.map((id) => [id, null])),
+      Promise.resolve(Object.fromEntries(ids.map((id) => [id, null]))),
     );
 
     const { result } = renderHook(() =>

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -194,11 +194,9 @@ describe("useIndividualTrackerViewer", () => {
     });
 
     let resolveAnalytics: ((value: Record<string, MatchAnalytics | null>) => void) | undefined;
-    const analyticsPromise = new Promise<Record<string, MatchAnalytics | null>>(
-      (resolve) => {
-        resolveAnalytics = resolve;
-      },
-    );
+    const analyticsPromise = new Promise<Record<string, MatchAnalytics | null>>((resolve) => {
+      resolveAnalytics = resolve;
+    });
     vi.spyOn(matchAnalyticsService, "getBatchMatchAnalytics").mockImplementation(async () => analyticsPromise);
 
     const { result } = renderHook(() =>
@@ -781,6 +779,72 @@ describe("useIndividualTrackerViewer", () => {
       expect(state.state.viewModel.seriesStats?.killMatrixStatus).toBe(ComponentLoaderStatus.LOADED);
       expect(state.state.viewModel.matchDetails[0]?.killMatrixStatus).toBe(ComponentLoaderStatus.LOADED);
     }
+  });
+
+  it("keeps series cross-team kill matrix empty when analytics contain no kill-matrix rows", async () => {
+    const matchIds = ["m-1", "m-2"];
+    const matches = matchIds.map((matchId) => aFakeTrackerMatchSummaryWith({ matchId }));
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
+      view: aFakeTrackerViewStateWith({
+        trackerId: "tracker-1",
+        status: "active",
+        matches,
+        series: [aFakeTrackerSeriesGroupWith({ id: "series-1", title: "Series With Empty Analytics", matchIds })],
+      }),
+    });
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
+    vi.spyOn(seriesMatchesService, "getSeriesMatches").mockResolvedValue({
+      playerXuidToGametag: {},
+      matches: matchIds.map((matchId) => ({
+        matchId,
+        gameTypeAndMap: "Slayer: Live Fire",
+        gameVariantCategory: 0,
+        gameType: "Slayer",
+        gameMap: "Live Fire",
+        gameMapThumbnailUrl: "data:",
+        duration: "10m 00s",
+        gameScore: "50:45",
+        gameSubScore: null,
+        startTime: "2026-01-01T00:00:00.000Z",
+        endTime: "2026-01-01T00:10:00.000Z",
+        rawMatch: {},
+      })),
+    });
+    vi.spyOn(matchAnalyticsService, "getBatchMatchAnalytics").mockImplementation(async (ids) =>
+      Object.fromEntries(ids.map((id) => [id, null])),
+    );
+
+    const { result } = renderHook(() =>
+      useIndividualTrackerViewer({
+        individualTrackerViewService,
+        matchAnalyticsService,
+        seriesMatchesService,
+        medalMetadataResolver,
+        trackerId: "tracker-1",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.snapshot.status).toBe(ComponentLoaderStatus.LOADED);
+    });
+
+    const seriesItem = result.current.model.renderModel?.timeline.find((item) => item.type === "series");
+    expect(seriesItem?.type).toBe("series");
+
+    act(() => {
+      if (seriesItem?.type === "series") {
+        result.current.onToggleEntry(seriesItem);
+      }
+    });
+
+    await waitFor(() => {
+      const state = result.current.snapshot.entryStates.get("series:series-1");
+      expect(state?.kind).toBe("series");
+      if (state?.kind === "series" && state.state.status === "loaded") {
+        expect(state.state.viewModel.seriesStats?.crossTeamKillMatrixData).toBeNull();
+        expect(state.state.viewModel.seriesStats?.swappedCrossTeamKillMatrixData).toBeNull();
+      }
+    });
   });
 
   it("retries a series load after an error when the entry is collapsed and re-expanded", async () => {

--- a/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { HaloInfiniteClient } from "halo-infinite-api";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { SeriesMatchesResponse } from "@guilty-spark/shared/contracts/stats/series-matches";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
@@ -158,6 +159,88 @@ describe("useIndividualTrackerViewer", () => {
 
     expect(getSeriesMatchesSpy).not.toHaveBeenCalled();
     expect(getMatchStatsSpy).not.toHaveBeenCalled();
+  });
+
+  it("loads match stats before analytics completes for an expanded match entry", async () => {
+    const matchId = "match-1";
+    const individualTrackerViewService = aFakeIndividualTrackerViewServiceWith({
+      view: aFakeTrackerViewStateWith({
+        trackerId: "tracker-1",
+        status: "active",
+        matches: [aFakeTrackerMatchSummaryWith({ matchId })],
+      }),
+    });
+    const { matchAnalyticsService, seriesMatchesService, medalMetadataResolver } = aViewerTestDependenciesWith();
+    const rawMatch = aFakeMatchStatsWith({ MatchId: matchId });
+
+    vi.spyOn(seriesMatchesService, "getSeriesMatches").mockResolvedValue({
+      playerXuidToGametag: {},
+      matches: [
+        {
+          matchId,
+          gameTypeAndMap: "Slayer: Live Fire",
+          gameVariantCategory: 0,
+          gameType: "Slayer",
+          gameMap: "Live Fire",
+          gameMapThumbnailUrl: "data:",
+          duration: "10m 00s",
+          gameScore: "50:45",
+          gameSubScore: null,
+          startTime: "2026-01-01T00:00:00.000Z",
+          endTime: "2026-01-01T00:10:00.000Z",
+          rawMatch,
+        },
+      ],
+    });
+
+    let resolveAnalytics: ((value: Record<string, MatchAnalytics | null>) => void) | undefined;
+    const analyticsPromise = new Promise<Record<string, MatchAnalytics | null>>(
+      (resolve) => {
+        resolveAnalytics = resolve;
+      },
+    );
+    vi.spyOn(matchAnalyticsService, "getBatchMatchAnalytics").mockImplementation(async () => analyticsPromise);
+
+    const { result } = renderHook(() =>
+      useIndividualTrackerViewer({
+        individualTrackerViewService,
+        matchAnalyticsService,
+        seriesMatchesService,
+        medalMetadataResolver,
+        trackerId: "tracker-1",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.snapshot.status).toBe(ComponentLoaderStatus.LOADED);
+    });
+
+    const matchItem = result.current.model.renderModel?.timeline.find((item) => item.type === "match");
+    expect(matchItem?.type).toBe("match");
+
+    act(() => {
+      if (matchItem?.type === "match") {
+        result.current.onToggleEntry(matchItem);
+      }
+    });
+
+    await waitFor(() => {
+      const state = result.current.snapshot.entryStates.get(`match:${matchId}`);
+      expect(state?.kind).toBe("match");
+      if (state?.kind === "match" && state.state.status === "loaded") {
+        expect(state.state.killMatrixStatus).toBe(ComponentLoaderStatus.LOADING);
+      }
+    });
+
+    resolveAnalytics?.({ [matchId]: null });
+
+    await waitFor(() => {
+      const state = result.current.snapshot.entryStates.get(`match:${matchId}`);
+      expect(state?.kind).toBe("match");
+      if (state?.kind === "match" && state.state.status === "loaded") {
+        expect(state.state.killMatrixStatus).toBe(ComponentLoaderStatus.LOADED);
+      }
+    });
   });
 
   it("connects the public viewer path after the initial view loads", async () => {

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -3,6 +3,7 @@ import type { TrackerStatus } from "@guilty-spark/shared/contracts/individual-tr
 import type { PlayerAssociationData } from "@guilty-spark/shared/live-tracker/types";
 import type { NormalizedMatchOutcome } from "@guilty-spark/shared/halo/match-enrichment";
 import type { StreamerViewSettings } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
+import type { ComponentLoaderStatus } from "../../component-loader/component-loader";
 import type { TrackerViewConnectionStatus } from "../../../services/individual-tracker/view-types";
 import type { MatchStatsData } from "../../../controllers/stats/types";
 import type { KillMatrixCrossTeamData, KillMatrixPivotData } from "../../../controllers/stats/kill-matrix/types";
@@ -126,6 +127,7 @@ export type MatchDetailsState =
       readonly transposedKillMatrixPivotData: KillMatrixPivotData;
       readonly crossTeamKillMatrixData: KillMatrixCrossTeamData | null;
       readonly swappedCrossTeamKillMatrixData: KillMatrixCrossTeamData | null;
+      readonly killMatrixStatus: ComponentLoaderStatus;
       readonly scoreProgressionViewData: ScoreProgressionViewData | null;
     }
   | { readonly status: "error"; readonly message: string };

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -108,10 +108,15 @@ function buildSeriesViewModel({
   const seriesPlayers = seriesController.getPlayers();
   const playersByGamertag = new Map(seriesPlayers.map((player) => [player.gamertag, player]));
   const resolvedSeriesPlayers = seriesTotals.playerData
-    .flatMap((teamData) => teamData.players.map((player) => playersByGamertag.get(player.name.replace(GAMES_SUFFIX_RE, ""))))
+    .flatMap((teamData) =>
+      teamData.players.map((player) => playersByGamertag.get(player.name.replace(GAMES_SUFFIX_RE, ""))),
+    )
     .filter((player): player is KillMatrixPlayer => player != null);
-  const orderedSeriesPlayers = resolvedSeriesPlayers.length === seriesPlayers.length ? resolvedSeriesPlayers : seriesPlayers;
-  const playersByXuid = new Map(seriesPlayers.map((player) => [player.xuid, { gamertag: player.gamertag, teamId: player.teamId }]));
+  const orderedSeriesPlayers =
+    resolvedSeriesPlayers.length === seriesPlayers.length ? resolvedSeriesPlayers : seriesPlayers;
+  const playersByXuid = new Map(
+    seriesPlayers.map((player) => [player.xuid, { gamertag: player.gamertag, teamId: player.teamId }]),
+  );
   const killMatrixFormatter = new KillMatrixFormatter();
 
   const metadata = calculateSeriesMetadata(
@@ -185,7 +190,9 @@ function buildSeriesViewModel({
         const matchPlayers = matchController.getPlayers();
         const matchPlayersByGamertag = new Map(matchPlayers.map((player) => [player.gamertag, player]));
         const resolvedPlayers = data
-          .flatMap((teamData) => teamData.players.map((player) => matchPlayersByGamertag.get(player.name.replace(GAMES_SUFFIX_RE, ""))))
+          .flatMap((teamData) =>
+            teamData.players.map((player) => matchPlayersByGamertag.get(player.name.replace(GAMES_SUFFIX_RE, ""))),
+          )
           .filter((player): player is KillMatrixPlayer => player != null);
         orderedPlayers = resolvedPlayers.length === matchPlayers.length ? resolvedPlayers : matchPlayers;
       } catch {
@@ -193,8 +200,7 @@ function buildSeriesViewModel({
       }
     }
 
-    const killMatrixRows =
-      analytics != null ? killMatrixFormatter.present({ analytics, playersByXuid }) : null;
+    const killMatrixRows = analytics != null ? killMatrixFormatter.present({ analytics, playersByXuid }) : null;
     if (killMatrixRows != null) {
       matchKillMatrixRows.set(m.matchId, killMatrixRows);
     }
@@ -238,8 +244,10 @@ function buildSeriesViewModel({
   const aggregatedKillMatrixRows = KillMatrixFormatter.aggregate(
     [...matchKillMatrixRows.values()].flatMap((rows) => rows),
   );
-  const aggregatedCrossTeam = KillMatrixFormatter.buildCrossTeam(aggregatedKillMatrixRows, orderedSeriesPlayers);
   const hasAggregatedKillMatrix = matchKillMatrixRows.size > 0;
+  const aggregatedCrossTeam = hasAggregatedKillMatrix
+    ? KillMatrixFormatter.buildCrossTeam(aggregatedKillMatrixRows, orderedSeriesPlayers)
+    : null;
 
   const seriesStatsWithAnalytics: SeriesStatsSummary = {
     ...seriesStats,

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -19,7 +19,7 @@ import type {
 import { isMatchStats } from "../../../controllers/stats/is-match-stats";
 import { calculateSeriesMetadata } from "../../../controllers/stats/series-metadata";
 import { StatsController } from "../../../controllers/stats/stats-controller";
-import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import { GAMES_SUFFIX_RE, KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPlayer } from "../../../controllers/stats/kill-matrix/types";
 import { ComponentLoaderStatus } from "../../component-loader/component-loader";
 import { DEFAULT_TEAM_COLORS, getTeamColorOrDefault, type TeamColor } from "../../team-colors/team-colors";
@@ -46,7 +46,6 @@ interface MatchStatsLoadedState {
   readonly stats: MatchStats;
   readonly playerMap: Map<string, string>;
   readonly medalMetadata: MedalMetadata;
-  readonly analytics: MatchAnalytics | null;
   readonly gameMapThumbnailUrl: string;
 }
 
@@ -70,6 +69,8 @@ interface BuildSeriesViewModelArgs {
   readonly medalMetadata: MedalMetadata;
   readonly playerMap: Map<string, string>;
   readonly teamColors: readonly TeamColor[];
+  readonly analyticsByMatchId: ReadonlyMap<string, MatchAnalytics>;
+  readonly analyticsStatus: ComponentLoaderStatus;
 }
 
 function getLatestRawMatch(rawMatches: readonly MatchStats[]): MatchStats | undefined {
@@ -97,11 +98,21 @@ function buildSeriesViewModel({
   medalMetadata,
   playerMap,
   teamColors,
+  analyticsByMatchId,
+  analyticsStatus,
 }: BuildSeriesViewModelArgs): SeriesStatsViewModel {
   // --- Series totals ---
   const seriesController = new StatsController();
   seriesController.loadSeries([...rawMatches], playerMap, medalMetadata);
   const seriesTotals = seriesController.getSeriesStats();
+  const seriesPlayers = seriesController.getPlayers();
+  const playersByGamertag = new Map(seriesPlayers.map((player) => [player.gamertag, player]));
+  const resolvedSeriesPlayers = seriesTotals.playerData
+    .flatMap((teamData) => teamData.players.map((player) => playersByGamertag.get(player.name.replace(GAMES_SUFFIX_RE, ""))))
+    .filter((player): player is KillMatrixPlayer => player != null);
+  const orderedSeriesPlayers = resolvedSeriesPlayers.length === seriesPlayers.length ? resolvedSeriesPlayers : seriesPlayers;
+  const playersByXuid = new Map(seriesPlayers.map((player) => [player.xuid, { gamertag: player.gamertag, teamId: player.teamId }]));
+  const killMatrixFormatter = new KillMatrixFormatter();
 
   const metadata = calculateSeriesMetadata(
     seriesData.matches.map((m) => ({ startTime: m.startTime, endTime: m.endTime })),
@@ -117,7 +128,7 @@ function buildSeriesViewModel({
     transposedKillMatrixPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
     crossTeamKillMatrixData: null,
     swappedCrossTeamKillMatrixData: null,
-    killMatrixStatus: ComponentLoaderStatus.LOADED,
+    killMatrixStatus: analyticsStatus,
   };
 
   // --- Match summaries (score cards) ---
@@ -157,19 +168,41 @@ function buildSeriesViewModel({
           teamColorHex: getTeamColorOrDefault(teamColors[teamIndex]?.id, teamIndex).hex,
         }));
 
+  const matchKillMatrixRows = new Map<string, ReturnType<KillMatrixFormatter["present"]>>();
+
   // --- Per-match detail sections ---
   const matchDetails: SeriesMatchDetail[] = seriesData.matches.map((m, index) => {
     const { rawMatch } = m;
     let data = null;
+    let orderedPlayers: readonly KillMatrixPlayer[] | undefined = undefined;
+    const analytics = analyticsByMatchId.get(m.matchId) ?? null;
     if (isMatchStats(rawMatch)) {
       try {
         const matchController = new StatsController();
         matchController.loadMatch(rawMatch, playerMap, medalMetadata);
         data = matchController.getMatchStats();
+
+        const matchPlayers = matchController.getPlayers();
+        const matchPlayersByGamertag = new Map(matchPlayers.map((player) => [player.gamertag, player]));
+        const resolvedPlayers = data
+          .flatMap((teamData) => teamData.players.map((player) => matchPlayersByGamertag.get(player.name.replace(GAMES_SUFFIX_RE, ""))))
+          .filter((player): player is KillMatrixPlayer => player != null);
+        orderedPlayers = resolvedPlayers.length === matchPlayers.length ? resolvedPlayers : matchPlayers;
       } catch {
         data = null;
       }
     }
+
+    const killMatrixRows =
+      analytics != null ? killMatrixFormatter.present({ analytics, playersByXuid }) : null;
+    if (killMatrixRows != null) {
+      matchKillMatrixRows.set(m.matchId, killMatrixRows);
+    }
+    const crossTeam =
+      killMatrixRows != null
+        ? KillMatrixFormatter.buildCrossTeam(killMatrixRows, orderedPlayers ?? orderedSeriesPlayers)
+        : null;
+
     return {
       matchId: m.matchId,
       data,
@@ -183,14 +216,42 @@ function buildSeriesViewModel({
       startTime: m.startTime,
       endTime: m.endTime,
       teamColors,
-      killMatrixPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
-      transposedKillMatrixPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
-      crossTeamKillMatrixData: null,
-      swappedCrossTeamKillMatrixData: null,
-      killMatrixStatus: ComponentLoaderStatus.LOADED,
-      scoreProgressionViewData: null,
+      killMatrixPivotData:
+        killMatrixRows != null
+          ? KillMatrixFormatter.pivot(killMatrixRows, orderedPlayers ?? orderedSeriesPlayers)
+          : EMPTY_KILL_MATRIX_PIVOT_DATA,
+      transposedKillMatrixPivotData:
+        killMatrixRows != null
+          ? KillMatrixFormatter.transpose(killMatrixRows, orderedPlayers ?? orderedSeriesPlayers)
+          : EMPTY_KILL_MATRIX_PIVOT_DATA,
+      crossTeamKillMatrixData: crossTeam?.crossTeamData ?? null,
+      swappedCrossTeamKillMatrixData: crossTeam?.swappedCrossTeamData ?? null,
+      killMatrixStatus: analyticsStatus,
+      scoreProgressionViewData: formatScoreProgression(
+        analytics?.scoreProgression ?? null,
+        teamColors,
+        data?.[0]?.players.length ?? null,
+      ),
     };
   });
+
+  const aggregatedKillMatrixRows = KillMatrixFormatter.aggregate(
+    [...matchKillMatrixRows.values()].flatMap((rows) => rows),
+  );
+  const aggregatedCrossTeam = KillMatrixFormatter.buildCrossTeam(aggregatedKillMatrixRows, orderedSeriesPlayers);
+  const hasAggregatedKillMatrix = matchKillMatrixRows.size > 0;
+
+  const seriesStatsWithAnalytics: SeriesStatsSummary = {
+    ...seriesStats,
+    killMatrixPivotData: hasAggregatedKillMatrix
+      ? KillMatrixFormatter.pivot(aggregatedKillMatrixRows, orderedSeriesPlayers)
+      : EMPTY_KILL_MATRIX_PIVOT_DATA,
+    transposedKillMatrixPivotData: hasAggregatedKillMatrix
+      ? KillMatrixFormatter.transpose(aggregatedKillMatrixRows, orderedSeriesPlayers)
+      : EMPTY_KILL_MATRIX_PIVOT_DATA,
+    crossTeamKillMatrixData: aggregatedCrossTeam?.crossTeamData ?? null,
+    swappedCrossTeamKillMatrixData: aggregatedCrossTeam?.swappedCrossTeamData ?? null,
+  };
 
   return {
     title: series.title,
@@ -198,7 +259,7 @@ function buildSeriesViewModel({
     seriesScore: series.score,
     matchSummaries,
     teams,
-    seriesStats,
+    seriesStats: seriesStatsWithAnalytics,
     matchDetails,
   };
 }
@@ -331,13 +392,7 @@ export class IndividualTrackerViewerPresenter {
   }
 
   private async fetchMatchSource(matchId: string): Promise<MatchStatsLoadedState> {
-    const [seriesMatches, analytics] = await Promise.all([
-      this.config.seriesMatchesService.getSeriesMatches([matchId], this.config.trackerId),
-      this.config.matchAnalyticsService
-        .getBatchMatchAnalytics([matchId], ["killMatrix", "scoreProgression"], this.config.trackerId)
-        .then((results) => results[matchId] ?? null)
-        .catch(() => null),
-    ]);
+    const seriesMatches = await this.config.seriesMatchesService.getSeriesMatches([matchId], this.config.trackerId);
 
     if (seriesMatches.matches.length === 0) {
       throw new Error("Failed to load match source");
@@ -359,14 +414,16 @@ export class IndividualTrackerViewerPresenter {
 
     const medalMetadata = await this.config.medalMetadataResolver.getMedalMetadataForMatch(stats);
 
-    return { stats, playerMap, medalMetadata, analytics, gameMapThumbnailUrl: matchSummary.gameMapThumbnailUrl };
+    return { stats, playerMap, medalMetadata, gameMapThumbnailUrl: matchSummary.gameMapThumbnailUrl };
   }
 
   private toMatchEntryLoadedState(
     loadedState: MatchStatsLoadedState,
+    analytics: MatchAnalytics | null,
+    analyticsStatus: ComponentLoaderStatus,
     teamColors: readonly TeamColor[],
   ): MatchEntryLoadedState {
-    const { stats, playerMap, medalMetadata, analytics, gameMapThumbnailUrl } = loadedState;
+    const { stats, playerMap, medalMetadata, gameMapThumbnailUrl } = loadedState;
     const controller = new StatsController();
     controller.loadMatch(stats, playerMap, medalMetadata);
     if (analytics != null) {
@@ -402,6 +459,7 @@ export class IndividualTrackerViewerPresenter {
           : EMPTY_KILL_MATRIX_PIVOT_DATA,
       crossTeamKillMatrixData: crossTeam?.crossTeamData ?? null,
       swappedCrossTeamKillMatrixData: crossTeam?.swappedCrossTeamData ?? null,
+      killMatrixStatus: analyticsStatus,
       scoreProgressionViewData: formatScoreProgression(
         analytics?.scoreProgression ?? null,
         teamColors,
@@ -413,18 +471,54 @@ export class IndividualTrackerViewerPresenter {
   private async fetchMatchEntry(key: string, matchId: string): Promise<void> {
     this.config.store.setEntryLoading(key, "match");
     try {
-      const loadedState = await this.fetchMatchSource(matchId);
+      const matchSource = await this.fetchMatchSource(matchId);
       if (this.isDisposed) {
         return;
       }
 
-      const state = this.toMatchEntryLoadedState(loadedState, this.resolveTeamColors());
-      this.config.store.setMatchEntryLoaded(key, state);
+      const teamColors = this.resolveTeamColors();
+      const loadingState = this.toMatchEntryLoadedState(matchSource, null, ComponentLoaderStatus.LOADING, teamColors);
+      this.config.store.setMatchEntryLoaded(key, loadingState);
+
+      void this.fetchMatchAnalyticsAsync(key, matchSource, teamColors, matchId);
     } catch (error) {
       if (this.isDisposed) {
         return;
       }
       this.config.store.setEntryError(key, "match", error instanceof Error ? error.message : "Failed to load stats");
+    }
+  }
+
+  private async fetchMatchAnalyticsAsync(
+    key: string,
+    matchSource: MatchStatsLoadedState,
+    teamColors: readonly TeamColor[],
+    matchId: string,
+  ): Promise<void> {
+    try {
+      const results = await this.config.matchAnalyticsService.getBatchMatchAnalytics(
+        [matchId],
+        ["killMatrix", "scoreProgression"],
+        this.config.trackerId,
+      );
+      if (this.shouldAbort()) {
+        return;
+      }
+
+      const loadedState = this.toMatchEntryLoadedState(
+        matchSource,
+        results[matchId] ?? null,
+        ComponentLoaderStatus.LOADED,
+        teamColors,
+      );
+      this.config.store.setMatchEntryLoaded(key, loadedState);
+    } catch {
+      if (this.shouldAbort()) {
+        return;
+      }
+
+      const loadedState = this.toMatchEntryLoadedState(matchSource, null, ComponentLoaderStatus.ERROR, teamColors);
+      this.config.store.setMatchEntryLoaded(key, loadedState);
     }
   }
 
@@ -472,15 +566,94 @@ export class IndividualTrackerViewerPresenter {
         medalMetadata,
         playerMap,
         teamColors,
+        analyticsByMatchId: new Map(),
+        analyticsStatus: ComponentLoaderStatus.LOADING,
       });
 
       const state: SeriesEntryLoadedState = { seriesId: series.id, viewModel };
       this.config.store.setSeriesEntryLoaded(key, state);
+
+      void this.fetchSeriesAnalyticsAsync({
+        key,
+        series,
+        seriesData: mergedSeriesData,
+        rawMatches,
+        medalMetadata,
+        playerMap,
+        teamColors,
+      });
     } catch (error) {
       if (this.isDisposed) {
         return;
       }
       this.config.store.setEntryError(key, "series", error instanceof Error ? error.message : "Failed to load series");
+    }
+  }
+
+  private async fetchSeriesAnalyticsAsync(args: {
+    readonly key: string;
+    readonly series: ViewerSeriesTab;
+    readonly seriesData: SeriesMatchesResponse;
+    readonly rawMatches: readonly MatchStats[];
+    readonly medalMetadata: MedalMetadata;
+    readonly playerMap: Map<string, string>;
+    readonly teamColors: readonly TeamColor[];
+  }): Promise<void> {
+    const requestedMatchIds = args.series.matches.map((match) => match.matchId);
+    const uniqueMatchIds = [...new Set(requestedMatchIds)];
+    if (uniqueMatchIds.length === 0) {
+      const loadedViewModel = buildSeriesViewModel({
+        ...args,
+        analyticsByMatchId: new Map(),
+        analyticsStatus: ComponentLoaderStatus.LOADED,
+      });
+      this.config.store.setSeriesEntryLoaded(args.key, { seriesId: args.series.id, viewModel: loadedViewModel });
+      return;
+    }
+
+    try {
+      const analyticsByMatchId = new Map<string, MatchAnalytics>();
+
+      for (let index = 0; index < uniqueMatchIds.length; index += SERIES_MATCHES_BATCH_SIZE) {
+        if (this.shouldAbort()) {
+          return;
+        }
+
+        const batchMatchIds = uniqueMatchIds.slice(index, index + SERIES_MATCHES_BATCH_SIZE);
+        const batch = await this.config.matchAnalyticsService.getBatchMatchAnalytics(
+          batchMatchIds,
+          ["killMatrix", "scoreProgression"],
+          this.config.trackerId,
+        );
+
+        if (this.shouldAbort()) {
+          return;
+        }
+
+        for (const [matchId, analytics] of Object.entries(batch)) {
+          if (analytics != null) {
+            analyticsByMatchId.set(matchId, analytics);
+          }
+        }
+      }
+
+      const loadedViewModel = buildSeriesViewModel({
+        ...args,
+        analyticsByMatchId,
+        analyticsStatus: ComponentLoaderStatus.LOADED,
+      });
+      this.config.store.setSeriesEntryLoaded(args.key, { seriesId: args.series.id, viewModel: loadedViewModel });
+    } catch {
+      if (this.shouldAbort()) {
+        return;
+      }
+
+      const erroredViewModel = buildSeriesViewModel({
+        ...args,
+        analyticsByMatchId: new Map(),
+        analyticsStatus: ComponentLoaderStatus.ERROR,
+      });
+      this.config.store.setSeriesEntryLoaded(args.key, { seriesId: args.series.id, viewModel: erroredViewModel });
     }
   }
 

--- a/pages/src/components/individual-tracker/viewer/viewer-store.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-store.ts
@@ -19,6 +19,7 @@ export interface MatchEntryLoadedState {
   readonly transposedKillMatrixPivotData: KillMatrixPivotData;
   readonly crossTeamKillMatrixData: KillMatrixCrossTeamData | null;
   readonly swappedCrossTeamKillMatrixData: KillMatrixCrossTeamData | null;
+  readonly killMatrixStatus: ComponentLoaderStatus;
   readonly scoreProgressionViewData: ScoreProgressionViewData | null;
 }
 

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -1,7 +1,7 @@
 import type { MatchStats } from "halo-infinite-api";
 import React from "react";
 import classNames from "classnames";
-import type { ComponentLoaderStatus } from "../component-loader/component-loader";
+import { ComponentLoader, ComponentLoaderStatus } from "../component-loader/component-loader";
 import { SortableTable, type SortableTableColumn } from "../table/sortable-table";
 import tableStyles from "../table/table.module.css";
 import { TabbedSection } from "../tabbed-section/tabbed-section";
@@ -9,6 +9,8 @@ import { TeamIcon } from "../icons/team-icon";
 import { MedalIcon } from "../icons/medal-icon";
 import type { TeamColor } from "../team-colors/team-colors";
 import { Container } from "../container/container";
+import { Alert } from "../alert/alert";
+import { LoadingState } from "../loading-state/loading-state";
 import {
   EMPTY_KILL_MATRIX_PIVOT_DATA,
   type KillMatrixCrossTeamData,
@@ -68,8 +70,13 @@ export function MatchStats({
   showHeader = true,
 }: MatchStatsProps): React.ReactElement {
   const [activeTab, setActiveTab] = React.useState<"players" | "timeline" | "kill-matrix">("players");
+  const hasTimelineTab =
+    scoreProgressionViewData != null ||
+    killMatrixStatus === ComponentLoaderStatus.LOADING ||
+    killMatrixStatus === ComponentLoaderStatus.PENDING ||
+    killMatrixStatus === ComponentLoaderStatus.ERROR;
   const safeActiveTab: "players" | "timeline" | "kill-matrix" =
-    activeTab === "timeline" && scoreProgressionViewData == null ? "players" : activeTab;
+    activeTab === "timeline" && !hasTimelineTab ? "players" : activeTab;
   const ScoreProgressionComponent = React.useMemo(() => createScoreProgression(), []);
   const hasTeamStats = data.length > 0 && data[0].teamStats.length > 0;
 
@@ -274,20 +281,28 @@ export function MatchStats({
               />
             ),
           },
-          ...(scoreProgressionViewData != null
+          ...(hasTimelineTab
             ? [
                 {
                   id: "timeline" as const,
                   label: "Timeline",
-                  content: (
-                    <ScoreProgressionComponent
-                      durationMs={scoreProgressionViewData.durationMs}
-                      teamLines={scoreProgressionViewData.teamLines}
-                      scoreDelta={scoreProgressionViewData.scoreDelta}
-                      playerAdvantage={scoreProgressionViewData.playerAdvantage}
-                      ariaLabel="Match score progression timeline"
-                    />
-                  ),
+                  content:
+                    scoreProgressionViewData != null ? (
+                      <ScoreProgressionComponent
+                        durationMs={scoreProgressionViewData.durationMs}
+                        teamLines={scoreProgressionViewData.teamLines}
+                        scoreDelta={scoreProgressionViewData.scoreDelta}
+                        playerAdvantage={scoreProgressionViewData.playerAdvantage}
+                        ariaLabel="Match score progression timeline"
+                      />
+                    ) : (
+                      <ComponentLoader
+                        status={killMatrixStatus ?? ComponentLoaderStatus.LOADING}
+                        loading={<LoadingState text="Loading timeline..." />}
+                        error={<Alert variant="warning">Failed to load timeline data for this match.</Alert>}
+                        loaded={<Alert variant="info">Timeline data is not available for this match.</Alert>}
+                      />
+                    ),
                 },
               ]
             : []),

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -70,11 +70,7 @@ export function MatchStats({
   showHeader = true,
 }: MatchStatsProps): React.ReactElement {
   const [activeTab, setActiveTab] = React.useState<"players" | "timeline" | "kill-matrix">("players");
-  const hasTimelineTab =
-    scoreProgressionViewData != null ||
-    killMatrixStatus === ComponentLoaderStatus.LOADING ||
-    killMatrixStatus === ComponentLoaderStatus.PENDING ||
-    killMatrixStatus === ComponentLoaderStatus.ERROR;
+  const hasTimelineTab = scoreProgressionViewData != null || killMatrixStatus !== undefined;
   const safeActiveTab: "players" | "timeline" | "kill-matrix" =
     activeTab === "timeline" && !hasTimelineTab ? "players" : activeTab;
   const ScoreProgressionComponent = React.useMemo(() => createScoreProgression(), []);

--- a/pages/src/components/stats/tests/match-stats.test.tsx
+++ b/pages/src/components/stats/tests/match-stats.test.tsx
@@ -8,6 +8,7 @@ import {
   aFakeMatchStatsDataWith,
   aFakeMatchStatsPlayerDataWith,
 } from "../../../controllers/stats/fakes/component-data";
+import { ComponentLoaderStatus } from "../../component-loader/component-loader";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type { ScoreProgressionViewData } from "../score-progression/types";
 
@@ -273,5 +274,31 @@ describe("MatchStats", () => {
     fireEvent.click(screen.getByRole("tab", { name: "Kill Matrix" }));
 
     expect(screen.getByText("Kill matrix data is not available for this match yet.")).toBeInTheDocument();
+  });
+
+  it("shows timeline tab with loading state while analytics is loading", () => {
+    const data = [aFakeMatchStatsDataWith({ teamId: 0 })];
+
+    render(
+      <MatchStats
+        data={data}
+        id="match-1"
+        backgroundImageUrl="https://example.com/bg.jpg"
+        gameModeIconUrl="https://example.com/icon.png"
+        gameModeAlt="Slayer"
+        matchNumber={1}
+        gameTypeAndMap="Slayer: Aquarius"
+        duration="10m 30s"
+        score="50:49"
+        startTime="2024-01-01T00:00:00.000Z"
+        endTime="2024-01-01T00:10:30.000Z"
+        scoreProgressionViewData={null}
+        killMatrixStatus={ComponentLoaderStatus.LOADING}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Timeline" }));
+
+    expect(screen.getByText("Loading timeline...")).toBeInTheDocument();
   });
 });

--- a/pages/src/components/stats/tests/match-stats.test.tsx
+++ b/pages/src/components/stats/tests/match-stats.test.tsx
@@ -301,4 +301,30 @@ describe("MatchStats", () => {
 
     expect(screen.getByText("Loading timeline...")).toBeInTheDocument();
   });
+
+  it("keeps timeline tab visible when analytics load completes without timeline data", () => {
+    const data = [aFakeMatchStatsDataWith({ teamId: 0 })];
+
+    render(
+      <MatchStats
+        data={data}
+        id="match-1"
+        backgroundImageUrl="https://example.com/bg.jpg"
+        gameModeIconUrl="https://example.com/icon.png"
+        gameModeAlt="Slayer"
+        matchNumber={1}
+        gameTypeAndMap="Slayer: Aquarius"
+        duration="10m 30s"
+        score="50:49"
+        startTime="2024-01-01T00:00:00.000Z"
+        endTime="2024-01-01T00:10:30.000Z"
+        scoreProgressionViewData={null}
+        killMatrixStatus={ComponentLoaderStatus.LOADED}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Timeline" }));
+
+    expect(screen.getByText("Timeline data is not available for this match.")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Context
The backend branch currently in progress introduces heavier analytics work, which can significantly delay full stats view rendering.
This PR delivers a frontend-only improvement that can ship independently: show core stats as soon as they are available, while analytics-heavy panels continue loading in the background.

## This change
- Splits match and series entry loading in individual tracker viewer into two phases:
  - phase 1: stats + metadata
  - phase 2: analytics (kill matrix + timeline/score progression)
- Applies the same split-loading behavior to individual tracker overlay match stats panel.
- Adds analytics status to match detail state and propagates it to view components.
- Updates shared match stats tab behavior so Timeline/Kill Matrix UI can appear immediately with loading/error states instead of waiting for analytics completion.
- Adds regression tests covering:
  - viewer match progressive loading
  - overlay progressive loading
  - timeline tab loading state visibility
- Verified with targeted tests:
  - pages/src/components/stats/tests/match-stats.test.tsx
  - pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
  - pages/src/components/individual-tracker/viewer/tests/use-individual-tracker-viewer.test.ts

## Subsequent work
- When backend analytics optimizations land, this UX improvement still provides better perceived responsiveness under cold-cache or degraded upstream conditions.