### PR TITLE
fix(individual-tracker): keep freshly-started series active through in-flight matchmaking match

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -396,13 +396,9 @@ function shouldEndSeriesForUnrelatedMatchmakingMatch(activeSeries: ActiveSeries)
 
   const minutesSinceStart = differenceInMinutes(new Date(), new Date(activeSeries.startedAt));
   if (!Number.isFinite(minutesSinceStart)) {
-    // startedAt didn't parse as a valid date - don't trust a series we can't age-check to stay
-    // active indefinitely, end it rather than risk it getting stuck forever.
     return true;
   }
 
-  // A series that never recorded a real match may just be waiting on the player's in-flight
-  // matchmaking game to finish - only treat it as abandoned once it's sat empty a while.
   return minutesSinceStart >= STALE_EMPTY_SERIES_MINUTES;
 }
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -394,9 +394,16 @@ function shouldEndSeriesForUnrelatedMatchmakingMatch(activeSeries: ActiveSeries)
     return true;
   }
 
+  const minutesSinceStart = differenceInMinutes(new Date(), new Date(activeSeries.startedAt));
+  if (!Number.isFinite(minutesSinceStart)) {
+    // startedAt didn't parse as a valid date - don't trust a series we can't age-check to stay
+    // active indefinitely, end it rather than risk it getting stuck forever.
+    return true;
+  }
+
   // A series that never recorded a real match may just be waiting on the player's in-flight
   // matchmaking game to finish - only treat it as abandoned once it's sat empty a while.
-  return differenceInMinutes(new Date(), new Date(activeSeries.startedAt)) >= STALE_EMPTY_SERIES_MINUTES;
+  return minutesSinceStart >= STALE_EMPTY_SERIES_MINUTES;
 }
 
 function normalizeRankTier(rankTier: string | null | undefined): string | null {

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/cloudflare";
-import { addMilliseconds, compareAsc, differenceInHours, differenceInSeconds } from "date-fns";
+import { addMilliseconds, compareAsc, differenceInHours, differenceInMinutes, differenceInSeconds } from "date-fns";
 import { z } from "zod";
 import {
   type PlayerMatchHistory,
@@ -92,6 +92,8 @@ const ALARM_INTERVAL_MS = DISPLAY_INTERVAL_MS - EXECUTION_BUFFER_MS;
 const NORMAL_INTERVAL_MINUTES = 3;
 const CONSECUTIVE_ERROR_INTERVAL_MINUTES = 5;
 const MAX_BACKOFF_INTERVAL_MINUTES = 10;
+
+const STALE_EMPTY_SERIES_MINUTES = 15;
 
 const PLAYER_MATCHES_PAGE_SIZE = 25;
 const MAX_MATCHES_TO_FETCH = 100;
@@ -385,6 +387,16 @@ function isEligibleForActiveSeries(
   }
 
   return matchesExpectedSeriesRoster(summary, expectedRosters);
+}
+
+function shouldEndSeriesForUnrelatedMatchmakingMatch(activeSeries: ActiveSeries): boolean {
+  if (activeSeries.matchIds.length > 0) {
+    return true;
+  }
+
+  // A series that never recorded a real match may just be waiting on the player's in-flight
+  // matchmaking game to finish - only treat it as abandoned once it's sat empty a while.
+  return differenceInMinutes(new Date(), new Date(activeSeries.startedAt)) >= STALE_EMPTY_SERIES_MINUTES;
 }
 
 function normalizeRankTier(rankTier: string | null | undefined): string | null {
@@ -712,15 +724,26 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           trackerState.activeSeries.matchIds.push(matchId);
           existingActiveSeriesMatchIds.add(matchId);
         } else if (isMatchmakingMatch) {
-          this.clearSeriesState(trackerState);
-          this.logService.info(
-            "IndividualTracker: series ended after matchmaking match was discovered",
-            new Map([
-              ["trackerId", trackerState.trackerId],
-              ["gamertag", trackerState.gamertag],
-              ["matchId", matchId],
-            ]),
-          );
+          if (shouldEndSeriesForUnrelatedMatchmakingMatch(trackerState.activeSeries)) {
+            this.clearSeriesState(trackerState);
+            this.logService.info(
+              "IndividualTracker: series ended after matchmaking match was discovered",
+              new Map([
+                ["trackerId", trackerState.trackerId],
+                ["gamertag", trackerState.gamertag],
+                ["matchId", matchId],
+              ]),
+            );
+          } else {
+            this.logService.debug(
+              "IndividualTracker: matchmaking match discovered before series recorded any matches, series left active",
+              new Map([
+                ["trackerId", trackerState.trackerId],
+                ["gamertag", trackerState.gamertag],
+                ["matchId", matchId],
+              ]),
+            );
+          }
         }
       }
       newlyDiscovered.add(matchId);

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1897,6 +1897,65 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.discoveredMatches["match-custom-newer"]?.isMatchmaking).toBe(false);
     });
 
