### PR TITLE
fix: refine series streamer overlay top-section layout

### DIFF
--- a/pages/src/components/streamer-overlay/streamer-overlay.module.css
+++ b/pages/src/components/streamer-overlay/streamer-overlay.module.css
@@ -45,9 +45,11 @@
   background-repeat: no-repeat;
   background-size: cover;
 }
+
 /* ============================================ */
 
 /* Top Section: Teams and Score                 */
+
 /* ============================================ */
 
 .topSection {
@@ -121,9 +123,8 @@
 }
 
 .serverIconSlotCompact {
-  align-self: stretch;
+  place-self: stretch center;
   height: 100%;
-  justify-self: center;
 }
 
 .serverIconSlotCentered {

--- a/pages/src/components/streamer-overlay/streamer-overlay.module.css
+++ b/pages/src/components/streamer-overlay/streamer-overlay.module.css
@@ -45,11 +45,9 @@
   background-repeat: no-repeat;
   background-size: cover;
 }
-
 /* ============================================ */
 
 /* Top Section: Teams and Score                 */
-
 /* ============================================ */
 
 .topSection {
@@ -63,6 +61,26 @@
   top: 0;
   width: 100%;
   z-index: 10;
+}
+
+.topSectionSingleMetadataLine {
+  grid-template: "teamLeft scoreLeft serverIcon scoreRight teamRight" min-content ". metadata metadata metadata ." min-content / 1fr min-content min-content min-content 1fr;
+}
+
+.topSectionNoMetadataLine {
+  grid-template: "teamLeft scoreLeft serverIcon scoreRight teamRight" min-content / 1fr min-content min-content min-content 1fr;
+}
+
+.topSectionNoScore {
+  grid-template: "teamLeft . serverIcon . teamRight" min-content "title title serverIcon subtitle subtitle" min-content / 1fr min-content min-content min-content 1fr;
+}
+
+.topSectionNoScore.topSectionSingleMetadataLine {
+  grid-template: "teamLeft teamLeft serverIcon teamRight teamRight" min-content ". metadata metadata metadata ." min-content / 1fr min-content min-content min-content 1fr;
+}
+
+.topSectionNoScore.topSectionNoMetadataLine {
+  grid-template: "teamLeft teamLeft serverIcon teamRight teamRight" min-content / 1fr min-content min-content min-content 1fr;
 }
 
 .title,
@@ -89,10 +107,27 @@
   justify-self: start;
 }
 
