### PR TITLE
feat(analytics): objective score progression — foundation (PR 1/5)

### DIFF
--- a/api/services/analytics/tests/analytics.test.ts
+++ b/api/services/analytics/tests/analytics.test.ts
@@ -100,9 +100,13 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
     expect(results["match-1"]?.scoreProgression?.durationMs).toBe(525500);
     expect(results["match-1"]?.scoreProgression?.teamCount).toBe(2);
     expect(results["match-1"]?.scoreProgression?.respawnDurationMs).toBe(8000);
-    expect(results["match-1"]?.scoreProgression?.timeline.type).toBe("kill-race");
-    expect(results["match-1"]?.scoreProgression?.timeline.events).toHaveLength(1);
-    expect(results["match-1"]?.scoreProgression?.timeline.deathTimeline).toEqual([{ timestampMs: 5100, teamId: 1 }]);
+    const timeline = results["match-1"]?.scoreProgression?.timeline;
+    expect(timeline?.type).toBe("kill-race");
+    if (timeline?.type !== "kill-race") {
+      throw new Error("expected kill-race timeline");
+    }
+    expect(timeline.events).toHaveLength(1);
+    expect(timeline.deathTimeline).toEqual([{ timestampMs: 5100, teamId: 1 }]);
   });
 
   it("returns scoreProgression null when scoreProgression module is requested but match has no teams", async () => {

--- a/api/services/halo/halo-film-type2.ts
+++ b/api/services/halo/halo-film-type2.ts
@@ -1,4 +1,12 @@
 import { KNOWN_WEAPON_IDS, hasCommonWeaponSuffix, lookupWeaponName, weaponIdToHex } from "./weapon-ids";
+import type { StateByte2Transition } from "./types";
+
+// The frame marker [0xa0, 0x7b, 0x42] precedes each frame's payload. Payload byte 2
+// (the 3rd byte after the marker) is a game-period counter that increments with each
+// objective transition: hill changes in KOTH, ball possession in Oddball, zone captures
+// in Strongholds, and flag interactions in CTF. It reads 0xa0/0x00 outside gameplay
+// and 0x40-onwards during active play, making it the universal objective state signal.
+const STATE_BYTE_PAYLOAD_OFFSET = 2; // index within payload (after the 3-byte frame marker)
 
 // Fire event scanner for the type-2 (replication) film chunk.
 // Ported from https://github.com/JGtm/LevelUp/blob/main/weapon_scanner.go
@@ -196,6 +204,38 @@ export function scanFormulaAEvents(data: Uint8Array): FormulaAEvent[] {
     pos = nextPos;
   }
   return events;
+}
+
+export function scanStateByte2Transitions(
+  data: Uint8Array,
+  startMs: number,
+  durationMs: number,
+): StateByte2Transition[] {
+  const frames = findFramePositions(data);
+  if (frames.length === 0) {
+    return [];
+  }
+  const msPerFrame = durationMs / frames.length;
+  const transitions: StateByte2Transition[] = [];
+  let prevValue: number | null = null;
+
+  for (let i = 0; i < frames.length; i++) {
+    const framePos = frames[i];
+    if (framePos == null) {
+      continue;
+    }
+    const stateValue = data[framePos + FRAME_MARKER.length + STATE_BYTE_PAYLOAD_OFFSET] ?? 0;
+    if (prevValue !== null && stateValue !== prevValue) {
+      transitions.push({
+        timeMs: Math.round(startMs + i * msPerFrame),
+        fromValue: prevValue,
+        toValue: stateValue,
+      });
+    }
+    prevValue = stateValue;
+  }
+
+  return transitions;
 }
 
 export class WeaponAttributor {

--- a/api/services/halo/halo-film-type2.ts
+++ b/api/services/halo/halo-film-type2.ts
@@ -6,7 +6,7 @@ import type { StateByte2Transition } from "./types";
 // objective transition: hill changes in KOTH, ball possession in Oddball, zone captures
 // in Strongholds, and flag interactions in CTF. It reads 0xa0/0x00 outside gameplay
 // and 0x40-onwards during active play, making it the universal objective state signal.
-const STATE_BYTE_PAYLOAD_OFFSET = 2; // index within payload (after the 3-byte frame marker)
+const STATE_BYTE_PAYLOAD_OFFSET = 2;
 
 // Fire event scanner for the type-2 (replication) film chunk.
 // Ported from https://github.com/JGtm/LevelUp/blob/main/weapon_scanner.go
@@ -219,12 +219,12 @@ export function scanStateByte2Transitions(
   const transitions: StateByte2Transition[] = [];
   let prevValue: number | null = null;
 
-  for (let i = 0; i < frames.length; i++) {
-    const framePos = frames[i];
-    if (framePos == null) {
+  for (const [i, framePos] of frames.entries()) {
+    const byteOffset = framePos + FRAME_MARKER.length + STATE_BYTE_PAYLOAD_OFFSET;
+    if (byteOffset >= data.length) {
       continue;
     }
-    const stateValue = data[framePos + FRAME_MARKER.length + STATE_BYTE_PAYLOAD_OFFSET] ?? 0;
+    const stateValue = data[byteOffset] ?? 0;
     if (prevValue !== null && stateValue !== prevValue) {
       transitions.push({
         timeMs: Math.round(startMs + i * msPerFrame),

--- a/api/services/halo/tests/halo-film-type2.test.ts
+++ b/api/services/halo/tests/halo-film-type2.test.ts
@@ -60,6 +60,12 @@ describe("scanStateByte2Transitions", () => {
     expect(result[2]).toMatchObject({ fromValue: 0x41, toValue: 0x42 });
   });
 
+  it("does not emit a transition when the state byte is out of bounds", () => {
+    // Frame marker at the very end of the buffer — no room for the 5-byte payload offset
+    const data = new Uint8Array([0xa0, 0x7b, 0x42]);
+    expect(scanStateByte2Transitions(data, 0, 1000)).toEqual([]);
+  });
+
   it("detects a back-and-forth transition (value reverts)", () => {
     const data = buildStateByte2Chunk([0x40, 0x41, 0x40]);
     const result = scanStateByte2Transitions(data, 0, 3000);

--- a/api/services/halo/tests/halo-film-type2.test.ts
+++ b/api/services/halo/tests/halo-film-type2.test.ts
@@ -1,6 +1,73 @@
 import { describe, expect, it } from "vitest";
-import { scanFireEvents, scanFormulaAEvents, WeaponAttributor } from "../halo-film-type2";
+import { scanFireEvents, scanFormulaAEvents, scanStateByte2Transitions, WeaponAttributor } from "../halo-film-type2";
 import { buildFireEventBytes, buildFormulaAEventBytes } from "./film-fire-event-builder";
+
+function buildStateByte2Chunk(byte2Sequence: number[]): Uint8Array {
+  const FRAME_SIZE = 16;
+  const data = new Uint8Array(byte2Sequence.length * FRAME_SIZE);
+  for (const [i, b2] of byte2Sequence.entries()) {
+    const pos = i * FRAME_SIZE;
+    // Frame marker [0xa0, 0x7b, 0x42] then payload; byte 2 of payload is at pos + 5
+    data[pos] = 0xa0;
+    data[pos + 1] = 0x7b;
+    data[pos + 2] = 0x42;
+    data[pos + 5] = b2;
+  }
+  return data;
+}
+
+describe("scanStateByte2Transitions", () => {
+  it("returns empty array for empty data", () => {
+    expect(scanStateByte2Transitions(new Uint8Array(0), 0, 1000)).toEqual([]);
+  });
+
+  it("returns empty array when no frame markers are present", () => {
+    expect(scanStateByte2Transitions(new Uint8Array(32), 0, 1000)).toEqual([]);
+  });
+
+  it("returns empty array when all frames carry the same byte 2 value", () => {
+    const data = buildStateByte2Chunk([0x40, 0x40, 0x40]);
+    expect(scanStateByte2Transitions(data, 0, 3000)).toEqual([]);
+  });
+
+  it("detects a single transition between two frames", () => {
+    const data = buildStateByte2Chunk([0xa0, 0x40]);
+    const result = scanStateByte2Transitions(data, 0, 2000);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.fromValue).toBe(0xa0);
+    expect(result[0]?.toValue).toBe(0x40);
+  });
+
+  it("timestamps the transition at the frame where the new value first appears", () => {
+    // 4 frames over 4000ms → 1000ms per frame; transition at frame 2 → timeMs = 2000
+    const data = buildStateByte2Chunk([0xa0, 0xa0, 0x40, 0x40]);
+    const result = scanStateByte2Transitions(data, 0, 4000);
+    expect(result[0]?.timeMs).toBe(2000);
+  });
+
+  it("applies startMs offset to all transition timestamps", () => {
+    const data = buildStateByte2Chunk([0xa0, 0x40]);
+    const result = scanStateByte2Transitions(data, 5000, 2000);
+    expect(result[0]?.timeMs).toBe(6000); // startMs=5000 + frame 1 of 2 frames = 5000 + 1*1000
+  });
+
+  it("detects multiple consecutive transitions", () => {
+    const data = buildStateByte2Chunk([0xa0, 0x40, 0x41, 0x42]);
+    const result = scanStateByte2Transitions(data, 0, 4000);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({ fromValue: 0xa0, toValue: 0x40 });
+    expect(result[1]).toMatchObject({ fromValue: 0x40, toValue: 0x41 });
+    expect(result[2]).toMatchObject({ fromValue: 0x41, toValue: 0x42 });
+  });
+
+  it("detects a back-and-forth transition (value reverts)", () => {
+    const data = buildStateByte2Chunk([0x40, 0x41, 0x40]);
+    const result = scanStateByte2Transitions(data, 0, 3000);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ fromValue: 0x40, toValue: 0x41 });
+    expect(result[1]).toMatchObject({ fromValue: 0x41, toValue: 0x40 });
+  });
+});
 
 describe("scanFireEvents", () => {
   it("returns empty array for empty data", () => {

--- a/api/services/halo/types.ts
+++ b/api/services/halo/types.ts
@@ -209,6 +209,12 @@ export interface KillRaceDeathEvent {
   teamId: number;
 }
 
+export interface StateByte2Transition {
+  timeMs: number;
+  fromValue: number;
+  toValue: number;
+}
+
 export interface KillRaceProgression {
   events: KillRaceProgressionEvent[];
   deathTimeline: KillRaceDeathEvent[];

--- a/pages/src/components/stats/score-progression/score-progression-formatter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-formatter.ts
@@ -170,7 +170,7 @@ export function formatScoreProgression(
   }
 
   const playerAdvantage =
-    respawnDurationMs != null
+    respawnDurationMs != null && timeline.type === "kill-race"
       ? buildPlayerAdvantage(teamIds, timeline.deathTimeline, respawnDurationMs, durationMs, teamSize)
       : null;
 

--- a/shared/src/contracts/stats/match-analytics.ts
+++ b/shared/src/contracts/stats/match-analytics.ts
@@ -28,9 +28,17 @@ const objectiveControlPeriodSchema = z.object({
 
 export type ObjectiveControlPeriod = z.infer<typeof objectiveControlPeriodSchema>;
 
+const objectiveControlEventSchema = z.object({
+  timestampMs: z.number().int().nonnegative(),
+  teamId: z.number().int().nonnegative(),
+  runningScores: z.record(z.string().regex(/^\d+$/), z.number().int().nonnegative()),
+});
+
+export type ObjectiveControlEvent = z.infer<typeof objectiveControlEventSchema>;
+
 const objectiveControlTimelineSchema = z.object({
   type: z.literal("objective-control"),
-  events: z.array(killRaceEventSchema),
+  events: z.array(objectiveControlEventSchema),
   controlPeriods: z.array(objectiveControlPeriodSchema),
 });
 

--- a/shared/src/contracts/stats/match-analytics.ts
+++ b/shared/src/contracts/stats/match-analytics.ts
@@ -20,6 +20,27 @@ const killRaceTimelineSchema = z.object({
   deathTimeline: z.array(killRaceDeathEventSchema),
 });
 
+const objectiveControlPeriodSchema = z.object({
+  startMs: z.number().int().nonnegative(),
+  endMs: z.number().int().nonnegative(),
+  controllingTeamId: z.number().int().nonnegative().nullable(),
+});
+
+export type ObjectiveControlPeriod = z.infer<typeof objectiveControlPeriodSchema>;
+
+const objectiveControlTimelineSchema = z.object({
+  type: z.literal("objective-control"),
+  events: z.array(killRaceEventSchema),
+  controlPeriods: z.array(objectiveControlPeriodSchema),
+});
+
+const scoreProgressionTimelineSchema = z.discriminatedUnion("type", [
+  killRaceTimelineSchema,
+  objectiveControlTimelineSchema,
+]);
+
+export type ScoreProgressionTimeline = z.infer<typeof scoreProgressionTimelineSchema>;
+
 export const killMatrixEntrySchema = z.object({
   count: z.number().int().nonnegative().describe("Total kills for this killer/victim pair"),
   headshotKills: z.number().int().nonnegative().describe("Headshot kill count for this killer/victim pair"),
@@ -79,7 +100,7 @@ export const matchAnalyticsSchema = z.object({
       durationMs: z.number().int().nonnegative(),
       teamCount: z.number().int().positive(),
       respawnDurationMs: z.number().int().positive().nullable(),
-      timeline: killRaceTimelineSchema,
+      timeline: scoreProgressionTimelineSchema,
     })
     .nullable(),
 });


### PR DESCRIPTION
## Context

Starting a 5-PR feature to add objective-mode score progression charts for Halo Infinite games. The existing chart system handles kill-race modes (Slayer, Fiesta, Attrition) using per-kill running scores. Objective modes (KOTH, Oddball, Strongholds, CTF) need a different approach based on raw film data.

Investigation confirmed that type-2 film chunk payload byte 2 (the "game period counter") is a universal objective state signal across all four modes — it increments with each objective transition (hill changes, ball possession, zone captures, flag interactions) and reads `0xa0`/`0x00` outside gameplay. Combined with 5-second highlight ticks for team attribution, this enables per-second score interpolation for all objective modes.

**Plan:**
- PR 1 (this): Foundational data layer
- PR 2: KOTH + Oddball analytics wiring
- PR 3: Strongholds + CTF analytics wiring
- PR 4: UI components
- PR 5: Polish and edge cases

## This change

- **`scanStateByte2Transitions(data, startMs, durationMs)`** in `halo-film-type2.ts` — scans a type-2 chunk for byte-2 changes frame by frame, producing `StateByte2Transition[]` with ms-precision timestamps via linear interpolation within the chunk
- **`StateByte2Transition`** interface in `api/services/halo/types.ts`
- **`objectiveControlTimelineSchema`** / **`objectiveControlPeriodSchema`** / **`ObjectiveControlEvent`** in the shared contracts — extends `scoreProgression.timeline` to a discriminated union `{ type: "kill-race" } | { type: "objective-control" }`
- Type-narrowing fixes in the score-progression formatter and analytics test (accessing `.deathTimeline` now requires the `"kill-race"` guard)
- 8 tests for `scanStateByte2Transitions` including the buffer-boundary edge case

## Subsequent work

PR 2 will wire `scanStateByte2Transitions` into `analytics.ts` for KOTH and Oddball, using byte-2 periods for timing and 5-second highlight ticks for team attribution.