+    it("keeps a freshly-started series active when a matchmaking match is discovered before any series match is recorded", async () => {
+      ownerClient.getPlayerMatches
+        .mockResolvedValueOnce([aFakePlayerMatch("match-matchmaking", "2024-11-26T11:55:00.000Z", 2, "PT5M", true)])
+        .mockResolvedValueOnce([]);
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          searchStartTime: "2024-11-26T11:00:00.000Z",
+          matchIds: [],
+          discoveredMatches: {},
+          activeSeries: {
+            title: "Active Series",
+            subtitle: "Customs",
+            guildIconUrl: null,
+            teams: [],
+            matchIds: [],
+            startedAt: "2024-11-26T11:50:00.000Z",
+            isActive: true,
+          },
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries?.matchIds).toEqual([]);
+      expect(persisted.matchIds).toEqual(["match-matchmaking"]);
+      expect(persisted.discoveredMatches["match-matchmaking"]?.isMatchmaking).toBe(true);
+    });
+
+    it("ends a still-empty series once it has sat stale for too long despite matchmaking matches being discovered", async () => {
+      ownerClient.getPlayerMatches
+        .mockResolvedValueOnce([aFakePlayerMatch("match-matchmaking", "2024-11-26T11:59:00.000Z", 2, "PT5M", true)])
+        .mockResolvedValueOnce([]);
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          searchStartTime: "2024-11-26T11:00:00.000Z",
+          matchIds: [],
+          discoveredMatches: {},
+          activeSeries: {
+            title: "Active Series",
+            subtitle: "Customs",
+            guildIconUrl: null,
+            teams: [],
+            matchIds: [],
+            startedAt: "2024-11-26T11:44:00.000Z",
+            isActive: true,
+          },
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries).toBeUndefined();
+      expect(persisted.completedSeries).toBeUndefined();
+    });
+
     it("stores outcome, score, and the resolved map name for a newly discovered match", async () => {
       ownerClient.getPlayerMatches
         .mockResolvedValueOnce([aFakePlayerMatch("match-new", "2024-11-26T11:30:00.000Z", 3)])

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1956,6 +1956,35 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.completedSeries).toBeUndefined();
     });
 
+    it("ends a still-empty series with an unparseable startedAt rather than leaving it stuck active forever", async () => {
+      ownerClient.getPlayerMatches
+        .mockResolvedValueOnce([aFakePlayerMatch("match-matchmaking", "2024-11-26T11:59:00.000Z", 2, "PT5M", true)])
+        .mockResolvedValueOnce([]);
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          searchStartTime: "2024-11-26T11:00:00.000Z",
+          matchIds: [],
+          discoveredMatches: {},
+          activeSeries: {
+            title: "Active Series",
+            subtitle: "Customs",
+            guildIconUrl: null,
+            teams: [],
+            matchIds: [],
+            startedAt: "not-a-valid-date",
+            isActive: true,
+          },
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries).toBeUndefined();
+      expect(persisted.completedSeries).toBeUndefined();
+    });
+
     it("stores outcome, score, and the resolved map name for a newly discovered match", async () => {
       ownerClient.getPlayerMatches
         .mockResolvedValueOnce([aFakePlayerMatch("match-new", "2024-11-26T11:30:00.000Z", 3)])


### PR DESCRIPTION
## Context

Part of the NeatQueue → individual tracker stability effort (phase 2, see local `NEATQUEUE-TRACKER-STABILITY-PLAN.md`). Phase 1 (#738-#743) addressed nudge propagation reliability; this addresses an adjacent bug found by user report during observation.

## This change

A player can join a NeatQueue queue while still finishing an unrelated matchmaking game. The queue fires and the tracker's `activeSeries` starts correctly via the `"started"` nudge - but when the in-flight matchmaking game then completes and is discovered by the poll loop, the tracker unconditionally cleared the just-started series (`clearSeriesState`), flipping the overlay back to "matchmaking" mode even though the player was about to go play their series.

Fix: only end the series for an unrelated matchmaking match once the series has actually recorded a real match (`activeSeries.matchIds.length > 0`), or once it has sat empty for 15+ minutes (stale-series fallback, in case a queue/series never materializes and NeatQueue's own `"ended"` nudge is missed).

## Test plan

- [x] `npm run done` (format, typecheck, lint, test) passes clean
- [x] New regression tests: series stays active through a 0-match matchmaking discovery; a stale (15+ min, still empty) series is still cleared
- [x] Existing matchmaking-flush tests (series already has recorded matches) unchanged - confirms behavior is unaffected once a series has real matches