+.metadataSingleLine {
+  border-left: 2px solid var(--halo-bg-primary);
+  border-right: 2px solid var(--halo-bg-primary);
+  grid-area: metadata;
+  justify-self: center;
+}
+
 .serverIconSlot {
   aspect-ratio: 1;
   grid-area: serverIcon;
   place-self: stretch center;
+}
+
+.serverIconSlotCompact {
+  align-self: stretch;
+  height: 100%;
+  justify-self: center;
+}
+
+.serverIconSlotCentered {
+  justify-self: center;
 }
 
 .serverIcon {

--- a/pages/src/components/streamer-overlay/streamer-overlay.module.css
+++ b/pages/src/components/streamer-overlay/streamer-overlay.module.css
@@ -123,8 +123,8 @@
 }
 
 .serverIconSlotCompact {
-  place-self: stretch center;
   height: 100%;
+  place-self: stretch center;
 }
 
 .serverIconSlotCentered {

--- a/pages/src/components/streamer-overlay/tests/top-section.test.tsx
+++ b/pages/src/components/streamer-overlay/tests/top-section.test.tsx
@@ -1,6 +1,5 @@
 import "@testing-library/jest-dom/vitest";
 
-import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import type { TeamColor } from "../../team-colors/team-colors";

--- a/pages/src/components/streamer-overlay/tests/top-section.test.tsx
+++ b/pages/src/components/streamer-overlay/tests/top-section.test.tsx
@@ -1,0 +1,110 @@
+import "@testing-library/jest-dom/vitest";
+
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { TeamColor } from "../../team-colors/team-colors";
+import { TopSection } from "../top-section";
+import styles from "../streamer-overlay.module.css";
+
+describe("TopSection", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const teamColors: TeamColor[] = [
+    { id: "eagle", name: "Eagle", hex: "#0066CC" },
+    { id: "cobra", name: "Cobra", hex: "#CC0000" },
+  ];
+
+  function renderTopSection({
+    title,
+    subtitle,
+    showScore,
+  }: {
+    title: string | null;
+    subtitle: string | null;
+    showScore: boolean;
+  }): HTMLDivElement {
+    const { container } = render(
+      <TopSection
+        title={title}
+        subtitle={subtitle}
+        iconUrl="/server-icon.png"
+        showScore={showScore}
+        showTeamDetails={false}
+        seriesScore="2:1"
+        teamColors={teamColors}
+        teamLeft={null}
+        teamRight={null}
+      />,
+    );
+
+    return container.firstElementChild as HTMLDivElement;
+  }
+
+  it("keeps the two-line layout when title and subtitle are both present with score", () => {
+    const topSection = renderTopSection({ title: "Main Event", subtitle: "Best of 5", showScore: true });
+
+    const classes = topSection.className.split(" ");
+    expect(classes).not.toContain(styles.topSectionNoScore);
+    expect(classes).not.toContain(styles.topSectionSingleMetadataLine);
+    expect(classes).not.toContain(styles.topSectionNoMetadataLine);
+
+    const iconSlot = screen.getByRole("img", { name: "Server" }).parentElement;
+    expect(iconSlot).not.toBeNull();
+    expect(iconSlot?.className.split(" ")).not.toContain(styles.serverIconSlotCompact);
+  });
+
+  it("uses compact icon and centered metadata row when only one metadata line exists with score", () => {
+    const topSection = renderTopSection({ title: "Grand Finals", subtitle: null, showScore: true });
+
+    expect(topSection.className.split(" ")).toContain(styles.topSectionSingleMetadataLine);
+
+    const iconSlot = screen.getByRole("img", { name: "Server" }).parentElement;
+    expect(iconSlot).not.toBeNull();
+    expect(iconSlot?.className.split(" ")).toContain(styles.serverIconSlotCompact);
+
+    const titleElement = screen.getByText("Grand Finals");
+    expect(titleElement.className.split(" ")).toContain(styles.metadataSingleLine);
+  });
+
+  it("uses a single row when title and subtitle are both missing", () => {
+    const topSection = renderTopSection({ title: null, subtitle: null, showScore: true });
+
+    expect(topSection.className.split(" ")).toContain(styles.topSectionNoMetadataLine);
+
+    const iconSlot = screen.getByRole("img", { name: "Server" }).parentElement;
+    expect(iconSlot).not.toBeNull();
+    expect(iconSlot?.className.split(" ")).toContain(styles.serverIconSlotCompact);
+  });
+
+  it("keeps title and subtitle on a second row when score is hidden", () => {
+    const topSection = renderTopSection({ title: "Championship", subtitle: "Upper Bracket", showScore: false });
+
+    const classes = topSection.className.split(" ");
+    expect(classes).toContain(styles.topSectionNoScore);
+    expect(classes).not.toContain(styles.topSectionSingleMetadataLine);
+
+    expect(screen.queryByText("2")).not.toBeInTheDocument();
+    expect(screen.queryByText("1")).not.toBeInTheDocument();
+  });
+
+  it("stacks icon over metadata when score is hidden and only one metadata line exists", () => {
+    const topSection = renderTopSection({ title: null, subtitle: "Losers Round 3", showScore: false });
+
+    const classes = topSection.className.split(" ");
+    expect(classes).toContain(styles.topSectionNoScore);
+    expect(classes).toContain(styles.topSectionSingleMetadataLine);
+
+    const iconSlot = screen.getByRole("img", { name: "Server" }).parentElement;
+    expect(iconSlot).not.toBeNull();
+
+    const iconSlotClasses = iconSlot?.className.split(" ") ?? [];
+    expect(iconSlotClasses).toContain(styles.serverIconSlotCompact);
+    expect(iconSlotClasses).toContain(styles.serverIconSlotCentered);
+
+    const subtitleElement = screen.getByText("Losers Round 3");
+    expect(subtitleElement.className.split(" ")).toContain(styles.metadataSingleLine);
+  });
+});

