### PR TITLE
fix(auth): graceful error UX + retry resilience for Microsoft/Xbox sign-in

### DIFF
--- a/api/routes/auth/microsoft/callback.ts
+++ b/api/routes/auth/microsoft/callback.ts
@@ -1,6 +1,5 @@
 import { parseQueryParams } from "@guilty-spark/shared/base/request-parsing";
 import { authCallbackQuerySchema } from "@guilty-spark/shared/contracts/auth/microsoft/callback";
-import { errorContract } from "@guilty-spark/shared/contracts/error";
 import type { XboxUserInfo } from "../../../services/xbox/types";
 import type { RoutesRegisterHandler } from "../../base/types";
 
@@ -9,14 +8,35 @@ export const authMicrosoftCallbackRoute: RoutesRegisterHandler = (router, instal
     const services = installServices({ env });
     const { authService, xboxService, databaseService, logService } = services;
 
+    function redirectToLoginWithError(errorCode: string): Response {
+      const rejectUrl = new URL("/login", env.PAGES_URL);
+      rejectUrl.searchParams.set("error", errorCode);
+      const rejectResponse = new Response(null, { status: 302, headers: { Location: rejectUrl.toString() } });
+      authService.clearPkceStateCookie(rejectResponse);
+      return rejectResponse;
+    }
+
     try {
       logService.info("Auth callback initiated");
 
       const url = new URL(request.url);
+
+      const providerError = url.searchParams.get("error");
+      if (providerError != null) {
+        logService.warn(
+          "Microsoft returned an OAuth error before issuing a code",
+          new Map([
+            ["error", providerError],
+            ["errorDescription", url.searchParams.get("error_description") ?? ""],
+          ]),
+        );
+        return redirectToLoginWithError("auth-failed");
+      }
+
       const parsedQuery = parseQueryParams(url, authCallbackQuerySchema, "Authentication failed");
       if (!parsedQuery.success) {
         logService.warn("OAuth query parameter validation failed", new Map([["error", "invalid params"]]));
-        return parsedQuery.response;
+        return redirectToLoginWithError("auth-failed");
       }
 
       const { code, state } = parsedQuery.data;
@@ -50,11 +70,7 @@ export const authMicrosoftCallbackRoute: RoutesRegisterHandler = (router, instal
           new Map([["sessionId", sessionPayload.sessionId]]),
         );
         await databaseService.deleteUserSession(sessionPayload.sessionId);
-        const rejectUrl = new URL("/login", env.PAGES_URL);
-        rejectUrl.searchParams.set("error", "xbox-required");
-        const rejectResponse = new Response(null, { status: 302, headers: { Location: rejectUrl.toString() } });
-        authService.clearPkceStateCookie(rejectResponse);
-        return rejectResponse;
+        return redirectToLoginWithError("xbox-required");
       }
 
       try {
@@ -114,7 +130,7 @@ export const authMicrosoftCallbackRoute: RoutesRegisterHandler = (router, instal
           ["errorType", error instanceof Error ? error.constructor.name : "unknown"],
         ]),
       );
-      return errorContract.toResponse({ error: "Authentication failed" }, { status: 400, noStore: true });
+      return redirectToLoginWithError("auth-failed");
     }
   });
 };

--- a/api/routes/auth/microsoft/callback.ts
+++ b/api/routes/auth/microsoft/callback.ts
@@ -43,13 +43,7 @@ export const authMicrosoftCallbackRoute: RoutesRegisterHandler = (router, instal
       }
 
       const { code, state } = parsedQuery.data;
