### PR TITLE
Persist websocket stats-highlight slots and skip pointless paused-tracker alarms

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -426,8 +426,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   private statsHighlightsCacheKey: string | undefined;
   private cachedStatsHighlights: readonly StatsHighlightItem[] | undefined;
   private cachedResolvedRosterCount: number | undefined;
-  private websocketStatsHighlightSlots: readonly IndividualStatsHighlightOption[] =
-    DEFAULT_WEBSOCKET_STATS_HIGHLIGHT_SLOTS;
   // Serializes state-mutating handlers (alarm + write fetch actions) against each other without
   // blocking read-only actions (status/view-state/websocket) behind a potentially multi-second
   // alarm poll - state.blockConcurrencyWhile blocks ALL events to the instance, not just writers,
@@ -2190,7 +2188,11 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     await this.setState(trackerState);
     this.notifyUserTracker(trackerState);
     await this.broadcastViewState(trackerState);
-    await this.state.storage.setAlarm(Date.now());
+    // A paused/stopped tracker has no alarm scheduled (handlePause/handleStop delete it) and
+    // won't reschedule one after this fires - forcing it here would just be a wasted wake-up.
+    if (!trackerState.isPaused && trackerState.status === "active") {
+      await this.state.storage.setAlarm(Date.now());
+    }
 
     return individualTrackerNudgeContract.toResponse({ success: true });
   }
