### PR TITLE
feat(h2h): enrich head-to-head dialog with weapons and perfects

### DIFF
--- a/api/services/halo/weapon-ids.ts
+++ b/api/services/halo/weapon-ids.ts
@@ -28,6 +28,7 @@ const WEAPON_ID_MAP: ReadonlyMap<bigint, string> = new Map([
   [0x30484ea642c9679fn, "Pulse Carbine"],
   [0xc30d87c742c9679fn, "Ravager"],
   [0x0a1992bc42c9679fn, "S7 Sniper"],
+  [0x94c3a67a42c9679fn, "S7 Sniper"],
   [0x880fe0bc42c9679fn, "Sandwich"],
   [0xa0955e9e42c9679fn, "Sentinel Beam"],
   [0xe86bd55e42c9679fn, "Sentinel Beam"],

--- a/api/services/halo/weapon-ids.ts
+++ b/api/services/halo/weapon-ids.ts
@@ -1,5 +1,12 @@
 const WEAPON_ID_MAP: ReadonlyMap<bigint, string> = new Map([
   [0x6acdc44d42c9679fn, "Bandit Evo"],
+  [0x6683257c42c9679fn, "Bandit Evo"],
+  [0xf2b458ec42c9679fn, "Bandit Evo"],
+  [0xd59b889a42c9679fn, "Bandit Evo"],
+  [0x0131ea1042c9679fn, "Bandit Evo"],
+  [0xb017106242c9679fn, "Bandit Evo"],
+  [0x91eb16de42c9679fn, "Bandit Evo"],
+  [0xedff0e9642c9679fn, "Bandit Evo"],
   [0x2b1824d542c9679fn, "BR75"],
   [0x230447b142c9679fn, "Cindershot"],
   [0xb619d84a42c9679fn, "CQS48 Bulldog"],
@@ -38,9 +45,6 @@ const WEAPON_ID_MAP: ReadonlyMap<bigint, string> = new Map([
   // Gravity Hammer family
   [0x841ac5e5a730e49fn, "Diminisher of Hope"],
   [0x841ac5e5d8d07ca1n, "Rushdown Hammer"],
-  [0xb017106242c9679fn, "Gravity Hammer"],
-  [0x91eb16de42c9679fn, "Gravity Hammer"],
-  [0xedff0e9642c9679fn, "Gravity Hammer"],
   // Grenades
   [0xb6dbead842c9679fn, "Frag Grenade"],
   [0xc1e1bab042c9679fn, "Plasma Grenade"],

--- a/api/services/halo/weapon-ids.ts
+++ b/api/services/halo/weapon-ids.ts
@@ -22,6 +22,7 @@ const WEAPON_ID_MAP: ReadonlyMap<bigint, string> = new Map([
   [0x767db96d42c9679fn, "MLRS-2 Hydra"],
   [0xf408190f42c9679fn, "Mk51 Sidekick"],
   [0x91833a5a42c9679fn, "Mk51 Sidekick"],
+  [0x831d801242c9679fn, "Mk51 Sidekick"],
   [0xd791556542c9679fn, "Mutilator"],
   [0xb533957e42c9679fn, "Needler"],
   [0xc354294642c9679fn, "Plasma Pistol"],

--- a/api/services/halo/weapon-ids.ts
+++ b/api/services/halo/weapon-ids.ts
@@ -14,6 +14,7 @@ const WEAPON_ID_MAP: ReadonlyMap<bigint, string> = new Map([
   [0x80977ba542c9679fn, "Mangler"],
   [0x767db96d42c9679fn, "MLRS-2 Hydra"],
   [0xf408190f42c9679fn, "Mk51 Sidekick"],
+  [0x91833a5a42c9679fn, "Mk51 Sidekick"],
   [0xd791556542c9679fn, "Mutilator"],
   [0xb533957e42c9679fn, "Needler"],
   [0xc354294642c9679fn, "Plasma Pistol"],
@@ -22,6 +23,7 @@ const WEAPON_ID_MAP: ReadonlyMap<bigint, string> = new Map([
   [0x0a1992bc42c9679fn, "S7 Sniper"],
   [0x880fe0bc42c9679fn, "Sandwich"],
   [0xa0955e9e42c9679fn, "Sentinel Beam"],
+  [0xe86bd55e42c9679fn, "Sentinel Beam"],
   [0x9387a8b942c9679fn, "Shock Rifle"],
   [0x1a22fee642c9679fn, "Shock Rifle (Ranked)"],
   [0x0d20c46942c9679fn, "Skewer"],
@@ -36,6 +38,9 @@ const WEAPON_ID_MAP: ReadonlyMap<bigint, string> = new Map([
   // Gravity Hammer family
   [0x841ac5e5a730e49fn, "Diminisher of Hope"],
   [0x841ac5e5d8d07ca1n, "Rushdown Hammer"],
+  [0xb017106242c9679fn, "Gravity Hammer"],
+  [0x91eb16de42c9679fn, "Gravity Hammer"],
+  [0xedff0e9642c9679fn, "Gravity Hammer"],
   // Grenades
   [0xb6dbead842c9679fn, "Frag Grenade"],
   [0xc1e1bab042c9679fn, "Plasma Grenade"],

--- a/pages/src/components/stats/kill-matrix/kill-matrix-h2h-dialog.module.css
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-h2h-dialog.module.css
@@ -41,3 +41,10 @@
   padding: 0.5rem 0.75rem;
   text-align: center;
 }
+
+.weaponName {
+  color: color-mix(in srgb, currentcolor 60%, transparent);
+  display: block;
+  font-size: 0.75rem;
+  font-weight: normal;
+}

--- a/pages/src/components/stats/kill-matrix/kill-matrix-h2h-dialog.module.css
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-h2h-dialog.module.css
@@ -41,10 +41,3 @@
   padding: 0.5rem 0.75rem;
   text-align: center;
 }
-
-.weaponName {
-  color: color-mix(in srgb, currentcolor 60%, transparent);
-  display: block;
-  font-size: 0.75rem;
-  font-weight: normal;
-}

--- a/pages/src/components/stats/kill-matrix/kill-matrix-h2h-dialog.module.css
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-h2h-dialog.module.css
@@ -41,3 +41,7 @@
   padding: 0.5rem 0.75rem;
   text-align: center;
 }
+
+.firstWeaponRow {
+  border-top: 1px dashed color-mix(in srgb, currentcolor 20%, transparent);
+}

--- a/pages/src/components/stats/kill-matrix/kill-matrix-h2h-dialog.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-h2h-dialog.tsx
@@ -51,8 +51,8 @@ export function KillMatrixH2HDialog({ data, onClose }: KillMatrixH2HDialogProps)
               <td className={styles.statCell}>Perfects</td>
               <td className={styles.valueCell}>{data.bPerfsOnA}</td>
             </tr>
-            {data.weaponRows.map((row) => (
-              <tr key={row.weaponId}>
+            {data.weaponRows.map((row, index) => (
+              <tr key={row.weaponId} className={index === 0 ? styles.firstWeaponRow : undefined}>
                 <td className={styles.valueCell}>{row.aCount}</td>
                 <td className={styles.statCell}>{row.name}</td>
                 <td className={styles.valueCell}>{row.bCount}</td>

--- a/pages/src/components/stats/kill-matrix/kill-matrix-h2h-dialog.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-h2h-dialog.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Dialog } from "../../dialog/dialog";
 import { TeamIcon } from "../../icons/team-icon";
-import type { H2HDialogData, KillMatrixWeaponUsage } from "../../../controllers/stats/kill-matrix/types";
+import type { H2HDialogData } from "../../../controllers/stats/kill-matrix/types";
 import styles from "./kill-matrix-h2h-dialog.module.css";
 
 interface KillMatrixH2HDialogProps {
@@ -24,22 +24,7 @@ function PlayerHeader({
   );
 }
 
-function topWeaponCell(weapons: readonly KillMatrixWeaponUsage[]): React.ReactNode {
-  const top = weapons.at(0);
-  if (top == null || top.count === 0) {
-    return "0";
-  }
-  return (
-    <>
-      {top.count}
-      <span className={styles.weaponName}>{top.name}</span>
-    </>
-  );
-}
-
 export function KillMatrixH2HDialog({ data, onClose }: KillMatrixH2HDialogProps): React.ReactElement {
-  const hasTopWeapon = (data?.aWeaponsOnB[0]?.count ?? 0) > 0 || (data?.bWeaponsOnA[0]?.count ?? 0) > 0;
-
   return (
     <Dialog open={data != null} title="Head to head" onClose={onClose} panelClassName={styles.dialogPanel}>
       {data != null && (
@@ -66,13 +51,13 @@ export function KillMatrixH2HDialog({ data, onClose }: KillMatrixH2HDialogProps)
               <td className={styles.statCell}>Perfects</td>
               <td className={styles.valueCell}>{data.bPerfsOnA}</td>
             </tr>
-            {hasTopWeapon && (
-              <tr>
-                <td className={styles.valueCell}>{topWeaponCell(data.aWeaponsOnB)}</td>
-                <td className={styles.statCell}>Top weapon kills</td>
-                <td className={styles.valueCell}>{topWeaponCell(data.bWeaponsOnA)}</td>
+            {data.weaponRows.map((row) => (
+              <tr key={row.weaponId}>
+                <td className={styles.valueCell}>{row.aCount}</td>
+                <td className={styles.statCell}>{row.name}</td>
+                <td className={styles.valueCell}>{row.bCount}</td>
               </tr>
-            )}
+            ))}
           </tbody>
         </table>
       )}

--- a/pages/src/components/stats/kill-matrix/kill-matrix-h2h-dialog.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-h2h-dialog.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Dialog } from "../../dialog/dialog";
 import { TeamIcon } from "../../icons/team-icon";
-import type { H2HDialogData } from "../../../controllers/stats/kill-matrix/types";
+import type { H2HDialogData, KillMatrixWeaponUsage } from "../../../controllers/stats/kill-matrix/types";
 import styles from "./kill-matrix-h2h-dialog.module.css";
 
 interface KillMatrixH2HDialogProps {
@@ -24,7 +24,22 @@ function PlayerHeader({
   );
 }
 
+function topWeaponCell(weapons: readonly KillMatrixWeaponUsage[]): React.ReactNode {
+  const top = weapons.at(0);
+  if (top == null || top.count === 0) {
+    return "0";
+  }
+  return (
+    <>
+      {top.count}
+      <span className={styles.weaponName}>{top.name}</span>
+    </>
+  );
+}
+
 export function KillMatrixH2HDialog({ data, onClose }: KillMatrixH2HDialogProps): React.ReactElement {
+  const hasTopWeapon = (data?.aWeaponsOnB[0]?.count ?? 0) > 0 || (data?.bWeaponsOnA[0]?.count ?? 0) > 0;
+
   return (
     <Dialog open={data != null} title="Head to head" onClose={onClose} panelClassName={styles.dialogPanel}>
       {data != null && (
@@ -46,11 +61,16 @@ export function KillMatrixH2HDialog({ data, onClose }: KillMatrixH2HDialogProps)
               <td className={styles.statCell}>Kills</td>
               <td className={styles.valueCell}>{data.bKillsOnA}</td>
             </tr>
-            {(data.aPerfsOnB > 0 || data.bPerfsOnA > 0) && (
+            <tr>
+              <td className={styles.valueCell}>{data.aPerfsOnB}</td>
+              <td className={styles.statCell}>Perfects</td>
+              <td className={styles.valueCell}>{data.bPerfsOnA}</td>
+            </tr>
+            {hasTopWeapon && (
               <tr>
-                <td className={styles.valueCell}>{data.aPerfsOnB}</td>
-                <td className={styles.statCell}>Perfects</td>
-                <td className={styles.valueCell}>{data.bPerfsOnA}</td>
+                <td className={styles.valueCell}>{topWeaponCell(data.aWeaponsOnB)}</td>
+                <td className={styles.statCell}>Top weapon kills</td>
+                <td className={styles.valueCell}>{topWeaponCell(data.bWeaponsOnA)}</td>
               </tr>
             )}
           </tbody>

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -14,6 +14,7 @@ import type {
   KillMatrixPivotData,
   KillMatrixPivotRow,
 } from "../../../controllers/stats/kill-matrix/types";
+import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { KillMatrixH2HDialog } from "./kill-matrix-h2h-dialog";
 import styles from "./kill-matrix-table.module.css";
 
@@ -167,8 +168,7 @@ export function KillMatrixTable({
                   bKillsOnA: cell?.deaths ?? 0,
                   aPerfsOnB: cell?.killPerfects ?? 0,
                   bPerfsOnA: cell?.deathPerfects ?? 0,
-                  aWeaponsOnB: cell?.killWeapons ?? [],
-                  bWeaponsOnA: cell?.deathWeapons ?? [],
+                  weaponRows: KillMatrixFormatter.buildH2HWeaponRows(cell?.killWeapons ?? [], cell?.deathWeapons ?? []),
                 });
               }}
               aria-label={`${row.playerGamertag} vs ${gamertag} head to head`}
@@ -234,8 +234,10 @@ export function KillMatrixTable({
                   bKillsOnA: bRow?.kills.get(row.killerGamertag) ?? 0,
                   aPerfsOnB: aRow?.perfects.get(gamertag) ?? 0,
                   bPerfsOnA: bRow?.perfects.get(row.killerGamertag) ?? 0,
-                  aWeaponsOnB: aRow?.weapons.get(gamertag) ?? [],
-                  bWeaponsOnA: bRow?.weapons.get(row.killerGamertag) ?? [],
+                  weaponRows: KillMatrixFormatter.buildH2HWeaponRows(
+                    aRow?.weapons.get(gamertag) ?? [],
+                    bRow?.weapons.get(row.killerGamertag) ?? [],
+                  ),
                 });
               }}
               aria-label={`${row.killerGamertag} vs ${gamertag} head to head`}

--- a/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
+++ b/pages/src/components/stats/kill-matrix/kill-matrix-table.tsx
@@ -167,6 +167,8 @@ export function KillMatrixTable({
                   bKillsOnA: cell?.deaths ?? 0,
                   aPerfsOnB: cell?.killPerfects ?? 0,
                   bPerfsOnA: cell?.deathPerfects ?? 0,
+                  aWeaponsOnB: cell?.killWeapons ?? [],
+                  bWeaponsOnA: cell?.deathWeapons ?? [],
                 });
               }}
               aria-label={`${row.playerGamertag} vs ${gamertag} head to head`}
@@ -232,6 +234,8 @@ export function KillMatrixTable({
                   bKillsOnA: bRow?.kills.get(row.killerGamertag) ?? 0,
                   aPerfsOnB: aRow?.perfects.get(gamertag) ?? 0,
                   bPerfsOnA: bRow?.perfects.get(row.killerGamertag) ?? 0,
+                  aWeaponsOnB: aRow?.weapons.get(gamertag) ?? [],
+                  bWeaponsOnA: bRow?.weapons.get(row.killerGamertag) ?? [],
                 });
               }}
               aria-label={`${row.killerGamertag} vs ${gamertag} head to head`}

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-store.test.ts
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-store.test.ts
@@ -20,6 +20,7 @@ describe("KillMatrixStore", () => {
         count: 3,
         headshotKills: 1,
         perfects: 0,
+        weapons: [],
       },
     ] satisfies readonly KillMatrixViewRow[]);
 

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -563,12 +563,16 @@ describe("KillMatrixTable", () => {
       expect(bKills).toBe("4");
     });
 
-    it("shows top weapon row when at least one player has weapon kills", async () => {
+    it("shows a row per weapon used between the two players", async () => {
       const user = userEvent.setup();
+      // Only Alpha→Bravo row — yields a single-column pivot so td:nth-child(2) is the data cell
       const pivotData = KillMatrixFormatter.pivot([
         {
           ...baseRow,
-          weapons: [{ weaponId: "2B1824D542C9679F", name: "BR75", count: 3 }],
+          weapons: [
+            { weaponId: "2B1824D542C9679F", name: "BR75", count: 3 },
+            { weaponId: "48C19D2D42C9679F", name: "MA40 AR", count: 1 },
+          ],
         },
       ]);
 
@@ -578,11 +582,11 @@ describe("KillMatrixTable", () => {
       const cellButton = table.querySelector("tbody tr td:nth-child(2) button");
       await user.click(cellButton as HTMLElement);
 
-      expect(screen.getByText("Top weapon kills")).toBeInTheDocument();
       expect(screen.getByText("BR75")).toBeInTheDocument();
+      expect(screen.getByText("MA40 AR")).toBeInTheDocument();
     });
 
-    it("hides top weapon row when both players have no weapon kills", async () => {
+    it("shows no weapon rows when both players have no weapon kills", async () => {
       const user = userEvent.setup();
       const pivotData = KillMatrixFormatter.pivot([{ ...baseRow, weapons: [] }]);
 
@@ -592,7 +596,9 @@ describe("KillMatrixTable", () => {
       const cellButton = table.querySelector("tbody tr td:nth-child(2) button");
       await user.click(cellButton as HTMLElement);
 
-      expect(screen.queryByText("Top weapon kills")).not.toBeInTheDocument();
+      const dialog = screen.getByRole("dialog", { name: "Head to head" });
+      // Only Kills and Perfects rows — no weapon rows
+      expect(dialog.querySelectorAll("tbody tr")).toHaveLength(2);
     });
   });
 

--- a/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
+++ b/pages/src/components/stats/kill-matrix/tests/kill-matrix-table.test.tsx
@@ -44,6 +44,7 @@ describe("KillMatrixTable", () => {
         count: 3,
         headshotKills: 1,
         perfects: 0,
+        weapons: [],
         classification: "enemy-kill",
       },
     ]);
@@ -163,6 +164,7 @@ describe("KillMatrixTable", () => {
         count: 3,
         headshotKills: 1,
         perfects: 0,
+        weapons: [],
         classification: "enemy-kill",
       },
     ]);
@@ -183,6 +185,7 @@ describe("KillMatrixTable", () => {
         count: 3,
         headshotKills: 1,
         perfects: 0,
+        weapons: [],
         classification: "enemy-kill" as const,
       },
     ];
@@ -239,6 +242,7 @@ describe("KillMatrixTable", () => {
         count: 3,
         headshotKills: 1,
         perfects: 0,
+        weapons: [],
         classification: "enemy-kill",
       },
     ]);
@@ -271,6 +275,7 @@ describe("KillMatrixTable", () => {
         count: 3,
         headshotKills: 1,
         perfects: 0,
+        weapons: [],
         classification: "enemy-kill",
       },
     ]);
@@ -301,7 +306,9 @@ describe("KillMatrixTable", () => {
           playerId: "111",
           playerGamertag: "Alpha",
           playerTeamId: 0,
-          cells: new Map([["Bravo", { kills: 3, deaths: 1, killPerfects: 0, deathPerfects: 0 }]]),
+          cells: new Map([
+            ["Bravo", { kills: 3, deaths: 1, killPerfects: 0, deathPerfects: 0, killWeapons: [], deathWeapons: [] }],
+          ]),
         },
       ],
       columnHeaders: [{ gamertag: "Bravo", teamId: 1, xuid: "222" }],
@@ -313,7 +320,9 @@ describe("KillMatrixTable", () => {
           playerId: "222",
           playerGamertag: "Bravo",
           playerTeamId: 1,
-          cells: new Map([["Alpha", { kills: 1, deaths: 3, killPerfects: 0, deathPerfects: 0 }]]),
+          cells: new Map([
+            ["Alpha", { kills: 1, deaths: 3, killPerfects: 0, deathPerfects: 0, killWeapons: [], deathWeapons: [] }],
+          ]),
         },
       ],
       columnHeaders: [{ gamertag: "Alpha", teamId: 0, xuid: "111" }],
@@ -442,6 +451,7 @@ describe("KillMatrixTable", () => {
       count: 4,
       headshotKills: 0,
       perfects: 1,
+      weapons: [],
       classification: "enemy-kill" as const,
     };
 
@@ -462,7 +472,7 @@ describe("KillMatrixTable", () => {
       expect(within(dialog).getByText("Kills")).toBeInTheDocument();
     });
 
-    it("shows perfects row only when at least one player has a perfect", async () => {
+    it("shows perfects row when at least one player has a perfect", async () => {
       const user = userEvent.setup();
       const pivotData = KillMatrixFormatter.pivot([baseRow]);
 
@@ -475,7 +485,7 @@ describe("KillMatrixTable", () => {
       expect(screen.getByText("Perfects")).toBeInTheDocument();
     });
 
-    it("omits perfects row when both players have zero perfects against each other", async () => {
+    it("shows perfects row even when both players have zero perfects against each other", async () => {
       const user = userEvent.setup();
       const pivotData = KillMatrixFormatter.pivot([{ ...baseRow, perfects: 0 }]);
 
@@ -485,7 +495,7 @@ describe("KillMatrixTable", () => {
       const cellButton = table.querySelector("tbody tr td:nth-child(2) button");
       await user.click(cellButton as HTMLElement);
 
-      expect(screen.queryByText("Perfects")).not.toBeInTheDocument();
+      expect(screen.getByText("Perfects")).toBeInTheDocument();
     });
 
     it("dialog closes when onClose fires", async () => {
@@ -514,6 +524,7 @@ describe("KillMatrixTable", () => {
           count: 2,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill" as const,
         },
       ];
@@ -551,6 +562,38 @@ describe("KillMatrixTable", () => {
       expect(aKills).toBe("2");
       expect(bKills).toBe("4");
     });
+
+    it("shows top weapon row when at least one player has weapon kills", async () => {
+      const user = userEvent.setup();
+      const pivotData = KillMatrixFormatter.pivot([
+        {
+          ...baseRow,
+          weapons: [{ weaponId: "2B1824D542C9679F", name: "BR75", count: 3 }],
+        },
+      ]);
+
+      render(<KillMatrixTable pivotData={pivotData} ariaLabel="Kill matrix" emptyMessage="No kill matrix data." />);
+
+      const table = screen.getByRole("table", { name: "Kill matrix" });
+      const cellButton = table.querySelector("tbody tr td:nth-child(2) button");
+      await user.click(cellButton as HTMLElement);
+
+      expect(screen.getByText("Top weapon kills")).toBeInTheDocument();
+      expect(screen.getByText("BR75")).toBeInTheDocument();
+    });
+
+    it("hides top weapon row when both players have no weapon kills", async () => {
+      const user = userEvent.setup();
+      const pivotData = KillMatrixFormatter.pivot([{ ...baseRow, weapons: [] }]);
+
+      render(<KillMatrixTable pivotData={pivotData} ariaLabel="Kill matrix" emptyMessage="No kill matrix data." />);
+
+      const table = screen.getByRole("table", { name: "Kill matrix" });
+      const cellButton = table.querySelector("tbody tr td:nth-child(2) button");
+      await user.click(cellButton as HTMLElement);
+
+      expect(screen.queryByText("Top weapon kills")).not.toBeInTheDocument();
+    });
   });
 
   it("toggles between kills and deaths view when toggle button is clicked", async () => {
@@ -563,6 +606,7 @@ describe("KillMatrixTable", () => {
         count: 3,
         headshotKills: 1,
         perfects: 0,
+        weapons: [],
         classification: "enemy-kill" as const,
       },
     ];

--- a/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
+++ b/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
@@ -1,6 +1,7 @@
 import type { KillMatrixWeaponUsage, MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import type {
+  H2HWeaponRow,
   KillMatrixClassification,
   KillMatrixColumnHeader,
   KillMatrixCrossTeamData,
@@ -272,6 +273,26 @@ export class KillMatrixFormatter {
       crossTeamData: KillMatrixFormatter.pivotCrossTeam(rows, firstTeamPlayers, secondTeamPlayers),
       swappedCrossTeamData: KillMatrixFormatter.pivotCrossTeam(rows, secondTeamPlayers, firstTeamPlayers),
     };
+  }
+
+  public static buildH2HWeaponRows(
+    aWeapons: readonly KillMatrixWeaponUsage[],
+    bWeapons: readonly KillMatrixWeaponUsage[],
+  ): H2HWeaponRow[] {
+    const byId = new Map<string, H2HWeaponRow>();
+    for (const w of aWeapons) {
+      byId.set(w.weaponId, { weaponId: w.weaponId, name: w.name, aCount: w.count, bCount: 0 });
+    }
+    for (const w of bWeapons) {
+      const existing = byId.get(w.weaponId);
+      byId.set(
+        w.weaponId,
+        existing != null
+          ? { ...existing, bCount: w.count }
+          : { weaponId: w.weaponId, name: w.name, aCount: 0, bCount: w.count },
+      );
+    }
+    return [...byId.values()].sort((x, y) => y.aCount + y.bCount - (x.aCount + x.bCount));
   }
 
   private static mergeWeapons(

--- a/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
+++ b/pages/src/controllers/stats/kill-matrix/kill-matrix-formatter.ts
@@ -1,4 +1,4 @@
-import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import type { KillMatrixWeaponUsage, MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import type {
   KillMatrixClassification,
@@ -43,6 +43,7 @@ export class KillMatrixFormatter {
         count: value.count,
         headshotKills: value.headshotKills,
         perfects: value.perfects,
+        weapons: [...value.weapons].sort((a, b) => b.count - a.count),
         classification: this.classify(killer, victim),
       });
     }
@@ -109,6 +110,7 @@ export class KillMatrixFormatter {
     const victimsMap = new Map<string, KillMatrixPlayer>();
     const killCounts = new Map<string, Map<string, number>>();
     const perfectCounts = new Map<string, Map<string, number>>();
+    const weaponLists = new Map<string, Map<string, readonly KillMatrixWeaponUsage[]>>();
 
     for (const row of rows) {
       killersMap.set(row.killer.xuid, row.killer);
@@ -117,10 +119,12 @@ export class KillMatrixFormatter {
       if (!killCounts.has(row.killer.xuid)) {
         killCounts.set(row.killer.xuid, new Map());
         perfectCounts.set(row.killer.xuid, new Map());
+        weaponLists.set(row.killer.xuid, new Map());
       }
       const victimCounts = Preconditions.checkExists(killCounts.get(row.killer.xuid));
       victimCounts.set(row.victim.xuid, row.count);
       Preconditions.checkExists(perfectCounts.get(row.killer.xuid)).set(row.victim.xuid, row.perfects);
+      Preconditions.checkExists(weaponLists.get(row.killer.xuid)).set(row.victim.xuid, row.weapons);
     }
 
     const byGamertag = (a: KillMatrixPlayer, b: KillMatrixPlayer): number => a.gamertag.localeCompare(b.gamertag);
@@ -149,11 +153,14 @@ export class KillMatrixFormatter {
     const tableRows = sortedKillers.map((killer) => {
       const victimCounts = Preconditions.checkExists(killCounts.get(killer.xuid));
       const victimPerfects = Preconditions.checkExists(perfectCounts.get(killer.xuid));
+      const victimWeapons = Preconditions.checkExists(weaponLists.get(killer.xuid));
       const kills = new Map<string, number>();
       const perfects = new Map<string, number>();
+      const weapons = new Map<string, readonly KillMatrixWeaponUsage[]>();
       for (const victim of sortedVictims) {
         kills.set(victim.gamertag, victimCounts.get(victim.xuid) ?? 0);
         perfects.set(victim.gamertag, victimPerfects.get(victim.xuid) ?? 0);
+        weapons.set(victim.gamertag, victimWeapons.get(victim.xuid) ?? []);
       }
       return {
         killerId: killer.xuid,
@@ -161,6 +168,7 @@ export class KillMatrixFormatter {
         killerTeamId: killer.teamId,
         kills,
         perfects,
+        weapons,
       };
     });
 
@@ -190,6 +198,7 @@ export class KillMatrixFormatter {
   ): KillMatrixCrossTeamData {
     const killCounts = new Map<string, Map<string, number>>();
     const perfectCounts = new Map<string, Map<string, number>>();
+    const weaponLists = new Map<string, Map<string, readonly KillMatrixWeaponUsage[]>>();
     let betrayals = 0;
     let suicides = 0;
 
@@ -205,9 +214,11 @@ export class KillMatrixFormatter {
       if (!killCounts.has(row.killer.xuid)) {
         killCounts.set(row.killer.xuid, new Map());
         perfectCounts.set(row.killer.xuid, new Map());
+        weaponLists.set(row.killer.xuid, new Map());
       }
       Preconditions.checkExists(killCounts.get(row.killer.xuid)).set(row.victim.xuid, row.count);
       Preconditions.checkExists(perfectCounts.get(row.killer.xuid)).set(row.victim.xuid, row.perfects);
+      Preconditions.checkExists(weaponLists.get(row.killer.xuid)).set(row.victim.xuid, row.weapons);
     }
 
     const tableRows = rowTeamPlayers.map((rowPlayer) => {
@@ -219,6 +230,8 @@ export class KillMatrixFormatter {
             deaths: killCounts.get(colPlayer.xuid)?.get(rowPlayer.xuid) ?? 0,
             killPerfects: perfectCounts.get(rowPlayer.xuid)?.get(colPlayer.xuid) ?? 0,
             deathPerfects: perfectCounts.get(colPlayer.xuid)?.get(rowPlayer.xuid) ?? 0,
+            killWeapons: weaponLists.get(rowPlayer.xuid)?.get(colPlayer.xuid) ?? [],
+            deathWeapons: weaponLists.get(colPlayer.xuid)?.get(rowPlayer.xuid) ?? [],
           },
         ]),
       );
@@ -261,6 +274,18 @@ export class KillMatrixFormatter {
     };
   }
 
+  private static mergeWeapons(
+    a: readonly KillMatrixWeaponUsage[],
+    b: readonly KillMatrixWeaponUsage[],
+  ): KillMatrixWeaponUsage[] {
+    const counts = new Map<string, KillMatrixWeaponUsage>();
+    for (const w of [...a, ...b]) {
+      const existing = counts.get(w.weaponId);
+      counts.set(w.weaponId, existing != null ? { ...existing, count: existing.count + w.count } : { ...w });
+    }
+    return [...counts.values()].sort((x, y) => y.count - x.count);
+  }
+
   public static aggregate(rows: readonly KillMatrixViewRow[]): KillMatrixViewRow[] {
     const merged = new Map<string, KillMatrixViewRow>();
 
@@ -274,6 +299,7 @@ export class KillMatrixFormatter {
           count: existing.count + row.count,
           headshotKills: existing.headshotKills + row.headshotKills,
           perfects: existing.perfects + row.perfects,
+          weapons: KillMatrixFormatter.mergeWeapons(existing.weapons, row.weapons),
         });
       }
     }

--- a/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
+++ b/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
@@ -723,4 +723,47 @@ describe("KillMatrixFormatter", () => {
       expect(KillMatrixFormatter.buildCrossTeam(rows, mixedPlayers)).toBeNull();
     });
   });
+
+  describe("buildH2HWeaponRows", () => {
+    it("returns empty array when both sides have no weapons", () => {
+      expect(KillMatrixFormatter.buildH2HWeaponRows([], [])).toEqual([]);
+    });
+
+    it("includes weapons from A's side with bCount 0 when B has none", () => {
+      const result = KillMatrixFormatter.buildH2HWeaponRows(
+        [{ weaponId: "2B1824D542C9679F", name: "BR75", count: 3 }],
+        [],
+      );
+      expect(result).toEqual([{ weaponId: "2B1824D542C9679F", name: "BR75", aCount: 3, bCount: 0 }]);
+    });
+
+    it("includes weapons from B's side with aCount 0 when A has none", () => {
+      const result = KillMatrixFormatter.buildH2HWeaponRows(
+        [],
+        [{ weaponId: "48C19D2D42C9679F", name: "MA40 AR", count: 2 }],
+      );
+      expect(result).toEqual([{ weaponId: "48C19D2D42C9679F", name: "MA40 AR", aCount: 0, bCount: 2 }]);
+    });
+
+    it("merges the same weapon from both sides into a single row", () => {
+      const result = KillMatrixFormatter.buildH2HWeaponRows(
+        [{ weaponId: "2B1824D542C9679F", name: "BR75", count: 4 }],
+        [{ weaponId: "2B1824D542C9679F", name: "BR75", count: 2 }],
+      );
+      expect(result).toEqual([{ weaponId: "2B1824D542C9679F", name: "BR75", aCount: 4, bCount: 2 }]);
+    });
+
+    it("sorts rows by total kills descending", () => {
+      const result = KillMatrixFormatter.buildH2HWeaponRows(
+        [
+          { weaponId: "48C19D2D42C9679F", name: "MA40 AR", count: 1 },
+          { weaponId: "2B1824D542C9679F", name: "BR75", count: 3 },
+        ],
+        [{ weaponId: "48C19D2D42C9679F", name: "MA40 AR", count: 3 }],
+      );
+      // MA40 AR total = 4, BR75 total = 3
+      expect(result[0]?.name).toBe("MA40 AR");
+      expect(result[1]?.name).toBe("BR75");
+    });
+  });
 });

--- a/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
+++ b/pages/src/controllers/stats/kill-matrix/tests/kill-matrix-formatter.test.ts
@@ -27,6 +27,35 @@ describe("KillMatrixFormatter", () => {
     expect(rows[2]).toMatchObject({ classification: "suicide" });
   });
 
+  it("includes weapons sorted by count descending from the analytics entry", () => {
+    const presenter = new KillMatrixFormatter();
+    const analytics = aFakeMatchAnalyticsWith({
+      killMatrix: {
+        "111:222": {
+          count: 3,
+          headshotKills: 0,
+          perfects: 0,
+          weapons: [
+            { weaponId: "6001000042C9679F", name: "BR75", count: 1 },
+            { weaponId: "5001000042C9679F", name: "MA40 AR", count: 2 },
+          ],
+        },
+      },
+    });
+    const [row] = presenter.present({
+      analytics,
+      playersByXuid: new Map([
+        ["111", { gamertag: "Alpha", teamId: 0 }],
+        ["222", { gamertag: "Bravo", teamId: 1 }],
+      ]),
+    });
+
+    expect(row.weapons).toEqual([
+      { weaponId: "5001000042C9679F", name: "MA40 AR", count: 2 },
+      { weaponId: "6001000042C9679F", name: "BR75", count: 1 },
+    ]);
+  });
+
   it("falls back to xuid when player details are missing", () => {
     const presenter = new KillMatrixFormatter();
     const analytics = aFakeMatchAnalyticsWith({
@@ -61,6 +90,7 @@ describe("KillMatrixFormatter", () => {
           count: 5,
           headshotKills: 2,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
       ];
@@ -82,6 +112,7 @@ describe("KillMatrixFormatter", () => {
           count: 2,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
         {
@@ -91,6 +122,7 @@ describe("KillMatrixFormatter", () => {
           count: 1,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
       ];
@@ -109,6 +141,7 @@ describe("KillMatrixFormatter", () => {
           count: 5,
           headshotKills: 0,
           perfects: 2,
+          weapons: [],
           classification: "enemy-kill",
         },
       ];
@@ -116,6 +149,27 @@ describe("KillMatrixFormatter", () => {
       const result = KillMatrixFormatter.pivot(rows);
 
       expect(result.tableRows[0].perfects.get("Bravo")).toBe(2);
+    });
+
+    it("propagates weapons into pivot rows keyed by victim gamertag", () => {
+      const rows: KillMatrixViewRow[] = [
+        {
+          key: "111:222",
+          killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          count: 3,
+          headshotKills: 0,
+          perfects: 0,
+          weapons: [{ weaponId: "2B1824D542C9679F", name: "BR75", count: 3 }],
+          classification: "enemy-kill",
+        },
+      ];
+
+      const result = KillMatrixFormatter.pivot(rows);
+
+      expect(result.tableRows[0].weapons.get("Bravo")).toEqual([
+        { weaponId: "2B1824D542C9679F", name: "BR75", count: 3 },
+      ]);
     });
 
     it("sorts killers and victims alphabetically and fills zeros for missing kills", () => {
@@ -127,6 +181,7 @@ describe("KillMatrixFormatter", () => {
           count: 2,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
         {
@@ -136,6 +191,7 @@ describe("KillMatrixFormatter", () => {
           count: 1,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
         {
@@ -145,6 +201,7 @@ describe("KillMatrixFormatter", () => {
           count: 3,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
       ];
@@ -170,6 +227,7 @@ describe("KillMatrixFormatter", () => {
           count: 3,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
         {
@@ -179,6 +237,7 @@ describe("KillMatrixFormatter", () => {
           count: 1,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
       ];
@@ -204,6 +263,7 @@ describe("KillMatrixFormatter", () => {
           count: 3,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
         {
@@ -213,6 +273,7 @@ describe("KillMatrixFormatter", () => {
           count: 1,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
       ];
@@ -236,6 +297,7 @@ describe("KillMatrixFormatter", () => {
           count: 3,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
         {
@@ -245,6 +307,7 @@ describe("KillMatrixFormatter", () => {
           count: 1,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
       ];
@@ -270,6 +333,7 @@ describe("KillMatrixFormatter", () => {
           count: 3,
           headshotKills: 1,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
         {
@@ -279,6 +343,7 @@ describe("KillMatrixFormatter", () => {
           count: 2,
           headshotKills: 2,
           perfects: 1,
+          weapons: [],
           classification: "enemy-kill",
         },
       ];
@@ -298,6 +363,7 @@ describe("KillMatrixFormatter", () => {
           count: 1,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
         {
@@ -307,6 +373,7 @@ describe("KillMatrixFormatter", () => {
           count: 3,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
       ];
@@ -318,6 +385,45 @@ describe("KillMatrixFormatter", () => {
 
     it("returns empty array when given no rows", () => {
       expect(KillMatrixFormatter.aggregate([])).toEqual([]);
+    });
+
+    it("merges weapons by weaponId and sorts by count descending", () => {
+      const rows: KillMatrixViewRow[] = [
+        {
+          key: "111:222",
+          killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          count: 3,
+          headshotKills: 0,
+          perfects: 0,
+          weapons: [
+            { weaponId: "2B1824D542C9679F", name: "BR75", count: 2 },
+            { weaponId: "48C19D2D42C9679F", name: "MA40 AR", count: 1 },
+          ],
+          classification: "enemy-kill",
+        },
+        {
+          key: "111:222",
+          killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          count: 2,
+          headshotKills: 0,
+          perfects: 0,
+          weapons: [
+            { weaponId: "2B1824D542C9679F", name: "BR75", count: 1 },
+            { weaponId: "F408190F42C9679F", name: "Mk51 Sidekick", count: 1 },
+          ],
+          classification: "enemy-kill",
+        },
+      ];
+
+      const result = KillMatrixFormatter.aggregate(rows);
+
+      expect(result[0].weapons).toEqual([
+        { weaponId: "2B1824D542C9679F", name: "BR75", count: 3 },
+        { weaponId: "48C19D2D42C9679F", name: "MA40 AR", count: 1 },
+        { weaponId: "F408190F42C9679F", name: "Mk51 Sidekick", count: 1 },
+      ]);
     });
   });
 
@@ -335,6 +441,7 @@ describe("KillMatrixFormatter", () => {
           count: 5,
           headshotKills: 2,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
       ];
@@ -366,6 +473,7 @@ describe("KillMatrixFormatter", () => {
         count: 3,
         headshotKills: 0,
         perfects: 0,
+        weapons: [],
         classification: "enemy-kill",
       },
       {
@@ -375,6 +483,7 @@ describe("KillMatrixFormatter", () => {
         count: 1,
         headshotKills: 0,
         perfects: 0,
+        weapons: [],
         classification: "enemy-kill",
       },
       {
@@ -384,6 +493,7 @@ describe("KillMatrixFormatter", () => {
         count: 1,
         headshotKills: 0,
         perfects: 0,
+        weapons: [],
         classification: "suicide",
       },
       {
@@ -393,6 +503,7 @@ describe("KillMatrixFormatter", () => {
         count: 2,
         headshotKills: 0,
         perfects: 0,
+        weapons: [],
         classification: "betrayal",
       },
     ];
@@ -408,12 +519,16 @@ describe("KillMatrixFormatter", () => {
         deaths: 1,
         killPerfects: 0,
         deathPerfects: 0,
+        killWeapons: [],
+        deathWeapons: [],
       });
       expect(result.tableRows[0].cells.get("Delta")).toEqual({
         kills: 0,
         deaths: 0,
         killPerfects: 0,
         deathPerfects: 0,
+        killWeapons: [],
+        deathWeapons: [],
       });
       expect(result.tableRows[1]).toMatchObject({ playerId: "333", playerGamertag: "Charlie", playerTeamId: 0 });
       expect(result.tableRows[1].cells.get("Bravo")).toEqual({
@@ -421,6 +536,8 @@ describe("KillMatrixFormatter", () => {
         deaths: 0,
         killPerfects: 0,
         deathPerfects: 0,
+        killWeapons: [],
+        deathWeapons: [],
       });
     });
 
@@ -433,6 +550,7 @@ describe("KillMatrixFormatter", () => {
           count: 3,
           headshotKills: 0,
           perfects: 1,
+          weapons: [],
           classification: "enemy-kill",
         },
         {
@@ -442,6 +560,7 @@ describe("KillMatrixFormatter", () => {
           count: 1,
           headshotKills: 0,
           perfects: 0,
+          weapons: [],
           classification: "enemy-kill",
         },
       ];
@@ -455,6 +574,8 @@ describe("KillMatrixFormatter", () => {
         deaths: 1,
         killPerfects: 1,
         deathPerfects: 0,
+        killWeapons: [],
+        deathWeapons: [],
       });
     });
 
@@ -477,6 +598,39 @@ describe("KillMatrixFormatter", () => {
       expect(result.tableRows).toHaveLength(0);
       expect(result.columnHeaders.map((h) => h.gamertag)).toEqual(["Bravo", "Delta"]);
     });
+
+    it("propagates weapons into killWeapons and deathWeapons for each cell", () => {
+      const rowsWithWeapons: KillMatrixViewRow[] = [
+        {
+          key: "111:222",
+          killer: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          victim: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          count: 3,
+          headshotKills: 0,
+          perfects: 0,
+          weapons: [{ weaponId: "2B1824D542C9679F", name: "BR75", count: 3 }],
+          classification: "enemy-kill",
+        },
+        {
+          key: "222:111",
+          killer: { xuid: "222", gamertag: "Bravo", teamId: 1 },
+          victim: { xuid: "111", gamertag: "Alpha", teamId: 0 },
+          count: 1,
+          headshotKills: 0,
+          perfects: 0,
+          weapons: [{ weaponId: "48C19D2D42C9679F", name: "MA40 AR", count: 1 }],
+          classification: "enemy-kill",
+        },
+      ];
+      const team0 = [{ xuid: "111", gamertag: "Alpha", teamId: 0 }];
+      const team1 = [{ xuid: "222", gamertag: "Bravo", teamId: 1 }];
+
+      const result = KillMatrixFormatter.pivotCrossTeam(rowsWithWeapons, team0, team1);
+
+      const cell = result.tableRows[0].cells.get("Bravo");
+      expect(cell?.killWeapons).toEqual([{ weaponId: "2B1824D542C9679F", name: "BR75", count: 3 }]);
+      expect(cell?.deathWeapons).toEqual([{ weaponId: "48C19D2D42C9679F", name: "MA40 AR", count: 1 }]);
+    });
   });
 
   describe("buildCrossTeam", () => {
@@ -498,6 +652,7 @@ describe("KillMatrixFormatter", () => {
         count: 4,
         headshotKills: 0,
         perfects: 0,
+        weapons: [],
         classification: "enemy-kill",
       },
       {
@@ -507,6 +662,7 @@ describe("KillMatrixFormatter", () => {
         count: 2,
         headshotKills: 0,
         perfects: 0,
+        weapons: [],
         classification: "enemy-kill",
       },
     ];
@@ -525,8 +681,22 @@ describe("KillMatrixFormatter", () => {
       const alphaVsBravo = result?.crossTeamData.tableRows[0]?.cells.get("Bravo");
       const bravoVsAlpha = result?.swappedCrossTeamData.tableRows[0]?.cells.get("Alpha");
 
-      expect(alphaVsBravo).toEqual({ kills: 4, deaths: 2, killPerfects: 0, deathPerfects: 0 });
-      expect(bravoVsAlpha).toEqual({ kills: 2, deaths: 4, killPerfects: 0, deathPerfects: 0 });
+      expect(alphaVsBravo).toEqual({
+        kills: 4,
+        deaths: 2,
+        killPerfects: 0,
+        deathPerfects: 0,
+        killWeapons: [],
+        deathWeapons: [],
+      });
+      expect(bravoVsAlpha).toEqual({
+        kills: 2,
+        deaths: 4,
+        killPerfects: 0,
+        deathPerfects: 0,
+        killWeapons: [],
+        deathWeapons: [],
+      });
     });
 
     it("returns null when all players have no teamId", () => {

--- a/pages/src/controllers/stats/kill-matrix/types.ts
+++ b/pages/src/controllers/stats/kill-matrix/types.ts
@@ -1,4 +1,6 @@
-import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import type { KillMatrixWeaponUsage, MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+
+export type { KillMatrixWeaponUsage };
 
 export type KillMatrixClassification = "enemy-kill" | "betrayal" | "suicide";
 
@@ -14,6 +16,7 @@ export interface KillMatrixPivotRow {
   readonly killerTeamId: number | null;
   readonly kills: ReadonlyMap<string, number>; // keyed by victim gamertag
   readonly perfects: ReadonlyMap<string, number>; // keyed by victim gamertag
+  readonly weapons: ReadonlyMap<string, readonly KillMatrixWeaponUsage[]>; // keyed by victim gamertag
 }
 
 export interface KillMatrixPivotData {
@@ -28,6 +31,8 @@ export interface KillMatrixCrossTeamCell {
   readonly deaths: number;
   readonly killPerfects: number;
   readonly deathPerfects: number;
+  readonly killWeapons: readonly KillMatrixWeaponUsage[];
+  readonly deathWeapons: readonly KillMatrixWeaponUsage[];
 }
 
 export interface H2HDialogData {
@@ -37,6 +42,8 @@ export interface H2HDialogData {
   readonly bKillsOnA: number;
   readonly aPerfsOnB: number;
   readonly bPerfsOnA: number;
+  readonly aWeaponsOnB: readonly KillMatrixWeaponUsage[];
+  readonly bWeaponsOnA: readonly KillMatrixWeaponUsage[];
 }
 
 export interface KillMatrixCrossTeamRow {
@@ -76,6 +83,7 @@ export interface KillMatrixViewRow {
   readonly count: number;
   readonly headshotKills: number;
   readonly perfects: number;
+  readonly weapons: readonly KillMatrixWeaponUsage[];
   readonly classification: KillMatrixClassification;
 }
 

--- a/pages/src/controllers/stats/kill-matrix/types.ts
+++ b/pages/src/controllers/stats/kill-matrix/types.ts
@@ -35,6 +35,13 @@ export interface KillMatrixCrossTeamCell {
   readonly deathWeapons: readonly KillMatrixWeaponUsage[];
 }
 
+export interface H2HWeaponRow {
+  readonly weaponId: string;
+  readonly name: string;
+  readonly aCount: number;
+  readonly bCount: number;
+}
+
 export interface H2HDialogData {
   readonly playerA: { readonly gamertag: string; readonly teamId: number | null };
   readonly playerB: { readonly gamertag: string; readonly teamId: number | null };
@@ -42,8 +49,7 @@ export interface H2HDialogData {
   readonly bKillsOnA: number;
   readonly aPerfsOnB: number;
   readonly bPerfsOnA: number;
-  readonly aWeaponsOnB: readonly KillMatrixWeaponUsage[];
-  readonly bWeaponsOnA: readonly KillMatrixWeaponUsage[];
+  readonly weaponRows: readonly H2HWeaponRow[];
 }
 
 export interface KillMatrixCrossTeamRow {

--- a/shared/src/contracts/stats/match-analytics.ts
+++ b/shared/src/contracts/stats/match-analytics.ts
@@ -34,6 +34,7 @@ export const killMatrixEntrySchema = z.object({
 });
 
 export type KillMatrixEntry = z.infer<typeof killMatrixEntrySchema>;
+export type KillMatrixWeaponUsage = KillMatrixEntry["weapons"][number];
 
 export const SUPPORTED_ANALYTICS_MODULES = ["killMatrix", "scoreProgression"] as const;
 export const analyticsModuleSchema = z.enum(SUPPORTED_ANALYTICS_MODULES);


### PR DESCRIPTION
## Context

Part of the kill matrix improvement plan. PR 17b ([#728](https://github.com/davidhouweling/guilty-spark/pull/728)) wired weapon attribution into `KillMatrixEntry.weapons` via type-2 film fire events. This PR surfaces that data in the UI alongside perfects.

## This change

- **Weapons in H2H dialog**: each weapon used between the two players gets its own row, sorted by combined kills (A + B) descending. Only weapons where at least one side has kills are shown — rows with zero on both sides are suppressed.
- **Perfects always shown**: the Perfects row is now always visible (previously hidden when both were 0), consistent with Kills.
- **`KillMatrixFormatter.buildH2HWeaponRows(a, b)`**: new static method merges the two per-direction weapon arrays by weapon ID and sorts by total. Owned by the formatter, covered by dedicated tests.
- **`H2HWeaponRow` type**: replaces the raw `aWeaponsOnB`/`bWeaponsOnA` arrays on `H2HDialogData` so the dialog component is purely presentational — no merge logic in the view.
- Weapons are propagated through `KillMatrixPivotRow`, `KillMatrixCrossTeamCell`, and the `aggregate` path.

## Subsequent work

- Investigate "Unknown" weapon names appearing in live matches — likely unmapped weapon variant IDs; will add to the lookup table once IDs are identified.
- PR-ack: Acknowledgements page crediting den.dev and LevelUp research.