### PR TITLE
Retroactively recheck series eligibility during enrichment backfill

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -777,7 +777,13 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
       if (trackerState.activeSeries != null && !existingActiveSeriesMatchIds.has(matchId)) {
         const durationSeconds = differenceInSeconds(new Date(summary.endTime), new Date(summary.startTime));
-        if (isEligibleForActiveSeries(summary, durationSeconds, trackerState.activeSeries)) {
+        // NaN/negative durations (e.g. missing or malformed timestamps) must not silently bypass
+        // isEligibleForActiveSeries's `< 120` guard - `NaN < 120` is false, not true.
+        if (
+          Number.isFinite(durationSeconds) &&
+          durationSeconds >= 0 &&
+          isEligibleForActiveSeries(summary, durationSeconds, trackerState.activeSeries)
+        ) {
           trackerState.activeSeries.matchIds.push(matchId);
           existingActiveSeriesMatchIds.add(matchId);
           viewChanged = true;

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/cloudflare";
-import { addMilliseconds, compareAsc, differenceInHours } from "date-fns";
+import { addMilliseconds, compareAsc, differenceInHours, differenceInSeconds } from "date-fns";
 import { z } from "zod";
 import {
   type PlayerMatchHistory,
@@ -772,6 +772,23 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         const enriched = await this.enrichScore(summary, trackerState.xuid);
         if (enriched) {
           viewChanged = true;
+        }
+      }
+
+      if (trackerState.activeSeries != null && !existingActiveSeriesMatchIds.has(matchId)) {
+        const durationSeconds = differenceInSeconds(new Date(summary.endTime), new Date(summary.startTime));
+        if (isEligibleForActiveSeries(summary, durationSeconds, trackerState.activeSeries)) {
+          trackerState.activeSeries.matchIds.push(matchId);
+          existingActiveSeriesMatchIds.add(matchId);
+          viewChanged = true;
+          this.logService.info(
+            "IndividualTracker: retroactively attached backfilled match to active series",
+            new Map([
+              ["trackerId", trackerState.trackerId],
+              ["gamertag", trackerState.gamertag],
+              ["matchId", matchId],
+            ]),
+          );
         }
       }
 

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2294,6 +2294,63 @@ describe("IndividualTrackerDO", () => {
       expect(afterSecond.activeSeries?.matchIds).toEqual(["match-new"]);
     });
 
+    it("does not retroactively attach a backfilled match with an invalid (NaN) duration to the active series", async () => {
+      ownerClient.getPlayerMatches.mockResolvedValue([]);
+      const activeSeries: ActiveSeries = {
+        title: "Active Series",
+        subtitle: "Customs",
+        guildIconUrl: null,
+        teams: [
+          {
+            id: 0,
+            name: "Eagle",
+            players: [
+              { discordId: null, discordName: null, gamertag: "Alpha", xboxId: "1111111111" },
+              { discordId: null, discordName: null, gamertag: "Bravo", xboxId: "2222222222" },
+            ],
+          },
+          {
+            id: 1,
+            name: "Cobra",
+            players: [
+              { discordId: null, discordName: null, gamertag: "Charlie", xboxId: "3333333333" },
+              { discordId: null, discordName: null, gamertag: "Delta", xboxId: "4444444444" },
+            ],
+          },
+        ],
+        matchIds: [],
+        startedAt: "2024-11-26T11:00:00.000Z",
+        isActive: true,
+      };
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          searchStartTime: "2024-11-26T11:00:00.000Z",
+          matchIds: ["match-bad-times"],
+          discoveredMatches: {
+            "match-bad-times": aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "match-bad-times",
+              // Empty timestamps make differenceInSeconds return NaN, and NaN < 120 is false -
+              // without an explicit finite/non-negative guard this would bypass the duration check.
+              startTime: "",
+              endTime: "",
+              isMatchmaking: false,
+              teamRosterSignature: "0:1111111111,2222222222|1:3333333333,4444444444",
+              teamOutcomes: [2, 3],
+              killsDeathsAssistsKda: "10:5:2 (3.3)",
+              damageDealtTakenRatio: "500:300 (1.7)",
+            }),
+          },
+          activeSeries,
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries?.matchIds).toEqual([]);
+    });
+
     it("retries enrichment for migrated match with null KDA fields when getMatchStats fails transiently", async () => {
       ownerClient.getPlayerMatches.mockResolvedValue([]);
       ownerClient.getMatchStats

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1,6 +1,8 @@
 import { describe, beforeEach, it, expect, vi, afterEach } from "vitest";
 import type { MockInstance } from "vitest";
+import { addSeconds } from "date-fns";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import { getDurationInSeconds } from "@guilty-spark/shared/halo/duration";
 import { trackerViewMessageContract } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import {
   aFakeCoreStatsWith,
@@ -96,7 +98,7 @@ const aFakePlayerMatch = (
     Outcome: outcome,
     MatchInfo: {
       StartTime: startTime,
-      EndTime: startTime,
+      EndTime: addSeconds(new Date(startTime), getDurationInSeconds(duration)).toISOString(),
       Duration: duration,
       GameVariantCategory: 6,
       MapVariant: { AssetId: "map-asset", VersionId: "v1" },
@@ -2234,6 +2236,62 @@ describe("IndividualTrackerDO", () => {
 
       const afterSecond = lastPersistedState(storagePutSpy);
       expect(afterSecond.discoveredMatches["match-new"]?.score).toBe("50:42");
+    });
+
+    it("retroactively attaches a match to the active series once backfill enrichment resolves its roster signature", async () => {
+      ownerClient.getPlayerMatches
+        .mockResolvedValueOnce([aFakePlayerMatch("match-new", "2024-11-26T11:30:00.000Z", 2)])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      ownerClient.getMatchStats.mockRejectedValueOnce(new Error("stats not ready"));
+      const activeSeries: ActiveSeries = {
+        title: "Active Series",
+        subtitle: "Customs",
+        guildIconUrl: null,
+        teams: [
+          {
+            id: 0,
+            name: "Eagle",
+            players: [
+              { discordId: null, discordName: null, gamertag: "Alpha", xboxId: "1111111111" },
+              { discordId: null, discordName: null, gamertag: "Bravo", xboxId: "2222222222" },
+            ],
+          },
+          {
+            id: 1,
+            name: "Cobra",
+            players: [
+              { discordId: null, discordName: null, gamertag: "Charlie", xboxId: "3333333333" },
+              { discordId: null, discordName: null, gamertag: "Delta", xboxId: "4444444444" },
+            ],
+          },
+        ],
+        matchIds: [],
+        startedAt: "2024-11-26T11:00:00.000Z",
+        isActive: true,
+      };
+      const state = aFakeIndividualTrackerInternalStateWith({
+        startTime: now.toISOString(),
+        searchStartTime: "2024-11-26T11:00:00.000Z",
+        matchIds: [],
+        discoveredMatches: {},
+        activeSeries,
+      });
+      storageGetSpy.mockResolvedValue(state);
+
+      await individualTrackerDO.alarm();
+
+      const afterFirst = lastPersistedState(storagePutSpy);
+      expect(afterFirst.discoveredMatches["match-new"]?.teamRosterSignature).toBeNull();
+      expect(afterFirst.activeSeries?.matchIds).toEqual([]);
+
+      await individualTrackerDO.alarm();
+
+      const afterSecond = lastPersistedState(storagePutSpy);
+      expect(afterSecond.discoveredMatches["match-new"]?.teamRosterSignature).toBe(
+        "0:1111111111,2222222222|1:3333333333,4444444444",
+      );
+      expect(afterSecond.activeSeries?.matchIds).toEqual(["match-new"]);
     });
 
     it("retries enrichment for migrated match with null KDA fields when getMatchStats fails transiently", async () => {


### PR DESCRIPTION
## Context
Part of the NeatQueue -> individual tracker stability effort (see #738). This is PR 5 of 6.

## This change
If `getMatchDetails` failed during first-pass match discovery, `teamRosterSignature` stayed null and the match was judged ineligible for the active series exactly once - permanently. The later backfill enrichment pass retries `getMatchDetails` and fills in the signature, but never re-checked series eligibility, so a single transient Halo API hiccup at discovery time could silently and permanently orphan a match from its series.

Adds that recheck: once backfill resolves a match's roster signature, it's attached to the active series if it now qualifies (reusing the identity-based check from PR 3).

Also fixes the test-local `aFakePlayerMatch` fixture, which set `EndTime` equal to `StartTime` regardless of `Duration` - harmless before, but the new recheck derives match duration from `endTime - startTime`, so the fixture needed to reflect a realistic duration.

## Subsequent work
- PR 6: misc hardening (hibernation stat-highlight persistence, paused-tracker alarm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)