### PR TITLE
feat(analytics): KOTH + Oddball score progression (PR 2/5)

### DIFF
--- a/api/services/analytics/analytics.ts
+++ b/api/services/analytics/analytics.ts
@@ -24,6 +24,11 @@ const KILL_RACE_GAME_MODES = new Set([
   GameVariantCategory.MultiplayerAttrition,
 ]);
 
+const OBJECTIVE_CONTROL_GAME_MODES = new Set([
+  GameVariantCategory.MultiplayerKingOfTheHill,
+  GameVariantCategory.MultiplayerOddball,
+]);
+
 function toContractKillMatrix(
   entries: Awaited<ReturnType<HaloFilmService["buildKillMatrixAnalytics"]>>["entries"],
 ): Record<string, ContractKillMatrixEntry> {
@@ -59,14 +64,28 @@ export class AnalyticsService {
     let scoreProgression: MatchAnalytics["scoreProgression"] = null;
     if (modules.includes("scoreProgression")) {
       const mode = matchStats.MatchInfo.GameVariantCategory;
+      const durationMs = Math.round(getDurationInSeconds(matchStats.MatchInfo.Duration) * 1000);
       if (KILL_RACE_GAME_MODES.has(mode) && matchStats.Teams.length > 0) {
         const progression = await this.haloFilmService.buildKillRaceProgression(matchStats);
         scoreProgression = {
           mode,
-          durationMs: Math.round(getDurationInSeconds(matchStats.MatchInfo.Duration) * 1000),
+          durationMs,
           teamCount: progression.teamCount,
           respawnDurationMs: KILL_RACE_RESPAWN_DURATION_MS[mode] ?? null,
           timeline: { type: "kill-race", events: progression.events, deathTimeline: progression.deathTimeline },
+        };
+      } else if (OBJECTIVE_CONTROL_GAME_MODES.has(mode) && matchStats.Teams.length > 0) {
+        const progression = await this.haloFilmService.buildObjectiveControlProgression(matchStats, durationMs);
+        scoreProgression = {
+          mode,
+          durationMs,
+          teamCount: progression.teamCount,
+          respawnDurationMs: null,
+          timeline: {
+            type: "objective-control",
+            events: progression.events,
+            controlPeriods: progression.controlPeriods,
+          },
         };
       }
     }

--- a/api/services/analytics/tests/analytics.test.ts
+++ b/api/services/analytics/tests/analytics.test.ts
@@ -109,6 +109,75 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
     expect(timeline.deathTimeline).toEqual([{ timestampMs: 5100, teamId: 1 }]);
   });
 