-      logService.info(
-        "OAuth query parameters validated, Exchanging OAuth code for tokens",
-        new Map([
-          ["code", code],
-          ["state", state],
-        ]),
-      );
+      logService.info("OAuth query parameters validated, exchanging OAuth code for tokens");
 
       const { sessionPayload, redirectTo } = await authService.handleCallback(request, code, state);
       logService.info(

--- a/api/routes/auth/microsoft/callback.ts
+++ b/api/routes/auth/microsoft/callback.ts
@@ -11,7 +11,10 @@ export const authMicrosoftCallbackRoute: RoutesRegisterHandler = (router, instal
     function redirectToLoginWithError(errorCode: string): Response {
       const rejectUrl = new URL("/login", env.PAGES_URL);
       rejectUrl.searchParams.set("error", errorCode);
-      const rejectResponse = new Response(null, { status: 302, headers: { Location: rejectUrl.toString() } });
+      const rejectResponse = new Response(null, {
+        status: 302,
+        headers: { Location: rejectUrl.toString(), "Cache-Control": "no-store" },
+      });
       authService.clearPkceStateCookie(rejectResponse);
       return rejectResponse;
     }

--- a/api/routes/auth/microsoft/tests/callback.test.ts
+++ b/api/routes/auth/microsoft/tests/callback.test.ts
@@ -107,7 +107,7 @@ describe("GET /auth/microsoft/callback", () => {
     expect(deleteSessionSpy).toHaveBeenCalledWith("session-123");
   });
 
-  it("returns a generic auth error and cleans up the session when attaching the xbox profile fails", async () => {
+  it("redirects to login with auth-failed and cleans up the session when attaching the xbox profile fails", async () => {
     let deleteSessionSpy!: MockInstance<DatabaseService["deleteUserSession"]>;
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });
@@ -141,13 +141,12 @@ describe("GET /auth/microsoft/callback", () => {
     });
     const res = (await router.fetch(req, env)) as Response;
 
-    expect(res.status).toBe(400);
-    const body = await res.json<{ error: string }>();
-    expect(body).toEqual({ error: "Authentication failed" });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(`${env.PAGES_URL}/login?error=auth-failed`);
     expect(deleteSessionSpy).toHaveBeenCalledWith("session-123");
   });
 
-  it("returns a generic authentication error when callback handling fails", async () => {
+  it("redirects to login with auth-failed when callback handling fails", async () => {
     const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
       const services = installFakeServicesWith({ env });
       vi.spyOn(services.authService, "handleCallback").mockRejectedValue(new Error("upstream microsoft response body"));
@@ -164,11 +163,44 @@ describe("GET /auth/microsoft/callback", () => {
     });
     const res = (await router.fetch(req, env)) as Response;
 
-    expect(res.status).toBe(400);
-    const body = await res.json<{ error: string }>();
-    expect(body).toEqual({ error: "Authentication failed" });
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(env.PAGES_URL);
-    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
-    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(`${env.PAGES_URL}/login?error=auth-failed`);
+  });
+
+  it("redirects to login with auth-failed when Microsoft returns an OAuth error instead of a code", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => installFakeServicesWith({ env }));
+
+    authMicrosoftCallbackRoute(router, localInstallServices);
+
+    const req = new Request(
+      "http://localhost/auth/microsoft/callback?error=server_error&error_description=Transient+failure&state=state-123",
+      {
+        method: "GET",
+        headers: {
+          Origin: env.PAGES_URL,
+        },
+      },
+    );
+    const res = (await router.fetch(req, env)) as Response;
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(`${env.PAGES_URL}/login?error=auth-failed`);
+  });
+
+  it("redirects to login with auth-failed when required query parameters are missing", async () => {
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => installFakeServicesWith({ env }));
+
+    authMicrosoftCallbackRoute(router, localInstallServices);
+
+    const req = new Request("http://localhost/auth/microsoft/callback?state=state-123", {
+      method: "GET",
+      headers: {
+        Origin: env.PAGES_URL,
+      },
+    });
+    const res = (await router.fetch(req, env)) as Response;
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(`${env.PAGES_URL}/login?error=auth-failed`);
   });
 });

