### PR TITLE
fix(individual-tracker): retire (not discard) series state on started nudge, add continuation matching

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -310,6 +310,28 @@ function getExpectedSeriesTeamRosters(
   return expectedRosters;
 }
 
+// Never tolerate mismatching every known identity on a team - at least one must still match when
+// any identity signal exists, otherwise this degrades to a count-only check.
+function xuidsMatchWithTolerance(expectedXuids: ReadonlySet<string>, actualXuids: ReadonlySet<string>): boolean {
+  if (expectedXuids.size === 0) {
+    return true;
+  }
+
+  const maxToleratedMismatches = Math.min(MAX_TOLERATED_ROSTER_MISMATCHES_PER_TEAM, expectedXuids.size - 1);
+  let mismatchedCount = 0;
+  for (const xuid of expectedXuids) {
+    if (actualXuids.has(xuid)) {
+      continue;
+    }
+    mismatchedCount += 1;
+    if (mismatchedCount > maxToleratedMismatches) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 // Matches a discovered match against the series roster by team identity (not just team size),
 // tolerating a limited number of per-team swaps for in-flight NeatQueue substitutions. Falls back
 // to a count-only comparison for any team with no resolved player identities (e.g. no linked Xbox
@@ -329,26 +351,42 @@ function matchesExpectedSeriesRoster(
 
   for (const [teamId, expected] of expectedRosters.entries()) {
     const actualXuids = actualRosters.get(teamId);
-    if (actualXuids?.size !== expected.playerCount) {
+    if (actualXuids?.size !== expected.playerCount || !xuidsMatchWithTolerance(expected.knownXuids, actualXuids)) {
       return false;
     }
+  }
 
-    if (expected.knownXuids.size === 0) {
-      continue;
-    }
+  return true;
+}
 
-    // Never tolerate mismatching every known identity on a team - at least one must still match
-    // when any identity signal exists, otherwise this degrades to the count-only check it replaced.
-    const maxToleratedMismatches = Math.min(MAX_TOLERATED_ROSTER_MISMATCHES_PER_TEAM, expected.knownXuids.size - 1);
-    let mismatchedCount = 0;
-    for (const xuid of expected.knownXuids) {
-      if (actualXuids.has(xuid)) {
-        continue;
-      }
-      mismatchedCount += 1;
-      if (mismatchedCount > maxToleratedMismatches) {
-        return false;
-      }
+// Compares an incoming series' roster against a previously completed series to decide whether a
+// "started" nudge is actually a continuation of that series (e.g. the "ended" nudge for it hasn't
+// finished processing yet) rather than a genuinely new one, so history/matchIds aren't lost.
+function seriesRosterMatchesPreviousSeries(
+  incomingTeams: readonly SeriesTeam[],
+  previousSeries: ActiveSeries | undefined,
+): boolean {
+  if (previousSeries == null) {
+    return false;
+  }
+
+  const previousRosters = getExpectedSeriesTeamRosters(previousSeries.teams);
+  const incomingRosters = getExpectedSeriesTeamRosters(incomingTeams);
+  if (previousRosters == null || incomingRosters == null) {
+    return false;
+  }
+
+  if (previousRosters.size !== incomingRosters.size) {
+    return false;
+  }
+
+  for (const [teamId, previous] of previousRosters.entries()) {
+    const incoming = incomingRosters.get(teamId);
+    if (
+      incoming?.playerCount !== previous.playerCount ||
+      !xuidsMatchWithTolerance(previous.knownXuids, incoming.knownXuids)
+    ) {
+      return false;
     }
   }
 
@@ -2181,26 +2219,51 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         break;
       }
       case "started": {
-        this.clearSeriesState(trackerState);
-        const startedAt = payload.startedAt ?? new Date().toISOString();
-        trackerState.activeSeries = {
-          title: payload.title,
-          subtitle: payload.subtitle,
-          guildIconUrl: payload.guildIconUrl,
-          teams: payload.teams,
-          matchIds: [],
-          startedAt,
-          isActive: true,
-        };
+        this.retireActiveSeries(trackerState);
 
-        this.logService.info(
-          "IndividualTracker: series started via nudge",
-          new Map([
-            ["trackerId", trackerState.trackerId],
-            ["gamertag", trackerState.gamertag],
-            ["title", payload.title],
-          ]),
-        );
+        const previousSeries = trackerState.completedSeries?.at(-1);
+        if (seriesRosterMatchesPreviousSeries(payload.teams, previousSeries) && previousSeries != null) {
+          trackerState.activeSeries = {
+            ...previousSeries,
+            title: payload.title,
+            subtitle: payload.subtitle,
+            guildIconUrl: payload.guildIconUrl,
+            teams: payload.teams,
+            isActive: true,
+          };
+          trackerState.completedSeries = (trackerState.completedSeries ?? []).filter(
+            (series) => series !== previousSeries,
+          );
+
+          this.logService.info(
+            "IndividualTracker: series continued from previously completed series via started nudge",
+            new Map([
+              ["trackerId", trackerState.trackerId],
+              ["gamertag", trackerState.gamertag],
+              ["title", payload.title],
+            ]),
+          );
+        } else {
+          const startedAt = payload.startedAt ?? new Date().toISOString();
+          trackerState.activeSeries = {
+            title: payload.title,
+            subtitle: payload.subtitle,
+            guildIconUrl: payload.guildIconUrl,
+            teams: payload.teams,
+            matchIds: [],
+            startedAt,
+            isActive: true,
+          };
+
+          this.logService.info(
+            "IndividualTracker: series started via nudge",
+            new Map([
+              ["trackerId", trackerState.trackerId],
+              ["gamertag", trackerState.gamertag],
+              ["title", payload.title],
+            ]),
+          );
+        }
 
         break;
       }

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -310,8 +310,6 @@ function getExpectedSeriesTeamRosters(
   return expectedRosters;
 }
 
-// Never tolerate mismatching every known identity on a team - at least one must still match when
-// any identity signal exists, otherwise this degrades to a count-only check.
 function xuidsMatchWithTolerance(expectedXuids: ReadonlySet<string>, actualXuids: ReadonlySet<string>): boolean {
   if (expectedXuids.size === 0) {
     return true;
@@ -359,9 +357,6 @@ function matchesExpectedSeriesRoster(
   return true;
 }
 
-// Compares an incoming series' roster against a previously completed series to decide whether a
-// "started" nudge is actually a continuation of that series (e.g. the "ended" nudge for it hasn't
-// finished processing yet) rather than a genuinely new one, so history/matchIds aren't lost.
 function seriesRosterMatchesPreviousSeries(
   incomingTeams: readonly SeriesTeam[],
   previousSeries: ActiveSeries | undefined,

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -359,12 +359,8 @@ function matchesExpectedSeriesRoster(
 
 function seriesRosterMatchesPreviousSeries(
   incomingTeams: readonly SeriesTeam[],
-  previousSeries: ActiveSeries | undefined,
+  previousSeries: ActiveSeries,
 ): boolean {
-  if (previousSeries == null) {
-    return false;
-  }
-
   const previousRosters = getExpectedSeriesTeamRosters(previousSeries.teams);
   const incomingRosters = getExpectedSeriesTeamRosters(incomingTeams);
   if (previousRosters == null || incomingRosters == null) {
@@ -2217,7 +2213,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         this.retireActiveSeries(trackerState);
 
         const previousSeries = trackerState.completedSeries?.at(-1);
-        if (seriesRosterMatchesPreviousSeries(payload.teams, previousSeries) && previousSeries != null) {
+        if (previousSeries != null && seriesRosterMatchesPreviousSeries(payload.teams, previousSeries)) {
           trackerState.activeSeries = {
             ...previousSeries,
             title: payload.title,

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -3447,6 +3447,97 @@ describe("IndividualTrackerDO", () => {
       expect(webSocketAdapter.broadcasts).toHaveLength(1);
     });
 
+    it("retires a still-live activeSeries instead of discarding it when a new started nudge arrives", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          activeSeries: anActiveSeries({
+            title: "Unrelated Series",
+            teams: [
+              {
+                id: 0,
+                name: "Eagle",
+                players: [{ discordId: null, discordName: null, gamertag: "Someone", xboxId: "xuid-unrelated" }],
+              },
+            ],
+            matchIds: ["match-unrelated"],
+          }),
+          completedSeries: [anActiveSeries({ title: "Older Series", isActive: false })],
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", { method: "POST", body: JSON.stringify(aSeriesPayload()) }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries).toMatchObject({ title: "Guilty Spark", matchIds: [] });
+      expect(persisted.completedSeries).toEqual([
+        expect.objectContaining({ title: "Older Series" }),
+        expect.objectContaining({ title: "Unrelated Series", matchIds: ["match-unrelated"] }),
+      ]);
+    });
+
+    it("folds a started nudge into the previously completed series when the roster matches", async () => {
+      const previousSeries = anActiveSeries({
+        title: "Guilty Spark",
+        subtitle: "Queue #1",
+        matchIds: ["match-1", "match-2"],
+        isActive: false,
+        teams: [
+          {
+            id: 0,
+            name: "Eagle",
+            players: [{ discordId: "discord-1", discordName: "PlayerOne", gamertag: "GT1", xboxId: "xuid-1" }],
+          },
+          {
+            id: 1,
+            name: "Cobra",
+            players: [{ discordId: "discord-2", discordName: "PlayerTwo", gamertag: "GT2", xboxId: "xuid-2" }],
+          },
+        ],
+      });
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ completedSeries: [previousSeries] }));
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", { method: "POST", body: JSON.stringify(aSeriesPayload()) }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries).toMatchObject({
+        title: "Guilty Spark",
+        matchIds: ["match-1", "match-2"],
+        isActive: true,
+      });
+      expect(persisted.completedSeries).toEqual([]);
+    });
+
+    it("does not fold a started nudge into a previously completed series with a different roster", async () => {
+      const previousSeries = anActiveSeries({
+        title: "Different Series",
+        matchIds: ["match-old"],
+        isActive: false,
+        teams: [
+          {
+            id: 0,
+            name: "Eagle",
+            players: [{ discordId: null, discordName: null, gamertag: "Someone Else", xboxId: "xuid-different" }],
+          },
+        ],
+      });
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ completedSeries: [previousSeries] }));
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", { method: "POST", body: JSON.stringify(aSeriesPayload()) }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries).toMatchObject({ title: "Guilty Spark", matchIds: [] });
+      expect(persisted.completedSeries).toEqual([expect.objectContaining({ title: "Different Series" })]);
+    });
+
     it("does not force an alarm when nudging a paused tracker", async () => {
       storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ status: "paused", isPaused: true }));
 
@@ -3703,7 +3794,7 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.activeSeries?.teams[0]?.players[0]?.xboxId).toBe("xuid-3");
     });
 