+  it("returns objective-control scoreProgression for KOTH when scoreProgression module is requested", async () => {
+    const env = aFakeEnvWith();
+    const haloService = aFakeHaloServiceWith({ env });
+    const haloFilmService = aFakeHaloFilmServiceWith({ env });
+    const logService = aFakeLogServiceWith();
+    const matchStats = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+    const kothMatchStats = {
+      ...matchStats,
+      MatchInfo: { ...matchStats.MatchInfo, GameVariantCategory: GameVariantCategory.MultiplayerKingOfTheHill },
+    };
+    vi.spyOn(haloService, "getMatchDetails").mockResolvedValue([kothMatchStats]);
+    vi.spyOn(haloFilmService, "warmAuthCache").mockResolvedValue(undefined);
+    vi.spyOn(haloFilmService, "buildKillMatrixAnalytics").mockResolvedValue({
+      entries: [],
+      pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 0 },
+      perfectCounts: { total: 0, byXuid: {} },
+    });
+    vi.spyOn(haloFilmService, "buildObjectiveControlProgression").mockResolvedValue({
+      events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+      controlPeriods: [],
+      teamCount: 2,
+    });
+
+    const service = new AnalyticsService({ haloService, haloFilmService, logService });
+    const results = await service.getBatchMatchAnalytics(["match-1"], ["killMatrix", "scoreProgression"]);
+
+    expect(results["match-1"]?.scoreProgression).not.toBeNull();
+    expect(results["match-1"]?.scoreProgression?.mode).toBe(GameVariantCategory.MultiplayerKingOfTheHill);
+    expect(results["match-1"]?.scoreProgression?.respawnDurationMs).toBeNull();
+    const timeline = results["match-1"]?.scoreProgression?.timeline;
+    expect(timeline?.type).toBe("objective-control");
+    if (timeline?.type !== "objective-control") {
+      throw new Error("expected objective-control timeline");
+    }
+    expect(timeline.events).toHaveLength(1);
+    expect(timeline.controlPeriods).toHaveLength(0);
+  });
+
+  it("returns objective-control scoreProgression for Oddball when scoreProgression module is requested", async () => {
+    const env = aFakeEnvWith();
+    const haloService = aFakeHaloServiceWith({ env });
+    const haloFilmService = aFakeHaloFilmServiceWith({ env });
+    const logService = aFakeLogServiceWith();
+    const matchStats = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+    const oddballMatchStats = {
+      ...matchStats,
+      MatchInfo: { ...matchStats.MatchInfo, GameVariantCategory: GameVariantCategory.MultiplayerOddball },
+    };
+    vi.spyOn(haloService, "getMatchDetails").mockResolvedValue([oddballMatchStats]);
+    vi.spyOn(haloFilmService, "warmAuthCache").mockResolvedValue(undefined);
+    vi.spyOn(haloFilmService, "buildKillMatrixAnalytics").mockResolvedValue({
+      entries: [],
+      pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 0 },
+      perfectCounts: { total: 0, byXuid: {} },
+    });
+    vi.spyOn(haloFilmService, "buildObjectiveControlProgression").mockResolvedValue({
+      events: [],
+      controlPeriods: [],
+      teamCount: 2,
+    });
+
+    const service = new AnalyticsService({ haloService, haloFilmService, logService });
+    const results = await service.getBatchMatchAnalytics(["match-1"], ["killMatrix", "scoreProgression"]);
+
+    expect(results["match-1"]?.scoreProgression?.mode).toBe(GameVariantCategory.MultiplayerOddball);
+    const timeline = results["match-1"]?.scoreProgression?.timeline;
+    expect(timeline?.type).toBe("objective-control");
+  });
+
   it("returns scoreProgression null when scoreProgression module is requested but match has no teams", async () => {
     const env = aFakeEnvWith();
     const haloService = aFakeHaloServiceWith({ env });

--- a/api/services/halo/halo-film.ts
+++ b/api/services/halo/halo-film.ts
@@ -3,7 +3,7 @@ import type { MatchStats, SpartanTokenProvider } from "halo-infinite-api";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { wrapXuid, unwrapXuid } from "@guilty-spark/shared/halo/match-stats";
 import type { FireEvent } from "./halo-film-type2";
-import { scanFireEvents, scanFormulaAEvents, WeaponAttributor } from "./halo-film-type2";
+import { scanFireEvents, scanFormulaAEvents, scanStateByte2Transitions, WeaponAttributor } from "./halo-film-type2";
 import { weaponIdToHex } from "./weapon-ids";
 import {
   HALO_PC_USER_AGENT,
@@ -28,8 +28,16 @@ import type {
   KillRaceDeathEvent,
   KillRaceProgression,
   KillRaceProgressionEvent,
+  ObjectiveControlProgression,
+  ObjectiveControlProgressionEvent,
+  ObjectiveControlPeriod,
+  StateByte2Transition,
   HaloFilmServiceOpts,
 } from "./types";
+
+const OBJECTIVE_TICK_DEDUP_MS = 2_500;
+const GAMEPLAY_BYTE2_MIN = 0x40;
+const GAMEPLAY_BYTE2_MAX = 0xa0;
 
 type WeaponTimeline = Map<number, Map<number, { weaponId: string; name: string }>>;
 interface ChunkTiming {
@@ -139,6 +147,119 @@ export class HaloFilmService {
       deathTimeline: this.buildDeathTimeline(events, knownTeamIds),
       teamCount: runningScores.size,
     };
+  }
+
+  async buildObjectiveControlProgression(
+    matchStats: MatchStats,
+    durationMs: number,
+  ): Promise<ObjectiveControlProgression> {
+    const [events, byte2Transitions] = await Promise.all([
+      this.loadEnrichedEventsForMatch(matchStats),
+      this.loadByte2Transitions(matchStats.MatchId),
+    ]);
+    const modeEvents = events.filter((e) => e.eventType === "mode");
+    const knownTeamIds = new Set<number>(matchStats.Teams.map((team) => team.TeamId));
+    return this.buildObjectiveControlProgressionFromData(modeEvents, byte2Transitions, knownTeamIds, durationMs);
+  }
+
+  private async loadByte2Transitions(matchId: string): Promise<StateByte2Transition[]> {
+    try {
+      let authPromise: Promise<{ spartanToken: string; clearanceToken: string }> | null = null;
+      const authResolver = async (): Promise<{ spartanToken: string; clearanceToken: string }> => {
+        authPromise ??= this.resolveAuthContext();
+        return authPromise;
+      };
+      const filmMetadata = await this.getOrFetchFilmMetadata(matchId, authResolver);
+      const scanResult = await this.scanAllReplicationChunks(matchId, filmMetadata, authResolver);
+      return scanResult?.byte2Transitions ?? [];
+    } catch {
+      return [];
+    }
+  }
+
+  private buildObjectiveControlProgressionFromData(
+    modeEvents: ParsedHighlightEvent[],
+    byte2Transitions: StateByte2Transition[],
+    knownTeamIds: ReadonlySet<number>,
+    durationMs: number,
+  ): ObjectiveControlProgression {
+    return {
+      events: this.buildObjectiveScoreEvents(modeEvents, knownTeamIds),
+      controlPeriods: this.buildObjectiveControlPeriods(byte2Transitions, modeEvents, durationMs),
+      teamCount: knownTeamIds.size,
+    };
+  }
+
+  private buildObjectiveScoreEvents(
+    modeEvents: ParsedHighlightEvent[],
+    knownTeamIds: ReadonlySet<number>,
+  ): ObjectiveControlProgressionEvent[] {
+    const runningScores = new Map<number, number>([...knownTeamIds].map((id) => [id, 0]));
+    const events: ObjectiveControlProgressionEvent[] = [];
+    const lastEventTimeByTeam = new Map<number, number>();
+
+    for (const event of modeEvents) {
+      if (event.teamId == null || !knownTeamIds.has(event.teamId)) {
+        continue;
+      }
+      const lastTime = lastEventTimeByTeam.get(event.teamId) ?? -Infinity;
+      if (event.timeMs - lastTime < OBJECTIVE_TICK_DEDUP_MS) {
+        continue;
+      }
+      lastEventTimeByTeam.set(event.teamId, event.timeMs);
+      runningScores.set(event.teamId, Preconditions.checkExists(runningScores.get(event.teamId)) + 1);
+      events.push({
+        timestampMs: event.timeMs,
+        teamId: event.teamId,
+        runningScores: Object.fromEntries(runningScores),
+      });
+    }
+
+    return events;
+  }
+
+  private buildObjectiveControlPeriods(
+    byte2Transitions: StateByte2Transition[],
+    modeEvents: ParsedHighlightEvent[],
+    durationMs: number,
+  ): ObjectiveControlPeriod[] {
+    const gameplayTransitions = byte2Transitions.filter(
+      (t) => t.toValue >= GAMEPLAY_BYTE2_MIN && t.toValue < GAMEPLAY_BYTE2_MAX,
+    );
+    if (gameplayTransitions.length === 0) {
+      return [];
+    }
+    const boundaries = [0, ...gameplayTransitions.map((t) => t.timeMs), durationMs];
+    const periods: ObjectiveControlPeriod[] = [];
+    for (let i = 0; i < boundaries.length - 1; i++) {
+      const startMs = boundaries[i] ?? 0;
+      const endMs = boundaries[i + 1] ?? durationMs;
+      periods.push({ startMs, endMs, controllingTeamId: this.findControllingTeamInWindow(modeEvents, startMs, endMs) });
+    }
+    return periods;
+  }
+
+  private findControllingTeamInWindow(
+    modeEvents: ParsedHighlightEvent[],
+    startMs: number,
+    endMs: number,
+  ): number | null {
+    const teamCounts = new Map<number, number>();
+    for (const event of modeEvents) {
+      if (event.teamId == null || event.timeMs < startMs || event.timeMs >= endMs) {
+        continue;
+      }
+      teamCounts.set(event.teamId, (teamCounts.get(event.teamId) ?? 0) + 1);
+    }
+    let controllingTeamId: number | null = null;
+    let maxCount = 0;
+    for (const [teamId, count] of teamCounts) {
+      if (count > maxCount) {
+        maxCount = count;
+        controllingTeamId = teamId;
+      }
+    }
+    return controllingTeamId;
   }
 
   private buildDeathTimeline(events: ParsedHighlightEvent[], knownTeamIds: ReadonlySet<number>): KillRaceDeathEvent[] {
@@ -254,7 +375,12 @@ export class HaloFilmService {
     matchId: string,
     filmMetadata: FilmMetadataResponse,
     authResolver: () => Promise<{ spartanToken: string; clearanceToken: string }>,
-  ): Promise<{ fireEvents: FireEvent[]; timeline: WeaponTimeline; chunkTimings: ChunkTiming[] } | null> {
+  ): Promise<{
+    fireEvents: FireEvent[];
+    timeline: WeaponTimeline;
+    chunkTimings: ChunkTiming[];
+    byte2Transitions: StateByte2Transition[];
+  } | null> {
     const chunks = this.findReplicationChunksWithStartMs(filmMetadata);
     if (chunks.length === 0) {
       return null;
@@ -267,6 +393,7 @@ export class HaloFilmService {
       ),
     );
     const allFireEvents: FireEvent[] = [];
+    const allByte2Transitions: StateByte2Transition[] = [];
     const timeline: WeaponTimeline = new Map();
     const chunkTimings: ChunkTiming[] = [];
     for (const { chunk, startMs, bytes } of chunksWithBytes) {
@@ -280,6 +407,9 @@ export class HaloFilmService {
       for (const ev of scanFireEvents(chunkData, startMs, chunk.DurationMilliseconds)) {
         allFireEvents.push(ev);
       }
+      for (const t of scanStateByte2Transitions(chunkData, startMs, chunk.DurationMilliseconds)) {
+        allByte2Transitions.push(t);
+      }
       const chunkState = new Map<number, { weaponId: string; name: string }>();
       for (const ev of scanFormulaAEvents(chunkData)) {
         chunkState.set(ev.playerIndex, { weaponId: weaponIdToHex(ev.weaponId), name: ev.weaponName });
@@ -289,7 +419,7 @@ export class HaloFilmService {
       }
       chunkTimings.push({ chunkIndex: chunk.Index, startMs });
     }
-    return { fireEvents: allFireEvents, timeline, chunkTimings };
+    return { fireEvents: allFireEvents, timeline, chunkTimings, byte2Transitions: allByte2Transitions };
   }
 
   private async getOrFetchFilmMetadata(

--- a/api/services/halo/tests/halo-film.test.ts
+++ b/api/services/halo/tests/halo-film.test.ts
@@ -2019,6 +2019,150 @@ describe("HaloFilmService", () => {
     });
   });
 
+  describe("buildObjectiveControlProgression", () => {
+    it("accumulates running scores from mode events in timestamp order", async () => {
+      const env = aFakeCacheBackedEnvWith();
+      const xboxService = aFakeXboxServiceWith({ env });
+      const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });
+      const service = new HaloFilmService({ env, spartanTokenProvider });
+      const match = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+      const team0PlayerXuid = unwrapXuid(Preconditions.checkExists(match.Players[0]).PlayerId);
+      const team1PlayerXuid = unwrapXuid(Preconditions.checkExists(match.Players[3]).PlayerId);
+
+      vi.spyOn(service, "getHighlightEventsForMatch").mockResolvedValue([
+        {
+          xuid: team0PlayerXuid,
+          gamertag: "p0",
+          typeHint: 40,
+          isMedal: false,
+          eventType: "mode",
+          timeMs: 5000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: team0PlayerXuid,
+          gamertag: "p0",
+          typeHint: 40,
+          isMedal: false,
+          eventType: "mode",
+          timeMs: 10000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: team1PlayerXuid,
+          gamertag: "p3",
+          typeHint: 40,
+          isMedal: false,
+          eventType: "mode",
+          timeMs: 15000,
+          medalValue: 0,
+          teamId: null,
+        },
+      ]);
+
+      const result = await service.buildObjectiveControlProgression(match, 30000);
+
+      expect(result.teamCount).toBe(2);
+      expect(result.events).toHaveLength(3);
+      expect(result.events[0]).toEqual({ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } });
+      expect(result.events[1]).toEqual({ timestampMs: 10000, teamId: 0, runningScores: { "0": 2, "1": 0 } });
+      expect(result.events[2]).toEqual({ timestampMs: 15000, teamId: 1, runningScores: { "0": 2, "1": 1 } });
+    });
+
+    it("deduplicates multiple player mode events within the same 5-second tick window", async () => {
+      const env = aFakeCacheBackedEnvWith();
+      const xboxService = aFakeXboxServiceWith({ env });
+      const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });
+      const service = new HaloFilmService({ env, spartanTokenProvider });
+      const match = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+      const team0Player0Xuid = unwrapXuid(Preconditions.checkExists(match.Players[0]).PlayerId);
+      const team0Player1Xuid = unwrapXuid(Preconditions.checkExists(match.Players[1]).PlayerId);
+
+      vi.spyOn(service, "getHighlightEventsForMatch").mockResolvedValue([
+        {
+          xuid: team0Player0Xuid,
+          gamertag: "p0",
+          typeHint: 40,
+          isMedal: false,
+          eventType: "mode",
+          timeMs: 5000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: team0Player1Xuid,
+          gamertag: "p1",
+          typeHint: 40,
+          isMedal: false,
+          eventType: "mode",
+          timeMs: 5001,
+          medalValue: 0,
+          teamId: null,
+        },
+      ]);
+
+      const result = await service.buildObjectiveControlProgression(match, 30000);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0]).toEqual({ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } });
+    });
+
+    it("skips mode events whose xuid is not mapped to any known team", async () => {
+      const env = aFakeCacheBackedEnvWith();
+      const xboxService = aFakeXboxServiceWith({ env });
+      const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });
+      const service = new HaloFilmService({ env, spartanTokenProvider });
+      const match = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+      const team0PlayerXuid = unwrapXuid(Preconditions.checkExists(match.Players[0]).PlayerId);
+
+      vi.spyOn(service, "getHighlightEventsForMatch").mockResolvedValue([
+        {
+          xuid: "9999999999",
+          gamertag: "ghost",
+          typeHint: 40,
+          isMedal: false,
+          eventType: "mode",
+          timeMs: 1000,
+          medalValue: 0,
+          teamId: null,
+        },
+        {
+          xuid: team0PlayerXuid,
+          gamertag: "p0",
+          typeHint: 40,
+          isMedal: false,
+          eventType: "mode",
+          timeMs: 5000,
+          medalValue: 0,
+          teamId: null,
+        },
+      ]);
+
+      const result = await service.buildObjectiveControlProgression(match, 30000);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0]?.teamId).toBe(0);
+    });
+
+    it("returns empty events and no control periods when no mode events are present", async () => {
+      const env = aFakeCacheBackedEnvWith();
+      const xboxService = aFakeXboxServiceWith({ env });
+      const spartanTokenProvider = new CustomSpartanTokenProvider({ env, xboxService });
+      const service = new HaloFilmService({ env, spartanTokenProvider });
+      const match = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+
+      vi.spyOn(service, "getHighlightEventsForMatch").mockResolvedValue([]);
+
+      const result = await service.buildObjectiveControlProgression(match, 30000);
+
+      expect(result.teamCount).toBe(2);
+      expect(result.events).toHaveLength(0);
+      expect(result.controlPeriods).toHaveLength(0);
+    });
+  });
+
   describe("highlight events KV cache", () => {
     it("returns KV-cached events without hitting the network", async () => {
       const env = aFakeCacheBackedEnvWith();

--- a/api/services/halo/types.ts
+++ b/api/services/halo/types.ts
@@ -221,6 +221,24 @@ export interface KillRaceProgression {
   teamCount: number;
 }
 
+export interface ObjectiveControlProgressionEvent {
+  timestampMs: number;
+  teamId: number;
+  runningScores: Record<string, number>;
+}
+
+export interface ObjectiveControlPeriod {
+  startMs: number;
+  endMs: number;
+  controllingTeamId: number | null;
+}
+
+export interface ObjectiveControlProgression {
+  events: ObjectiveControlProgressionEvent[];
+  controlPeriods: ObjectiveControlPeriod[];
+  teamCount: number;
+}
+
 export interface HaloFilmServiceOpts {
   env: Env;
   spartanTokenProvider: SpartanTokenProvider;


### PR DESCRIPTION
## Context

Part of the 5-PR series adding objective-mode score progression charts.

[PR 1](https://github.com/davidhouweling/guilty-spark/pull/752) added the foundational data types: `scanStateByte2Transitions()`, `objectiveControlTimelineSchema`, and the discriminated union for `scoreProgression.timeline`.

## This change

Wires KOTH and Oddball into the analytics pipeline by implementing `buildObjectiveControlProgression()` on `HaloFilmService`:

- **Score events** — filters highlight chunk mode events (5-second objective scoring ticks) per team. Deduplicates multiple player events within the same tick window (team members on the hill simultaneously each fire a mode event; only the first per 2.5s window is counted).
- **Control periods** — fetches all type-2 replication chunks via `loadByte2Transitions()`, filtering byte-2 transitions to the gameplay range (`0x40–0x9f`). Each consecutive pair of transitions defines a period; the controlling team is whichever team has the majority of mode events in that window. Falls back to an empty control periods array when the film API is unreachable.
- **`scanAllReplicationChunks`** — extended to collect `StateByte2Transition[]` alongside fire events in the same scan pass (no additional chunk fetches).
- **`analytics.ts`** — adds `OBJECTIVE_CONTROL_GAME_MODES = { KOTH, Oddball }` and routes those modes to the new progression builder with `respawnDurationMs: null`.

## Subsequent work

- PR 3: Strongholds + CTF (adds `OBJECTIVE_CONTROL_GAME_MODES` entries for those modes — same builder, no scoring semantics change needed)
- PR 4: UI chart component consuming `objective-control` timeline
- PR 5: Polish and edge cases