--- a/pages/src/components/streamer-overlay/top-section.tsx
+++ b/pages/src/components/streamer-overlay/top-section.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from "react";
+import classNames from "classnames";
 import type { TeamColor } from "../team-colors/team-colors";
 import { TeamIcon } from "../icons/team-icon";
 import styles from "./streamer-overlay.module.css";
@@ -27,15 +28,39 @@ function TopSectionComponent({
   teamRight,
 }: TopSectionProps): React.ReactElement {
   const [leftScore = "0", rightScore = "0"] = seriesScore.split(":");
+  const hasTitle = title != null;
+  const hasSubtitle = subtitle != null;
+  const hasSingleMetadataLine = hasTitle !== hasSubtitle;
+  const hasAnyMetadataLine = hasTitle || hasSubtitle;
+
+  const topSectionClassName = classNames(styles.topSection, {
+    [styles.topSectionNoScore]: !showScore,
+    [styles.topSectionSingleMetadataLine]: hasSingleMetadataLine,
+    [styles.topSectionNoMetadataLine]: !hasAnyMetadataLine,
+  });
+
+  const serverIconSlotClassName = classNames(styles.serverIconSlot, {
+    [styles.serverIconSlotCompact]: hasSingleMetadataLine || !hasAnyMetadataLine,
+    [styles.serverIconSlotCentered]: !showScore && hasSingleMetadataLine,
+  });
+
+  const titleClassName = classNames(styles.title, {
+    [styles.metadataSingleLine]: hasSingleMetadataLine,
+  });
+
+  const subtitleClassName = classNames(styles.subtitle, {
+    [styles.metadataSingleLine]: hasSingleMetadataLine,
+  });
+
   return (
-    <div className={styles.topSection}>
-      {title != null && <div className={styles.title}>{title}</div>}
+    <div className={topSectionClassName}>
+      {title != null && <div className={titleClassName}>{title}</div>}
       {iconUrl != null && (
-        <div className={styles.serverIconSlot}>
+        <div className={serverIconSlotClassName}>
           <img src={iconUrl} alt="Server" className={styles.serverIcon} />
         </div>
       )}
-      {subtitle != null && <div className={styles.subtitle}>{subtitle}</div>}
+      {subtitle != null && <div className={subtitleClassName}>{subtitle}</div>}
       {showScore && (
         <>
           <div className={styles.teamLeftScore} style={{ "--team-color": teamColors[0]?.hex } as React.CSSProperties}>


### PR DESCRIPTION
## Context
Series overlay top section needed better behavior when score/title/subtitle visibility toggles changed. The previous grid kept the server icon spanning two rows and produced awkward spacing/border combinations when only one metadata line (title or subtitle) was present, when both were absent, or when score was hidden.

## This PR
- Adds conditional top-section layout variants in [pages/src/components/streamer-overlay/top-section.tsx](pages/src/components/streamer-overlay/top-section.tsx) based on score/title/subtitle presence.
- Refines top-section grid templates and icon-slot behavior in [pages/src/components/streamer-overlay/streamer-overlay.module.css](pages/src/components/streamer-overlay/streamer-overlay.module.css):
  - Compact icon behavior for single/no metadata states while preserving square sizing.
  - No-score variants retain two-row structure where applicable.
  - Team sections expand into former score columns when score is hidden and only one/no metadata line is shown.
  - Border behavior aligns with original style expectations (no-score title/subtitle keep original edge-only treatment; single metadata line has the requested treatment).
- Adds focused coverage in [pages/src/components/streamer-overlay/tests/top-section.test.tsx](pages/src/components/streamer-overlay/tests/top-section.test.tsx) for key layout combinations.

## Subsequent Work
- Validate the same states in OBS/browser visual checks for both individual tracker and live tracker overlays with real settings presets.
