### PR TITLE
fix: series ordering and pre-series player info in NeatQueue transitions

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -2251,6 +2251,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         };
         // Update searchStartTime so pre-series matches aren't included in the active series
         trackerState.searchStartTime = startedAt;
+        // Invalidate preSeriesPlayerInfo cache since the series context has changed
+        delete trackerState.preSeriesPlayerInfoLatestMatchId;
+        delete trackerState.preSeriesPlayerInfo;
 
         this.logService.info(
           "IndividualTracker: series started via nudge",

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -2249,13 +2249,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           startedAt,
           isActive: true,
         };
-        // Update searchStartTime so pre-series matches aren't included in the active series
         trackerState.searchStartTime = startedAt;
-        // Invalidate preSeriesPlayerInfo cache when series starts. The cache key is based on
-        // the latest match ID, which doesn't change when activeSeries becomes empty. This can
-        // cause stale cached rank/ESRA data to be returned for the new series context. By
-        // invalidating here, we force fresh pre-series player stats to be fetched and
-        // displayed in the overlay and viewer for the new series.
         delete trackerState.preSeriesPlayerInfoLatestMatchId;
         delete trackerState.preSeriesPlayerInfo;
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -2251,9 +2251,6 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         };
         // Update searchStartTime so pre-series matches aren't included in the active series
         trackerState.searchStartTime = startedAt;
-        // Invalidate preSeriesPlayerInfo cache since the series context has changed
-        delete trackerState.preSeriesPlayerInfoLatestMatchId;
-        delete trackerState.preSeriesPlayerInfo;
 
         this.logService.info(
           "IndividualTracker: series started via nudge",

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -2249,6 +2249,8 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           startedAt,
           isActive: true,
         };
+        // Update searchStartTime so pre-series matches aren't included in the active series
+        trackerState.searchStartTime = startedAt;
 
         this.logService.info(
           "IndividualTracker: series started via nudge",

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -404,6 +404,10 @@ function shouldEndSeriesForUnrelatedMatchmakingMatch(activeSeries: ActiveSeries)
   return minutesSinceStart >= STALE_EMPTY_SERIES_MINUTES;
 }
 
+function isParseableTimestamp(value: string): boolean {
+  return !Number.isNaN(Date.parse(value));
+}
+
 function normalizeRankTier(rankTier: string | null | undefined): string | null {
   if (rankTier == null || rankTier === "") {
     return null;
@@ -2249,7 +2253,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           startedAt,
           isActive: true,
         };
-        trackerState.searchStartTime = startedAt;
+        if (payload.startedAt != null && isParseableTimestamp(payload.startedAt)) {
+          trackerState.searchStartTime = payload.startedAt;
+        }
         delete trackerState.preSeriesPlayerInfoLatestMatchId;
         delete trackerState.preSeriesPlayerInfo;
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -2251,6 +2251,13 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         };
         // Update searchStartTime so pre-series matches aren't included in the active series
         trackerState.searchStartTime = startedAt;
+        // Invalidate preSeriesPlayerInfo cache when series starts. The cache key is based on
+        // the latest match ID, which doesn't change when activeSeries becomes empty. This can
+        // cause stale cached rank/ESRA data to be returned for the new series context. By
+        // invalidating here, we force fresh pre-series player stats to be fetched and
+        // displayed in the overlay and viewer for the new series.
+        delete trackerState.preSeriesPlayerInfoLatestMatchId;
+        delete trackerState.preSeriesPlayerInfo;
 
         this.logService.info(
           "IndividualTracker: series started via nudge",

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -2243,7 +2243,10 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       case "started": {
         this.retireActiveSeries(trackerState);
 
-        const startedAt = payload.startedAt ?? new Date().toISOString();
+        const startedAt =
+          payload.startedAt != null && isParseableTimestamp(payload.startedAt)
+            ? payload.startedAt
+            : new Date().toISOString();
         trackerState.activeSeries = {
           title: payload.title,
           subtitle: payload.subtitle,

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -3582,7 +3582,9 @@ describe("IndividualTrackerDO", () => {
 
     it("updates searchStartTime to series startedAt when a started nudge arrives", async () => {
       const startedAt = "2026-07-25T12:00:00Z";
-      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ searchStartTime: "2026-01-01T00:00:00Z" }));
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({ searchStartTime: "2026-01-01T00:00:00Z" }),
+      );
 
       const response = await individualTrackerDO.fetch(
         new Request("http://do/nudge", {
@@ -3596,10 +3598,55 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.searchStartTime).toBe(startedAt);
     });
 
+    it("keeps existing searchStartTime when a started nudge omits startedAt", async () => {
+      const previousSearchStartTime = "2026-01-01T00:00:00Z";
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({ searchStartTime: previousSearchStartTime }),
+      );
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", {
+          method: "POST",
+          body: JSON.stringify(aSeriesPayload({ startedAt: undefined })),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.searchStartTime).toBe(previousSearchStartTime);
+    });
+
+    it("keeps existing searchStartTime when a started nudge has an unparseable startedAt", async () => {
+      const previousSearchStartTime = "2026-01-01T00:00:00Z";
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({ searchStartTime: previousSearchStartTime }),
+      );
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", {
+          method: "POST",
+          body: JSON.stringify(aSeriesPayload({ startedAt: "not-a-valid-date" })),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.searchStartTime).toBe(previousSearchStartTime);
+    });
+
     it("clears preSeriesPlayerInfo cache when a started nudge arrives", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({
-          preSeriesPlayerInfo: { currentRank: 1500, allTimePeakRank: 2000, esra: 42.5 } as any,
+          preSeriesPlayerInfo: {
+            currentRank: 1500,
+            currentRankTier: "Onyx",
+            currentRankSubTier: 1,
+            currentRankMeasurementMatchesRemaining: null,
+            currentRankInitialMeasurementMatches: null,
+            allTimePeakRank: 2000,
+            esra: 42.5,
+            lastRankedGamePlayed: "2026-01-01T00:00:00.000Z",
+          },
           preSeriesPlayerInfoLatestMatchId: "match-old",
         }),
       );

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -3634,6 +3634,22 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.searchStartTime).toBe(previousSearchStartTime);
     });
 