--- a/api/services/auth/microsoft-auth.ts
+++ b/api/services/auth/microsoft-auth.ts
@@ -116,8 +116,13 @@ export class MicrosoftAuthService {
   /**
    * Exchange authorization code for tokens.
    * Must include the original codeVerifier used in the authorization request.
+   * Retried once — this call is a common source of transient failures in the sign-in flow.
    */
   public async exchangeCodeForTokens(code: string, codeVerifier: string): Promise<MicrosoftTokenResponse> {
+    return this.withSingleRetry(async () => this.exchangeCodeForTokensOnce(code, codeVerifier));
+  }
+
+  private async exchangeCodeForTokensOnce(code: string, codeVerifier: string): Promise<MicrosoftTokenResponse> {
     const url = new URL(`https://login.microsoftonline.com/${this.tenant}/oauth2/v2.0/token`);
 
     const body = new URLSearchParams();
@@ -144,6 +149,14 @@ export class MicrosoftAuthService {
 
     const tokens: MicrosoftTokenResponse = await response.json();
     return tokens;
+  }
+
+  private async withSingleRetry<T>(operation: () => Promise<T>): Promise<T> {
+    try {
+      return await operation();
+    } catch {
+      return await operation();
+    }
   }
 
   /**

--- a/api/services/auth/microsoft-auth.ts
+++ b/api/services/auth/microsoft-auth.ts
@@ -28,6 +28,12 @@ interface CachedValue<T> {
   readonly value: T;
 }
 
+function isRetryableStatus(status: number): boolean {
+  return status >= 500 || status === 408 || status === 429;
+}
+
+class NonRetryableAuthError extends Error {}
+
 interface SigningJsonWebKey extends JsonWebKey {
   readonly e: string;
   readonly kid?: string;
@@ -142,9 +148,11 @@ export class MicrosoftAuthService {
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(
-        `Microsoft OAuth token exchange failed: ${response.status.toString()} ${response.statusText} - ${errorText}`,
-      );
+      const message = `Microsoft OAuth token exchange failed: ${response.status.toString()} ${response.statusText} - ${errorText}`;
+      if (!isRetryableStatus(response.status)) {
+        throw new NonRetryableAuthError(message);
+      }
+      throw new Error(message);
     }
 
     const tokens: MicrosoftTokenResponse = await response.json();
@@ -154,7 +162,10 @@ export class MicrosoftAuthService {
   private async withSingleRetry<T>(operation: () => Promise<T>): Promise<T> {
     try {
       return await operation();
-    } catch {
+    } catch (error) {
+      if (error instanceof NonRetryableAuthError) {
+        throw error;
+      }
       return await operation();
     }
   }

--- a/api/services/auth/tests/microsoft-auth.test.ts
+++ b/api/services/auth/tests/microsoft-auth.test.ts
@@ -259,6 +259,30 @@ describe("MicrosoftAuthService", () => {
     await expect(service.exchangeCodeForTokens("code-123", "code-verifier")).rejects.toThrow("persistent failure");
   });
 
+  it("does not retry the token exchange for a non-retryable 4xx status", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 }));
+
+    await expect(service.exchangeCodeForTokens("code-123", "code-verifier")).rejects.toThrow();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the token exchange for a retryable 5xx status", async () => {
+    const tokens = { access_token: "access-token", refresh_token: "refresh-token", expires_in: 3600 };
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: "server_error" }), { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(tokens), { status: 200, headers: { "Content-Type": "application/json" } }),
+      );
+
+    const result = await service.exchangeCodeForTokens("code-123", "code-verifier");
+
+    expect(result).toEqual(tokens);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("throws on token refresh failure", async () => {
     vi.stubGlobal(
       "fetch",

--- a/api/services/auth/tests/microsoft-auth.test.ts
+++ b/api/services/auth/tests/microsoft-auth.test.ts
@@ -240,6 +240,25 @@ describe("MicrosoftAuthService", () => {
     await expect(service.exchangeCodeForTokens("invalid-code", "code-verifier")).rejects.toThrow();
   });
 
+  it("retries once and succeeds when the token exchange fails transiently", async () => {
+    const tokens = { access_token: "access-token", refresh_token: "refresh-token", expires_in: 3600 };
+    vi.spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("network blip"))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(tokens), { status: 200, headers: { "Content-Type": "application/json" } }),
+      );
+
+    const result = await service.exchangeCodeForTokens("code-123", "code-verifier");
+
+    expect(result).toEqual(tokens);
+  });
+
+  it("throws after a second consecutive token exchange failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("persistent failure"));
+
+    await expect(service.exchangeCodeForTokens("code-123", "code-verifier")).rejects.toThrow("persistent failure");
+  });
+
   it("throws on token refresh failure", async () => {
     vi.stubGlobal(
       "fetch",

--- a/api/services/xbox/tests/xbox.test.ts
+++ b/api/services/xbox/tests/xbox.test.ts
@@ -323,6 +323,69 @@ describe("Xbox Service", () => {
       );
       expect(xsapiClientGetSpy).not.toHaveBeenCalled();
     });
+
+    it("retries once and succeeds when the user token exchange fails transiently", async () => {
+      vi.spyOn(globalThis, "fetch")
+        .mockRejectedValueOnce(new Error("network blip"))
+        .mockResolvedValueOnce(
+          createJsonResponse({
+            IssueInstant: "2025-01-01T00:00:00.000Z",
+            NotAfter: "2025-01-01T06:00:00.000Z",
+            Token: "user-token",
+            DisplayClaims: { xui: [{ uhs: "user_hash" }] },
+          }),
+        )
+        .mockResolvedValueOnce(
+          createJsonResponse({
+            IssueInstant: "2025-01-01T00:00:00.000Z",
+            NotAfter: "2025-01-01T06:00:00.000Z",
+            Token: "xsts_token",
+            DisplayClaims: { xui: [{ uhs: "user_hash", xid: "2533274" }] },
+          }),
+        );
+      xsapiClientGetSpy.mockResolvedValueOnce(
+        createMockXSAPIResponse([
+          {
+            id: "2533274",
+            hostId: "2533274",
+            settings: [{ id: "Gamertag", value: "Spartan117" }],
+            isSponsoredUser: false,
+          },
+        ]),
+      );
+
+      const result = await xboxService.getUserFromMicrosoftAccessToken("microsoft-access-token");
+
+      expect(result).toEqual({ xuid: "2533274", gamertag: "Spartan117" });
+    });
+
+    it("throws after a second consecutive failure of the user token exchange", async () => {
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("persistent failure"));
+
+      await expect(xboxService.getUserFromMicrosoftAccessToken("microsoft-access-token")).rejects.toThrow(
+        "persistent failure",
+      );
+    });
+
+    it("retries once and succeeds when the profile lookup returns a transient error status", async () => {
+      mockXboxTokenExchange([{ uhs: "user_hash", xid: "2533274" }]);
+      xsapiClientGetSpy
+        .mockResolvedValueOnce({ data: { profileUsers: [] }, response: new Response(), headers: {}, statusCode: 503 })
+        .mockResolvedValueOnce(
+          createMockXSAPIResponse([
+            {
+              id: "2533274",
+              hostId: "2533274",
+              settings: [{ id: "Gamertag", value: "Spartan117" }],
+              isSponsoredUser: false,
+            },
+          ]),
+        );
+
+      const result = await xboxService.getUserFromMicrosoftAccessToken("microsoft-access-token");
+
+      expect(result).toEqual({ xuid: "2533274", gamertag: "Spartan117" });
+    });
   });
 
   describe("getUsersByXuids", () => {

--- a/api/services/xbox/tests/xbox.test.ts
+++ b/api/services/xbox/tests/xbox.test.ts
@@ -386,6 +386,21 @@ describe("Xbox Service", () => {
 
       expect(result).toEqual({ xuid: "2533274", gamertag: "Spartan117" });
     });
+
+    it("does not retry the profile lookup for a non-retryable 4xx status", async () => {
+      mockXboxTokenExchange([{ uhs: "user_hash", xid: "2533274" }]);
+      xsapiClientGetSpy.mockResolvedValueOnce({
+        data: { profileUsers: [] },
+        response: new Response(),
+        headers: {},
+        statusCode: 403,
+      });
+
+      await expect(xboxService.getUserFromMicrosoftAccessToken("microsoft-access-token")).rejects.toThrow(
+        "Xbox profile lookup failed (403)",
+      );
+      expect(xsapiClientGetSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("getUsersByXuids", () => {

--- a/api/services/xbox/xbox.ts
+++ b/api/services/xbox/xbox.ts
@@ -72,12 +72,20 @@ export class XboxService {
     };
   }
 
+  /**
+   * Each network call is retried once — these are the sign-in critical path and prone to
+   * occasional transient failures against Xbox Live's user/XSTS token and profile endpoints.
+   */
   async getUserFromMicrosoftAccessToken(accessToken: string): Promise<XboxUserInfo> {
-    const userTokenResponse = await xnet.exchangeRpsTicketForUserToken(accessToken, MICROSOFT_OAUTH_RPS_PREAMBLE);
-    const xstsTokenResponse = await xnet.exchangeTokenForXSTSToken(userTokenResponse.Token, {
-      sandboxId: XBOX_LIVE_SANDBOX_ID,
-      XSTSRelyingParty: XBOX_LIVE_XSTS_RELYING_PARTY,
-    });
+    const userTokenResponse = await this.withSingleRetry(async () =>
+      xnet.exchangeRpsTicketForUserToken(accessToken, MICROSOFT_OAUTH_RPS_PREAMBLE),
+    );
+    const xstsTokenResponse = await this.withSingleRetry(async () =>
+      xnet.exchangeTokenForXSTSToken(userTokenResponse.Token, {
+        sandboxId: XBOX_LIVE_SANDBOX_ID,
+        XSTSRelyingParty: XBOX_LIVE_XSTS_RELYING_PARTY,
+      }),
+    );
 
     const [displayClaim] = xstsTokenResponse.DisplayClaims.xui;
     const userHash = displayClaim?.uhs;
@@ -89,16 +97,18 @@ export class XboxService {
       throw new Error("Xbox XSTS response missing xuid");
     }
 
-    const profileResponse = await XSAPIClient.get<{ profileUsers: ProfileUser[] }>(
-      `https://profile.xboxlive.com/users/xuid(${xuid})/profile/settings?settings=Gamertag,GameDisplayPicRaw`,
-      {
-        options: { contractVersion: 2, userHash, XSTSToken: xstsTokenResponse.Token },
-      },
-    );
-
-    if (profileResponse.statusCode !== 200) {
-      throw new Error(`Xbox profile lookup failed (${profileResponse.statusCode.toString()})`);
-    }
+    const profileResponse = await this.withSingleRetry(async () => {
+      const response = await XSAPIClient.get<{ profileUsers: ProfileUser[] }>(
+        `https://profile.xboxlive.com/users/xuid(${xuid})/profile/settings?settings=Gamertag,GameDisplayPicRaw`,
+        {
+          options: { contractVersion: 2, userHash, XSTSToken: xstsTokenResponse.Token },
+        },
+      );
+      if (response.statusCode !== 200) {
+        throw new Error(`Xbox profile lookup failed (${response.statusCode.toString()})`);
+      }
+      return response;
+    });
 
     const [profileUser] = profileResponse.data.profileUsers;
     if (profileUser == null) {
@@ -106,6 +116,14 @@ export class XboxService {
     }
 
     return profileUserToXboxUserInfo(profileUser);
+  }
+
+  private async withSingleRetry<T>(operation: () => Promise<T>): Promise<T> {
+    try {
+      return await operation();
+    } catch {
+      return await operation();
+    }
   }
 
   async getUserByGamertag(gamertag: string): Promise<XboxUserInfo> {

--- a/api/services/xbox/xbox.ts
+++ b/api/services/xbox/xbox.ts
@@ -8,6 +8,12 @@ const XBOX_LIVE_XSTS_RELYING_PARTY = "http://xboxlive.com";
 const XBOX_LIVE_SANDBOX_ID = "RETAIL";
 const MICROSOFT_OAUTH_RPS_PREAMBLE = "d";
 
+function isRetryableStatus(status: number): boolean {
+  return status >= 500 || status === 408 || status === 429;
+}
+
+class NonRetryableXboxError extends Error {}
+
 export interface XboxServiceOpts {
   env: Env;
   authenticate: typeof authenticate;
@@ -105,7 +111,11 @@ export class XboxService {
         },
       );
       if (response.statusCode !== 200) {
-        throw new Error(`Xbox profile lookup failed (${response.statusCode.toString()})`);
+        const message = `Xbox profile lookup failed (${response.statusCode.toString()})`;
+        if (!isRetryableStatus(response.statusCode)) {
+          throw new NonRetryableXboxError(message);
+        }
+        throw new Error(message);
       }
       return response;
     });
@@ -121,7 +131,10 @@ export class XboxService {
   private async withSingleRetry<T>(operation: () => Promise<T>): Promise<T> {
     try {
       return await operation();
-    } catch {
+    } catch (error) {
+      if (error instanceof NonRetryableXboxError) {
+        throw error;
+      }
       return await operation();
     }
   }

--- a/pages/src/components/login/create.tsx
+++ b/pages/src/components/login/create.tsx
@@ -36,6 +36,9 @@ function readSignInErrorMessage(): string | null {
   if (error === "xbox-required") {
     return "We couldn't verify your Xbox profile. Make sure your Microsoft account has Xbox set up, then try again.";
   }
+  if (error === "auth-failed") {
+    return "Something went wrong completing Microsoft sign-in. This is usually a temporary hiccup — please try signing in again.";
+  }
   return null;
 }
 

--- a/pages/src/components/login/tests/create.test.tsx
+++ b/pages/src/components/login/tests/create.test.tsx
@@ -94,4 +94,25 @@ describe("LoginPage", () => {
       expect(getSessionSpy).toHaveBeenCalledTimes(1);
     });
   });
+
+  it("shows the auth-failed error when sign-in was rejected, then clears it on retry", async () => {
+    const user = userEvent.setup();
+    window.history.pushState({}, "", "/login?error=auth-failed");
+    const getSessionSpy = vi.spyOn(authService, "getSession").mockResolvedValue({ authenticated: false });
+    const LoginPage = createLoginPage({ authService, apiHost: API_HOST });
+
+    render(<LoginPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/temporary hiccup/i)).toBeInTheDocument();
+    });
+    expect(getSessionSpy).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Retry Connection" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Continue With Microsoft" })).toBeInTheDocument();
+      expect(getSessionSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
## Context

Users reported that Microsoft/Xbox sign-in sometimes lands them on a raw JSON error page (`{"error":"Authentication failed"}`) at `api.guilty-spark.app/auth/microsoft/callback`, but a second sign-in attempt typically works fine.

## This change

**Graceful error UX** — `api/routes/auth/microsoft/callback.ts` returned raw JSON on every failure path, including when Microsoft's own OAuth authorize endpoint bounces back with `?error=server_error` before ever issuing a code (matches the reported screenshot). All failure paths now redirect to `/login?error=auth-failed`, reusing the existing login-page `ErrorState` pattern already used for the `xbox-required` case, with messaging that tells the user this is usually transient and to try again.

**Retry resilience** — investigating why a retry "just works" turned up several unguarded, single-shot network calls in the sign-in hot path with no retry logic: the Microsoft OAuth token exchange, and the Xbox user-token / XSTS-token / profile-lookup chain — unlike other Xbox Live lookups elsewhere in the codebase which already retry on failure. Each of these now gets a single retry, so a one-off transient blip against Microsoft or Xbox Live no longer surfaces as a user-visible sign-in failure at all. Validation failures (e.g. no Xbox profile linked) are intentionally left outside the retry since those aren't transient.

Note: the exact `server_error` in the reported screenshot originates from Microsoft's own authorize endpoint before any of our code runs, so it isn't something we can retry server-side — the UX fix is the correct mitigation for that specific case.

## Testing

- Added/updated tests for both the callback route's redirect behavior and the new retry paths in `microsoft-auth.ts` and `xbox.ts`
- Full suite: `npm run done` (format, typecheck, lint, test) all pass — 3171 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)