### PR TITLE
fix: individual tracker series state in NeatQueue transitions

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -357,33 +357,6 @@ function matchesExpectedSeriesRoster(
   return true;
 }
 
-function seriesRosterMatchesPreviousSeries(
-  incomingTeams: readonly SeriesTeam[],
-  previousSeries: ActiveSeries,
-): boolean {
-  const previousRosters = getExpectedSeriesTeamRosters(previousSeries.teams);
-  const incomingRosters = getExpectedSeriesTeamRosters(incomingTeams);
-  if (previousRosters == null || incomingRosters == null) {
-    return false;
-  }
-
-  if (previousRosters.size !== incomingRosters.size) {
-    return false;
-  }
-
-  for (const [teamId, previous] of previousRosters.entries()) {
-    const incoming = incomingRosters.get(teamId);
-    if (
-      incoming?.playerCount !== previous.playerCount ||
-      !xuidsMatchWithTolerance(previous.knownXuids, incoming.knownXuids)
-    ) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 function getSeriesSummariesForSeriesList(
   groupSummaries: readonly IndividualTrackerMatchSummary[],
   teams: readonly SeriesTeam[] | undefined,
@@ -2266,49 +2239,25 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       case "started": {
         this.retireActiveSeries(trackerState);
 
-        const previousSeries = trackerState.completedSeries?.at(-1);
-        if (previousSeries != null && seriesRosterMatchesPreviousSeries(payload.teams, previousSeries)) {
-          trackerState.activeSeries = {
-            ...previousSeries,
-            title: payload.title,
-            subtitle: payload.subtitle,
-            guildIconUrl: payload.guildIconUrl,
-            teams: payload.teams,
-            isActive: true,
-          };
-          trackerState.completedSeries = (trackerState.completedSeries ?? []).filter(
-            (series) => series !== previousSeries,
-          );
+        const startedAt = payload.startedAt ?? new Date().toISOString();
+        trackerState.activeSeries = {
+          title: payload.title,
+          subtitle: payload.subtitle,
+          guildIconUrl: payload.guildIconUrl,
+          teams: payload.teams,
+          matchIds: [],
+          startedAt,
+          isActive: true,
+        };
 
-          this.logService.info(
-            "IndividualTracker: series continued from previously completed series via started nudge",
-            new Map([
-              ["trackerId", trackerState.trackerId],
-              ["gamertag", trackerState.gamertag],
-              ["title", payload.title],
-            ]),
-          );
-        } else {
-          const startedAt = payload.startedAt ?? new Date().toISOString();
-          trackerState.activeSeries = {
-            title: payload.title,
-            subtitle: payload.subtitle,
-            guildIconUrl: payload.guildIconUrl,
-            teams: payload.teams,
-            matchIds: [],
-            startedAt,
-            isActive: true,
-          };
-
-          this.logService.info(
-            "IndividualTracker: series started via nudge",
-            new Map([
-              ["trackerId", trackerState.trackerId],
-              ["gamertag", trackerState.gamertag],
-              ["title", payload.title],
-            ]),
-          );
-        }
+        this.logService.info(
+          "IndividualTracker: series started via nudge",
+          new Map([
+            ["trackerId", trackerState.trackerId],
+            ["gamertag", trackerState.gamertag],
+            ["title", payload.title],
+          ]),
+        );
 
         break;
       }
@@ -2680,7 +2629,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     const activeSeriesMatchIds = state.activeSeries?.matchIds ?? [];
     const activeSeriesMatchIdSet = new Set(activeSeriesMatchIds);
     const groupings =
-      activeSeriesMatchIds.length > 0
+      state.activeSeries != null
         ? [activeSeriesMatchIds, ...autoGroupings.filter((g) => !g.some((id) => activeSeriesMatchIdSet.has(id)))]
         : autoGroupings;
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -2642,13 +2642,16 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       seriesGroupOverridesByKey.set(buildSeriesGroupKey(override.matchIds), override);
     }
 
-    const series = groupings.map((matchIds): IndividualTrackerSeriesGroup => {
+    const series = groupings.map((matchIds, index): IndividualTrackerSeriesGroup => {
       const groupSummaries = matchIds
         .map((matchId) => summariesById.get(matchId))
         .filter((summary): summary is IndividualTrackerMatchSummary => summary != null);
 
       const matchIdSet = new Set(matchIds);
-      const seriesContext = allSeriesContexts.find((ctx) => ctx.matchIds.some((id) => matchIdSet.has(id)));
+      const isActiveSeriesSlot = state.activeSeries != null && index === 0;
+      const seriesContext = isActiveSeriesSlot
+        ? state.activeSeries
+        : allSeriesContexts.find((ctx) => ctx.matchIds.some((id) => matchIdSet.has(id)));
       const seriesGroupOverride = seriesGroupOverridesByKey.get(buildSeriesGroupKey(matchIds));
       const teams = seriesContext?.teams;
 

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -3478,7 +3478,7 @@ describe("IndividualTrackerDO", () => {
       ]);
     });
 
-    it("folds a started nudge into the previously completed series when the roster matches", async () => {
+    it("starts a fresh series via nudge even when the roster matches a previously completed series", async () => {
       const previousSeries = anActiveSeries({
         title: "Guilty Spark",
         subtitle: "Queue #1",
@@ -3507,10 +3507,10 @@ describe("IndividualTrackerDO", () => {
       const persisted = lastPersistedState(storagePutSpy);
       expect(persisted.activeSeries).toMatchObject({
         title: "Guilty Spark",
-        matchIds: ["match-1", "match-2"],
+        matchIds: [],
         isActive: true,
       });
-      expect(persisted.completedSeries).toEqual([]);
+      expect(persisted.completedSeries).toEqual([expect.objectContaining({ title: "Guilty Spark", matchIds: ["match-1", "match-2"], isActive: false })]);
     });
 
     it("does not fold a started nudge into a previously completed series with a different roster", async () => {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -1541,6 +1541,45 @@ describe("IndividualTrackerDO", () => {
       expect(body.state?.series[0]?.title).toBe("Active Series Title");
       expect(body.state?.series[0]?.subtitle).toBe("Active Sub");
     });
+
+    it("uses active series title and subtitle for the leading group even when activeSeries has no matchIds yet", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["m1", "m2"],
+          selectedMatchIds: ["m1", "m2"],
+          discoveredMatches: {
+            m1: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m1",
+              teamRosterSignature: "0:1|1:2",
+              teamOutcomes: [2, 3],
+            }),
+            m2: aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "m2",
+              teamRosterSignature: "0:1|1:2",
+              teamOutcomes: [2, 3],
+            }),
+          },
+          activeSeries: {
+            title: "Active Series Title",
+            subtitle: "Active Sub",
+            guildIconUrl: null,
+            teams: [],
+            matchIds: [],
+            startedAt: new Date().toISOString(),
+            isActive: true,
+          },
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/view-state", { method: "GET" }));
+      const body: IndividualTrackerViewStateResponse = await response.json();
+
+      expect(body.state?.series).toHaveLength(2);
+      expect(body.state?.series[0]?.title).toBe("Active Series Title");
+      expect(body.state?.series[0]?.subtitle).toBe("Active Sub");
+      expect(body.state?.series[0]?.matchIds).toEqual([]);
+      expect(body.state?.series[1]?.matchIds).toEqual(["m1", "m2"]);
+    });
   });
 
   describe("alarm()", () => {
@@ -3510,7 +3549,9 @@ describe("IndividualTrackerDO", () => {
         matchIds: [],
         isActive: true,
       });
-      expect(persisted.completedSeries).toEqual([expect.objectContaining({ title: "Guilty Spark", matchIds: ["match-1", "match-2"], isActive: false })]);
+      expect(persisted.completedSeries).toEqual([
+        expect.objectContaining({ title: "Guilty Spark", matchIds: ["match-1", "match-2"], isActive: false }),
+      ]);
     });
 
     it("does not fold a started nudge into a previously completed series with a different roster", async () => {


### PR DESCRIPTION
## Context

The individual tracker maintains a series state that gets updated via NeatQueue nudges (TEAMS_CREATED → `started`, MATCH_COMPLETED → `ended`). When a player starts the tracker mid-session (after custom games have already been played) and then joins a NeatQueue queue, the transition to the new series had two bugs that caused stale data to surface incorrectly in the overlay UI.

## This PR

**Bug 1 — Fold logic removed from `started` nudge handler**

The handler had a "fold" path: if the incoming NeatQueue teams' roster matched the last `completedSeries`, it would pull that completed series back as the new `activeSeries` — including its old `matchIds` and `startedAt`. This caused custom game matches (and their timestamps) from a previous session to bleed into the new NeatQueue series.

Fix: removed the fold entirely. A `started` nudge now always creates a fresh `activeSeries` with `matchIds: []`. The previous series stays in `completedSeries` where it belongs. Also deleted the now-unused `seriesRosterMatchesPreviousSeries` function.

**Bug 2 — `toViewState` groupings condition**

When `activeSeries.matchIds` was empty (fresh NeatQueue series with no matches yet), the condition `activeSeriesMatchIds.length > 0` was false, so `toViewState` fell back to pure `autoGroupings`. Organic match groups from before the NeatQueue series started (e.g. "Eagle vs Cobra" from earlier custom games) would appear as `series[0]` and inherit the IN PROGRESS label (since `hasActiveSeries: true`).

Fix: changed the condition to `state.activeSeries != null`, so even an empty NeatQueue `activeSeries` takes the front slot in the series groupings. The organic pre-series groups follow behind as historical data.

## Subsequent Work

- Consider whether the `searchStartTime` boundary should be updated when a NeatQueue series starts, to prevent pre-series matches from being polled and displayed as historical organic groups at all
- The Slayer: Streets match (first game of the new NeatQueue series) wasn't attributed to the active series due to roster mismatch — worth investigating whether the team roster matching tolerance needs tuning for cases where some NeatQueue players don't have linked Xbox accounts