### PR TITLE
Public page polish + header profile UX fixes

### DIFF
--- a/pages/src/components/dropdown/dropdown.tsx
+++ b/pages/src/components/dropdown/dropdown.tsx
@@ -9,6 +9,8 @@ interface DropdownProps {
   readonly dropdownWidth?: number;
   readonly dropdownHeight?: number;
   readonly scrollToSelected?: boolean;
+  readonly containerClassName?: string;
+  readonly triggerClassName?: string;
 }
 
 export function Dropdown({
@@ -18,6 +20,8 @@ export function Dropdown({
   dropdownWidth = 200,
   dropdownHeight = 150,
   scrollToSelected = false,
+  containerClassName,
+  triggerClassName,
 }: DropdownProps): React.ReactElement {
   const [isOpen, setIsOpen] = useState(false);
   const [position, setPosition] = useState<{ right?: string; left?: string; top?: string; bottom?: string }>({});
@@ -111,12 +115,15 @@ export function Dropdown({
     }
   }, [isOpen, scrollToSelected]);
 
+  const containerClassNames = [styles.container, containerClassName].filter((value) => value != null).join(" ");
+  const triggerClassNames = [styles.triggerButton, triggerClassName].filter((value) => value != null).join(" ");
+
   return (
-    <div className={styles.container} ref={dropdownRef}>
+    <div className={containerClassNames} ref={dropdownRef}>
       <button
         ref={triggerRef}
         type="button"
-        className={styles.triggerButton}
+        className={triggerClassNames}
         onClick={(): void => {
           setIsOpen(!isOpen);
         }}

--- a/pages/src/components/header/header.astro
+++ b/pages/src/components/header/header.astro
@@ -4,12 +4,20 @@ import Logo from "../logo/logo.astro";
 import Container from "../container/container.astro";
 import { SUPPORT_SERVER_URL, GITHUB_URL, API_HOST } from "../../constants";
 import { ProfileMenu } from "./profile-menu";
+import { ProfileAvatar } from "./profile-avatar";
 import styles from "./header.module.css";
+import profileMenuStyles from "./profile-menu.module.css";
 
 interface NavLink {
   href: string;
   label: string;
 }
+
+interface Props {
+  readonly hasAuthSessionCookie?: boolean;
+}
+
+const { hasAuthSessionCookie = false } = Astro.props;
 
 const navLinks: NavLink[] = [
   { href: "/discord-commands", label: "Commands" },
@@ -77,7 +85,20 @@ const navLinks: NavLink[] = [
             ></path>
           </svg>
         </a>
-        <ProfileMenu client:load apiHost={API_HOST} />
+        {
+          hasAuthSessionCookie ? (
+            <ProfileMenu client:load apiHost={API_HOST} />
+          ) : (
+            <a
+              href="/login"
+              class={`${styles.iconLink} ${profileMenuStyles.profileIconButton}`}
+              aria-label="Sign in"
+              title="Sign in"
+            >
+              <ProfileAvatar />
+            </a>
+          )
+        }
       </div>
     </div>
   </Container>

--- a/pages/src/components/header/header.astro
+++ b/pages/src/components/header/header.astro
@@ -25,6 +25,7 @@ const navLinks: NavLink[] = [
   { href: "/guides/obs-overlays", label: "OBS Guide" },
   { href: "/faq", label: "FAQ" },
 ];
+const signInLinkClassName = [styles.iconLink, profileMenuStyles.profileIconButton].join(" ");
 ---
 
 <nav id="halo-nav" class={styles.haloNav} aria-label="Primary">
@@ -87,14 +88,9 @@ const navLinks: NavLink[] = [
         </a>
         {
           hasAuthSessionCookie ? (
-            <ProfileMenu client:load apiHost={API_HOST} />
+            <ProfileMenu client:load apiHost={API_HOST} iconLinkClassName={styles.iconLink} />
           ) : (
-            <a
-              href="/login"
-              class={`${styles.iconLink} ${profileMenuStyles.profileIconButton}`}
-              aria-label="Sign in"
-              title="Sign in"
-            >
+            <a href="/login" class={signInLinkClassName} aria-label="Sign in" title="Sign in">
               <ProfileAvatar />
             </a>
           )

--- a/pages/src/components/header/header.astro
+++ b/pages/src/components/header/header.astro
@@ -88,7 +88,12 @@ const signInLinkClassName = [styles.iconLink, profileMenuStyles.profileIconButto
         </a>
         {
           hasAuthSessionCookie ? (
-            <ProfileMenu client:load apiHost={API_HOST} iconLinkClassName={styles.iconLink} />
+            <ProfileMenu
+              client:load
+              apiHost={API_HOST}
+              iconLinkClassName={styles.iconLink}
+              expectAuthenticated={hasAuthSessionCookie}
+            />
           ) : (
             <a href="/login" class={signInLinkClassName} aria-label="Sign in" title="Sign in">
               <ProfileAvatar />

--- a/pages/src/components/header/header.module.css
+++ b/pages/src/components/header/header.module.css
@@ -59,7 +59,7 @@
     opacity 0.25s ease 0.05s;
 }
 
-.navLinks a {
+.navLinks > a {
   align-items: center;
   border-bottom: 1px solid var(--halo-teal-darker);
   color: var(--halo-teal-primary);
@@ -99,11 +99,11 @@
   width: 20px;
 }
 
-.navLinks a:last-child {
+.navLinks > a:last-of-type {
   border-bottom: none;
 }
 
-.navLinks a:hover {
+.navLinks > a:hover {
   color: var(--halo-white);
   padding-left: var(--space-2);
   text-shadow: 0 0 10px color-mix(in srgb, var(--halo-teal-primary) 80%, transparent);
@@ -193,7 +193,7 @@
     z-index: auto;
   }
 
-  .navLinks a {
+  .navLinks > a {
     border-bottom: none;
     padding: 0;
   }
@@ -214,7 +214,7 @@
     text-shadow: 0 0 10px color-mix(in srgb, var(--halo-teal-primary) 80%, transparent);
   }
 
-  .navLinks a::after {
+  .navLinks > a::after {
     background: var(--halo-teal-primary);
     bottom: -5px;
     content: "";
@@ -225,11 +225,11 @@
     width: 0;
   }
 
-  .navLinks a:hover {
+  .navLinks > a:hover {
     padding-left: 0;
   }
 
-  .navLinks a:hover::after {
+  .navLinks > a:hover::after {
     box-shadow: 0 0 10px var(--halo-teal-primary);
     width: 100%;
   }

--- a/pages/src/components/header/profile-avatar.tsx
+++ b/pages/src/components/header/profile-avatar.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import styles from "./profile-menu.module.css";
+
+interface ProfileAvatarProps {
+  readonly avatarUrl?: string | null;
+  readonly onError?: () => void;
+}
+
+export function ProfileAvatar({ avatarUrl = null, onError }: ProfileAvatarProps): React.ReactElement {
+  return (
+    <span className={styles.profileAvatar} aria-hidden="true">
+      {avatarUrl != null && avatarUrl !== "" ? (
+        <img src={avatarUrl} className={styles.profileAvatarImage} alt="" onError={onError} />
+      ) : (
+        <span className={styles.profileAvatarGeneric}>
+          <span className={styles.avatarHead} />
+          <span className={styles.avatarBody} />
+        </span>
+      )}
+    </span>
+  );
+}

--- a/pages/src/components/header/profile-menu.module.css
+++ b/pages/src/components/header/profile-menu.module.css
@@ -1,5 +1,6 @@
 .profileIconButton {
   align-items: center;
+  opacity: 1;
   background: transparent;
   border: 0;
   color: var(--halo-teal-primary);
@@ -21,22 +22,6 @@
   opacity: 1;
   outline: 2px solid var(--halo-teal-primary);
   outline-offset: 2px;
-}
-
-.profileDropdownContainer {
-  align-items: center;
-  display: inline-flex;
-  justify-content: center;
-  min-height: 44px;
-  min-width: 44px;
-}
-
-.profileDropdownTrigger {
-  opacity: 1;
-}
-
-.profileDropdownTrigger:hover {
-  opacity: 1;
 }
 
 .profileAvatar {

--- a/pages/src/components/header/profile-menu.module.css
+++ b/pages/src/components/header/profile-menu.module.css
@@ -23,6 +23,22 @@
   outline-offset: 2px;
 }
 
+.profileDropdownContainer {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  min-height: 44px;
+  min-width: 44px;
+}
+
+.profileDropdownTrigger {
+  opacity: 1;
+}
+
+.profileDropdownTrigger:hover {
+  opacity: 1;
+}
+
 .profileAvatar {
   align-items: center;
   border: 1px solid var(--halo-teal-primary);
@@ -40,11 +56,15 @@
   display: block;
   height: 100%;
   object-fit: cover;
+  object-position: 50% 42%;
   width: 100%;
 }
 
 .profileAvatarGeneric {
-  display: contents;
+  display: block;
+  height: 100%;
+  position: relative;
+  width: 100%;
 }
 
 .avatarHead {
@@ -52,9 +72,10 @@
   border-radius: 9999px;
   display: block;
   height: 7px;
-  left: 9px;
+  left: 50%;
   position: absolute;
-  top: 5px;
+  top: 38%;
+  transform: translate(-50%, -50%);
   width: 7px;
 }
 
@@ -63,9 +84,10 @@
   border-radius: 7px 7px 3px 3px;
   display: block;
   height: 8px;
-  left: 7px;
+  left: 50%;
   position: absolute;
-  top: 14px;
+  top: 68%;
+  transform: translate(-50%, -50%);
   width: 11px;
 }
 

--- a/pages/src/components/header/profile-menu.module.css
+++ b/pages/src/components/header/profile-menu.module.css
@@ -1,6 +1,5 @@
 .profileIconButton {
   align-items: center;
-  opacity: 1;
   background: transparent;
   border: 0;
   color: var(--halo-teal-primary);
@@ -9,6 +8,7 @@
   justify-content: center;
   min-height: 44px;
   min-width: 44px;
+  opacity: 1;
   padding: 0;
   position: relative;
 }

--- a/pages/src/components/header/profile-menu.module.css
+++ b/pages/src/components/header/profile-menu.module.css
@@ -127,6 +127,5 @@
 .profileMenuList .profileMenuItem:hover {
   background: color-mix(in srgb, var(--halo-teal-primary) 14%, transparent);
   color: var(--halo-white);
-  padding-left: var(--space-4);
   text-shadow: none;
 }

--- a/pages/src/components/header/profile-menu.tsx
+++ b/pages/src/components/header/profile-menu.tsx
@@ -3,6 +3,7 @@ import type { SessionResponse } from "@guilty-spark/shared/contracts/auth/sessio
 import { Dropdown } from "../dropdown/dropdown";
 import type { AuthService } from "../../services/auth/types";
 import { installAuthService } from "../../services/auth/install";
+import { ProfileAvatar } from "./profile-avatar";
 import styles from "./profile-menu.module.css";
 
 interface ProfileMenuProps {
@@ -43,27 +44,9 @@ export function ProfileMenu({ apiHost }: ProfileMenuProps): React.ReactElement {
     };
   }, [apiHost]);
 
-  const avatarUrl = session.authenticated ? (session.avatarUrl ?? null) : null;
+  const avatarUrl = session.authenticated && !avatarFailed ? (session.avatarUrl ?? null) : null;
 
-  const avatar = (
-    <span className={styles.profileAvatar} aria-hidden="true">
-      {avatarUrl != null && avatarUrl !== "" && !avatarFailed ? (
-        <img
-          src={avatarUrl}
-          className={styles.profileAvatarImage}
-          alt=""
-          onError={() => {
-            setAvatarFailed(true);
-          }}
-        />
-      ) : (
-        <span className={styles.profileAvatarGeneric}>
-          <span className={styles.avatarHead} />
-          <span className={styles.avatarBody} />
-        </span>
-      )}
-    </span>
-  );
+  const avatar = <ProfileAvatar avatarUrl={avatarUrl} onError={() => setAvatarFailed(true)} />;
 
   const profileTrigger = <span className={styles.profileIconButton}>{avatar}</span>;
 

--- a/pages/src/components/header/profile-menu.tsx
+++ b/pages/src/components/header/profile-menu.tsx
@@ -52,7 +52,8 @@ export function ProfileMenu({
   }, [apiHost]);
 
   const hasAuthenticatedSession = session?.authenticated === true;
-  const isAuthenticated = session?.authenticated ?? expectAuthenticated;
+  const isLoadingExpectedSession = expectAuthenticated && session == null;
+  const showDropdown = hasAuthenticatedSession || isLoadingExpectedSession;
   const avatarUrl = hasAuthenticatedSession && !avatarFailed ? (session.avatarUrl ?? null) : null;
 
   const avatar = (
@@ -66,7 +67,7 @@ export function ProfileMenu({
 
   const profileButtonClassName = classNames(styles.profileIconButton, iconLinkClassName);
 
-  if (!isAuthenticated && !expectAuthenticated) {
+  if (!showDropdown) {
     return (
       <a href="/login" className={profileButtonClassName} aria-label="Sign in" title="Sign in">
         {avatar}
@@ -95,7 +96,7 @@ export function ProfileMenu({
       triggerClassName={profileButtonClassName}
     >
       <div className={styles.profileMenuList}>
-        {isAuthenticated ? (
+        {hasAuthenticatedSession ? (
           <>
             {gamertag != null && gamertag !== "" ? <span className={styles.profileMenuLabel}>{gamertag}</span> : null}
             <a href="/individual-tracker" className={styles.profileMenuItem}>

--- a/pages/src/components/header/profile-menu.tsx
+++ b/pages/src/components/header/profile-menu.tsx
@@ -63,16 +63,11 @@ export function ProfileMenu({
     />
   );
 
-  const profileTrigger = <span className={classNames(styles.profileIconButton, iconLinkClassName)}>{avatar}</span>;
+  const profileButtonClassName = classNames(styles.profileIconButton, iconLinkClassName);
 
   if (!isAuthenticated && !expectAuthenticated) {
     return (
-      <a
-        href="/login"
-        className={classNames(styles.profileIconButton, iconLinkClassName)}
-        aria-label="Sign in"
-        title="Sign in"
-      >
+      <a href="/login" className={profileButtonClassName} aria-label="Sign in" title="Sign in">
         {avatar}
       </a>
     );
@@ -92,12 +87,11 @@ export function ProfileMenu({
 
   return (
     <Dropdown
-      trigger={profileTrigger}
+      trigger={avatar}
       ariaLabel="Profile menu"
       dropdownWidth={220}
       dropdownHeight={180}
-      containerClassName={styles.profileDropdownContainer}
-      triggerClassName={styles.profileDropdownTrigger}
+      triggerClassName={profileButtonClassName}
     >
       <div className={styles.profileMenuList}>
         {isAuthenticated ? (

--- a/pages/src/components/header/profile-menu.tsx
+++ b/pages/src/components/header/profile-menu.tsx
@@ -51,8 +51,9 @@ export function ProfileMenu({
     };
   }, [apiHost]);
 
+  const hasAuthenticatedSession = session?.authenticated === true;
   const isAuthenticated = session?.authenticated ?? expectAuthenticated;
-  const avatarUrl = session?.authenticated && !avatarFailed ? (session.avatarUrl ?? null) : null;
+  const avatarUrl = hasAuthenticatedSession && !avatarFailed ? (session.avatarUrl ?? null) : null;
 
   const avatar = (
     <ProfileAvatar
@@ -73,7 +74,7 @@ export function ProfileMenu({
     );
   }
 
-  const gamertag = session?.authenticated ? session.xboxGamertag : undefined;
+  const gamertag = hasAuthenticatedSession ? session.xboxGamertag : undefined;
 
   const handleLogout = (): void => {
     void (async (): Promise<void> => {

--- a/pages/src/components/header/profile-menu.tsx
+++ b/pages/src/components/header/profile-menu.tsx
@@ -90,7 +90,7 @@ export function ProfileMenu({
       trigger={avatar}
       ariaLabel="Profile menu"
       dropdownWidth={220}
-      dropdownHeight={180}
+      dropdownHeight={200}
       triggerClassName={profileButtonClassName}
     >
       <div className={styles.profileMenuList}>

--- a/pages/src/components/header/profile-menu.tsx
+++ b/pages/src/components/header/profile-menu.tsx
@@ -10,11 +10,16 @@ import styles from "./profile-menu.module.css";
 interface ProfileMenuProps {
   readonly apiHost: string;
   readonly iconLinkClassName?: string;
+  readonly expectAuthenticated?: boolean;
 }
 
-export function ProfileMenu({ apiHost, iconLinkClassName }: ProfileMenuProps): React.ReactElement {
+export function ProfileMenu({
+  apiHost,
+  iconLinkClassName,
+  expectAuthenticated = false,
+}: ProfileMenuProps): React.ReactElement {
   const [authService, setAuthService] = useState<AuthService | null>(null);
-  const [session, setSession] = useState<SessionResponse>({ authenticated: false });
+  const [session, setSession] = useState<SessionResponse | null>(null);
   const [avatarFailed, setAvatarFailed] = useState(false);
 
   useEffect(() => {
@@ -46,7 +51,8 @@ export function ProfileMenu({ apiHost, iconLinkClassName }: ProfileMenuProps): R
     };
   }, [apiHost]);
 
-  const avatarUrl = session.authenticated && !avatarFailed ? (session.avatarUrl ?? null) : null;
+  const isAuthenticated = session?.authenticated ?? expectAuthenticated;
+  const avatarUrl = session?.authenticated && !avatarFailed ? (session.avatarUrl ?? null) : null;
 
   const avatar = (
     <ProfileAvatar
@@ -57,9 +63,9 @@ export function ProfileMenu({ apiHost, iconLinkClassName }: ProfileMenuProps): R
     />
   );
 
-  const profileTrigger = <span className={styles.profileIconButton}>{avatar}</span>;
+  const profileTrigger = <span className={classNames(styles.profileIconButton, iconLinkClassName)}>{avatar}</span>;
 
-  if (!session.authenticated) {
+  if (!isAuthenticated && !expectAuthenticated) {
     return (
       <a
         href="/login"
@@ -72,7 +78,7 @@ export function ProfileMenu({ apiHost, iconLinkClassName }: ProfileMenuProps): R
     );
   }
 
-  const gamertag = session.xboxGamertag;
+  const gamertag = session?.authenticated ? session.xboxGamertag : undefined;
 
   const handleLogout = (): void => {
     void (async (): Promise<void> => {
@@ -85,15 +91,30 @@ export function ProfileMenu({ apiHost, iconLinkClassName }: ProfileMenuProps): R
   };
 
   return (
-    <Dropdown trigger={profileTrigger} ariaLabel="Profile menu" dropdownWidth={220} dropdownHeight={180}>
+    <Dropdown
+      trigger={profileTrigger}
+      ariaLabel="Profile menu"
+      dropdownWidth={220}
+      dropdownHeight={180}
+      containerClassName={styles.profileDropdownContainer}
+      triggerClassName={styles.profileDropdownTrigger}
+    >
       <div className={styles.profileMenuList}>
-        {gamertag != null && gamertag !== "" ? <span className={styles.profileMenuLabel}>{gamertag}</span> : null}
-        <a href="/individual-tracker" className={styles.profileMenuItem}>
-          Individual Tracker
-        </a>
-        <button type="button" className={styles.profileMenuItem} onClick={handleLogout}>
-          Sign out
-        </button>
+        {isAuthenticated ? (
+          <>
+            {gamertag != null && gamertag !== "" ? <span className={styles.profileMenuLabel}>{gamertag}</span> : null}
+            <a href="/individual-tracker" className={styles.profileMenuItem}>
+              Individual Tracker
+            </a>
+            <button type="button" className={styles.profileMenuItem} onClick={handleLogout}>
+              Sign out
+            </button>
+          </>
+        ) : (
+          <a href="/login" className={styles.profileMenuItem}>
+            Sign in
+          </a>
+        )}
       </div>
     </Dropdown>
   );

--- a/pages/src/components/header/profile-menu.tsx
+++ b/pages/src/components/header/profile-menu.tsx
@@ -46,7 +46,14 @@ export function ProfileMenu({ apiHost }: ProfileMenuProps): React.ReactElement {
 
   const avatarUrl = session.authenticated && !avatarFailed ? (session.avatarUrl ?? null) : null;
 
-  const avatar = <ProfileAvatar avatarUrl={avatarUrl} onError={() => setAvatarFailed(true)} />;
+  const avatar = (
+    <ProfileAvatar
+      avatarUrl={avatarUrl}
+      onError={() => {
+        setAvatarFailed(true);
+      }}
+    />
+  );
 
   const profileTrigger = <span className={styles.profileIconButton}>{avatar}</span>;
 

--- a/pages/src/components/header/profile-menu.tsx
+++ b/pages/src/components/header/profile-menu.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import classNames from "classnames";
 import type { SessionResponse } from "@guilty-spark/shared/contracts/auth/session";
 import { Dropdown } from "../dropdown/dropdown";
 import type { AuthService } from "../../services/auth/types";
@@ -8,9 +9,10 @@ import styles from "./profile-menu.module.css";
 
 interface ProfileMenuProps {
   readonly apiHost: string;
+  readonly iconLinkClassName?: string;
 }
 
-export function ProfileMenu({ apiHost }: ProfileMenuProps): React.ReactElement {
+export function ProfileMenu({ apiHost, iconLinkClassName }: ProfileMenuProps): React.ReactElement {
   const [authService, setAuthService] = useState<AuthService | null>(null);
   const [session, setSession] = useState<SessionResponse>({ authenticated: false });
   const [avatarFailed, setAvatarFailed] = useState(false);
@@ -59,7 +61,12 @@ export function ProfileMenu({ apiHost }: ProfileMenuProps): React.ReactElement {
 
   if (!session.authenticated) {
     return (
-      <a href="/login" className={styles.profileIconButton} aria-label="Sign in" title="Sign in">
+      <a
+        href="/login"
+        className={classNames(styles.profileIconButton, iconLinkClassName)}
+        aria-label="Sign in"
+        title="Sign in"
+      >
         {avatar}
       </a>
     );

--- a/pages/src/components/header/tests/profile-menu.test.tsx
+++ b/pages/src/components/header/tests/profile-menu.test.tsx
@@ -52,6 +52,16 @@ describe("ProfileMenu", () => {
     expect(signIn.className).not.toBe("iconLink");
   });
 
+  it("renders a direct sign-in link after expected auth resolves unauthenticated", async () => {
+    installWithSession({ authenticated: false });
+
+    render(<ProfileMenu apiHost="https://api.example.com" expectAuthenticated />);
+
+    const signIn = await screen.findByRole("link", { name: "Sign in" });
+    expect(signIn).toHaveAttribute("href", "/login");
+    expect(screen.queryByRole("button", { name: "Profile menu" })).toBeNull();
+  });
+
   it("shows the avatar menu and signs out when authenticated", async () => {
     const authService = installWithSession({
       authenticated: true,

--- a/pages/src/components/header/tests/profile-menu.test.tsx
+++ b/pages/src/components/header/tests/profile-menu.test.tsx
@@ -48,8 +48,8 @@ describe("ProfileMenu", () => {
     render(<ProfileMenu apiHost="https://api.example.com" iconLinkClassName="iconLink" />);
 
     const signIn = await screen.findByRole("link", { name: "Sign in" });
-    expect(signIn.className).toContain("profileIconButton");
     expect(signIn).toHaveClass("iconLink");
+    expect(signIn.className).not.toBe("iconLink");
   });
 
   it("shows the avatar menu and signs out when authenticated", async () => {

--- a/pages/src/components/header/tests/profile-menu.test.tsx
+++ b/pages/src/components/header/tests/profile-menu.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { SessionResponse } from "@guilty-spark/shared/contracts/auth/session";
 import { aFakeAuthServiceWith } from "../../../services/auth/fakes/auth.fake";
@@ -42,6 +42,16 @@ describe("ProfileMenu", () => {
     expect(signIn).toHaveAttribute("href", "/login");
   });
 
+  it("keeps icon link styling for unauthenticated sessions", async () => {
+    installWithSession({ authenticated: false });
+
+    render(<ProfileMenu apiHost="https://api.example.com" iconLinkClassName="iconLink" />);
+
+    const signIn = await screen.findByRole("link", { name: "Sign in" });
+    expect(signIn.className).toContain("profileIconButton");
+    expect(signIn).toHaveClass("iconLink");
+  });
+
   it("shows the avatar menu and signs out when authenticated", async () => {
     const authService = installWithSession({
       authenticated: true,
@@ -66,6 +76,32 @@ describe("ProfileMenu", () => {
     });
     await waitFor(() => {
       expect(window.location.href).toBe("/login");
+    });
+  });
+
+  it("shows the generic avatar after avatar image load failure", async () => {
+    installWithSession({
+      authenticated: true,
+      userId: "user-123",
+      expiresAt: 4102444800000,
+      avatarUrl: "https://avatar.example/pic.png",
+      xboxGamertag: "Spartan117",
+    });
+
+    const { container } = render(<ProfileMenu apiHost="https://api.example.com" />);
+
+    await waitFor(() => {
+      expect(container.querySelector("img")).not.toBeNull();
+    });
+
+    const avatarImageBeforeError = container.querySelector("img");
+    if (avatarImageBeforeError == null) {
+      throw new Error("Expected avatar image before error");
+    }
+    fireEvent.error(avatarImageBeforeError);
+
+    await waitFor(() => {
+      expect(container.querySelector("img")).toBeNull();
     });
   });
 });

--- a/pages/src/layouts/layout.astro
+++ b/pages/src/layouts/layout.astro
@@ -15,6 +15,8 @@ const {
   description = "A powerful Discord bot that brings Halo Infinite match statistics to your server. Track custom games, generate HCS maps, and analyze player performance.",
   fullFooter = false,
 } = Astro.props;
+
+const hasAuthSessionCookie = Astro.cookies.has("auth-session");
 ---
 
 <!doctype html>
@@ -89,7 +91,7 @@ const {
     <title>{title}</title>
   </head>
   <body>
-    <Header />
+    <Header hasAuthSessionCookie={hasAuthSessionCookie} />
     <main>
       <slot />
     </main>

--- a/pages/src/pages/capabilities.astro
+++ b/pages/src/pages/capabilities.astro
@@ -18,7 +18,7 @@ import styles from "./_styles/content-page.module.css";
     <Container>
       <header class={styles.heroBlock}>
         <p class={styles.eyebrow}>Capability Briefing</p>
-        <Heading tagName="h1" class={styles.title}>Mission Systems</Heading>
+        <Heading tagName="h1" class={styles.title}>Installation Systems</Heading>
         <p class={styles.subtitle}>
           Guilty Spark now supports both community operations and streamer workflows. Use this page to review the
           current capability map before configuration or broadcast setup.
@@ -29,7 +29,7 @@ import styles from "./_styles/content-page.module.css";
         <div class={styles.grid}>
           <article class={styles.card}>
             <h3>Discord Operations</h3>
-            <p>Queue and match workflows remain first-class through slash commands and server setup controls.</p>
+            <p>Queue and match workflows remain mission-critical through slash commands and server setup controls.</p>
             <ul>
               <li>Resolve NeatQueue series stats in Discord</li>
               <li>Configure channel posting behavior and integration settings</li>

--- a/pages/src/pages/discord-commands.astro
+++ b/pages/src/pages/discord-commands.astro
@@ -77,8 +77,8 @@ const commandGroups = [
         <p class={styles.eyebrow}>Command Uplink</p>
         <Heading tagName="h1" class={styles.title}>Discord Commands</Heading>
         <p class={styles.subtitle}>
-          Quick-reference index for Guilty Spark slash commands. Use this page as your operator handbook for setup, stat
-          retrieval, and live operations.
+          Quick-reference index for Guilty Spark slash commands. Use this operator deck for setup, stat retrieval, and
+          live operations.
         </p>
       </header>
 

--- a/pages/src/pages/faq.astro
+++ b/pages/src/pages/faq.astro
@@ -53,10 +53,11 @@ const faqItems = [
     <section class={styles.heroSection}>
       <Container>
         <header class={styles.heroBlock}>
-          <p class={styles.eyebrow}>Knowledge Base</p>
+          <p class={styles.eyebrow}>Archive Reference</p>
           <Heading tagName="h1" class={styles.heroTitle}>Frequently Asked Questions</Heading>
           <p class={styles.heroSubtitle}>
-            Answers to common questions about Discord automation, Individual Tracker workflows, and OBS overlay setup.
+            Answers to common questions about operating Guilty Spark across Discord automation, Individual Tracker
+            workflows, and OBS overlay setup.
           </p>
         </header>
       </Container>

--- a/pages/src/pages/guides/obs-overlays.astro
+++ b/pages/src/pages/guides/obs-overlays.astro
@@ -22,7 +22,7 @@ import styles from "../_styles/content-page.module.css";
         <p class={styles.eyebrow}>Field Guide</p>
         <Heading tagName="h1" class={styles.title}>OBS Overlay Setup</Heading>
         <p class={styles.subtitle}>
-          Use this guide to deploy Guilty Spark overlays in OBS from either live series tracker mode or individual
+          Use this guide to bring Guilty Spark overlays into OBS from either live series tracker mode or individual
           tracker mode.
         </p>
       </header>

--- a/pages/src/pages/index.astro
+++ b/pages/src/pages/index.astro
@@ -154,7 +154,7 @@ const testimonialItems: CommunityTestimonial[] = [
         <span class={styles.titleLine}>Spark</span>
       </h1>
 
-      <div class={styles.heroSubtitle}>Halo Infinite Statistics and Overlay Interface</div>
+      <div class={styles.heroSubtitle}>Halo Infinite Combat Intelligence and Overlay Interface</div>
 
       <p class={styles.heroDescription}>
         Greetings, Reclaimer. Guilty Spark unifies Discord automation, NeatQueue workflows, and Individual Tracker
@@ -175,7 +175,7 @@ const testimonialItems: CommunityTestimonial[] = [
   <!-- Demo Section -->
   <section class={styles.demoSection}>
     <Container>
-      <SectionHeader title="Operational Demonstrations" subtitle="Monitor Protocol Systems in Active Deployment" />
+      <SectionHeader title="Operational Demonstrations" subtitle="Inspect protocol systems in active deployment" />
       <div class={styles.demoGrid}>
         {
           featuredDemoItem && (
@@ -208,7 +208,7 @@ const testimonialItems: CommunityTestimonial[] = [
   <!-- Testimonials Section -->
   <section class={styles.testimonialsSection} aria-label="Community testimonials">
     <Container>
-      <SectionHeader title="Community Intel" subtitle="Deployed Units Reporting In" />
+      <SectionHeader title="Community Intel" subtitle="Deployed units reporting in" />
       <TestimonialCarousel items={testimonialItems} autoRotateMs={5000} />
     </Container>
   </section>
@@ -216,7 +216,7 @@ const testimonialItems: CommunityTestimonial[] = [
   <!-- Features Section -->
   <section id="features" class={styles.featuresSection}>
     <Container>
-      <SectionHeader title="Capabilities" subtitle="Advanced Combat Analysis Systems" />
+      <SectionHeader title="Capabilities" subtitle="Advanced combat analysis systems" />
 
       <div class={styles.featuresGrid}>
         {


### PR DESCRIPTION
## Context
This branch started as a public-content polish pass after the larger content refresh work, then expanded through multiple review/fix iterations focused on header profile UX stability. The goal was to keep public messaging aligned with Guilty Spark’s tone while removing auth-state and dropdown interaction rough edges in the top navigation.

## This PR
- Public page wording alignment to a consistent Guilty Spark / Installation voice:
  - `pages/src/pages/index.astro`
  - `pages/src/pages/capabilities.astro`
  - `pages/src/pages/discord-commands.astro`
  - `pages/src/pages/faq.astro`
  - `pages/src/pages/guides/obs-overlays.astro`
- Header/profile auth UX hardening:
  - Added server-side cookie gating (`auth-session`) so anonymous public visits do not probe session auth by default.
  - Reused the logged-out avatar treatment for profile entry consistency.
  - Preserved sign-in icon styling while moving through authenticated/unauthenticated states.
- Profile/menu transition and alignment fixes:
  - Reduced profile icon layout shift when auth session resolves.
  - Improved fallback avatar/image visual alignment.
  - Simplified duplicated profile-menu CSS and TSX wiring where possible.
- Dropdown/menu behavior fixes:
  - Scoped header nav anchor selectors to top-level links only so profile dropdown items no longer inherit unrelated nav hover rules.
  - Fixed profile dropdown hover behavior that caused left-padding jitter and intermittent scrollbar appearance.

## Subsequent Work
- Optional: squash/reword intermediate fixup commit messages before merge if you want a cleaner linear history.
- Optional: one final visual sweep on slow network throttling to confirm zero perceived profile icon movement across hydration/auth resolution.

## Validation
- `npm run typecheck:pages` passes.
