### PR TITLE
feat(analytics): Strongholds + CTF score progression (PR 3/5)

### DIFF
--- a/api/services/analytics/analytics.ts
+++ b/api/services/analytics/analytics.ts
@@ -27,6 +27,8 @@ const KILL_RACE_GAME_MODES = new Set([
 const OBJECTIVE_CONTROL_GAME_MODES = new Set([
   GameVariantCategory.MultiplayerKingOfTheHill,
   GameVariantCategory.MultiplayerOddball,
+  GameVariantCategory.MultiplayerStrongholds,
+  GameVariantCategory.MultiplayerCtf,
 ]);
 
 function toContractKillMatrix(

--- a/api/services/analytics/tests/analytics.test.ts
+++ b/api/services/analytics/tests/analytics.test.ts
@@ -255,7 +255,38 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
     expect(buildKillRaceProgressionSpy).not.toHaveBeenCalled();
   });
 
-  it("returns scoreProgression null for unsupported game modes when scoreProgression is requested", async () => {
+  it("returns objective-control scoreProgression for Strongholds when scoreProgression module is requested", async () => {
+    const env = aFakeEnvWith();
+    const haloService = aFakeHaloServiceWith({ env });
+    const haloFilmService = aFakeHaloFilmServiceWith({ env });
+    const logService = aFakeLogServiceWith();
+    const matchStats = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+    const strongholdsMatchStats = {
+      ...matchStats,
+      MatchInfo: { ...matchStats.MatchInfo, GameVariantCategory: GameVariantCategory.MultiplayerStrongholds },
+    };
+    vi.spyOn(haloService, "getMatchDetails").mockResolvedValue([strongholdsMatchStats]);
+    vi.spyOn(haloFilmService, "warmAuthCache").mockResolvedValue(undefined);
+    vi.spyOn(haloFilmService, "buildKillMatrixAnalytics").mockResolvedValue({
+      entries: [],
+      pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 0 },
+      perfectCounts: { total: 0, byXuid: {} },
+    });
+    vi.spyOn(haloFilmService, "buildObjectiveControlProgression").mockResolvedValue({
+      events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+      controlPeriods: [],
+      teamCount: 2,
+    });
+
+    const service = new AnalyticsService({ haloService, haloFilmService, logService });
+    const results = await service.getBatchMatchAnalytics(["match-1"], ["killMatrix", "scoreProgression"]);
+
+    expect(results["match-1"]?.scoreProgression?.mode).toBe(GameVariantCategory.MultiplayerStrongholds);
+    const timeline = results["match-1"]?.scoreProgression?.timeline;
+    expect(timeline?.type).toBe("objective-control");
+  });
+
+  it("returns objective-control scoreProgression for CTF when scoreProgression module is requested", async () => {
     const env = aFakeEnvWith();
     const haloService = aFakeHaloServiceWith({ env });
     const haloFilmService = aFakeHaloFilmServiceWith({ env });
@@ -266,6 +297,37 @@ describe("AnalyticsService.getBatchMatchAnalytics", () => {
       MatchInfo: { ...matchStats.MatchInfo, GameVariantCategory: GameVariantCategory.MultiplayerCtf },
     };
     vi.spyOn(haloService, "getMatchDetails").mockResolvedValue([ctfMatchStats]);
+    vi.spyOn(haloFilmService, "warmAuthCache").mockResolvedValue(undefined);
+    vi.spyOn(haloFilmService, "buildKillMatrixAnalytics").mockResolvedValue({
+      entries: [],
+      pairingQuality: { unpairedDeathCount: 0, maxTimeDeltaMs: 0 },
+      perfectCounts: { total: 0, byXuid: {} },
+    });
+    vi.spyOn(haloFilmService, "buildObjectiveControlProgression").mockResolvedValue({
+      events: [{ timestampMs: 30000, teamId: 1, runningScores: { "0": 0, "1": 1 } }],
+      controlPeriods: [],
+      teamCount: 2,
+    });
+
+    const service = new AnalyticsService({ haloService, haloFilmService, logService });
+    const results = await service.getBatchMatchAnalytics(["match-1"], ["killMatrix", "scoreProgression"]);
+
+    expect(results["match-1"]?.scoreProgression?.mode).toBe(GameVariantCategory.MultiplayerCtf);
+    const timeline = results["match-1"]?.scoreProgression?.timeline;
+    expect(timeline?.type).toBe("objective-control");
+  });
+
+  it("returns scoreProgression null for unsupported game modes when scoreProgression is requested", async () => {
+    const env = aFakeEnvWith();
+    const haloService = aFakeHaloServiceWith({ env });
+    const haloFilmService = aFakeHaloFilmServiceWith({ env });
+    const logService = aFakeLogServiceWith();
+    const matchStats = Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"));
+    const escalationMatchStats = {
+      ...matchStats,
+      MatchInfo: { ...matchStats.MatchInfo, GameVariantCategory: GameVariantCategory.MultiplayerElimination },
+    };
+    vi.spyOn(haloService, "getMatchDetails").mockResolvedValue([escalationMatchStats]);
     vi.spyOn(haloFilmService, "warmAuthCache").mockResolvedValue(undefined);
     vi.spyOn(haloFilmService, "buildKillMatrixAnalytics").mockResolvedValue({
       entries: [],


### PR DESCRIPTION
## Context

Part of the 5-PR series adding objective-mode score progression charts.

- [PR 1](https://github.com/davidhouweling/guilty-spark/pull/752): foundational data layer
- [PR 2](https://github.com/davidhouweling/guilty-spark/pull/753): KOTH + Oddball wiring

## This change

Extends `OBJECTIVE_CONTROL_GAME_MODES` to include `MultiplayerStrongholds` and `MultiplayerCtf`. Both modes use the same `buildObjectiveControlProgression()` builder from PR 2 — no new scoring semantics are needed:

- **Strongholds**: mode events fire per-player per-zone tick while a zone is controlled; the builder deduplicates them per 2.5s window per team and accumulates the running score correctly.
- **CTF**: mode events fire on flag captures; each capture is a distinct score event well separated in time, so no deduplication applies.

Updates the "unsupported modes" analytics test to use `MultiplayerElimination` (which genuinely remains unsupported) now that CTF is wired.

## Subsequent work

- PR 4: UI chart component consuming `objective-control` timeline
- PR 5: Polish and edge cases