@@ -2642,10 +2644,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
   }
 
   private async buildRealtimeViewState(state: IndividualTrackerInternalState): Promise<IndividualTrackerViewState> {
+    const statsHighlightSlots = state.websocketStatsHighlightSlots ?? DEFAULT_WEBSOCKET_STATS_HIGHLIGHT_SLOTS;
     const statsHighlights =
-      this.websocketStatsHighlightSlots.length > 0
-        ? await this.buildStatsHighlights(state, this.websocketStatsHighlightSlots)
-        : [];
+      statsHighlightSlots.length > 0 ? await this.buildStatsHighlights(state, statsHighlightSlots) : [];
     const preSeriesPlayerInfo = await this.getPreSeriesPlayerInfo(state, false);
 
     return {
@@ -2668,8 +2669,11 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
 
     const trackerState = await this.getState();
     const url = new URL(request.url);
-    if (url.searchParams.has("statsHighlightSlots")) {
-      this.websocketStatsHighlightSlots = parseStatsHighlightSlots(url);
+    if (url.searchParams.has("statsHighlightSlots") && trackerState != null) {
+      // Persisted (not an instance field) so the configured slots survive DO hibernation -
+      // otherwise a hibernate/wake cycle would silently reset the streamer's view to defaults.
+      trackerState.websocketStatsHighlightSlots = parseStatsHighlightSlots(url);
+      await this.setState(trackerState);
     }
 
     this.logService.info(

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -2292,6 +2292,21 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     });
   }
 
+  // Called from the websocket upgrade path, which is otherwise read-only - same reasoning as
+  // persistPreSeriesPlayerInfo above: re-reads fresh state inside the lock so this doesn't race
+  // and clobber a concurrent alarm/nudge write.
+  private async persistWebsocketStatsHighlightSlots(slots: readonly IndividualStatsHighlightOption[]): Promise<void> {
+    await this.withStateLock(async () => {
+      const latestState = await this.getState();
+      if (latestState == null) {
+        return;
+      }
+
+      latestState.websocketStatsHighlightSlots = slots;
+      await this.setState(latestState);
+    });
+  }
+
   private async buildPreSeriesPlayerInfo(
     state: IndividualTrackerInternalState,
   ): Promise<PreSeriesPlayerInfo | undefined> {
@@ -2672,8 +2687,11 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     if (url.searchParams.has("statsHighlightSlots") && trackerState != null) {
       // Persisted (not an instance field) so the configured slots survive DO hibernation -
       // otherwise a hibernate/wake cycle would silently reset the streamer's view to defaults.
-      trackerState.websocketStatsHighlightSlots = parseStatsHighlightSlots(url);
-      await this.setState(trackerState);
+      const slots = parseStatsHighlightSlots(url);
+      // Mutate the local copy so this request's own initial view message reflects the new slots
+      // immediately, without waiting on the write lock below.
+      trackerState.websocketStatsHighlightSlots = slots;
+      await this.persistWebsocketStatsHighlightSlots(slots);
     }
 
     this.logService.info(

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2894,6 +2894,47 @@ describe("IndividualTrackerDO", () => {
       expect(parsed.view.statsHighlights).toEqual([]);
     });
 
+    it("keeps configured stats highlight slots after the DO instance is recreated (hibernation)", async () => {
+      const trackerState = aFakeIndividualTrackerInternalStateWith({
+        trackerId: "t1",
+        gamertag: "Tag1",
+        status: "active",
+        matchIds: ["m1"],
+        selectedMatchIds: ["m1"],
+        discoveredMatches: {
+          m1: aFakeIndividualTrackerMatchSummaryWith({
+            matchId: "m1",
+            startTime: "s",
+            endTime: "e",
+            mapAssetId: "map",
+            mapVersionId: "map-v",
+            mapName: "Streets",
+            modeAssetId: "mode",
+            gameVariantCategory: 6,
+            outcome: "Win",
+            score: "50:42",
+          }),
+        },
+      });
+      storageGetSpy.mockResolvedValue(trackerState);
+
+      await individualTrackerDO.fetch(
+        wsRequest(`?statsHighlightSlots=${encodeURIComponent('["kills-deaths-assists-kda"]')}`),
+      );
+
+      // Simulates the DO instance being evicted and recreated on wake from hibernation - the
+      // in-memory instance field is gone, but the underlying storage (mockState) is unchanged.
+      const rehydratedWebSocketAdapter = aFakeWebSocketHibernationAdapter();
+      const rehydratedDO = new IndividualTrackerDO(mockState, env, () => services, rehydratedWebSocketAdapter);
+
+      await rehydratedDO.fetch(wsRequest());
+
+      const parsed = trackerViewMessageContract.parse(
+        Preconditions.checkExists(rehydratedWebSocketAdapter.initialMessages[0]),
+      );
+      expect(parsed.view.statsHighlights).toHaveLength(1);
+    });
+
     it("does not overwrite configured stats highlight slots when websocket query is absent", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
@@ -3307,6 +3348,17 @@ describe("IndividualTrackerDO", () => {
 
       expect(storageSetAlarmSpy).toHaveBeenCalledWith(Date.now());
       expect(webSocketAdapter.broadcasts).toHaveLength(1);
+    });
+
+    it("does not force an alarm when nudging a paused tracker", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ status: "paused", isPaused: true }));
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", { method: "POST", body: JSON.stringify(aSeriesPayload()) }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(storageSetAlarmSpy).not.toHaveBeenCalled();
     });
 
     it("returns 400 for malformed JSON body", async () => {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2895,7 +2895,10 @@ describe("IndividualTrackerDO", () => {
     });
 
     it("keeps configured stats highlight slots after the DO instance is recreated (hibernation)", async () => {
-      const trackerState = aFakeIndividualTrackerInternalStateWith({
+      // Backs storageGetSpy/storagePutSpy with a real key-value store (get returns a deep clone
+      // of whatever was last put) instead of a single shared object reference - otherwise this
+      // test would "pass" from in-memory object identity alone without proving persistence.
+      let persistedState: IndividualTrackerInternalState = aFakeIndividualTrackerInternalStateWith({
         trackerId: "t1",
         gamertag: "Tag1",
         status: "active",
@@ -2916,11 +2919,17 @@ describe("IndividualTrackerDO", () => {
           }),
         },
       });
-      storageGetSpy.mockResolvedValue(trackerState);
+      storageGetSpy.mockImplementation(async () => Promise.resolve(structuredClone(persistedState)));
+      storagePutSpy.mockImplementation(async (_key, value) => {
+        persistedState = value;
+        return Promise.resolve();
+      });
 
       await individualTrackerDO.fetch(
         wsRequest(`?statsHighlightSlots=${encodeURIComponent('["kills-deaths-assists-kda"]')}`),
       );
+
+      expect(persistedState.websocketStatsHighlightSlots).toEqual(["kills-deaths-assists-kda"]);
 
       // Simulates the DO instance being evicted and recreated on wake from hibernation - the
       // in-memory instance field is gone, but the underlying storage (mockState) is unchanged.

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -1,4 +1,5 @@
 import type { NormalizedMatchOutcome } from "@guilty-spark/shared/halo/match-enrichment";
+import type { IndividualStatsHighlightOption } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import type { IndividualTrackerStatus } from "../../services/database/types/individual_trackers";
 
 export interface IndividualTrackerState {
@@ -152,6 +153,7 @@ export interface IndividualTrackerInternalState extends IndividualTrackerState {
   activeSeries?: ActiveSeries;
   completedSeries?: ActiveSeries[];
   seriesGroupOverrides?: IndividualTrackerSeriesGroupOverride[];
+  websocketStatsHighlightSlots?: readonly IndividualStatsHighlightOption[];
   errorState: {
     consecutiveErrors: number;
     backoffMinutes: number;


### PR DESCRIPTION
## Context
Part of the NeatQueue -> individual tracker stability effort (see #738). This is PR 6 of 6 (final).

## This change
Two small hardening fixes found during the investigation, unrelated to each other but both small enough to bundle:

1. `websocketStatsHighlightSlots` lived on an `IndividualTrackerDO` instance field, so a hibernation cycle (constructor rerun on wake) silently reset a streamer's configured stat-highlight slots back to defaults on the next broadcast - even though their WebSocket connection never dropped or reconnected. Moved onto persisted tracker state so it survives hibernation. Added a regression test that recreates the DO instance against the same underlying storage to simulate a hibernate/wake cycle.

2. A nudge unconditionally forced `setAlarm(Date.now())` even when the tracker is paused/stopped. That alarm fires once, finds the tracker inactive, and drops with no reschedule - harmless (no infinite loop or leak) but a pointless wake, and noisy in the PR 1 logs. Now skipped when paused/stopped.

## Scope note
The plan also considered "reduce reliance on queueStateCache correctness across NeatQueue webhook requests" (KV eventual consistency). On inspection this wasn't separately actionable: `queueStateCache` is per-request only (a fresh `NeatQueueService` per webhook), and PR 2 already removes the practical risk by always doing a fresh association-data fetch rather than trusting cached/KV state to have caught up in time. No further change identified as worth the added complexity here.

This closes out the stability effort's initial 6-PR pass. If the underlying instability persists after these land, the PR 1 logging should make it visible where.

🤖 Generated with [Claude Code](https://claude.com/claude-code)