+    it("falls back activeSeries.startedAt when a started nudge has an unparseable startedAt", async () => {
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith());
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", {
+          method: "POST",
+          body: JSON.stringify(aSeriesPayload({ startedAt: "not-a-valid-date" })),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries?.startedAt).not.toBe("not-a-valid-date");
+      expect(Number.isNaN(Date.parse(persisted.activeSeries?.startedAt ?? ""))).toBe(false);
+    });
+
     it("clears preSeriesPlayerInfo cache when a started nudge arrives", async () => {
       storageGetSpy.mockResolvedValue(
         aFakeIndividualTrackerInternalStateWith({

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -3400,7 +3400,7 @@ describe("IndividualTrackerDO", () => {
   });
 
   describe("handleNudge()", () => {
-    const aSeriesPayload = (): SeriesStartedPayload => ({
+    const aSeriesPayload = (overrides: Partial<SeriesStartedPayload> = {}): SeriesStartedPayload => ({
       type: "started",
       title: "Guilty Spark",
       subtitle: "Queue #1",
@@ -3417,6 +3417,7 @@ describe("IndividualTrackerDO", () => {
           players: [{ discordId: "discord-2", discordName: "PlayerTwo", gamertag: "GT2", xboxId: "xuid-2" }],
         },
       ],
+      ...overrides,
     });
 
     const anActiveSeries = (overrides: Partial<ActiveSeries> = {}): ActiveSeries => ({
@@ -3577,6 +3578,40 @@ describe("IndividualTrackerDO", () => {
       const persisted = lastPersistedState(storagePutSpy);
       expect(persisted.activeSeries).toMatchObject({ title: "Guilty Spark", matchIds: [] });
       expect(persisted.completedSeries).toEqual([expect.objectContaining({ title: "Different Series" })]);
+    });
+
+    it("updates searchStartTime to series startedAt when a started nudge arrives", async () => {
+      const startedAt = "2026-07-25T12:00:00Z";
+      storageGetSpy.mockResolvedValue(aFakeIndividualTrackerInternalStateWith({ searchStartTime: "2026-01-01T00:00:00Z" }));
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", {
+          method: "POST",
+          body: JSON.stringify(aSeriesPayload({ startedAt })),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.searchStartTime).toBe(startedAt);
+    });
+
+    it("clears preSeriesPlayerInfo cache when a started nudge arrives", async () => {
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          preSeriesPlayerInfo: { currentRank: 1500, allTimePeakRank: 2000, esra: 42.5 } as any,
+          preSeriesPlayerInfoLatestMatchId: "match-old",
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", { method: "POST", body: JSON.stringify(aSeriesPayload()) }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.preSeriesPlayerInfo).toBeUndefined();
+      expect(persisted.preSeriesPlayerInfoLatestMatchId).toBeUndefined();
     });
 
     it("does not force an alarm when nudging a paused tracker", async () => {


### PR DESCRIPTION
## Context

When dreekzzzz started a new NeatQueue series mid-stream, two issues appeared:
1. The series displayed in the wrong position in the timeline (first/oldest instead of last/newest)
2. The overlay showed empty pre-series player stats (`Matches: -` placeholder) instead of the actual rank/ESRA data

Both issues stemmed from state transitions when `started` nudges arrive to begin new series.

## This PR

**Fix 1: Update searchStartTime when NeatQueue series starts**

When a 'started' nudge arrives to begin a new series, update `searchStartTime` to the series `startedAt` timestamp. This ensures:
- Matches discovered before the series started aren't included in the active series grouping
- The series appears in the correct position in the timeline (oldest first, newest last)
- The timeline ordering is stable once the first match arrives

**Fix 2: Invalidate preSeriesPlayerInfo cache when series starts**

When a new series starts, invalidate the cached `preSeriesPlayerInfo` by deleting both the cached data and its cache key. The cache key is based on the latest match ID, which doesn't change when `activeSeries` transitions to an empty state. This can cause stale cached rank/ESRA data to be returned for the new series context.

By invalidating here, we force fresh pre-series player stats (current rank, peak rank, ESRA, etc.) to be fetched and displayed correctly in both overlay and viewer when a new series begins.