### PR TITLE
Consolidate heading elements with React Heading component

### DIFF
--- a/pages/src/components/dialog/dialog.tsx
+++ b/pages/src/components/dialog/dialog.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useId, useRef } from "react";
 import classNames from "classnames";
+import { Heading } from "../heading/heading";
 import styles from "./dialog.module.css";
 
 interface DialogProps {
@@ -72,9 +73,9 @@ export function Dialog({
             <path d="M18 6L6 18M6 6l12 12" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
         </button>
-        <h2 id={titleId} className={styles.title}>
+        <Heading tagName="h2" className={styles.title} id={titleId}>
           {title}
-        </h2>
+        </Heading>
         <div className={classNames(styles.body, bodyClassName)}>{children}</div>
         {footer != null && <div className={styles.footer}>{footer}</div>}
       </div>

--- a/pages/src/components/discord-series-stats/discord-series-stats.module.css
+++ b/pages/src/components/discord-series-stats/discord-series-stats.module.css
@@ -1,9 +1,6 @@
 .title {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
   font-size: var(--text-2xl);
   line-height: 1.2;
-  margin: 0;
 }
 
 .subtitle {

--- a/pages/src/components/discord-series-stats/discord-series-stats.module.css
+++ b/pages/src/components/discord-series-stats/discord-series-stats.module.css
@@ -1,8 +1,3 @@
-.title {
-  font-size: var(--text-2xl);
-  line-height: 1.2;
-}
-
 .subtitle {
   color: var(--halo-gray);
   font-family: var(--font-body);

--- a/pages/src/components/discord-series-stats/discord-series-stats.tsx
+++ b/pages/src/components/discord-series-stats/discord-series-stats.tsx
@@ -9,7 +9,9 @@ export function DiscordSeriesStatsView({ title, subtitle, ...stats }: DiscordSer
   return (
     <>
       <Container>
-        <Heading tagName="h1">{title}</Heading>
+        <Heading tagName="h1" className={styles.title}>
+          {title}
+        </Heading>
         <p className={styles.subtitle}>{subtitle}</p>
       </Container>
       <div className={styles.content}>

--- a/pages/src/components/discord-series-stats/discord-series-stats.tsx
+++ b/pages/src/components/discord-series-stats/discord-series-stats.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { Heading } from "../heading/heading";
 import { Container } from "../container/container";
 import { SeriesStatsView as SharedSeriesStatsView } from "../series-stats/series-stats";
 import type { SeriesStatsViewModel as DiscordSeriesStatsViewModel } from "../series-stats/types";
@@ -8,7 +9,7 @@ export function DiscordSeriesStatsView({ title, subtitle, ...stats }: DiscordSer
   return (
     <>
       <Container>
-        <h1 className={styles.title}>{title}</h1>
+        <Heading tagName="h1">{title}</Heading>
         <p className={styles.subtitle}>{subtitle}</p>
       </Container>
       <div className={styles.content}>

--- a/pages/src/components/discord-series-stats/discord-series-stats.tsx
+++ b/pages/src/components/discord-series-stats/discord-series-stats.tsx
@@ -9,7 +9,7 @@ export function DiscordSeriesStatsView({ title, subtitle, ...stats }: DiscordSer
   return (
     <>
       <Container>
-        <Heading tagName="h1" className={styles.title}>
+        <Heading tagName="h1" styleAs="h3">
           {title}
         </Heading>
         <p className={styles.subtitle}>{subtitle}</p>

--- a/pages/src/components/error-state/error-state.module.css
+++ b/pages/src/components/error-state/error-state.module.css
@@ -43,16 +43,6 @@
   text-align: center;
 }
 
-.errorTitle {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
-  font-size: var(--text-2xl);
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  margin: 0;
-  text-transform: uppercase;
-}
-
 .errorMessage {
   color: var(--halo-gray);
   font-family: var(--font-body);

--- a/pages/src/components/error-state/error-state.tsx
+++ b/pages/src/components/error-state/error-state.tsx
@@ -19,7 +19,9 @@ export function ErrorState({ message, onRetry }: ErrorStateProps): React.ReactEl
         <div className={styles.iconGlow}></div>
       </div>
       <div className={styles.content}>
-        <Heading tagName="h3">Connection Failed</Heading>
+        <Heading tagName="h3" variant="display">
+          Connection Failed
+        </Heading>
         <p className={styles.errorMessage}>{message ?? "Unable to establish connection to the server."}</p>
         {onRetry && (
           <button className={styles.retryButton} onClick={onRetry} type="button">

--- a/pages/src/components/error-state/error-state.tsx
+++ b/pages/src/components/error-state/error-state.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Heading } from "../heading/heading";
 import styles from "./error-state.module.css";
 
 interface ErrorStateProps {
@@ -18,7 +19,7 @@ export function ErrorState({ message, onRetry }: ErrorStateProps): React.ReactEl
         <div className={styles.iconGlow}></div>
       </div>
       <div className={styles.content}>
-        <h3 className={styles.errorTitle}>Connection Failed</h3>
+        <Heading tagName="h3">Connection Failed</Heading>
         <p className={styles.errorMessage}>{message ?? "Unable to establish connection to the server."}</p>
         {onRetry && (
           <button className={styles.retryButton} onClick={onRetry} type="button">

--- a/pages/src/components/heading/heading.astro
+++ b/pages/src/components/heading/heading.astro
@@ -2,16 +2,24 @@
 import styles from "./heading.module.css";
 
 type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+type HeadingVariant = "plain" | "display";
+type HeadingSpacing = 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12 | 16 | 20 | 24;
 
 interface Props {
   tagName: HeadingTag;
+  variant?: HeadingVariant;
+  spacing?: HeadingSpacing;
   class?: string;
 }
 
-const { tagName, class: className } = Astro.props;
+const { tagName, variant = "plain", spacing, class: className } = Astro.props;
 const Tag = tagName;
+const spacingStyle = spacing === undefined ? undefined : `--heading-spacing: var(--space-${spacing});`;
 ---
 
-<Tag class:list={[styles.heading, styles[tagName], className]}>
+<Tag
+  class:list={[styles.heading, styles[tagName], styles[variant], spacing !== undefined && styles.spaced, className]}
+  style={spacingStyle}
+>
   <slot />
 </Tag>

--- a/pages/src/components/heading/heading.astro
+++ b/pages/src/components/heading/heading.astro
@@ -7,18 +7,25 @@ type HeadingSpacing = 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12 | 16 | 20 | 24;
 
 interface Props {
   tagName: HeadingTag;
+  styleAs?: HeadingTag;
   variant?: HeadingVariant;
   spacing?: HeadingSpacing;
   class?: string;
 }
 
-const { tagName, variant = "plain", spacing, class: className } = Astro.props;
+const { tagName, styleAs, variant = "plain", spacing, class: className } = Astro.props;
 const Tag = tagName;
 const spacingStyle = spacing === undefined ? undefined : `--heading-spacing: var(--space-${spacing});`;
 ---
 
 <Tag
-  class:list={[styles.heading, styles[tagName], styles[variant], spacing !== undefined && styles.spaced, className]}
+  class:list={[
+    styles.heading,
+    styles[styleAs ?? tagName],
+    styles[variant],
+    spacing !== undefined && styles.spaced,
+    className,
+  ]}
   style={spacingStyle}
 >
   <slot />

--- a/pages/src/components/heading/heading.module.css
+++ b/pages/src/components/heading/heading.module.css
@@ -1,38 +1,47 @@
 .heading {
   color: var(--halo-white);
   font-family: var(--font-heading);
+  margin: 0;
+}
+
+/* Base styling for semantic levels */
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
   letter-spacing: 0.06em;
   line-height: 1.15;
-  margin: 0;
   text-transform: uppercase;
 }
 
 .h1 {
-  font-size: clamp(2rem, 5.5vw, 3rem);
+  font-size: var(--text-4xl);
   font-weight: 800;
 }
 
 .h2 {
-  font-size: clamp(1.55rem, 4vw, 2.1rem);
+  font-size: var(--text-3xl);
   font-weight: 700;
 }
 
 .h3 {
-  font-size: clamp(1.2rem, 3.2vw, 1.55rem);
+  font-size: var(--text-2xl);
   font-weight: 700;
 }
 
 .h4 {
-  font-size: clamp(1.05rem, 2.5vw, 1.3rem);
+  font-size: var(--text-xl);
   font-weight: 700;
 }
 
 .h5 {
-  font-size: var(--text-base);
+  font-size: var(--text-lg);
   font-weight: 700;
 }
 
 .h6 {
-  font-size: var(--text-sm);
+  font-size: var(--text-base);
   font-weight: 700;
 }

--- a/pages/src/components/heading/heading.module.css
+++ b/pages/src/components/heading/heading.module.css
@@ -1,47 +1,46 @@
 .heading {
   color: var(--halo-white);
   font-family: var(--font-heading);
+  font-weight: 700;
   margin: 0;
 }
 
-/* Base styling for semantic levels */
-.h1,
-.h2,
-.h3,
-.h4,
-.h5,
+/* Base font-size ladder by semantic level, independent of visual variant */
+.h1 {
+  font-size: var(--text-4xl);
+}
+
+.h2 {
+  font-size: var(--text-3xl);
+}
+
+.h3 {
+  font-size: var(--text-2xl);
+}
+
+.h4 {
+  font-size: var(--text-xl);
+}
+
+.h5 {
+  font-size: var(--text-lg);
+}
+
 .h6 {
+  font-size: var(--text-base);
+}
+
+/* display: loud, uppercase treatment for page/hero-level titles. plain (default) has no extra rules. */
+.display {
   letter-spacing: 0.06em;
   line-height: 1.15;
   text-transform: uppercase;
 }
 
-.h1 {
-  font-size: var(--text-4xl);
+.display.h1 {
   font-weight: 800;
 }
 
-.h2 {
-  font-size: var(--text-3xl);
-  font-weight: 700;
-}
-
-.h3 {
-  font-size: var(--text-2xl);
-  font-weight: 700;
-}
-
-.h4 {
-  font-size: var(--text-xl);
-  font-weight: 700;
-}
-
-.h5 {
-  font-size: var(--text-lg);
-  font-weight: 700;
-}
-
-.h6 {
-  font-size: var(--text-base);
-  font-weight: 700;
+.spaced {
+  margin-bottom: var(--heading-spacing);
 }

--- a/pages/src/components/heading/heading.tsx
+++ b/pages/src/components/heading/heading.tsx
@@ -3,17 +3,43 @@ import classNames from "classnames";
 import styles from "./heading.module.css";
 
 type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+type HeadingVariant = "plain" | "display";
+type HeadingSpacing = 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12 | 16 | 20 | 24;
 
 interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
   readonly tagName: HeadingTag;
+  readonly variant?: HeadingVariant;
+  readonly spacing?: HeadingSpacing;
   readonly children: React.ReactNode;
 }
 
-export function Heading({ tagName, children, className, ...props }: HeadingProps): React.ReactElement {
+export function Heading({
+  tagName,
+  variant = "plain",
+  spacing,
+  children,
+  className,
+  style,
+  ...props
+}: HeadingProps): React.ReactElement {
   const Tag = tagName;
+  const spacingStyle =
+    spacing === undefined
+      ? style
+      : ({ ...style, "--heading-spacing": `var(--space-${spacing.toString()})` } as React.CSSProperties);
 
   return (
-    <Tag className={classNames(styles.heading, styles[tagName], className)} {...props}>
+    <Tag
+      className={classNames(
+        styles.heading,
+        styles[tagName],
+        styles[variant],
+        spacing !== undefined && styles.spaced,
+        className,
+      )}
+      style={spacingStyle}
+      {...props}
+    >
       {children}
     </Tag>
   );

--- a/pages/src/components/heading/heading.tsx
+++ b/pages/src/components/heading/heading.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import classNames from "classnames";
+import styles from "./heading.module.css";
+
+type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  readonly tagName: HeadingTag;
+  readonly children: React.ReactNode;
+}
+
+export function Heading({ tagName, children, className, ...props }: HeadingProps): React.ReactElement {
+  const Tag = tagName;
+  return (
+    <Tag className={classNames(styles.heading, styles[tagName], className)} {...props}>
+      {children}
+    </Tag>
+  );
+}

--- a/pages/src/components/heading/heading.tsx
+++ b/pages/src/components/heading/heading.tsx
@@ -11,6 +11,7 @@ interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
 
 export function Heading({ tagName, children, className, ...props }: HeadingProps): React.ReactElement {
   const Tag = tagName;
+
   return (
     <Tag className={classNames(styles.heading, styles[tagName], className)} {...props}>
       {children}

--- a/pages/src/components/heading/heading.tsx
+++ b/pages/src/components/heading/heading.tsx
@@ -5,6 +5,7 @@ import styles from "./heading.module.css";
 type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 type HeadingVariant = "plain" | "display";
 type HeadingSpacing = 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12 | 16 | 20 | 24;
+type HeadingCSSProperties = React.CSSProperties & { "--heading-spacing"?: string };
 
 interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
   readonly tagName: HeadingTag;
@@ -25,10 +26,8 @@ export function Heading({
   ...props
 }: HeadingProps): React.ReactElement {
   const Tag = tagName;
-  const spacingStyle =
-    spacing === undefined
-      ? style
-      : ({ ...style, "--heading-spacing": `var(--space-${spacing.toString()})` } as React.CSSProperties);
+  const spacingStyle: HeadingCSSProperties | undefined =
+    spacing === undefined ? style : { ...style, "--heading-spacing": `var(--space-${spacing.toString()})` };
 
   return (
     <Tag

--- a/pages/src/components/heading/heading.tsx
+++ b/pages/src/components/heading/heading.tsx
@@ -8,6 +8,7 @@ type HeadingSpacing = 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12 | 16 | 20 | 24;
 
 interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
   readonly tagName: HeadingTag;
+  readonly styleAs?: HeadingTag;
   readonly variant?: HeadingVariant;
   readonly spacing?: HeadingSpacing;
   readonly children: React.ReactNode;
@@ -15,6 +16,7 @@ interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
 
 export function Heading({
   tagName,
+  styleAs,
   variant = "plain",
   spacing,
   children,
@@ -32,7 +34,7 @@ export function Heading({
     <Tag
       className={classNames(
         styles.heading,
-        styles[tagName],
+        styles[styleAs ?? tagName],
         styles[variant],
         spacing !== undefined && styles.spaced,
         className,

--- a/pages/src/components/heading/tests/heading.test.tsx
+++ b/pages/src/components/heading/tests/heading.test.tsx
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { Heading } from "../heading";
+import styles from "../heading.module.css";
 
 describe("Heading", () => {
   afterEach(() => {
@@ -20,7 +21,7 @@ describe("Heading", () => {
     render(<Heading tagName="h2">Plain title</Heading>);
 
     const heading = screen.getByRole("heading", { name: "Plain title" });
-    expect(heading.className).not.toContain("display");
+    expect(heading.className.split(" ")).not.toContain(styles.display);
   });
 
   it("applies the display variant when requested", () => {
@@ -31,7 +32,7 @@ describe("Heading", () => {
     );
 
     const heading = screen.getByRole("heading", { name: "Display title" });
-    expect(heading.className).toContain("display");
+    expect(heading.className.split(" ")).toContain(styles.display);
   });
 
   it("sets a heading-spacing CSS variable from the space scale when spacing is provided", () => {
@@ -60,8 +61,9 @@ describe("Heading", () => {
     );
 
     const heading = screen.getByRole("heading", { level: 3, name: "Styled title" });
-    expect(heading.className).toContain("_h5_");
-    expect(heading.className).not.toContain("_h3_");
+    const classes = heading.className.split(" ");
+    expect(classes).toContain(styles.h5);
+    expect(classes).not.toContain(styles.h3);
   });
 
   it("merges a consumer-provided className alongside the base heading classes", () => {

--- a/pages/src/components/heading/tests/heading.test.tsx
+++ b/pages/src/components/heading/tests/heading.test.tsx
@@ -1,0 +1,65 @@
+import "@testing-library/jest-dom/vitest";
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Heading } from "../heading";
+
+describe("Heading", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the given semantic tag with the provided text", () => {
+    render(<Heading tagName="h3">Section title</Heading>);
+
+    const heading = screen.getByRole("heading", { level: 3, name: "Section title" });
+    expect(heading.tagName).toBe("H3");
+  });
+
+  it("applies the plain variant by default", () => {
+    render(<Heading tagName="h2">Plain title</Heading>);
+
+    const heading = screen.getByRole("heading", { name: "Plain title" });
+    expect(heading.className).not.toContain("display");
+  });
+
+  it("applies the display variant when requested", () => {
+    render(
+      <Heading tagName="h1" variant="display">
+        Display title
+      </Heading>,
+    );
+
+    const heading = screen.getByRole("heading", { name: "Display title" });
+    expect(heading.className).toContain("display");
+  });
+
+  it("sets a heading-spacing CSS variable from the space scale when spacing is provided", () => {
+    render(
+      <Heading tagName="h2" spacing={4}>
+        Spaced title
+      </Heading>,
+    );
+
+    const heading = screen.getByRole("heading", { name: "Spaced title" });
+    expect(heading.style.getPropertyValue("--heading-spacing")).toBe("var(--space-4)");
+  });
+
+  it("omits the heading-spacing CSS variable when spacing is not provided", () => {
+    render(<Heading tagName="h2">Unspaced title</Heading>);
+
+    const heading = screen.getByRole("heading", { name: "Unspaced title" });
+    expect(heading.style.getPropertyValue("--heading-spacing")).toBe("");
+  });
+
+  it("merges a consumer-provided className alongside the base heading classes", () => {
+    render(
+      <Heading tagName="h4" className="custom-class">
+        Custom title
+      </Heading>,
+    );
+
+    const heading = screen.getByRole("heading", { name: "Custom title" });
+    expect(heading.className).toContain("custom-class");
+  });
+});

--- a/pages/src/components/heading/tests/heading.test.tsx
+++ b/pages/src/components/heading/tests/heading.test.tsx
@@ -52,6 +52,18 @@ describe("Heading", () => {
     expect(heading.style.getPropertyValue("--heading-spacing")).toBe("");
   });
 
+  it("renders the given semantic tag but sizes it as a different tag when styleAs is provided", () => {
+    render(
+      <Heading tagName="h3" styleAs="h5">
+        Styled title
+      </Heading>,
+    );
+
+    const heading = screen.getByRole("heading", { level: 3, name: "Styled title" });
+    expect(heading.className).toContain("_h5_");
+    expect(heading.className).not.toContain("_h3_");
+  });
+
   it("merges a consumer-provided className alongside the base heading classes", () => {
     render(
       <Heading tagName="h4" className="custom-class">

--- a/pages/src/components/individual-tracker-manager/individual-tracker.module.css
+++ b/pages/src/components/individual-tracker-manager/individual-tracker.module.css
@@ -4,10 +4,6 @@
   padding: var(--space-6) var(--gutter-mobile);
 }
 
-.heading {
-  font-size: var(--text-3xl);
-}
-
 .authWall {
   align-items: center;
   display: flex;

--- a/pages/src/components/individual-tracker-manager/individual-tracker.module.css
+++ b/pages/src/components/individual-tracker-manager/individual-tracker.module.css
@@ -5,12 +5,7 @@
 }
 
 .heading {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
   font-size: var(--text-3xl);
-  letter-spacing: 0.04em;
-  margin: 0 0 var(--space-6);
-  text-transform: uppercase;
 }
 
 .authWall {

--- a/pages/src/components/individual-tracker-manager/individual-tracker.tsx
+++ b/pages/src/components/individual-tracker-manager/individual-tracker.tsx
@@ -52,7 +52,9 @@ export function IndividualTrackerShell({
 
   return (
     <div className={styles.container}>
-      <Heading tagName="h1">Individual Tracker</Heading>
+      <Heading tagName="h1" variant="display" spacing={6} className={styles.heading}>
+        Individual Tracker
+      </Heading>
 
       {authState === "loading" && <LoadingState text="Checking session..." />}
 

--- a/pages/src/components/individual-tracker-manager/individual-tracker.tsx
+++ b/pages/src/components/individual-tracker-manager/individual-tracker.tsx
@@ -52,7 +52,7 @@ export function IndividualTrackerShell({
 
   return (
     <div className={styles.container}>
-      <Heading tagName="h1" variant="display" spacing={6} className={styles.heading}>
+      <Heading tagName="h1" styleAs="h2" variant="display" spacing={6}>
         Individual Tracker
       </Heading>
 

--- a/pages/src/components/individual-tracker-manager/individual-tracker.tsx
+++ b/pages/src/components/individual-tracker-manager/individual-tracker.tsx
@@ -52,7 +52,7 @@ export function IndividualTrackerShell({
 
   return (
     <div className={styles.container}>
-      <Heading tagName="h1" styleAs="h2" variant="display" spacing={6}>
+      <Heading tagName="h1" spacing={6}>
         Individual Tracker
       </Heading>
 

--- a/pages/src/components/individual-tracker-manager/individual-tracker.tsx
+++ b/pages/src/components/individual-tracker-manager/individual-tracker.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement, ReactNode } from "react";
 import { useMemo } from "react";
 import { Button } from "../button/button";
+import { Heading } from "../heading/heading";
 import { LoadingState } from "../loading-state/loading-state";
 import { TabbedSection } from "../tabbed-section/tabbed-section";
 import type { TabbedSectionTab } from "../tabbed-section/types";
@@ -51,7 +52,7 @@ export function IndividualTrackerShell({
 
   return (
     <div className={styles.container}>
-      <h1 className={styles.heading}>Individual Tracker</h1>
+      <Heading tagName="h1">Individual Tracker</Heading>
 
       {authState === "loading" && <LoadingState text="Checking session..." />}
 

--- a/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-onboarding.tsx
+++ b/pages/src/components/individual-tracker-manager/live-trackers/live-trackers-onboarding.tsx
@@ -1,17 +1,22 @@
 import React from "react";
+import { Heading } from "../../heading/heading";
 import styles from "./live-trackers-onboarding.module.css";
 
 export function LiveTrackersOnboarding(): React.ReactElement {
   return (
     <div className={styles.onboarding}>
-      <h3 className={styles.title}>Getting Started with Individual Tracking</h3>
+      <Heading tagName="h3" className={styles.title}>
+        Getting Started with Individual Tracking
+      </Heading>
       <ol className={styles.steps}>
         <li className={styles.step}>
           <div className={styles.stepNumber} aria-hidden="true">
             1
           </div>
           <div className={styles.stepContent}>
-            <h4 className={styles.stepTitle}>Start a Tracker</h4>
+            <Heading tagName="h4" className={styles.stepTitle}>
+              Start a Tracker
+            </Heading>
             <p className={styles.stepDescription}>
               Start a tracker for your gamertag or add one for another player to monitor their live matches.
             </p>
@@ -23,7 +28,9 @@ export function LiveTrackersOnboarding(): React.ReactElement {
             2
           </div>
           <div className={styles.stepContent}>
-            <h4 className={styles.stepTitle}>Configure Stats & Settings</h4>
+            <Heading tagName="h4" className={styles.stepTitle}>
+              Configure Stats & Settings
+            </Heading>
             <p className={styles.stepDescription}>
               Customize stat highlights and streamer display settings using the tabs above to tailor the overlay to your
               stream.
@@ -36,7 +43,9 @@ export function LiveTrackersOnboarding(): React.ReactElement {
             3
           </div>
           <div className={styles.stepContent}>
-            <h4 className={styles.stepTitle}>Share Viewer URL</h4>
+            <Heading tagName="h4" className={styles.stepTitle}>
+              Share Viewer URL
+            </Heading>
             <p className={styles.stepDescription}>
               Grab the Viewer URL from your tracker and paste it in your stream chat so viewers can follow along in real
               time.
@@ -49,7 +58,9 @@ export function LiveTrackersOnboarding(): React.ReactElement {
             4
           </div>
           <div className={styles.stepContent}>
-            <h4 className={styles.stepTitle}>Add Overlay to Stream</h4>
+            <Heading tagName="h4" className={styles.stepTitle}>
+              Add Overlay to Stream
+            </Heading>
             <p className={styles.stepDescription}>
               Use the Overlay URL with your streaming software (OBS, Streamlabs, etc.) to display live stats on your
               broadcast.

--- a/pages/src/components/individual-tracker-manager/stats-highlights/stats-highlights.module.css
+++ b/pages/src/components/individual-tracker-manager/stats-highlights/stats-highlights.module.css
@@ -4,10 +4,6 @@
   gap: var(--space-4);
 }
 
-.sectionTitle {
-  font-size: var(--text-2xl);
-}
-
 .sectionDescription {
   color: var(--halo-gray);
   font-family: var(--font-body);
@@ -24,10 +20,6 @@
   flex-direction: column;
   gap: var(--space-3);
   padding: var(--space-3);
-}
-
-.cardTitle {
-  font-size: var(--text-lg);
 }
 
 .cardDescription {

--- a/pages/src/components/individual-tracker-manager/stats-highlights/stats-highlights.module.css
+++ b/pages/src/components/individual-tracker-manager/stats-highlights/stats-highlights.module.css
@@ -5,10 +5,7 @@
 }
 
 .sectionTitle {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
   font-size: var(--text-2xl);
-  margin: 0;
 }
 
 .sectionDescription {
@@ -30,10 +27,7 @@
 }
 
 .cardTitle {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
   font-size: var(--text-lg);
-  margin: 0;
 }
 
 .cardDescription {

--- a/pages/src/components/individual-tracker-manager/stats-highlights/stats-highlights.tsx
+++ b/pages/src/components/individual-tracker-manager/stats-highlights/stats-highlights.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { INDIVIDUAL_STATS_HIGHLIGHTS_MAX_SLOT_COUNT } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { Alert } from "../../alert/alert";
 import { Checkbox } from "../../checkbox/checkbox";
+import { Heading } from "../../heading/heading";
 import { Select } from "../../select/select";
 import type { StatsHighlightsSectionViewModel } from "./types";
 import styles from "./stats-highlights.module.css";
@@ -26,7 +27,7 @@ export function StatsHighlightsSectionView({
 }: StatsHighlightsSectionViewProps): React.ReactElement {
   return (
     <div className={styles.panel}>
-      <h2 className={styles.sectionTitle}>Stats Highlights</h2>
+      <Heading tagName="h2">Stats Highlights</Heading>
       <p className={styles.sectionDescription}>
         Control the stats highlights row shown in the tracker view. Choose whether it is visible, how many highlight
         slots are shown, and which metric appears in each slot.
@@ -65,7 +66,7 @@ export function StatsHighlightsSectionView({
 
       {isEnabled ? (
         <div className={styles.card}>
-          <h3 className={styles.cardTitle}>Selected Highlights</h3>
+          <Heading tagName="h3">Selected Highlights</Heading>
           <p className={styles.cardDescription}>
             Each slot keeps its own label in the stats highlights row and updates live from the durable object.
           </p>

--- a/pages/src/components/individual-tracker-manager/stats-highlights/stats-highlights.tsx
+++ b/pages/src/components/individual-tracker-manager/stats-highlights/stats-highlights.tsx
@@ -27,7 +27,9 @@ export function StatsHighlightsSectionView({
 }: StatsHighlightsSectionViewProps): React.ReactElement {
   return (
     <div className={styles.panel}>
-      <Heading tagName="h2">Stats Highlights</Heading>
+      <Heading tagName="h2" className={styles.sectionTitle}>
+        Stats Highlights
+      </Heading>
       <p className={styles.sectionDescription}>
         Control the stats highlights row shown in the tracker view. Choose whether it is visible, how many highlight
         slots are shown, and which metric appears in each slot.
@@ -66,7 +68,9 @@ export function StatsHighlightsSectionView({
 
       {isEnabled ? (
         <div className={styles.card}>
-          <Heading tagName="h3">Selected Highlights</Heading>
+          <Heading tagName="h3" className={styles.cardTitle}>
+            Selected Highlights
+          </Heading>
           <p className={styles.cardDescription}>
             Each slot keeps its own label in the stats highlights row and updates live from the durable object.
           </p>

--- a/pages/src/components/individual-tracker-manager/stats-highlights/stats-highlights.tsx
+++ b/pages/src/components/individual-tracker-manager/stats-highlights/stats-highlights.tsx
@@ -27,7 +27,7 @@ export function StatsHighlightsSectionView({
 }: StatsHighlightsSectionViewProps): React.ReactElement {
   return (
     <div className={styles.panel}>
-      <Heading tagName="h2" className={styles.sectionTitle}>
+      <Heading tagName="h2" styleAs="h3">
         Stats Highlights
       </Heading>
       <p className={styles.sectionDescription}>
@@ -68,7 +68,7 @@ export function StatsHighlightsSectionView({
 
       {isEnabled ? (
         <div className={styles.card}>
-          <Heading tagName="h3" className={styles.cardTitle}>
+          <Heading tagName="h3" styleAs="h5">
             Selected Highlights
           </Heading>
           <p className={styles.cardDescription}>

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
@@ -151,10 +151,6 @@
   padding-left: var(--space-3);
 }
 
-.nestedSubsectionTitle {
-  font-size: var(--text-sm);
-}
-
 .sectionDivider {
   border: 0;
   border-top: 1px solid color-mix(in srgb, var(--halo-teal-primary) 22%, transparent);

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
@@ -5,10 +5,7 @@
 }
 
 .sectionTitle {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
   font-size: var(--text-2xl);
-  margin: 0;
 }
 
 .sectionDescription {
@@ -35,10 +32,7 @@
 }
 
 .cardTitle {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
   font-size: var(--text-lg);
-  margin: 0;
 }
 
 .cardDescription {
@@ -166,17 +160,11 @@
 }
 
 .subsectionTitle {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
   font-size: var(--text-base);
-  margin: 0;
 }
 
 .nestedSubsectionTitle {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
   font-size: var(--text-sm);
-  margin: 0;
 }
 
 .sectionDivider {

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
@@ -4,10 +4,6 @@
   gap: var(--space-4);
 }
 
-.sectionTitle {
-  font-size: var(--text-2xl);
-}
-
 .sectionDescription {
   color: var(--halo-gray);
   font-family: var(--font-body);
@@ -29,10 +25,6 @@
   flex-direction: column;
   gap: var(--space-3);
   padding: var(--space-3);
-}
-
-.cardTitle {
-  font-size: var(--text-lg);
 }
 
 .cardDescription {
@@ -157,10 +149,6 @@
   gap: var(--space-1);
   margin-left: var(--space-4);
   padding-left: var(--space-3);
-}
-
-.subsectionTitle {
-  font-size: var(--text-base);
 }
 
 .nestedSubsectionTitle {

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.module.css
@@ -156,6 +156,15 @@
   gap: var(--space-1);
 }
 
+.nestedSettings {
+  border-left: 2px solid color-mix(in srgb, var(--halo-teal-primary) 30%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-left: var(--space-4);
+  padding-left: var(--space-3);
+}
+
 .subsectionTitle {
   color: var(--halo-white);
   font-family: var(--font-heading);

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -203,9 +203,7 @@ export function StreamerSettingsSectionView({
 
   return (
     <div className={styles.panel}>
-      <Heading tagName="h2" styleAs="h3">
-        Streamer Settings
-      </Heading>
+      <Heading tagName="h2">Streamer Settings</Heading>
       <p className={styles.sectionDescription}>
         Configure the stable public URLs for your active tracker viewer and OBS overlay. These routes follow whichever
         tracker is currently marked live.
@@ -218,9 +216,7 @@ export function StreamerSettingsSectionView({
       ) : (
         <div className={styles.urlList}>
           <div className={styles.card}>
-            <Heading tagName="h3" styleAs="h5">
-              Viewer URL
-            </Heading>
+            <Heading tagName="h3">Viewer URL</Heading>
             <p className={styles.cardDescription}>Share this with viewers to follow the active tracker.</p>
             <p className={styles.urlText}>{urls?.viewUrl}</p>
             <div className={styles.buttonRow}>
@@ -246,9 +242,7 @@ export function StreamerSettingsSectionView({
 
             <hr className={styles.sectionDivider} />
 
-            <Heading tagName="h3" styleAs="h5">
-              Overlay URL
-            </Heading>
+            <Heading tagName="h3">Overlay URL</Heading>
             <p className={styles.cardDescription}>Use this in OBS as a Browser Source.</p>
             <p className={styles.urlText}>{urls?.overlayUrl}</p>
             <div className={styles.buttonRow}>
@@ -285,14 +279,10 @@ export function StreamerSettingsSectionView({
       )}
 
       <div className={styles.card}>
-        <Heading tagName="h3" styleAs="h5">
-          Global Defaults
-        </Heading>
+        <Heading tagName="h3">Global Defaults</Heading>
         <p className={styles.cardDescription}>These controls apply to both In Series and Matchmaking overlay states.</p>
         <div className={styles.subsection}>
-          <Heading tagName="h4" styleAs="h6">
-            Default Color Mode
-          </Heading>
+          <Heading tagName="h4">Default Color Mode</Heading>
           <p className={styles.cardDescription}>Configure the default color mode for the overlay.</p>
         </div>
         <div className={styles.modeToggle} role="group" aria-label="Default color mode">
@@ -327,9 +317,7 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4" styleAs="h6">
-            Player Colors
-          </Heading>
+          <Heading tagName="h4">Player Colors</Heading>
           <p className={styles.cardDescription}>Used whenever color mode is set to player.</p>
         </div>
         <div className={styles.pickerGrid}>
@@ -358,9 +346,7 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4" styleAs="h6">
-            Observer Colors
-          </Heading>
+          <Heading tagName="h4">Observer Colors</Heading>
           <p className={styles.cardDescription}>Global observer colors for fixed-team mode.</p>
         </div>
         <div className={styles.pickerGrid}>
@@ -389,9 +375,7 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4" styleAs="h6">
-            Information Ticker
-          </Heading>
+          <Heading tagName="h4">Bottom section</Heading>
         </div>
         <TickerSettingsSection
           settings={tickerSettings}
@@ -403,9 +387,7 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4" styleAs="h6">
-            Text Sizes
-          </Heading>
+          <Heading tagName="h4">Text Sizes</Heading>
           <p className={styles.cardDescription}>Adjust the size of text for different sections.</p>
         </div>
         <div className={styles.fontSizeContainer}>
@@ -448,16 +430,12 @@ export function StreamerSettingsSectionView({
       </div>
 
       <div className={styles.card}>
-        <Heading tagName="h3" styleAs="h5">
-          In Series UI
-        </Heading>
+        <Heading tagName="h3">In Series UI</Heading>
         <p className={styles.cardDescription}>
           Controls in this section apply when the overlay is currently in a series.
         </p>
         <div className={styles.subsection}>
-          <Heading tagName="h4" styleAs="h6">
-            Top Section
-          </Heading>
+          <Heading tagName="h4">Top Section</Heading>
           <p className={styles.cardDescription}>
             Control title, teams, and score display for in-series top bar rendering.
           </p>
@@ -475,18 +453,14 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4" styleAs="h6">
-            Bottom Section
-          </Heading>
+          <Heading tagName="h4">Bottom Section</Heading>
           <p className={styles.cardDescription}>
             Configure in-series ticker behavior before and during active series match flow.
           </p>
         </div>
 
         <div className={styles.subsection}>
-          <Heading tagName="h5" className={styles.nestedSubsectionTitle}>
-            Tabs
-          </Heading>
+          <Heading tagName="h5">Tabs</Heading>
           <p className={styles.cardDescription}>Configure which tabs are visible while in a series.</p>
         </div>
         <Checkbox
@@ -512,9 +486,7 @@ export function StreamerSettingsSectionView({
         />
 
         <div className={styles.subsection}>
-          <Heading tagName="h5" className={styles.nestedSubsectionTitle}>
-            Information ticker
-          </Heading>
+          <Heading tagName="h5">Information ticker</Heading>
           <p className={styles.cardDescription}>Configure ticker visibility and row rotation while in a series.</p>
         </div>
         <Checkbox
@@ -558,16 +530,12 @@ export function StreamerSettingsSectionView({
       </div>
 
       <div className={styles.card}>
-        <Heading tagName="h3" styleAs="h5">
-          Matchmaking UI
-        </Heading>
+        <Heading tagName="h3">Matchmaking UI</Heading>
         <p className={styles.cardDescription}>
           Controls in this section apply when no active series context is present.
         </p>
         <div className={styles.subsection}>
-          <Heading tagName="h4" styleAs="h6">
-            Top Section
-          </Heading>
+          <Heading tagName="h4">Top Section</Heading>
           <p className={styles.cardDescription}>
             Matchmaking top-section stats depend on Stats Highlights and this overlay visibility toggle.
           </p>
@@ -584,16 +552,12 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4" styleAs="h6">
-            Bottom Section
-          </Heading>
+          <Heading tagName="h4">Bottom Section</Heading>
           <p className={styles.cardDescription}>Configure matchmaking-only tabs and ticker behavior.</p>
         </div>
 
         <div className={styles.subsection}>
-          <Heading tagName="h5" className={styles.nestedSubsectionTitle}>
-            Tabs
-          </Heading>
+          <Heading tagName="h5">Tabs</Heading>
           <p className={styles.cardDescription}>Configure which tabs are visible during matchmaking.</p>
         </div>
         <Checkbox
@@ -619,9 +583,7 @@ export function StreamerSettingsSectionView({
         />
 
         <div className={styles.subsection}>
-          <Heading tagName="h5" className={styles.nestedSubsectionTitle}>
-            Information ticker
-          </Heading>
+          <Heading tagName="h5">Information ticker</Heading>
           <p className={styles.cardDescription}>Configure ticker visibility and row rotation during matchmaking.</p>
         </div>
         <Checkbox

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -203,7 +203,9 @@ export function StreamerSettingsSectionView({
 
   return (
     <div className={styles.panel}>
-      <Heading tagName="h2">Streamer Settings</Heading>
+      <Heading tagName="h2" className={styles.sectionTitle}>
+        Streamer Settings
+      </Heading>
       <p className={styles.sectionDescription}>
         Configure the stable public URLs for your active tracker viewer and OBS overlay. These routes follow whichever
         tracker is currently marked live.
@@ -216,7 +218,9 @@ export function StreamerSettingsSectionView({
       ) : (
         <div className={styles.urlList}>
           <div className={styles.card}>
-            <Heading tagName="h3">Viewer URL</Heading>
+            <Heading tagName="h3" className={styles.cardTitle}>
+              Viewer URL
+            </Heading>
             <p className={styles.cardDescription}>Share this with viewers to follow the active tracker.</p>
             <p className={styles.urlText}>{urls?.viewUrl}</p>
             <div className={styles.buttonRow}>
@@ -242,7 +246,9 @@ export function StreamerSettingsSectionView({
 
             <hr className={styles.sectionDivider} />
 
-            <Heading tagName="h3">Overlay URL</Heading>
+            <Heading tagName="h3" className={styles.cardTitle}>
+              Overlay URL
+            </Heading>
             <p className={styles.cardDescription}>Use this in OBS as a Browser Source.</p>
             <p className={styles.urlText}>{urls?.overlayUrl}</p>
             <div className={styles.buttonRow}>
@@ -279,10 +285,14 @@ export function StreamerSettingsSectionView({
       )}
 
       <div className={styles.card}>
-        <Heading tagName="h3">Global Defaults</Heading>
+        <Heading tagName="h3" className={styles.cardTitle}>
+          Global Defaults
+        </Heading>
         <p className={styles.cardDescription}>These controls apply to both In Series and Matchmaking overlay states.</p>
         <div className={styles.subsection}>
-          <Heading tagName="h4">Default Color Mode</Heading>
+          <Heading tagName="h4" className={styles.subsectionTitle}>
+            Default Color Mode
+          </Heading>
           <p className={styles.cardDescription}>Configure the default color mode for the overlay.</p>
         </div>
         <div className={styles.modeToggle} role="group" aria-label="Default color mode">
@@ -317,7 +327,9 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4">Player Colors</Heading>
+          <Heading tagName="h4" className={styles.subsectionTitle}>
+            Player Colors
+          </Heading>
           <p className={styles.cardDescription}>Used whenever color mode is set to player.</p>
         </div>
         <div className={styles.pickerGrid}>
@@ -346,7 +358,9 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4">Observer Colors</Heading>
+          <Heading tagName="h4" className={styles.subsectionTitle}>
+            Observer Colors
+          </Heading>
           <p className={styles.cardDescription}>Global observer colors for fixed-team mode.</p>
         </div>
         <div className={styles.pickerGrid}>
@@ -375,7 +389,9 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4">Bottom section</Heading>
+          <Heading tagName="h4" className={styles.subsectionTitle}>
+            Information Ticker
+          </Heading>
         </div>
         <TickerSettingsSection
           settings={tickerSettings}
@@ -387,7 +403,9 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4">Text Sizes</Heading>
+          <Heading tagName="h4" className={styles.subsectionTitle}>
+            Text Sizes
+          </Heading>
           <p className={styles.cardDescription}>Adjust the size of text for different sections.</p>
         </div>
         <div className={styles.fontSizeContainer}>
@@ -430,12 +448,16 @@ export function StreamerSettingsSectionView({
       </div>
 
       <div className={styles.card}>
-        <Heading tagName="h3">In Series UI</Heading>
+        <Heading tagName="h3" className={styles.cardTitle}>
+          In Series UI
+        </Heading>
         <p className={styles.cardDescription}>
           Controls in this section apply when the overlay is currently in a series.
         </p>
         <div className={styles.subsection}>
-          <Heading tagName="h4">Top Section</Heading>
+          <Heading tagName="h4" className={styles.subsectionTitle}>
+            Top Section
+          </Heading>
           <p className={styles.cardDescription}>
             Control title, teams, and score display for in-series top bar rendering.
           </p>
@@ -453,14 +475,18 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4">Bottom Section</Heading>
+          <Heading tagName="h4" className={styles.subsectionTitle}>
+            Bottom Section
+          </Heading>
           <p className={styles.cardDescription}>
             Configure in-series ticker behavior before and during active series match flow.
           </p>
         </div>
 
         <div className={styles.subsection}>
-          <Heading tagName="h5">Tabs</Heading>
+          <Heading tagName="h5" className={styles.nestedSubsectionTitle}>
+            Tabs
+          </Heading>
           <p className={styles.cardDescription}>Configure which tabs are visible while in a series.</p>
         </div>
         <Checkbox
@@ -486,7 +512,9 @@ export function StreamerSettingsSectionView({
         />
 
         <div className={styles.subsection}>
-          <Heading tagName="h5">Information ticker</Heading>
+          <Heading tagName="h5" className={styles.nestedSubsectionTitle}>
+            Information ticker
+          </Heading>
           <p className={styles.cardDescription}>Configure ticker visibility and row rotation while in a series.</p>
         </div>
         <Checkbox
@@ -530,12 +558,16 @@ export function StreamerSettingsSectionView({
       </div>
 
       <div className={styles.card}>
-        <Heading tagName="h3">Matchmaking UI</Heading>
+        <Heading tagName="h3" className={styles.cardTitle}>
+          Matchmaking UI
+        </Heading>
         <p className={styles.cardDescription}>
           Controls in this section apply when no active series context is present.
         </p>
         <div className={styles.subsection}>
-          <Heading tagName="h4">Top Section</Heading>
+          <Heading tagName="h4" className={styles.subsectionTitle}>
+            Top Section
+          </Heading>
           <p className={styles.cardDescription}>
             Matchmaking top-section stats depend on Stats Highlights and this overlay visibility toggle.
           </p>
@@ -552,12 +584,16 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4">Bottom Section</Heading>
+          <Heading tagName="h4" className={styles.subsectionTitle}>
+            Bottom Section
+          </Heading>
           <p className={styles.cardDescription}>Configure matchmaking-only tabs and ticker behavior.</p>
         </div>
 
         <div className={styles.subsection}>
-          <Heading tagName="h5">Tabs</Heading>
+          <Heading tagName="h5" className={styles.nestedSubsectionTitle}>
+            Tabs
+          </Heading>
           <p className={styles.cardDescription}>Configure which tabs are visible during matchmaking.</p>
         </div>
         <Checkbox
@@ -583,7 +619,9 @@ export function StreamerSettingsSectionView({
         />
 
         <div className={styles.subsection}>
-          <Heading tagName="h5">Information ticker</Heading>
+          <Heading tagName="h5" className={styles.nestedSubsectionTitle}>
+            Information ticker
+          </Heading>
           <p className={styles.cardDescription}>Configure ticker visibility and row rotation during matchmaking.</p>
         </div>
         <Checkbox

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -4,6 +4,7 @@ import type { StreamerViewColorMode } from "@guilty-spark/shared/individual-trac
 import { Alert } from "../../alert/alert";
 import { Button } from "../../button/button";
 import { Checkbox } from "../../checkbox/checkbox";
+import { Heading } from "../../heading/heading";
 import { TeamColorPicker } from "../../team-colors/team-color-picker";
 import { DisplaySettingsSection } from "../../live-tracker/settings/display-settings-section";
 import { TickerSettingsSection } from "../../live-tracker/settings/ticker-settings-section";
@@ -202,7 +203,7 @@ export function StreamerSettingsSectionView({
 
   return (
     <div className={styles.panel}>
-      <h2 className={styles.sectionTitle}>Streamer Settings</h2>
+      <Heading tagName="h2">Streamer Settings</Heading>
       <p className={styles.sectionDescription}>
         Configure the stable public URLs for your active tracker viewer and OBS overlay. These routes follow whichever
         tracker is currently marked live.
@@ -215,7 +216,7 @@ export function StreamerSettingsSectionView({
       ) : (
         <div className={styles.urlList}>
           <div className={styles.card}>
-            <h3 className={styles.cardTitle}>Viewer URL</h3>
+            <Heading tagName="h3">Viewer URL</Heading>
             <p className={styles.cardDescription}>Share this with viewers to follow the active tracker.</p>
             <p className={styles.urlText}>{urls?.viewUrl}</p>
             <div className={styles.buttonRow}>
@@ -241,7 +242,7 @@ export function StreamerSettingsSectionView({
 
             <hr className={styles.sectionDivider} />
 
-            <h3 className={styles.cardTitle}>Overlay URL</h3>
+            <Heading tagName="h3">Overlay URL</Heading>
             <p className={styles.cardDescription}>Use this in OBS as a Browser Source.</p>
             <p className={styles.urlText}>{urls?.overlayUrl}</p>
             <div className={styles.buttonRow}>
@@ -278,10 +279,10 @@ export function StreamerSettingsSectionView({
       )}
 
       <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Global Defaults</h3>
+        <Heading tagName="h3">Global Defaults</Heading>
         <p className={styles.cardDescription}>These controls apply to both In Series and Matchmaking overlay states.</p>
         <div className={styles.subsection}>
-          <h4 className={styles.subsectionTitle}>Default Color Mode</h4>
+          <Heading tagName="h4">Default Color Mode</Heading>
           <p className={styles.cardDescription}>Configure the default color mode for the overlay.</p>
         </div>
         <div className={styles.modeToggle} role="group" aria-label="Default color mode">
@@ -316,7 +317,7 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <h4 className={styles.subsectionTitle}>Player Colors</h4>
+          <Heading tagName="h4">Player Colors</Heading>
           <p className={styles.cardDescription}>Used whenever color mode is set to player.</p>
         </div>
         <div className={styles.pickerGrid}>
@@ -345,7 +346,7 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <h4 className={styles.subsectionTitle}>Observer Colors</h4>
+          <Heading tagName="h4">Observer Colors</Heading>
           <p className={styles.cardDescription}>Global observer colors for fixed-team mode.</p>
         </div>
         <div className={styles.pickerGrid}>
@@ -374,10 +375,7 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <h4 className={styles.subsectionTitle}>Information Ticker</h4>
-          <p className={styles.cardDescription}>
-            These ticker stat and medal filters apply to both In Series and Matchmaking ticker rows.
-          </p>
+          <Heading tagName="h4">Bottom section</Heading>
         </div>
         <TickerSettingsSection
           settings={tickerSettings}
@@ -389,7 +387,7 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <h4 className={styles.subsectionTitle}>Text Sizes</h4>
+          <Heading tagName="h4">Text Sizes</Heading>
           <p className={styles.cardDescription}>Adjust the size of text for different sections.</p>
         </div>
         <div className={styles.fontSizeContainer}>
@@ -432,12 +430,12 @@ export function StreamerSettingsSectionView({
       </div>
 
       <div className={styles.card}>
-        <h3 className={styles.cardTitle}>In Series UI</h3>
+        <Heading tagName="h3">In Series UI</Heading>
         <p className={styles.cardDescription}>
           Controls in this section apply when the overlay is currently in a series.
         </p>
         <div className={styles.subsection}>
-          <h4 className={styles.subsectionTitle}>Top Section</h4>
+          <Heading tagName="h4">Top Section</Heading>
           <p className={styles.cardDescription}>
             Control title, teams, and score display for in-series top bar rendering.
           </p>
@@ -455,14 +453,14 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <h4 className={styles.subsectionTitle}>Bottom Section</h4>
+          <Heading tagName="h4">Bottom Section</Heading>
           <p className={styles.cardDescription}>
             Configure in-series ticker behavior before and during active series match flow.
           </p>
         </div>
 
         <div className={styles.subsection}>
-          <h5 className={styles.nestedSubsectionTitle}>Tabs</h5>
+          <Heading tagName="h5">Tabs</Heading>
           <p className={styles.cardDescription}>Configure which tabs are visible while in a series.</p>
         </div>
         <Checkbox
@@ -487,20 +485,10 @@ export function StreamerSettingsSectionView({
           description="Show a first tab with the series score. When clicked, opens the overall series stats panel for the active series."
         />
 
-        <hr className={styles.sectionDivider} />
-
         <div className={styles.subsection}>
-          <h5 className={styles.nestedSubsectionTitle}>Information ticker</h5>
+          <Heading tagName="h5">Information ticker</Heading>
           <p className={styles.cardDescription}>Configure ticker visibility and row rotation while in a series.</p>
         </div>
-        <Checkbox
-          checked={tickerSettings.showPreSeriesInfo}
-          onChange={(checked): void => {
-            onTickerSettingsChange({ showPreSeriesInfo: checked });
-          }}
-          label="Display Pre-Series Player Info"
-          description="Show individual player info before the first match starts"
-        />
         <Checkbox
           checked={inSeriesShowTicker}
           onChange={(checked): void => {
@@ -514,28 +502,40 @@ export function StreamerSettingsSectionView({
           }
           description="Toggle ticker visibility for in-series overlay state."
         />
-        <Checkbox
-          checked={inSeriesMyStatsOnly}
-          onChange={(checked): void => {
-            onInSeriesMyStatsOnlyChange(checked);
-          }}
-          label={
-            <>
-              <span className={styles.srOnly}>In Series </span>
-              Show only my stats
-            </>
-          }
-          description="When enabled, the ticker only rotates your player row during an active series."
-        />
+        {inSeriesShowTicker ? (
+          <div className={styles.nestedSettings}>
+            <Checkbox
+              checked={tickerSettings.showPreSeriesInfo}
+              onChange={(checked): void => {
+                onTickerSettingsChange({ showPreSeriesInfo: checked });
+              }}
+              label="Display Pre-Series Player Info"
+              description="Show individual player info before the first match starts"
+            />
+            <Checkbox
+              checked={inSeriesMyStatsOnly}
+              onChange={(checked): void => {
+                onInSeriesMyStatsOnlyChange(checked);
+              }}
+              label={
+                <>
+                  <span className={styles.srOnly}>In Series </span>
+                  Show only my stats
+                </>
+              }
+              description="When enabled, the ticker only rotates your player row during an active series."
+            />
+          </div>
+        ) : null}
       </div>
 
       <div className={styles.card}>
-        <h3 className={styles.cardTitle}>Matchmaking UI</h3>
+        <Heading tagName="h3">Matchmaking UI</Heading>
         <p className={styles.cardDescription}>
           Controls in this section apply when no active series context is present.
         </p>
         <div className={styles.subsection}>
-          <h4 className={styles.subsectionTitle}>Top Section</h4>
+          <Heading tagName="h4">Top Section</Heading>
           <p className={styles.cardDescription}>
             Matchmaking top-section stats depend on Stats Highlights and this overlay visibility toggle.
           </p>
@@ -552,12 +552,12 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <h4 className={styles.subsectionTitle}>Bottom Section</h4>
+          <Heading tagName="h4">Bottom Section</Heading>
           <p className={styles.cardDescription}>Configure matchmaking-only tabs and ticker behavior.</p>
         </div>
 
         <div className={styles.subsection}>
-          <h5 className={styles.nestedSubsectionTitle}>Tabs</h5>
+          <Heading tagName="h5">Tabs</Heading>
           <p className={styles.cardDescription}>Configure which tabs are visible during matchmaking.</p>
         </div>
         <Checkbox
@@ -582,10 +582,8 @@ export function StreamerSettingsSectionView({
           description="Show a first tab with the Win:Loss count. When clicked, opens the overall stats panel."
         />
 
-        <hr className={styles.sectionDivider} />
-
         <div className={styles.subsection}>
-          <h5 className={styles.nestedSubsectionTitle}>Information ticker</h5>
+          <Heading tagName="h5">Information ticker</Heading>
           <p className={styles.cardDescription}>Configure ticker visibility and row rotation during matchmaking.</p>
         </div>
         <Checkbox
@@ -601,19 +599,23 @@ export function StreamerSettingsSectionView({
           }
           description="Toggle ticker visibility for matchmaking overlay state."
         />
-        <Checkbox
-          checked={matchmakingMyStatsOnly}
-          onChange={(checked): void => {
-            onMatchmakingMyStatsOnlyChange(checked);
-          }}
-          label={
-            <>
-              <span className={styles.srOnly}>Matchmaking </span>
-              Show only my stats
-            </>
-          }
-          description="When enabled, the ticker only rotates your player row during matchmaking matches."
-        />
+        {matchmakingShowTicker ? (
+          <div className={styles.nestedSettings}>
+            <Checkbox
+              checked={matchmakingMyStatsOnly}
+              onChange={(checked): void => {
+                onMatchmakingMyStatsOnlyChange(checked);
+              }}
+              label={
+                <>
+                  <span className={styles.srOnly}>Matchmaking </span>
+                  Show only my stats
+                </>
+              }
+              description="When enabled, the ticker only rotates your player row during matchmaking matches."
+            />
+          </div>
+        ) : null}
       </div>
 
       {showSaveToast ? (

--- a/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
+++ b/pages/src/components/individual-tracker-manager/streamer-settings/streamer-settings.tsx
@@ -203,7 +203,7 @@ export function StreamerSettingsSectionView({
 
   return (
     <div className={styles.panel}>
-      <Heading tagName="h2" className={styles.sectionTitle}>
+      <Heading tagName="h2" styleAs="h3">
         Streamer Settings
       </Heading>
       <p className={styles.sectionDescription}>
@@ -218,7 +218,7 @@ export function StreamerSettingsSectionView({
       ) : (
         <div className={styles.urlList}>
           <div className={styles.card}>
-            <Heading tagName="h3" className={styles.cardTitle}>
+            <Heading tagName="h3" styleAs="h5">
               Viewer URL
             </Heading>
             <p className={styles.cardDescription}>Share this with viewers to follow the active tracker.</p>
@@ -246,7 +246,7 @@ export function StreamerSettingsSectionView({
 
             <hr className={styles.sectionDivider} />
 
-            <Heading tagName="h3" className={styles.cardTitle}>
+            <Heading tagName="h3" styleAs="h5">
               Overlay URL
             </Heading>
             <p className={styles.cardDescription}>Use this in OBS as a Browser Source.</p>
@@ -285,12 +285,12 @@ export function StreamerSettingsSectionView({
       )}
 
       <div className={styles.card}>
-        <Heading tagName="h3" className={styles.cardTitle}>
+        <Heading tagName="h3" styleAs="h5">
           Global Defaults
         </Heading>
         <p className={styles.cardDescription}>These controls apply to both In Series and Matchmaking overlay states.</p>
         <div className={styles.subsection}>
-          <Heading tagName="h4" className={styles.subsectionTitle}>
+          <Heading tagName="h4" styleAs="h6">
             Default Color Mode
           </Heading>
           <p className={styles.cardDescription}>Configure the default color mode for the overlay.</p>
@@ -327,7 +327,7 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4" className={styles.subsectionTitle}>
+          <Heading tagName="h4" styleAs="h6">
             Player Colors
           </Heading>
           <p className={styles.cardDescription}>Used whenever color mode is set to player.</p>
@@ -358,7 +358,7 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4" className={styles.subsectionTitle}>
+          <Heading tagName="h4" styleAs="h6">
             Observer Colors
           </Heading>
           <p className={styles.cardDescription}>Global observer colors for fixed-team mode.</p>
@@ -389,7 +389,7 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4" className={styles.subsectionTitle}>
+          <Heading tagName="h4" styleAs="h6">
             Information Ticker
           </Heading>
         </div>
@@ -403,7 +403,7 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4" className={styles.subsectionTitle}>
+          <Heading tagName="h4" styleAs="h6">
             Text Sizes
           </Heading>
           <p className={styles.cardDescription}>Adjust the size of text for different sections.</p>
@@ -448,14 +448,14 @@ export function StreamerSettingsSectionView({
       </div>
 
       <div className={styles.card}>
-        <Heading tagName="h3" className={styles.cardTitle}>
+        <Heading tagName="h3" styleAs="h5">
           In Series UI
         </Heading>
         <p className={styles.cardDescription}>
           Controls in this section apply when the overlay is currently in a series.
         </p>
         <div className={styles.subsection}>
-          <Heading tagName="h4" className={styles.subsectionTitle}>
+          <Heading tagName="h4" styleAs="h6">
             Top Section
           </Heading>
           <p className={styles.cardDescription}>
@@ -475,7 +475,7 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4" className={styles.subsectionTitle}>
+          <Heading tagName="h4" styleAs="h6">
             Bottom Section
           </Heading>
           <p className={styles.cardDescription}>
@@ -558,14 +558,14 @@ export function StreamerSettingsSectionView({
       </div>
 
       <div className={styles.card}>
-        <Heading tagName="h3" className={styles.cardTitle}>
+        <Heading tagName="h3" styleAs="h5">
           Matchmaking UI
         </Heading>
         <p className={styles.cardDescription}>
           Controls in this section apply when no active series context is present.
         </p>
         <div className={styles.subsection}>
-          <Heading tagName="h4" className={styles.subsectionTitle}>
+          <Heading tagName="h4" styleAs="h6">
             Top Section
           </Heading>
           <p className={styles.cardDescription}>
@@ -584,7 +584,7 @@ export function StreamerSettingsSectionView({
         <hr className={styles.sectionDivider} />
 
         <div className={styles.subsection}>
-          <Heading tagName="h4" className={styles.subsectionTitle}>
+          <Heading tagName="h4" styleAs="h6">
             Bottom Section
           </Heading>
           <p className={styles.cardDescription}>Configure matchmaking-only tabs and ticker behavior.</p>

--- a/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.tsx
+++ b/pages/src/components/individual-tracker-manager/tracker-list/tracker-list.tsx
@@ -4,6 +4,7 @@ import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { Alert } from "../../alert/alert";
 import { Button } from "../../button/button";
 import { Dropdown } from "../../dropdown/dropdown";
+import { Heading } from "../../heading/heading";
 import styles from "./tracker-list.module.css";
 
 export type TrackerDisplayStatus = "active" | "paused" | "stopped" | "not-started";
@@ -149,7 +150,9 @@ function TrackerRow({ item, actions }: TrackerRowProps): React.ReactElement {
 function EmptyInfoPanel(): React.ReactElement {
   return (
     <div className={styles.emptyInfo}>
-      <h3 className={styles.emptyInfoTitle}>How individual tracking works</h3>
+      <Heading tagName="h3" className={styles.emptyInfoTitle}>
+        How individual tracking works
+      </Heading>
       <p className={styles.emptyInfoText}>
         Your live tracker monitors your Halo Infinite match history in real time. Once started, it polls for new matches
         and displays them on your streamer overlay — without requiring your browser to stay open.
@@ -170,7 +173,9 @@ export function TrackerList({ items, onAddTracker, getActions }: TrackerListProp
   return (
     <div className={styles.listContainer}>
       <div className={styles.listHeader}>
-        <h2 className={styles.listTitle}>Live Trackers</h2>
+        <Heading tagName="h2" className={styles.listTitle}>
+          Live Trackers
+        </Heading>
         <Button type="button" size="small" variant="secondary" onClick={onAddTracker}>
           Add tracker
         </Button>

--- a/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.module.css
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.module.css
@@ -9,10 +9,7 @@
 }
 
 .sectionTitle {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
   font-size: var(--text-lg);
-  margin: 0;
 }
 
 .sectionDescription {

--- a/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.module.css
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.module.css
@@ -8,10 +8,6 @@
   padding: var(--space-4);
 }
 
-.sectionTitle {
-  font-size: var(--text-lg);
-}
-
 .sectionDescription {
   color: var(--halo-gray);
   flex: 1 1 auto;

--- a/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.tsx
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.tsx
@@ -87,7 +87,7 @@ export function AddTrackerDialog({
       }
     >
       <section className={styles.section}>
-        <Heading tagName="h3" className={styles.sectionTitle}>
+        <Heading tagName="h3" styleAs="h5">
           1. Gamertag
         </Heading>
         <div className={styles.searchRow}>
@@ -110,7 +110,7 @@ export function AddTrackerDialog({
       </section>
 
       <section className={styles.section}>
-        <Heading tagName="h3" className={styles.sectionTitle}>
+        <Heading tagName="h3" styleAs="h5">
           2. Add past games
         </Heading>
         <div className={styles.controlsRow}>

--- a/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.tsx
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.tsx
@@ -87,7 +87,9 @@ export function AddTrackerDialog({
       }
     >
       <section className={styles.section}>
-        <Heading tagName="h3">1. Gamertag</Heading>
+        <Heading tagName="h3" className={styles.sectionTitle}>
+          1. Gamertag
+        </Heading>
         <div className={styles.searchRow}>
           <Input
             label="Gamertag"
@@ -108,7 +110,9 @@ export function AddTrackerDialog({
       </section>
 
       <section className={styles.section}>
-        <Heading tagName="h3">2. Add past games</Heading>
+        <Heading tagName="h3" className={styles.sectionTitle}>
+          2. Add past games
+        </Heading>
         <div className={styles.controlsRow}>
           <p className={styles.sectionDescription}>Optional — you can skip this section if you want a clean start.</p>
 

--- a/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.tsx
+++ b/pages/src/components/individual-tracker/add-tracker-dialog/add-tracker-dialog.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { IndividualTrackerSeriesGroup } from "../series-group-metadata";
 import type { TrackerMatchHistoryEntry, TrackerSearchResult } from "../../../services/individual-tracker/types";
 import { Alert } from "../../alert/alert";
+import { Heading } from "../../heading/heading";
 import { Button } from "../../button/button";
 import { Checkbox } from "../../checkbox/checkbox";
 import { Dialog } from "../../dialog/dialog";
@@ -86,7 +87,7 @@ export function AddTrackerDialog({
       }
     >
       <section className={styles.section}>
-        <h3 className={styles.sectionTitle}>1. Gamertag</h3>
+        <Heading tagName="h3">1. Gamertag</Heading>
         <div className={styles.searchRow}>
           <Input
             label="Gamertag"
@@ -107,7 +108,7 @@ export function AddTrackerDialog({
       </section>
 
       <section className={styles.section}>
-        <h3 className={styles.sectionTitle}>2. Add past games</h3>
+        <Heading tagName="h3">2. Add past games</Heading>
         <div className={styles.controlsRow}>
           <p className={styles.sectionDescription}>Optional — you can skip this section if you want a clean start.</p>
 

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.module.css
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.module.css
@@ -23,10 +23,6 @@
   justify-content: space-between;
 }
 
-.sectionTitle {
-  font-size: var(--text-base);
-}
-
 .metaGrid {
   display: grid;
   gap: var(--space-2);

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.module.css
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.module.css
@@ -25,7 +25,6 @@
 
 .sectionTitle {
   font-size: var(--text-base);
-  margin: 0;
 }
 
 .metaGrid {
@@ -45,10 +44,6 @@
   flex-direction: column;
   gap: var(--space-2);
   padding: var(--space-2);
-}
-
-.teamTitle {
-  margin: 0;
 }
 
 .membersList {

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.tsx
@@ -136,7 +136,9 @@ export function ManualSeriesDialog({
         </p>
 
         <section className={styles.section}>
-          <Heading tagName="h3">Series details (optional)</Heading>
+          <Heading tagName="h3" className={styles.sectionTitle}>
+            Series details (optional)
+          </Heading>
           <div className={styles.metaGrid}>
             <Input
               label="Series title"
@@ -158,7 +160,9 @@ export function ManualSeriesDialog({
         </section>
 
         <section className={styles.section}>
-          <Heading tagName="h3">Teams</Heading>
+          <Heading tagName="h3" className={styles.sectionTitle}>
+            Teams
+          </Heading>
 
           <div className={styles.teamsGrid}>
             {snapshot.teams.map((team, teamIndex) => (

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.tsx
@@ -3,6 +3,7 @@ import { Button } from "../../button/button";
 import { Dialog } from "../../dialog/dialog";
 import { Input } from "../../input/input";
 import { Alert } from "../../alert/alert";
+import { Heading } from "../../heading/heading";
 import { createMatchHistorySection } from "../../match-history/create";
 import type { ManualSeriesDialogSnapshot, ManualSeriesTeamSnapshot } from "./manual-series-dialog-store";
 import styles from "./manual-series-dialog.module.css";
@@ -42,7 +43,7 @@ function TeamColumn({
 }): React.JSX.Element {
   return (
     <div className={styles.teamColumn}>
-      <h4 className={styles.teamTitle}>Team {teamIndex + 1}</h4>
+      <Heading tagName="h4">Team {teamIndex + 1}</Heading>
       <Input
         label="Team name (optional)"
         value={team.name}
@@ -135,7 +136,7 @@ export function ManualSeriesDialog({
         </p>
 
         <section className={styles.section}>
-          <h3 className={styles.sectionTitle}>Series details (optional)</h3>
+          <Heading tagName="h3">Series details (optional)</Heading>
           <div className={styles.metaGrid}>
             <Input
               label="Series title"
@@ -157,7 +158,7 @@ export function ManualSeriesDialog({
         </section>
 
         <section className={styles.section}>
-          <h3 className={styles.sectionTitle}>Teams</h3>
+          <Heading tagName="h3">Teams</Heading>
 
           <div className={styles.teamsGrid}>
             {snapshot.teams.map((team, teamIndex) => (

--- a/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.tsx
+++ b/pages/src/components/individual-tracker/manual-series-dialog/manual-series-dialog.tsx
@@ -136,7 +136,7 @@ export function ManualSeriesDialog({
         </p>
 
         <section className={styles.section}>
-          <Heading tagName="h3" className={styles.sectionTitle}>
+          <Heading tagName="h3" styleAs="h6">
             Series details (optional)
           </Heading>
           <div className={styles.metaGrid}>
@@ -160,7 +160,7 @@ export function ManualSeriesDialog({
         </section>
 
         <section className={styles.section}>
-          <Heading tagName="h3" className={styles.sectionTitle}>
+          <Heading tagName="h3" styleAs="h6">
             Teams
           </Heading>
 

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.module.css
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.module.css
@@ -33,13 +33,8 @@
 }
 
 .title {
-  color: var(--halo-white);
   display: inline-block;
-  font-family: var(--font-heading);
   font-size: var(--text-2xl);
-  letter-spacing: 0.04em;
-  margin: 0;
-  text-transform: uppercase;
 }
 
 .badges {
@@ -232,9 +227,7 @@
 }
 
 .sectionTitle {
-  font-family: var(--font-heading);
   font-size: var(--text-lg);
-  margin: 0;
 }
 
 @media (--tablet-viewport) {

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.module.css
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.module.css
@@ -32,11 +32,6 @@
   margin-bottom: var(--space-5);
 }
 
-.title {
-  display: inline-block;
-  font-size: var(--text-2xl);
-}
-
 .badges {
   align-items: center;
   display: flex;
@@ -224,10 +219,6 @@
   position: fixed;
   transform: translateX(-50%);
   z-index: 20;
-}
-
-.sectionTitle {
-  font-size: var(--text-lg);
 }
 
 @media (--tablet-viewport) {

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
@@ -376,7 +376,9 @@ export function IndividualTrackerViewer({
       )}
       <Container>
         <div className={styles.header}>
-          <Heading tagName="h1">{renderModel.gamertag} Tracker</Heading>
+          <Heading tagName="h1" variant="display" className={styles.title}>
+            {renderModel.gamertag} Tracker
+          </Heading>
           <div className={styles.badges}>
             <span
               className={classNames(styles.statusBadge, {
@@ -395,7 +397,9 @@ export function IndividualTrackerViewer({
       </Container>
       <section className={styles.matchesSection}>
         <Container>
-          <Heading tagName="h2">Tracked Gameplay</Heading>
+          <Heading tagName="h2" className={styles.sectionTitle}>
+            Tracked Gameplay
+          </Heading>
         </Container>
         <Container mobileDown="0">
           <StatsHighlights items={renderModel.statsHighlights ?? []} />

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
@@ -7,6 +7,7 @@ import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import type { TrackerStatus } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import { summarizeSeriesOutcome } from "@guilty-spark/shared/halo/match-enrichment";
 import { Alert } from "../../alert/alert";
+import { Heading } from "../../heading/heading";
 import { Button } from "../../button/button";
 import { Container } from "../../container/container";
 import { LoadingState } from "../../loading-state/loading-state";
@@ -375,7 +376,7 @@ export function IndividualTrackerViewer({
       )}
       <Container>
         <div className={styles.header}>
-          <h1 className={styles.title}>{renderModel.gamertag} Tracker</h1>
+          <Heading tagName="h1">{renderModel.gamertag} Tracker</Heading>
           <div className={styles.badges}>
             <span
               className={classNames(styles.statusBadge, {
@@ -394,7 +395,7 @@ export function IndividualTrackerViewer({
       </Container>
       <section className={styles.matchesSection}>
         <Container>
-          <h2 className={styles.sectionTitle}>Tracked Gameplay</h2>
+          <Heading tagName="h2">Tracked Gameplay</Heading>
         </Container>
         <Container mobileDown="0">
           <StatsHighlights items={renderModel.statsHighlights ?? []} />

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
@@ -376,7 +376,7 @@ export function IndividualTrackerViewer({
       )}
       <Container>
         <div className={styles.header}>
-          <Heading tagName="h1" variant="display" className={styles.title}>
+          <Heading tagName="h1" styleAs="h3" variant="display">
             {renderModel.gamertag} Tracker
           </Heading>
           <div className={styles.badges}>
@@ -397,7 +397,7 @@ export function IndividualTrackerViewer({
       </Container>
       <section className={styles.matchesSection}>
         <Container>
-          <Heading tagName="h2" className={styles.sectionTitle}>
+          <Heading tagName="h2" styleAs="h5">
             Tracked Gameplay
           </Heading>
         </Container>

--- a/pages/src/components/live-tracker/live-tracker.module.css
+++ b/pages/src/components/live-tracker/live-tracker.module.css
@@ -17,11 +17,6 @@
   gap: var(--space-1);
 }
 
-.headerTitle {
-  font-size: var(--text-2xl);
-  line-height: 1.2;
-}
-
 .headerSubtitle {
   color: var(--halo-gray);
   font-family: var(--font-body);
@@ -78,10 +73,6 @@
 
 .contentContainer.wide {
   max-width: 100%;
-}
-
-.sectionTitle {
-  font-size: var(--text-2xl);
 }
 
 .notice {

--- a/pages/src/components/live-tracker/live-tracker.module.css
+++ b/pages/src/components/live-tracker/live-tracker.module.css
@@ -18,11 +18,8 @@
 }
 
 .headerTitle {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
   font-size: var(--text-2xl);
   line-height: 1.2;
-  margin: 0;
 }
 
 .headerSubtitle {
@@ -84,11 +81,7 @@
 }
 
 .sectionTitle {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
   font-size: var(--text-2xl);
-  margin-bottom: var(--space-3);
-  margin-top: 0;
 }
 
 .notice {

--- a/pages/src/components/live-tracker/live-tracker.tsx
+++ b/pages/src/components/live-tracker/live-tracker.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { Heading } from "../heading/heading";
 import ReactTimeAgo from "react-time-ago";
 import classNames from "classnames";
+import { Heading } from "../heading/heading";
 import { MatchStats as MatchStatsView } from "../stats/match-stats";
 import { SeriesStats } from "../stats/series-stats";
 import { Container } from "../container/container";

--- a/pages/src/components/live-tracker/live-tracker.tsx
+++ b/pages/src/components/live-tracker/live-tracker.tsx
@@ -236,7 +236,9 @@ export function LiveTrackerView(): React.ReactElement {
       <Container>
         <div className={styles.headerBar}>
           <div className={styles.headerLeft}>
-            <Heading tagName="h1">{displayTitle}</Heading>
+            <Heading tagName="h1" className={styles.headerTitle}>
+              {displayTitle}
+            </Heading>
             <div className={styles.headerSubtitle}>
               {hasState(state) ? `Queue #${state.queueNumber.toString()}` : displaySubtitle}
             </div>
@@ -271,7 +273,9 @@ export function LiveTrackerView(): React.ReactElement {
           <>
             {hasState(state) && (
               <Container className={classNames(styles.contentContainer, styles[viewMode])}>
-                <Heading tagName="h2">Series overview</Heading>
+                <Heading tagName="h2" spacing={3} className={styles.sectionTitle}>
+                  Series overview
+                </Heading>
                 <div className={styles.seriesOverview}>
                   <section className={styles.seriesScores}>
                     {hasMatches ? (
@@ -389,7 +393,9 @@ export function LiveTrackerView(): React.ReactElement {
             {hasState(state) && hasMatches && (
               <>
                 <Container className={classNames(styles.contentContainer, styles[viewMode])}>
-                  <Heading tagName="h2">Matches</Heading>
+                  <Heading tagName="h2" spacing={3} className={styles.sectionTitle}>
+                    Matches
+                  </Heading>
                 </Container>
                 {((): React.ReactElement[] => {
                   const elements: React.ReactElement[] = [];

--- a/pages/src/components/live-tracker/live-tracker.tsx
+++ b/pages/src/components/live-tracker/live-tracker.tsx
@@ -236,7 +236,7 @@ export function LiveTrackerView(): React.ReactElement {
       <Container>
         <div className={styles.headerBar}>
           <div className={styles.headerLeft}>
-            <Heading tagName="h1" className={styles.headerTitle}>
+            <Heading tagName="h1" styleAs="h3">
               {displayTitle}
             </Heading>
             <div className={styles.headerSubtitle}>
@@ -273,7 +273,7 @@ export function LiveTrackerView(): React.ReactElement {
           <>
             {hasState(state) && (
               <Container className={classNames(styles.contentContainer, styles[viewMode])}>
-                <Heading tagName="h2" spacing={3} className={styles.sectionTitle}>
+                <Heading tagName="h2" styleAs="h3" spacing={3}>
                   Series overview
                 </Heading>
                 <div className={styles.seriesOverview}>
@@ -393,7 +393,7 @@ export function LiveTrackerView(): React.ReactElement {
             {hasState(state) && hasMatches && (
               <>
                 <Container className={classNames(styles.contentContainer, styles[viewMode])}>
-                  <Heading tagName="h2" spacing={3} className={styles.sectionTitle}>
+                  <Heading tagName="h2" styleAs="h3" spacing={3}>
                     Matches
                   </Heading>
                 </Container>

--- a/pages/src/components/live-tracker/live-tracker.tsx
+++ b/pages/src/components/live-tracker/live-tracker.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { Heading } from "../heading/heading";
 import ReactTimeAgo from "react-time-ago";
 import classNames from "classnames";
 import { MatchStats as MatchStatsView } from "../stats/match-stats";
@@ -235,7 +236,7 @@ export function LiveTrackerView(): React.ReactElement {
       <Container>
         <div className={styles.headerBar}>
           <div className={styles.headerLeft}>
-            <h1 className={styles.headerTitle}>{displayTitle}</h1>
+            <Heading tagName="h1">{displayTitle}</Heading>
             <div className={styles.headerSubtitle}>
               {hasState(state) ? `Queue #${state.queueNumber.toString()}` : displaySubtitle}
             </div>
@@ -270,14 +271,14 @@ export function LiveTrackerView(): React.ReactElement {
           <>
             {hasState(state) && (
               <Container className={classNames(styles.contentContainer, styles[viewMode])}>
-                <h2 className={styles.sectionTitle}>Series overview</h2>
+                <Heading tagName="h2">Series overview</Heading>
                 <div className={styles.seriesOverview}>
                   <section className={styles.seriesScores}>
                     {hasMatches ? (
                       <>
-                        <h3 className={styles.seriesScoresHeader} aria-label="Series scores">
+                        <Heading tagName="h3" className={styles.seriesScoresHeader} aria-label="Series scores">
                           {state.seriesScore}
-                        </h3>
+                        </Heading>
                         <ul className={styles.seriesScoresList}>
                           {state.matches.map((match) => {
                             // Determine winning team for overlay color
@@ -346,7 +347,9 @@ export function LiveTrackerView(): React.ReactElement {
                         className={styles.teamCard}
                         style={{ "--team-color": teamColor.hex } as React.CSSProperties}
                       >
-                        <h3 className={styles.teamName}>{team.name}</h3>
+                        <Heading tagName="h3" className={styles.teamName}>
+                          {team.name}
+                        </Heading>
                         <ul className={styles.playerList}>
                           {team.players.map((player) => {
                             const playerData = state.playersAssociationData?.[player.id];
@@ -386,7 +389,7 @@ export function LiveTrackerView(): React.ReactElement {
             {hasState(state) && hasMatches && (
               <>
                 <Container className={classNames(styles.contentContainer, styles[viewMode])}>
-                  <h2 className={styles.sectionTitle}>Matches</h2>
+                  <Heading tagName="h2">Matches</Heading>
                 </Container>
                 {((): React.ReactElement[] => {
                   const elements: React.ReactElement[] = [];

--- a/pages/src/components/live-tracker/settings/display-settings-section.module.css
+++ b/pages/src/components/live-tracker/settings/display-settings-section.module.css
@@ -12,7 +12,6 @@
 
 .subsectionHeader {
   font-family: var(--font-body);
-  font-size: var(--text-base);
   font-weight: 600;
 }
 

--- a/pages/src/components/live-tracker/settings/display-settings-section.module.css
+++ b/pages/src/components/live-tracker/settings/display-settings-section.module.css
@@ -11,10 +11,9 @@
 }
 
 .subsectionHeader {
-  color: var(--halo-white);
+  font-family: var(--font-body);
   font-size: var(--text-base);
   font-weight: 600;
-  margin: 0 0 var(--space-1) 0;
 }
 
 .sectionDescription {

--- a/pages/src/components/live-tracker/settings/display-settings-section.tsx
+++ b/pages/src/components/live-tracker/settings/display-settings-section.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Checkbox } from "../../checkbox/checkbox";
+import { Heading } from "../../heading/heading";
 import type { DisplaySettings } from "./types";
 import styles from "./display-settings-section.module.css";
-import { Heading } from "../../heading/heading";
 
 interface DisplaySettingsSectionProps {
   readonly settings: DisplaySettings;

--- a/pages/src/components/live-tracker/settings/display-settings-section.tsx
+++ b/pages/src/components/live-tracker/settings/display-settings-section.tsx
@@ -14,7 +14,7 @@ export function DisplaySettingsSection({ settings, onChange }: DisplaySettingsSe
     <div className={styles.container}>
       {/* Team Details Section */}
       <div className={styles.section}>
-        <Heading tagName="h5" spacing={1} className={styles.subsectionHeader}>
+        <Heading tagName="h5" styleAs="h6" spacing={1} className={styles.subsectionHeader}>
           Team Information
         </Heading>
 
@@ -69,7 +69,7 @@ export function DisplaySettingsSection({ settings, onChange }: DisplaySettingsSe
 
       {/* Queue Info Section */}
       <div className={styles.section}>
-        <Heading tagName="h5" spacing={1} className={styles.subsectionHeader}>
+        <Heading tagName="h5" styleAs="h6" spacing={1} className={styles.subsectionHeader}>
           Queue Information
         </Heading>
         <p className={styles.sectionDescription}>Control the parts shown in the top section</p>

--- a/pages/src/components/live-tracker/settings/display-settings-section.tsx
+++ b/pages/src/components/live-tracker/settings/display-settings-section.tsx
@@ -14,7 +14,9 @@ export function DisplaySettingsSection({ settings, onChange }: DisplaySettingsSe
     <div className={styles.container}>
       {/* Team Details Section */}
       <div className={styles.section}>
-        <Heading tagName="h5">Team Information</Heading>
+        <Heading tagName="h5" spacing={1} className={styles.subsectionHeader}>
+          Team Information
+        </Heading>
 
         <Checkbox
           checked={settings.showTeamDetails}
@@ -67,7 +69,9 @@ export function DisplaySettingsSection({ settings, onChange }: DisplaySettingsSe
 
       {/* Queue Info Section */}
       <div className={styles.section}>
-        <Heading tagName="h5">Queue Information</Heading>
+        <Heading tagName="h5" spacing={1} className={styles.subsectionHeader}>
+          Queue Information
+        </Heading>
         <p className={styles.sectionDescription}>Control the parts shown in the top section</p>
 
         <Checkbox

--- a/pages/src/components/live-tracker/settings/display-settings-section.tsx
+++ b/pages/src/components/live-tracker/settings/display-settings-section.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Checkbox } from "../../checkbox/checkbox";
 import type { DisplaySettings } from "./types";
 import styles from "./display-settings-section.module.css";
+import { Heading } from "../../heading/heading";
 
 interface DisplaySettingsSectionProps {
   readonly settings: DisplaySettings;
@@ -13,7 +14,7 @@ export function DisplaySettingsSection({ settings, onChange }: DisplaySettingsSe
     <div className={styles.container}>
       {/* Team Details Section */}
       <div className={styles.section}>
-        <h4 className={styles.subsectionHeader}>Team Information</h4>
+        <Heading tagName="h5">Team Information</Heading>
 
         <Checkbox
           checked={settings.showTeamDetails}
@@ -66,7 +67,7 @@ export function DisplaySettingsSection({ settings, onChange }: DisplaySettingsSe
 
       {/* Queue Info Section */}
       <div className={styles.section}>
-        <h4 className={styles.subsectionHeader}>Queue Information</h4>
+        <Heading tagName="h5">Queue Information</Heading>
         <p className={styles.sectionDescription}>Control the parts shown in the top section</p>
 
         <Checkbox

--- a/pages/src/components/live-tracker/settings/settings-dialog.module.css
+++ b/pages/src/components/live-tracker/settings/settings-dialog.module.css
@@ -123,10 +123,9 @@
 }
 
 .sectionHeader {
-  color: var(--halo-white);
+  font-family: var(--font-body);
   font-size: var(--text-base);
   font-weight: 600;
-  margin: 0 0 var(--space-3) 0;
 }
 
 .sectionDescription {
@@ -142,12 +141,9 @@
 }
 
 .subsectionHeader {
-  color: var(--halo-teal-primary);
+  font-family: var(--font-body);
   font-size: var(--text-base);
   font-weight: 600;
-  letter-spacing: 0.5px;
-  margin: 0 0 var(--space-2) 0;
-  text-transform: uppercase;
 }
 
 .subsectionDescription {

--- a/pages/src/components/live-tracker/settings/settings-dialog.module.css
+++ b/pages/src/components/live-tracker/settings/settings-dialog.module.css
@@ -124,7 +124,6 @@
 
 .sectionHeader {
   font-family: var(--font-body);
-  font-size: var(--text-base);
   font-weight: 600;
 }
 
@@ -142,7 +141,6 @@
 
 .subsectionHeader {
   font-family: var(--font-body);
-  font-size: var(--text-base);
   font-weight: 600;
 }
 

--- a/pages/src/components/live-tracker/settings/settings-dialog.tsx
+++ b/pages/src/components/live-tracker/settings/settings-dialog.tsx
@@ -210,7 +210,7 @@ export function SettingsDialog({
             <div className={styles.leftColumn}>
               {/* Global Settings - Consolidated */}
               <div className={styles.section}>
-                <Heading tagName="h3" spacing={3} className={styles.sectionHeader}>
+                <Heading tagName="h3" styleAs="h6" spacing={3} className={styles.sectionHeader}>
                   Global Settings
                 </Heading>
                 <p className={styles.sectionDescription}>These settings apply across all series</p>
@@ -218,7 +218,7 @@ export function SettingsDialog({
                 <hr className={styles.divider} />
 
                 {/* Color Settings */}
-                <Heading tagName="h4" spacing={2} className={styles.subsectionHeader}>
+                <Heading tagName="h4" styleAs="h6" spacing={2} className={styles.subsectionHeader}>
                   Team Colors
                 </Heading>
                 <p className={styles.subsectionDescription}>Customize team colors for player or observer view</p>
@@ -235,7 +235,7 @@ export function SettingsDialog({
                 <hr className={styles.divider} />
 
                 {/* Display Settings */}
-                <Heading tagName="h4" spacing={2} className={styles.subsectionHeader}>
+                <Heading tagName="h4" styleAs="h6" spacing={2} className={styles.subsectionHeader}>
                   Display Options
                 </Heading>
                 <p className={styles.subsectionDescription}>Control what information is shown</p>
@@ -244,7 +244,7 @@ export function SettingsDialog({
                 <hr className={styles.divider} />
 
                 {/* Ticker Settings */}
-                <Heading tagName="h4" spacing={2} className={styles.subsectionHeader}>
+                <Heading tagName="h4" styleAs="h6" spacing={2} className={styles.subsectionHeader}>
                   Information Ticker
                 </Heading>
                 <p className={styles.subsectionDescription}>Customize stats and medals shown in ticker</p>
@@ -253,7 +253,7 @@ export function SettingsDialog({
                 <hr className={styles.divider} />
 
                 {/* Font Size Settings */}
-                <Heading tagName="h4" spacing={2} className={styles.subsectionHeader}>
+                <Heading tagName="h4" styleAs="h6" spacing={2} className={styles.subsectionHeader}>
                   Font Sizes
                 </Heading>
                 <p className={styles.subsectionDescription}>Adjust text size for each section (100% = default)</p>
@@ -298,10 +298,10 @@ export function SettingsDialog({
 
               {/* Series-Specific Settings */}
               <div className={styles.section}>
-                <Heading tagName="h3" spacing={3} className={styles.sectionHeader}>
+                <Heading tagName="h3" styleAs="h6" spacing={3} className={styles.sectionHeader}>
                   This Series Settings
                 </Heading>
-                <Heading tagName="h4" spacing={2} className={styles.subsectionHeader}>
+                <Heading tagName="h4" styleAs="h6" spacing={2} className={styles.subsectionHeader}>
                   Series title
                 </Heading>
                 <SeriesTitleSection
@@ -313,7 +313,7 @@ export function SettingsDialog({
 
                 <hr className={styles.divider} />
 
-                <Heading tagName="h4" spacing={2} className={styles.subsectionHeader}>
+                <Heading tagName="h4" styleAs="h6" spacing={2} className={styles.subsectionHeader}>
                   Team Names
                 </Heading>
                 <SeriesTeamSection settings={settings.series} onChange={handleSeriesChange} />
@@ -323,7 +323,7 @@ export function SettingsDialog({
             {/* Right Column - View Mode Selection */}
             <div className={styles.rightColumn}>
               <div className={styles.section}>
-                <Heading tagName="h3" spacing={3} className={styles.sectionHeader}>
+                <Heading tagName="h3" styleAs="h6" spacing={3} className={styles.sectionHeader}>
                   View Mode
                 </Heading>
                 <p className={styles.sectionDescription}>Select how to display the tracker</p>
@@ -370,7 +370,7 @@ export function SettingsDialog({
 
               {/* Copy URL for OBS */}
               <div className={styles.section}>
-                <Heading tagName="h3" spacing={3} className={styles.sectionHeader}>
+                <Heading tagName="h3" styleAs="h6" spacing={3} className={styles.sectionHeader}>
                   Share Settings
                 </Heading>
                 <p className={styles.sectionDescription}>Copy URL with all current settings for OBS Browser Source</p>

--- a/pages/src/components/live-tracker/settings/settings-dialog.tsx
+++ b/pages/src/components/live-tracker/settings/settings-dialog.tsx
@@ -210,13 +210,17 @@ export function SettingsDialog({
             <div className={styles.leftColumn}>
               {/* Global Settings - Consolidated */}
               <div className={styles.section}>
-                <Heading tagName="h3">Global Settings</Heading>
+                <Heading tagName="h3" spacing={3} className={styles.sectionHeader}>
+                  Global Settings
+                </Heading>
                 <p className={styles.sectionDescription}>These settings apply across all series</p>
 
                 <hr className={styles.divider} />
 
                 {/* Color Settings */}
-                <Heading tagName="h4">Team Colors</Heading>
+                <Heading tagName="h4" spacing={2} className={styles.subsectionHeader}>
+                  Team Colors
+                </Heading>
                 <p className={styles.subsectionDescription}>Customize team colors for player or observer view</p>
                 <ColorSettingsSection
                   mode={settings.global.colors.mode}
@@ -231,21 +235,27 @@ export function SettingsDialog({
                 <hr className={styles.divider} />
 
                 {/* Display Settings */}
-                <Heading tagName="h4">Display Options</Heading>
+                <Heading tagName="h4" spacing={2} className={styles.subsectionHeader}>
+                  Display Options
+                </Heading>
                 <p className={styles.subsectionDescription}>Control what information is shown</p>
                 <DisplaySettingsSection settings={settings.global.display} onChange={handleDisplayChange} />
 
                 <hr className={styles.divider} />
 
                 {/* Ticker Settings */}
-                <Heading tagName="h4">Information Ticker</Heading>
+                <Heading tagName="h4" spacing={2} className={styles.subsectionHeader}>
+                  Information Ticker
+                </Heading>
                 <p className={styles.subsectionDescription}>Customize stats and medals shown in ticker</p>
                 <TickerSettingsSection settings={settings.global.ticker} onChange={handleTickerChange} />
 
                 <hr className={styles.divider} />
 
                 {/* Font Size Settings */}
-                <Heading tagName="h4">Font Sizes</Heading>
+                <Heading tagName="h4" spacing={2} className={styles.subsectionHeader}>
+                  Font Sizes
+                </Heading>
                 <p className={styles.subsectionDescription}>Adjust text size for each section (100% = default)</p>
                 <div className={styles.fontSizeContainer}>
                   <FontSizeSlider
@@ -288,8 +298,12 @@ export function SettingsDialog({
 
               {/* Series-Specific Settings */}
               <div className={styles.section}>
-                <Heading tagName="h3">This Series Settings</Heading>
-                <Heading tagName="h4">Series title</Heading>
+                <Heading tagName="h3" spacing={3} className={styles.sectionHeader}>
+                  This Series Settings
+                </Heading>
+                <Heading tagName="h4" spacing={2} className={styles.subsectionHeader}>
+                  Series title
+                </Heading>
                 <SeriesTitleSection
                   settings={settings.series}
                   onChange={handleSeriesChange}
@@ -299,7 +313,9 @@ export function SettingsDialog({
 
                 <hr className={styles.divider} />
 
-                <Heading tagName="h4">Team Names</Heading>
+                <Heading tagName="h4" spacing={2} className={styles.subsectionHeader}>
+                  Team Names
+                </Heading>
                 <SeriesTeamSection settings={settings.series} onChange={handleSeriesChange} />
               </div>
             </div>
@@ -307,7 +323,9 @@ export function SettingsDialog({
             {/* Right Column - View Mode Selection */}
             <div className={styles.rightColumn}>
               <div className={styles.section}>
-                <Heading tagName="h3">View Mode</Heading>
+                <Heading tagName="h3" spacing={3} className={styles.sectionHeader}>
+                  View Mode
+                </Heading>
                 <p className={styles.sectionDescription}>Select how to display the tracker</p>
 
                 <div className={styles.viewModeButtonsContainer}>
@@ -352,7 +370,9 @@ export function SettingsDialog({
 
               {/* Copy URL for OBS */}
               <div className={styles.section}>
-                <Heading tagName="h3">Share Settings</Heading>
+                <Heading tagName="h3" spacing={3} className={styles.sectionHeader}>
+                  Share Settings
+                </Heading>
                 <p className={styles.sectionDescription}>Copy URL with all current settings for OBS Browser Source</p>
                 <div className={styles.copyUrlContainer}>
                   <CopyUrlButton settings={settings} server={server} queue={queue} viewMode={"streamer"} />

--- a/pages/src/components/live-tracker/settings/settings-dialog.tsx
+++ b/pages/src/components/live-tracker/settings/settings-dialog.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import classNames from "classnames";
+import { Heading } from "../../heading/heading";
 import type { ViewMode } from "../../view-mode/view-mode-selector";
 import { Checkbox } from "../../checkbox/checkbox";
 import type {
@@ -192,9 +193,9 @@ export function SettingsDialog({
       <div className={styles.dialog}>
         {/* Header */}
         <div className={styles.header}>
-          <h2 id="settings-dialog-title" className={styles.title}>
+          <Heading tagName="h2" id="settings-dialog-title" className={styles.title}>
             Overlay Settings
-          </h2>
+          </Heading>
           <button type="button" className={styles.closeButton} onClick={onClose} aria-label="Close settings">
             <svg className={styles.closeIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor">
               <path d="M18 6L6 18M6 6l12 12" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
@@ -209,13 +210,13 @@ export function SettingsDialog({
             <div className={styles.leftColumn}>
               {/* Global Settings - Consolidated */}
               <div className={styles.section}>
-                <h3 className={styles.sectionHeader}>Global Settings</h3>
+                <Heading tagName="h3">Global Settings</Heading>
                 <p className={styles.sectionDescription}>These settings apply across all series</p>
 
                 <hr className={styles.divider} />
 
                 {/* Color Settings */}
-                <h4 className={styles.subsectionHeader}>Team Colors</h4>
+                <Heading tagName="h4">Team Colors</Heading>
                 <p className={styles.subsectionDescription}>Customize team colors for player or observer view</p>
                 <ColorSettingsSection
                   mode={settings.global.colors.mode}
@@ -230,21 +231,21 @@ export function SettingsDialog({
                 <hr className={styles.divider} />
 
                 {/* Display Settings */}
-                <h4 className={styles.subsectionHeader}>Display Options</h4>
+                <Heading tagName="h4">Display Options</Heading>
                 <p className={styles.subsectionDescription}>Control what information is shown</p>
                 <DisplaySettingsSection settings={settings.global.display} onChange={handleDisplayChange} />
 
                 <hr className={styles.divider} />
 
                 {/* Ticker Settings */}
-                <h4 className={styles.subsectionHeader}>Information Ticker</h4>
+                <Heading tagName="h4">Information Ticker</Heading>
                 <p className={styles.subsectionDescription}>Customize stats and medals shown in ticker</p>
                 <TickerSettingsSection settings={settings.global.ticker} onChange={handleTickerChange} />
 
                 <hr className={styles.divider} />
 
                 {/* Font Size Settings */}
-                <h4 className={styles.subsectionHeader}>Font Sizes</h4>
+                <Heading tagName="h4">Font Sizes</Heading>
                 <p className={styles.subsectionDescription}>Adjust text size for each section (100% = default)</p>
                 <div className={styles.fontSizeContainer}>
                   <FontSizeSlider
@@ -287,8 +288,8 @@ export function SettingsDialog({
 
               {/* Series-Specific Settings */}
               <div className={styles.section}>
-                <h3 className={styles.sectionHeader}>This Series Settings</h3>
-                <h4 className={styles.subsectionHeader}>Series title</h4>
+                <Heading tagName="h3">This Series Settings</Heading>
+                <Heading tagName="h4">Series title</Heading>
                 <SeriesTitleSection
                   settings={settings.series}
                   onChange={handleSeriesChange}
@@ -298,7 +299,7 @@ export function SettingsDialog({
 
                 <hr className={styles.divider} />
 
-                <h4 className={styles.subsectionHeader}>Team Names</h4>
+                <Heading tagName="h4">Team Names</Heading>
                 <SeriesTeamSection settings={settings.series} onChange={handleSeriesChange} />
               </div>
             </div>
@@ -306,7 +307,7 @@ export function SettingsDialog({
             {/* Right Column - View Mode Selection */}
             <div className={styles.rightColumn}>
               <div className={styles.section}>
-                <h3 className={styles.sectionHeader}>View Mode</h3>
+                <Heading tagName="h3">View Mode</Heading>
                 <p className={styles.sectionDescription}>Select how to display the tracker</p>
 
                 <div className={styles.viewModeButtonsContainer}>
@@ -351,7 +352,7 @@ export function SettingsDialog({
 
               {/* Copy URL for OBS */}
               <div className={styles.section}>
-                <h3 className={styles.sectionHeader}>Share Settings</h3>
+                <Heading tagName="h3">Share Settings</Heading>
                 <p className={styles.sectionDescription}>Copy URL with all current settings for OBS Browser Source</p>
                 <div className={styles.copyUrlContainer}>
                   <CopyUrlButton settings={settings} server={server} queue={queue} viewMode={"streamer"} />

--- a/pages/src/components/live-tracker/settings/ticker-settings-section.module.css
+++ b/pages/src/components/live-tracker/settings/ticker-settings-section.module.css
@@ -18,10 +18,9 @@
 }
 
 .subsectionHeader {
-  color: var(--halo-white);
+  font-family: var(--font-body);
   font-size: var(--text-base);
   font-weight: 600;
-  margin: 0;
 }
 
 .sectionDescription {

--- a/pages/src/components/live-tracker/settings/ticker-settings-section.module.css
+++ b/pages/src/components/live-tracker/settings/ticker-settings-section.module.css
@@ -19,7 +19,6 @@
 
 .subsectionHeader {
   font-family: var(--font-body);
-  font-size: var(--text-base);
   font-weight: 600;
 }
 

--- a/pages/src/components/live-tracker/settings/ticker-settings-section.module.css
+++ b/pages/src/components/live-tracker/settings/ticker-settings-section.module.css
@@ -17,11 +17,6 @@
   justify-content: space-between;
 }
 
-.subsectionHeader {
-  font-family: var(--font-body);
-  font-weight: 600;
-}
-
 .sectionDescription {
   color: var(--halo-gray);
   font-size: var(--text-xs);

--- a/pages/src/components/live-tracker/settings/ticker-settings-section.tsx
+++ b/pages/src/components/live-tracker/settings/ticker-settings-section.tsx
@@ -79,7 +79,9 @@ export function TickerSettingsSection({
   return (
     <div className={styles.container}>
       <div className={styles.section}>
-        <Heading tagName="h5">Tabs</Heading>
+        <Heading tagName="h5" className={styles.subsectionHeader}>
+          Tabs
+        </Heading>
         <p className={styles.sectionDescription}>Configure how many recent match tabs are shown.</p>
         <Input
           label="Max number of previous games to show"
@@ -96,7 +98,9 @@ export function TickerSettingsSection({
       <hr className={styles.sectionDivider} />
 
       <div className={styles.section}>
-        <Heading tagName="h5">Information ticker</Heading>
+        <Heading tagName="h5" className={styles.subsectionHeader}>
+          Information ticker
+        </Heading>
         <p className={styles.sectionDescription}>
           Customize stats and medals shown in the ticker. Toggle visibility available in the Series UI / Matchmaking UI
           sections further down.
@@ -116,7 +120,9 @@ export function TickerSettingsSection({
       {/* Stats Selection */}
       <div className={styles.section}>
         <div className={styles.sectionTitleRow}>
-          <Heading tagName="h6">Slayer Statistics</Heading>
+          <Heading tagName="h6" className={styles.subsectionHeader}>
+            Slayer Statistics
+          </Heading>
           <div className={styles.bulkActions}>
             <Button onClick={handleSelectAll} variant="secondary" size="small">
               Select All
@@ -156,7 +162,9 @@ export function TickerSettingsSection({
 
       {/* Medal Rarity Filter */}
       <div className={styles.section}>
-        <Heading tagName="h6">Medal Rarity Filter</Heading>
+        <Heading tagName="h6" className={styles.subsectionHeader}>
+          Medal Rarity Filter
+        </Heading>
         <p className={styles.sectionDescription}>Select which medal rarities to display in the ticker</p>
 
         <div className={styles.checkboxGrid}>

--- a/pages/src/components/live-tracker/settings/ticker-settings-section.tsx
+++ b/pages/src/components/live-tracker/settings/ticker-settings-section.tsx
@@ -79,7 +79,7 @@ export function TickerSettingsSection({
   return (
     <div className={styles.container}>
       <div className={styles.section}>
-        <Heading tagName="h5" className={styles.subsectionHeader}>
+        <Heading tagName="h5" styleAs="h6" className={styles.subsectionHeader}>
           Tabs
         </Heading>
         <p className={styles.sectionDescription}>Configure how many recent match tabs are shown.</p>
@@ -98,7 +98,7 @@ export function TickerSettingsSection({
       <hr className={styles.sectionDivider} />
 
       <div className={styles.section}>
-        <Heading tagName="h5" className={styles.subsectionHeader}>
+        <Heading tagName="h5" styleAs="h6" className={styles.subsectionHeader}>
           Information ticker
         </Heading>
         <p className={styles.sectionDescription}>

--- a/pages/src/components/live-tracker/settings/ticker-settings-section.tsx
+++ b/pages/src/components/live-tracker/settings/ticker-settings-section.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { Button } from "../../button/button";
 import { Checkbox } from "../../checkbox/checkbox";
 import { Input } from "../../input/input";
-import type { TickerSettings } from "./types";
 import { Heading } from "../../heading/heading";
+import type { TickerSettings } from "./types";
 import { ALL_SLAYER_STATS, MAX_PREVIOUS_GAMES_TO_SHOW, MEDAL_RARITY_LEVELS, MIN_PREVIOUS_GAMES_TO_SHOW } from "./types";
 import styles from "./ticker-settings-section.module.css";
 

--- a/pages/src/components/live-tracker/settings/ticker-settings-section.tsx
+++ b/pages/src/components/live-tracker/settings/ticker-settings-section.tsx
@@ -3,6 +3,7 @@ import { Button } from "../../button/button";
 import { Checkbox } from "../../checkbox/checkbox";
 import { Input } from "../../input/input";
 import type { TickerSettings } from "./types";
+import { Heading } from "../../heading/heading";
 import { ALL_SLAYER_STATS, MAX_PREVIOUS_GAMES_TO_SHOW, MEDAL_RARITY_LEVELS, MIN_PREVIOUS_GAMES_TO_SHOW } from "./types";
 import styles from "./ticker-settings-section.module.css";
 
@@ -78,7 +79,7 @@ export function TickerSettingsSection({
   return (
     <div className={styles.container}>
       <div className={styles.section}>
-        <h4 className={styles.subsectionHeader}>Tabs</h4>
+        <Heading tagName="h5">Tabs</Heading>
         <p className={styles.sectionDescription}>Configure how many recent match tabs are shown.</p>
         <Input
           label="Max number of previous games to show"
@@ -95,8 +96,11 @@ export function TickerSettingsSection({
       <hr className={styles.sectionDivider} />
 
       <div className={styles.section}>
-        <h4 className={styles.subsectionHeader}>Information ticker</h4>
-        <p className={styles.sectionDescription}>Customize stats and medals shown in the ticker.</p>
+        <Heading tagName="h5">Information ticker</Heading>
+        <p className={styles.sectionDescription}>
+          Customize stats and medals shown in the ticker. Toggle visibility available in the Series UI / Matchmaking UI
+          sections further down.
+        </p>
 
         {showTickerVisibilityToggle ? (
           <Checkbox
@@ -112,7 +116,7 @@ export function TickerSettingsSection({
       {/* Stats Selection */}
       <div className={styles.section}>
         <div className={styles.sectionTitleRow}>
-          <h4 className={styles.subsectionHeader}>Slayer Statistics</h4>
+          <Heading tagName="h6">Slayer Statistics</Heading>
           <div className={styles.bulkActions}>
             <Button onClick={handleSelectAll} variant="secondary" size="small">
               Select All
@@ -152,7 +156,7 @@ export function TickerSettingsSection({
 
       {/* Medal Rarity Filter */}
       <div className={styles.section}>
-        <h4 className={styles.subsectionHeader}>Medal Rarity Filter</h4>
+        <Heading tagName="h6">Medal Rarity Filter</Heading>
         <p className={styles.sectionDescription}>Select which medal rarities to display in the ticker</p>
 
         <div className={styles.checkboxGrid}>

--- a/pages/src/components/live-tracker/settings/ticker-settings-section.tsx
+++ b/pages/src/components/live-tracker/settings/ticker-settings-section.tsx
@@ -79,9 +79,7 @@ export function TickerSettingsSection({
   return (
     <div className={styles.container}>
       <div className={styles.section}>
-        <Heading tagName="h5" styleAs="h6" className={styles.subsectionHeader}>
-          Tabs
-        </Heading>
+        <Heading tagName="h5">Tabs</Heading>
         <p className={styles.sectionDescription}>Configure how many recent match tabs are shown.</p>
         <Input
           label="Max number of previous games to show"
@@ -95,12 +93,8 @@ export function TickerSettingsSection({
         />
       </div>
 
-      <hr className={styles.sectionDivider} />
-
       <div className={styles.section}>
-        <Heading tagName="h5" styleAs="h6" className={styles.subsectionHeader}>
-          Information ticker
-        </Heading>
+        <Heading tagName="h5">Information ticker</Heading>
         <p className={styles.sectionDescription}>
           Customize stats and medals shown in the ticker. Toggle visibility available in the Series UI / Matchmaking UI
           sections further down.
@@ -120,9 +114,7 @@ export function TickerSettingsSection({
       {/* Stats Selection */}
       <div className={styles.section}>
         <div className={styles.sectionTitleRow}>
-          <Heading tagName="h6" className={styles.subsectionHeader}>
-            Slayer Statistics
-          </Heading>
+          <Heading tagName="h6">Slayer Statistics</Heading>
           <div className={styles.bulkActions}>
             <Button onClick={handleSelectAll} variant="secondary" size="small">
               Select All

--- a/pages/src/components/login/login.module.css
+++ b/pages/src/components/login/login.module.css
@@ -14,12 +14,7 @@
 }
 
 .heading {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
   font-size: var(--text-3xl);
-  letter-spacing: 0.04em;
-  margin: 0;
-  text-transform: uppercase;
 }
 
 .subtext {

--- a/pages/src/components/login/login.module.css
+++ b/pages/src/components/login/login.module.css
@@ -13,10 +13,6 @@
   width: 100%;
 }
 
-.heading {
-  font-size: var(--text-3xl);
-}
-
 .subtext {
   color: var(--halo-gray);
   margin: var(--space-3) 0 var(--space-6);

--- a/pages/src/components/login/login.tsx
+++ b/pages/src/components/login/login.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Heading } from "../heading/heading";
 import { Button } from "../button/button";
 import styles from "./login.module.css";
 
@@ -9,7 +10,7 @@ interface LoginProps {
 export function Login({ signInHref }: LoginProps): React.ReactElement {
   return (
     <div className={styles.card}>
-      <h1 className={styles.heading}>Sign In</h1>
+      <Heading tagName="h1">Sign In</Heading>
       <p className={styles.subtext}>Authenticate with Microsoft to access your saved tracker profile.</p>
       <Button href={signInHref} className={styles.signInButton}>
         Continue With Microsoft

--- a/pages/src/components/login/login.tsx
+++ b/pages/src/components/login/login.tsx
@@ -10,7 +10,9 @@ interface LoginProps {
 export function Login({ signInHref }: LoginProps): React.ReactElement {
   return (
     <div className={styles.card}>
-      <Heading tagName="h1">Sign In</Heading>
+      <Heading tagName="h1" variant="display" className={styles.heading}>
+        Sign In
+      </Heading>
       <p className={styles.subtext}>Authenticate with Microsoft to access your saved tracker profile.</p>
       <Button href={signInHref} className={styles.signInButton}>
         Continue With Microsoft

--- a/pages/src/components/login/login.tsx
+++ b/pages/src/components/login/login.tsx
@@ -10,7 +10,7 @@ interface LoginProps {
 export function Login({ signInHref }: LoginProps): React.ReactElement {
   return (
     <div className={styles.card}>
-      <Heading tagName="h1" variant="display" className={styles.heading}>
+      <Heading tagName="h1" styleAs="h2" variant="display">
         Sign In
       </Heading>
       <p className={styles.subtext}>Authenticate with Microsoft to access your saved tracker profile.</p>

--- a/pages/src/components/match-card/match-card.tsx
+++ b/pages/src/components/match-card/match-card.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Heading } from "../heading/heading";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { normalizeOutcomeString } from "@guilty-spark/shared/halo/match-enrichment";
+import { Heading } from "../heading/heading";
 import type { TrackerMatchHistoryEntry } from "../../services/individual-tracker/types";
 import { gameModeIconSrc } from "../individual-tracker/game-mode-icon";
 import { Checkbox } from "../checkbox/checkbox";

--- a/pages/src/components/match-card/match-card.tsx
+++ b/pages/src/components/match-card/match-card.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Heading } from "../heading/heading";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { normalizeOutcomeString } from "@guilty-spark/shared/halo/match-enrichment";
 import type { TrackerMatchHistoryEntry } from "../../services/individual-tracker/types";
@@ -98,9 +99,9 @@ export function MatchCard({
           <div className={styles.matchHeader}>
             <div className={styles.matchHeaderContent}>
               <div className={styles.matchTitleRow}>
-                <h3 className={styles.matchTitle}>
+                <Heading tagName="h3" className={styles.matchTitle}>
                   {entry.modeName}: {entry.mapName}
-                </h3>
+                </Heading>
                 <span className={styles.categoryBadge} data-category={entry.category}>
                   {categoryLabel}
                 </span>

--- a/pages/src/components/match-history/match-history.tsx
+++ b/pages/src/components/match-history/match-history.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Heading } from "../heading/heading";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { getDefaultSeriesGroupTitle } from "@guilty-spark/shared/individual-tracker/series-grouping";
 import type { TrackerMatchHistoryEntry } from "../../services/individual-tracker/types";
@@ -156,9 +157,9 @@ export function MatchHistory({
                 <section key={`group-${String(segment.groupIndex)}`} className={styles.seriesBlock} style={groupStyle}>
                   <div className={styles.seriesHeader}>
                     <div className={styles.seriesHeaderTopRow}>
-                      <h3 className={styles.seriesTitle}>
+                      <Heading tagName="h3" className={styles.seriesTitle}>
                         {segment.seriesGroup?.titleOverride ?? getDefaultSeriesGroupTitle()}
-                      </h3>
+                      </Heading>
                       <p className={styles.seriesGameCount}>{groupMatchIds.length} games</p>
                     </div>
                     <div className={styles.seriesLabelOptions}>

--- a/pages/src/components/match-history/match-history.tsx
+++ b/pages/src/components/match-history/match-history.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Heading } from "../heading/heading";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { getDefaultSeriesGroupTitle } from "@guilty-spark/shared/individual-tracker/series-grouping";
+import { Heading } from "../heading/heading";
 import type { TrackerMatchHistoryEntry } from "../../services/individual-tracker/types";
 import type { IndividualTrackerSeriesGroup } from "../individual-tracker/series-group-metadata";
 import { getDefaultSeriesGroupSubtitle } from "../individual-tracker/series-group-metadata";

--- a/pages/src/components/player-pre-series-info/player-pre-series-info.module.css
+++ b/pages/src/components/player-pre-series-info/player-pre-series-info.module.css
@@ -3,11 +3,7 @@
 }
 
 .title {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
   font-size: var(--text-2xl);
-  margin-bottom: var(--space-4);
-  margin-top: 0;
 }
 
 .rankValue {

--- a/pages/src/components/player-pre-series-info/player-pre-series-info.module.css
+++ b/pages/src/components/player-pre-series-info/player-pre-series-info.module.css
@@ -2,10 +2,6 @@
   margin: var(--space-6) 0;
 }
 
-.title {
-  font-size: var(--text-2xl);
-}
-
 .rankValue {
   line-height: 1;
 }

--- a/pages/src/components/player-pre-series-info/player-pre-series-info.tsx
+++ b/pages/src/components/player-pre-series-info/player-pre-series-info.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Heading } from "../heading/heading";
 import ReactTimeAgo from "react-time-ago";
 import type { PlayerAssociationData } from "@guilty-spark/shared/live-tracker/types";
 import { getRankTierFromCsr } from "@guilty-spark/shared/halo/rank";
@@ -218,7 +219,7 @@ export function PlayerPreSeriesInfo({
   return (
     <Container className={className}>
       <div className={styles.container}>
-        <h2 className={styles.title}>Player Info</h2>
+        <Heading tagName="h2">Player Info</Heading>
         <SortableTable
           data={playerRows}
           columns={columns}

--- a/pages/src/components/player-pre-series-info/player-pre-series-info.tsx
+++ b/pages/src/components/player-pre-series-info/player-pre-series-info.tsx
@@ -219,7 +219,7 @@ export function PlayerPreSeriesInfo({
   return (
     <Container className={className}>
       <div className={styles.container}>
-        <Heading tagName="h2" spacing={4} className={styles.title}>
+        <Heading tagName="h2" styleAs="h3" spacing={4}>
           Player Info
         </Heading>
         <SortableTable

--- a/pages/src/components/player-pre-series-info/player-pre-series-info.tsx
+++ b/pages/src/components/player-pre-series-info/player-pre-series-info.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { Heading } from "../heading/heading";
 import ReactTimeAgo from "react-time-ago";
 import type { PlayerAssociationData } from "@guilty-spark/shared/live-tracker/types";
 import { getRankTierFromCsr } from "@guilty-spark/shared/halo/rank";
+import { Heading } from "../heading/heading";
 import { RankIcon } from "../icons/rank-icon";
 import { SortableTable, type SortableTableColumn } from "../table/sortable-table";
 import tableStyles from "../table/table.module.css";

--- a/pages/src/components/player-pre-series-info/player-pre-series-info.tsx
+++ b/pages/src/components/player-pre-series-info/player-pre-series-info.tsx
@@ -219,7 +219,9 @@ export function PlayerPreSeriesInfo({
   return (
     <Container className={className}>
       <div className={styles.container}>
-        <Heading tagName="h2">Player Info</Heading>
+        <Heading tagName="h2" spacing={4} className={styles.title}>
+          Player Info
+        </Heading>
         <SortableTable
           data={playerRows}
           columns={columns}

--- a/pages/src/components/section-header/section-header.astro
+++ b/pages/src/components/section-header/section-header.astro
@@ -12,7 +12,7 @@ import styles from "./section-header.module.css";
 ---
 
 <div class={styles.sectionHeader}>
-  <Heading tagName={headingTagName} class={styles.sectionTitle}>
+  <Heading tagName={headingTagName} variant="display" class={styles.sectionTitle}>
     <span class={styles.titleBracket}>&lt;</span>
     {title}
     <span class={styles.titleBracket}>/&gt;</span>

--- a/pages/src/components/series-stats/series-stats.module.css
+++ b/pages/src/components/series-stats/series-stats.module.css
@@ -14,10 +14,7 @@
 }
 
 .sectionTitle {
-  color: var(--halo-white);
-  font-family: var(--font-heading);
   font-size: var(--text-2xl);
-  margin: 0;
 }
 
 .seriesOverviewWrap {

--- a/pages/src/components/series-stats/series-stats.module.css
+++ b/pages/src/components/series-stats/series-stats.module.css
@@ -13,10 +13,6 @@
   padding: 0;
 }
 
-.sectionTitle {
-  font-size: var(--text-2xl);
-}
-
 .seriesOverviewWrap {
   overflow-x: auto;
 }

--- a/pages/src/components/series-stats/series-stats.tsx
+++ b/pages/src/components/series-stats/series-stats.tsx
@@ -105,7 +105,9 @@ export function SeriesStatsView({
   return (
     <div className={styles.seriesStats}>
       <Container className={styles.contentContainer}>
-        <Heading tagName="h2">Series overview</Heading>
+        <Heading tagName="h2" className={styles.sectionTitle}>
+          Series overview
+        </Heading>
         <div className={styles.seriesOverviewWrap}>
           <div className={styles.seriesOverview}>
             <section className={styles.seriesScores}>
@@ -145,7 +147,9 @@ export function SeriesStatsView({
       )}
 
       <Container className={styles.contentContainer}>
-        <Heading tagName="h2">Matches</Heading>
+        <Heading tagName="h2" className={styles.sectionTitle}>
+          Matches
+        </Heading>
       </Container>
 
       {matchDetails.map((detail) => (

--- a/pages/src/components/series-stats/series-stats.tsx
+++ b/pages/src/components/series-stats/series-stats.tsx
@@ -1,6 +1,6 @@
 import { type CSSProperties, type ReactElement } from "react";
-import { Heading } from "../heading/heading";
 import classNames from "classnames";
+import { Heading } from "../heading/heading";
 import { Container } from "../container/container";
 import { Alert } from "../alert/alert";
 import { MatchStats as MatchStatsView } from "../stats/match-stats";

--- a/pages/src/components/series-stats/series-stats.tsx
+++ b/pages/src/components/series-stats/series-stats.tsx
@@ -1,4 +1,5 @@
 import { type CSSProperties, type ReactElement } from "react";
+import { Heading } from "../heading/heading";
 import classNames from "classnames";
 import { Container } from "../container/container";
 import { Alert } from "../alert/alert";
@@ -44,7 +45,9 @@ interface TeamCardSectionProps {
 function TeamCardSection({ team }: TeamCardSectionProps): ReactElement {
   return (
     <section className={styles.teamCard} style={{ "--team-color": team.teamColorHex } as CSSProperties}>
-      <h3 className={styles.teamName}>{team.name}</h3>
+      <Heading tagName="h3" className={styles.teamName}>
+        {team.name}
+      </Heading>
       <ul className={styles.playerList}>
         {team.players.map((player, playerIndex) => (
           <li key={`${team.name}:${player}:${playerIndex.toString()}`}>{player}</li>
@@ -102,11 +105,13 @@ export function SeriesStatsView({
   return (
     <div className={styles.seriesStats}>
       <Container className={styles.contentContainer}>
-        <h2 className={styles.sectionTitle}>Series overview</h2>
+        <Heading tagName="h2">Series overview</Heading>
         <div className={styles.seriesOverviewWrap}>
           <div className={styles.seriesOverview}>
             <section className={styles.seriesScores}>
-              <h3 className={styles.seriesScoresHeader}>{seriesScore}</h3>
+              <Heading tagName="h3" className={styles.seriesScoresHeader}>
+                {seriesScore}
+              </Heading>
               <ul className={styles.seriesScoresList}>
                 {matchSummaries.map((summary) => (
                   <MatchSummaryItem key={summary.matchId} summary={summary} />
@@ -140,7 +145,7 @@ export function SeriesStatsView({
       )}
 
       <Container className={styles.contentContainer}>
-        <h2 className={styles.sectionTitle}>Matches</h2>
+        <Heading tagName="h2">Matches</Heading>
       </Container>
 
       {matchDetails.map((detail) => (

--- a/pages/src/components/series-stats/series-stats.tsx
+++ b/pages/src/components/series-stats/series-stats.tsx
@@ -105,7 +105,7 @@ export function SeriesStatsView({
   return (
     <div className={styles.seriesStats}>
       <Container className={styles.contentContainer}>
-        <Heading tagName="h2" className={styles.sectionTitle}>
+        <Heading tagName="h2" styleAs="h3">
           Series overview
         </Heading>
         <div className={styles.seriesOverviewWrap}>
@@ -147,7 +147,7 @@ export function SeriesStatsView({
       )}
 
       <Container className={styles.contentContainer}>
-        <Heading tagName="h2" className={styles.sectionTitle}>
+        <Heading tagName="h2" styleAs="h3">
           Matches
         </Heading>
       </Container>

--- a/pages/src/components/stats/match-stats.module.css
+++ b/pages/src/components/stats/match-stats.module.css
@@ -141,7 +141,6 @@
 .subsectionHeader {
   color: var(--halo-gray, #9ca3af);
   font-family: var(--font-body, "Inter", sans-serif);
-  font-size: var(--text-base);
   font-weight: 500;
   margin: var(--space-3) 0 0;
 }

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -1,4 +1,5 @@
 import type { MatchStats } from "halo-infinite-api";
+import { Heading } from "../heading/heading";
 import React from "react";
 import classNames from "classnames";
 import { ComponentLoader, ComponentLoaderStatus } from "../component-loader/component-loader";
@@ -234,7 +235,7 @@ export function MatchStats({
       {hasTeamStats && (
         <div className={styles.teamTotals}>
           <Container>
-            <h3 className={styles.subsectionHeader}>Team Totals</h3>
+            <Heading tagName="h3">Team Totals</Heading>
           </Container>
           <SortableTable
             data={data}

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -1,7 +1,7 @@
 import type { MatchStats } from "halo-infinite-api";
-import { Heading } from "../heading/heading";
 import React from "react";
 import classNames from "classnames";
+import { Heading } from "../heading/heading";
 import { ComponentLoader, ComponentLoaderStatus } from "../component-loader/component-loader";
 import { SortableTable, type SortableTableColumn } from "../table/sortable-table";
 import tableStyles from "../table/table.module.css";

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -235,7 +235,7 @@ export function MatchStats({
       {hasTeamStats && (
         <div className={styles.teamTotals}>
           <Container>
-            <Heading tagName="h3" className={styles.subsectionHeader}>
+            <Heading tagName="h3" styleAs="h6" className={styles.subsectionHeader}>
               Team Totals
             </Heading>
           </Container>

--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -235,7 +235,9 @@ export function MatchStats({
       {hasTeamStats && (
         <div className={styles.teamTotals}>
           <Container>
-            <Heading tagName="h3">Team Totals</Heading>
+            <Heading tagName="h3" className={styles.subsectionHeader}>
+              Team Totals
+            </Heading>
           </Container>
           <SortableTable
             data={data}

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Heading } from "../heading/heading";
 import classNames from "classnames";
+import { Heading } from "../heading/heading";
 import type { ComponentLoaderStatus } from "../component-loader/component-loader";
 import { SortableTable, type SortableTableColumn } from "../table/sortable-table";
 import tableStyles from "../table/table.module.css";

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -218,7 +218,9 @@ export function SeriesStats({
       {hasTeamStats && (
         <>
           <Container>
-            <Heading tagName="h3">Accumulated Team Stats</Heading>
+            <Heading tagName="h3" className={styles.subsectionHeader}>
+              Accumulated Team Stats
+            </Heading>
           </Container>
           <SortableTable
             data={teamData}

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Heading } from "../heading/heading";
 import classNames from "classnames";
 import type { ComponentLoaderStatus } from "../component-loader/component-loader";
 import { SortableTable, type SortableTableColumn } from "../table/sortable-table";
@@ -217,7 +218,7 @@ export function SeriesStats({
       {hasTeamStats && (
         <>
           <Container>
-            <h3 className={styles.subsectionHeader}>Accumulated Team Stats</h3>
+            <Heading tagName="h3">Accumulated Team Stats</Heading>
           </Container>
           <SortableTable
             data={teamData}

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -218,7 +218,7 @@ export function SeriesStats({
       {hasTeamStats && (
         <>
           <Container>
-            <Heading tagName="h3" className={styles.subsectionHeader}>
+            <Heading tagName="h3" styleAs="h6" className={styles.subsectionHeader}>
               Accumulated Team Stats
             </Heading>
           </Container>

--- a/pages/src/components/stats/stats-header.tsx
+++ b/pages/src/components/stats/stats-header.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Heading } from "../heading/heading";
 import { Container } from "../container/container";
 import styles from "./match-stats.module.css";
 
@@ -29,7 +30,9 @@ export function StatsHeader({
   return (
     <Container className={styles.matchHeader} style={backgroundStyle}>
       <div className={styles.matchHeaderContent}>
-        <h3 className={styles.matchTitle}>{title}</h3>
+        <Heading tagName="h3" className={styles.matchTitle}>
+          {title}
+        </Heading>
         {subtitle != null && subtitle !== "" ? <p className={styles.matchSubtitle}>{subtitle}</p> : null}
         <ul className={styles.matchMetadata}>
           {metadata.map((item) => (

--- a/pages/src/pages/privacy-policy.astro
+++ b/pages/src/pages/privacy-policy.astro
@@ -11,7 +11,7 @@ import PrivacyPolicyMarkdown from "./_generated/legal/privacy-policy.md";
     <Container>
       <header class={styles.heroBlock}>
         <p class={styles.eyebrow}>Legal Transmission</p>
-        <Heading tagName="h1" class={styles.title}>Privacy Policy</Heading>
+        <Heading tagName="h1" variant="display" class={styles.title}>Privacy Policy</Heading>
       </header>
 
       <article class={styles.markdownContent}>

--- a/pages/src/pages/terms-of-service.astro
+++ b/pages/src/pages/terms-of-service.astro
@@ -14,7 +14,7 @@ import TermsOfServiceMarkdown from "./_generated/legal/terms-of-service.md";
     <Container>
       <header class={styles.heroBlock}>
         <p class={styles.eyebrow}>Legal Transmission</p>
-        <Heading tagName="h1" class={styles.title}>Terms of Service</Heading>
+        <Heading tagName="h1" variant="display" class={styles.title}>Terms of Service</Heading>
       </header>
 
       <article class={styles.markdownContent}>


### PR DESCRIPTION
## Context
This work consolidates heading markup and heading styling behavior across the Individual Tracker pages so hierarchy is more consistent and maintainable. The original implementation mixed raw h-tags and ad hoc heading styles in many components, which made semantics and visual consistency harder to audit.

## This PR
- Migrates tracker-related pages/components to the shared React `Heading` component pattern.
- Gives `Heading` a `variant` prop, decoupled from `tagName`: `tagName` is purely semantic (heading depth/a11y), `variant` controls the visual treatment.
  - `plain` (default): white, heading-font, no uppercase/letter-spacing — the look the majority of existing call sites actually want.
  - `display`: the loud uppercase/bold/letter-spaced treatment, opted into explicitly by page-level and marketing titles (login, individual tracker page header, legal pages, home/FAQ section headers, error state).
- Adds a `styleAs` prop: lets a heading render as one tag (for correct document outline/a11y depth) while visually sizing as another. Most headings in this codebase are nested inside cards/panels and want to *look* shallower or deeper than their real DOM depth — `styleAs` reuses another tag's size class instead of every call site carrying its own one-off `font-size` override. This eliminated the majority of the remaining per-component CSS.
- Adds a `spacing` prop (`1`–`24`, matching the `--space-N` token scale) so consumers can express heading-to-content margin via the existing CSS-variable `style` prop convention, instead of baking margin into ad hoc heading classes.
- Re-applies each component's original color/casing/family intent as a minimal `className` override layered on top of `Heading`'s shared base — only for genuine visual divergences (e.g. the settings-label family intentionally uses body-font/weight-600 instead of the heading look) rather than sizing, which `styleAs` now covers. This addresses the extensive Copilot review feedback on the earlier commit, which correctly flagged that most migrated call sites lost their component-specific styling because the className was dropped rather than carried through.
- Unifies the three divergent "subsectionHeader" settings labels (`settings-dialog`, `display-settings-section`, `ticker-settings-section`) — previously one was teal/uppercase and two were white/plain-case for the same semantic role — onto a single white/plain-case look.
- Fixes several additional dropped-styling regressions Copilot's review missed (same root cause, different call sites): `player-pre-series-info`, `live-tracker`'s header title, and the `series-stats` component's two section titles.
- Adds direct test coverage for `Heading`'s `variant`/`spacing`/`styleAs` behavior.
- Cleans up heading base CSS to reduce repetition and use typography tokens for all heading font sizes.
- Adjusts semantic heading levels in nested settings sections so document outline depth matches UI nesting.
- Applies parent-toggle nesting behavior for Information Ticker options in:
  - In Series UI
  - Matchmaking UI
  so child controls are shown in an indented nested block only when the parent ticker toggle is enabled.

Validation performed:
- `npm run done` passes (format/typecheck/lint). `test:changed`'s `related` filter reports no matches (pre-existing quirk, not new).
- Full suite: `npm test` — 234 test files, 3189 tests, all passing.
- Manually verified rendering in a dev server (real + `--mode fake`) for home, FAQ, privacy policy, login/error-state, and the individual tracker page header — confirmed `display` vs `plain` variants render as intended and no marketing/legal pages regressed.

## Note for reviewers
The earlier Copilot review comments suggesting "just re-add the dropped className" are individually correct as diagnosis but are **not** what the fixup commits do — re-adding the exact original class would have kept every heading a one-off style, defeating the point of consolidating onto a shared component. Instead each fix re-adds only the properties `Heading`'s `variant`/`styleAs`/base styling doesn't already provide, so the shared component ends up doing as much of the work as possible. Sizes are intentionally not pixel-identical to the pre-migration styling in every case (e.g. `styleAs` maps onto the nearest existing tag-size tier rather than introducing new one-off sizes) — close enough, not identical, per direction from the PR author.

## Subsequent Work
- Optional: decide whether disabling parent ticker toggles should also force-reset nested child flags (currently they are hidden when off, not auto-reset).
- Optional: follow-up visual polish pass for heading rhythm (spacing/weight) now that semantic levels are standardized.