-    it("flushes existing series metadata when starting a new one via nudge", async () => {
+    it("retires existing series metadata instead of discarding it when starting a new one via nudge", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
           activeSeries: anActiveSeries({ title: "Old Queue", matchIds: ["stale-match-id"] }),
@@ -3717,7 +3808,9 @@ describe("IndividualTrackerDO", () => {
       expect(response.status).toBe(200);
 
       const persisted = lastPersistedState(storagePutSpy);
-      expect(persisted.completedSeries).toBeUndefined();
+      expect(persisted.completedSeries).toEqual([
+        expect.objectContaining({ title: "Old Queue", matchIds: ["stale-match-id"], isActive: false }),
+      ]);
       expect(persisted.activeSeries).toMatchObject({ title: "Guilty Spark", matchIds: [], isActive: true });
     });
   });


### PR DESCRIPTION
## Context

Part of the NeatQueue → individual tracker stability effort (phase 2, see local `NEATQUEUE-TRACKER-STABILITY-PLAN.md`). Stacked on #744.

## This change

Two related bugs in back-to-back series handling in `case "started"` (`individual-tracker-do.ts`):

1. **Data loss, independent of any race**: `case "started"` always called `clearSeriesState`, which deletes the *entire* `completedSeries` history array (not just the current active series) every time a new series begins. Previously finalized series for a tracker vanished from history each time a new one started.
2. **Genuine race**: the `"ended"` nudge's forced alarm (`setAlarm(Date.now())`) only *schedules* a poll - it doesn't guarantee it runs before a fast-following `"started"` nudge for the next series is processed. If `"started"` wins that race, the mutex prevents a torn write, but the previous series' final match (which the delayed alarm poll hasn't discovered yet) and its metadata are still lost outright.

Fix: `"started"` now retires any live series via `retireActiveSeries` (archiving it, matching `"ended"`'s own behavior) before deciding on the new series - so nothing is ever discarded outright, regardless of arrival order. It then compares the incoming roster against `completedSeries.at(-1)` (reusing the identity-based roster-matching helpers from the phase 1 stability work) and, if it matches, folds into that series (keeping its `matchIds`/history) rather than starting fresh - covering the case where NeatQueue's series-boundary events for the same series arrive out of order or get split.

## Test plan

- [x] `npm run done` passes clean
- [x] New regression tests: live `activeSeries` is retired (not discarded) on a new `"started"` nudge, with existing `completedSeries` history preserved; roster-matching `completedSeries.at(-1)` folds in; non-matching roster still starts fresh without touching other history
- [x] Existing "flushes existing series metadata" test updated to assert the corrected (retain, don't wipe) behavior