### PR TITLE
feat(ui): objective control period shading on score progression chart

### DIFF
--- a/pages/src/components/stats/match-stats.tsx
+++ b/pages/src/components/stats/match-stats.tsx
@@ -292,6 +292,7 @@ export function MatchStats({
                         teamLines={scoreProgressionViewData.teamLines}
                         scoreDelta={scoreProgressionViewData.scoreDelta}
                         playerAdvantage={scoreProgressionViewData.playerAdvantage}
+                        controlPeriods={scoreProgressionViewData.controlPeriods}
                         ariaLabel="Match score progression timeline"
                       />
                     ) : (

--- a/pages/src/components/stats/score-progression/create.tsx
+++ b/pages/src/components/stats/score-progression/create.tsx
@@ -2,13 +2,19 @@ import React, { useMemo, useSyncExternalStore } from "react";
 import { ScoreProgressionPresenter } from "./score-progression-presenter";
 import { ScoreProgressionStore } from "./score-progression-store";
 import { ScoreProgression } from "./score-progression";
-import type { PlayerAdvantageData, ScoreDeltaData, ScoreProgressionTeamLine } from "./types";
+import type {
+  ObjectiveControlPeriodDisplay,
+  PlayerAdvantageData,
+  ScoreDeltaData,
+  ScoreProgressionTeamLine,
+} from "./types";
 
 export interface ScoreProgressionProps {
   readonly durationMs: number;
   readonly teamLines: readonly ScoreProgressionTeamLine[];
   readonly scoreDelta: ScoreDeltaData | null;
   readonly playerAdvantage: PlayerAdvantageData | null;
+  readonly controlPeriods: readonly ObjectiveControlPeriodDisplay[];
   readonly ariaLabel: string;
 }
 
@@ -17,6 +23,7 @@ function ScoreProgressionInternal({
   teamLines,
   scoreDelta,
   playerAdvantage,
+  controlPeriods,
   ariaLabel,
 }: ScoreProgressionProps): React.ReactElement {
   const store = useMemo(() => new ScoreProgressionStore(), []);
@@ -25,8 +32,9 @@ function ScoreProgressionInternal({
   const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
 
   const model = useMemo(
-    () => presenter.present(snapshot, { durationMs, teamLines, scoreDelta, playerAdvantage, ariaLabel }),
-    [presenter, snapshot, durationMs, teamLines, scoreDelta, playerAdvantage, ariaLabel],
+    () =>
+      presenter.present(snapshot, { durationMs, teamLines, scoreDelta, playerAdvantage, controlPeriods, ariaLabel }),
+    [presenter, snapshot, durationMs, teamLines, scoreDelta, playerAdvantage, controlPeriods, ariaLabel],
   );
 
   return <ScoreProgression {...model} />;

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -1,5 +1,15 @@
 import React from "react";
-import { Area, AreaChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ReferenceArea,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import {
   ADVANTAGE_STROKE,
   AXIS_STROKE,
@@ -19,6 +29,7 @@ export function ProgressionChart({
   durationMs,
   teamLines,
   playerAdvantage,
+  controlPeriods,
   tooltipFormatter,
 }: ScoreProgressionProgressionViewModel): React.ReactElement {
   const margin = playerAdvantage != null ? { ...CHART_MARGIN, right: 36 } : CHART_MARGIN;
@@ -47,6 +58,18 @@ export function ProgressionChart({
           labelFormatter={formatTooltipLabel}
           formatter={tooltipFormatter}
         />
+        {controlPeriods.map((period, i) =>
+          period.color != null ? (
+            <ReferenceArea
+              key={i}
+              x1={period.startMs}
+              x2={period.endMs}
+              fill={period.color}
+              fillOpacity={0.12}
+              stroke="none"
+            />
+          ) : null,
+        )}
         {teamLines.map((line) => (
           <Area
             key={line.teamId}

--- a/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/progression-chart.tsx
@@ -58,10 +58,10 @@ export function ProgressionChart({
           labelFormatter={formatTooltipLabel}
           formatter={tooltipFormatter}
         />
-        {controlPeriods.map((period, i) =>
+        {controlPeriods.map((period) =>
           period.color != null ? (
             <ReferenceArea
-              key={i}
+              key={period.startMs}
               x1={period.startMs}
               x2={period.endMs}
               fill={period.color}

--- a/pages/src/components/stats/score-progression/progression-chart/tests/progression-chart.test.tsx
+++ b/pages/src/components/stats/score-progression/progression-chart/tests/progression-chart.test.tsx
@@ -1,9 +1,13 @@
 import "@testing-library/jest-dom/vitest";
 
 import React from "react";
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
 import { ProgressionChart } from "../progression-chart";
+
+afterEach(() => {
+  cleanup();
+});
 
 vi.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: { children: React.ReactNode }): React.ReactElement => <div>{children}</div>,
@@ -12,23 +16,29 @@ vi.mock("recharts", () => ({
   XAxis: (): null => null,
   YAxis: (): null => null,
   Tooltip: (): null => null,
+  ReferenceLine: (): null => null,
+  ReferenceArea: ({ fill }: { fill: string }): React.ReactElement => (
+    <div data-testid="reference-area" data-fill={fill} />
+  ),
   Area: ({ name }: { name: string }): React.ReactElement => <div data-testid="area">{name}</div>,
 }));
 
+const TOOLTIP_FORMATTER = (value: unknown): [string, string] => [String(value), ""];
+
+const TEAM_LINES = [
+  { teamId: 0, name: "Eagle", color: "#0000ff", points: [] },
+  { teamId: 1, name: "Cobra", color: "#ff0000", points: [] },
+] as const;
+
 describe("ProgressionChart", () => {
   it("renders an Area for each team line", () => {
-    const teamLines = [
-      { teamId: 0, name: "Eagle", color: "#0000ff", points: [] },
-      { teamId: 1, name: "Cobra", color: "#ff0000", points: [] },
-    ] as const;
-
-    const tooltipFormatter = (value: unknown): [string, string] => [String(value), ""];
     render(
       <ProgressionChart
         durationMs={600000}
-        teamLines={teamLines}
+        teamLines={TEAM_LINES}
         playerAdvantage={null}
-        tooltipFormatter={tooltipFormatter}
+        controlPeriods={[]}
+        tooltipFormatter={TOOLTIP_FORMATTER}
       />,
     );
 
@@ -36,5 +46,62 @@ describe("ProgressionChart", () => {
     expect(areas).toHaveLength(2);
     expect(areas[0]).toHaveTextContent("Eagle");
     expect(areas[1]).toHaveTextContent("Cobra");
+  });
+
+  it("renders a ReferenceArea for each control period with a non-null color", () => {
+    const controlPeriods = [
+      { startMs: 0, endMs: 5000, color: "#0000ff" },
+      { startMs: 5000, endMs: 10000, color: "#ff0000" },
+    ] as const;
+
+    render(
+      <ProgressionChart
+        durationMs={600000}
+        teamLines={TEAM_LINES}
+        playerAdvantage={null}
+        controlPeriods={controlPeriods}
+        tooltipFormatter={TOOLTIP_FORMATTER}
+      />,
+    );
+
+    const referenceAreas = screen.getAllByTestId("reference-area");
+    expect(referenceAreas).toHaveLength(2);
+    expect(referenceAreas[0]).toHaveAttribute("data-fill", "#0000ff");
+    expect(referenceAreas[1]).toHaveAttribute("data-fill", "#ff0000");
+  });
+
+  it("does not render a ReferenceArea for contested periods with null color", () => {
+    const controlPeriods = [
+      { startMs: 0, endMs: 5000, color: null },
+      { startMs: 5000, endMs: 10000, color: "#ff0000" },
+    ] as const;
+
+    render(
+      <ProgressionChart
+        durationMs={600000}
+        teamLines={TEAM_LINES}
+        playerAdvantage={null}
+        controlPeriods={controlPeriods}
+        tooltipFormatter={TOOLTIP_FORMATTER}
+      />,
+    );
+
+    const referenceAreas = screen.getAllByTestId("reference-area");
+    expect(referenceAreas).toHaveLength(1);
+    expect(referenceAreas[0]).toHaveAttribute("data-fill", "#ff0000");
+  });
+
+  it("renders no ReferenceArea elements when controlPeriods is empty", () => {
+    render(
+      <ProgressionChart
+        durationMs={600000}
+        teamLines={TEAM_LINES}
+        playerAdvantage={null}
+        controlPeriods={[]}
+        tooltipFormatter={TOOLTIP_FORMATTER}
+      />,
+    );
+
+    expect(screen.queryAllByTestId("reference-area")).toHaveLength(0);
   });
 });

--- a/pages/src/components/stats/score-progression/score-progression-formatter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-formatter.ts
@@ -7,6 +7,7 @@ import { getTeamName } from "@guilty-spark/shared/halo/team";
 import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type {
+  ObjectiveControlPeriodDisplay,
   PlayerAdvantageData,
   ScoreDeltaData,
   ScoreProgressionPoint,
@@ -120,6 +121,22 @@ function buildPlayerAdvantage(
   return { points, minScore, maxScore };
 }
 
+type Timeline = NonNullable<MatchAnalytics["scoreProgression"]>["timeline"];
+
+function buildControlPeriods(
+  timeline: Timeline,
+  teamColorByTeamId: Map<number, string>,
+): readonly ObjectiveControlPeriodDisplay[] {
+  if (timeline.type !== "objective-control") {
+    return [];
+  }
+  return timeline.controlPeriods.map((period) => ({
+    startMs: period.startMs,
+    endMs: period.endMs,
+    color: period.controllingTeamId != null ? (teamColorByTeamId.get(period.controllingTeamId) ?? null) : null,
+  }));
+}
+
 export function formatScoreProgression(
   scoreProgression: MatchAnalytics["scoreProgression"],
   teamColors: readonly TeamColor[],
@@ -148,6 +165,8 @@ export function formatScoreProgression(
       },
     ]),
   );
+
+  const teamColorByTeamId = new Map([...teamState.entries()].map(([teamId, state]) => [teamId, state.color]));
 
   for (const event of events) {
     const newScore = event.runningScores[String(event.teamId)] ?? 0;
@@ -179,5 +198,6 @@ export function formatScoreProgression(
     teamLines,
     scoreDelta: buildScoreDelta(teamIds, events, durationMs),
     playerAdvantage,
+    controlPeriods: buildControlPeriods(timeline, teamColorByTeamId),
   };
 }

--- a/pages/src/components/stats/score-progression/score-progression-presenter.ts
+++ b/pages/src/components/stats/score-progression/score-progression-presenter.ts
@@ -2,6 +2,7 @@ import { TICK_FILL } from "./chart-constants";
 import type { ScoreProgressionSnapshot, ScoreProgressionStore } from "./score-progression-store";
 import type {
   ChartType,
+  ObjectiveControlPeriodDisplay,
   PlayerAdvantageData,
   ScoreDeltaData,
   ScoreProgressionDeltaViewModel,
@@ -18,6 +19,7 @@ export interface ScoreProgressionInput {
   readonly teamLines: readonly ScoreProgressionTeamLine[];
   readonly scoreDelta: ScoreDeltaData | null;
   readonly playerAdvantage: PlayerAdvantageData | null;
+  readonly controlPeriods: readonly ObjectiveControlPeriodDisplay[];
   readonly ariaLabel: string;
 }
 
@@ -78,6 +80,7 @@ export class ScoreProgressionPresenter {
         durationMs: input.durationMs,
         teamLines: input.teamLines,
         playerAdvantage: effectivePlayerAdvantage,
+        controlPeriods: input.controlPeriods,
         tooltipFormatter: (
           value: number | string | readonly (number | string)[] | undefined,
           name: string | number | undefined,

--- a/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-formatter.test.ts
@@ -174,6 +174,55 @@ describe("formatScoreProgression", () => {
     });
   });
 
+  describe("controlPeriods", () => {
+    it("returns empty controlPeriods for kill-race timeline", () => {
+      const result = formatScoreProgression(aFakeScoreProgressionWith(), TEAM_COLORS);
+      expect(result?.controlPeriods).toEqual([]);
+    });
+
+    it("returns empty controlPeriods when objective-control timeline has no control periods", () => {
+      const data = aFakeScoreProgressionWith({
+        timeline: {
+          type: "objective-control",
+          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+          controlPeriods: [],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.controlPeriods).toEqual([]);
+    });
+
+    it("maps controlling team id to team color for each control period", () => {
+      const data = aFakeScoreProgressionWith({
+        timeline: {
+          type: "objective-control",
+          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+          controlPeriods: [
+            { startMs: 0, endMs: 5000, controllingTeamId: 0 },
+            { startMs: 5000, endMs: 10000, controllingTeamId: 1 },
+          ],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.controlPeriods).toEqual([
+        { startMs: 0, endMs: 5000, color: "#0000ff" },
+        { startMs: 5000, endMs: 10000, color: "#ff0000" },
+      ]);
+    });
+
+    it("sets color to null for contested periods with no controlling team", () => {
+      const data = aFakeScoreProgressionWith({
+        timeline: {
+          type: "objective-control",
+          events: [{ timestampMs: 5000, teamId: 0, runningScores: { "0": 1, "1": 0 } }],
+          controlPeriods: [{ startMs: 2000, endMs: 4000, controllingTeamId: null }],
+        },
+      });
+      const result = formatScoreProgression(data, TEAM_COLORS);
+      expect(result?.controlPeriods).toEqual([{ startMs: 2000, endMs: 4000, color: null }]);
+    });
+  });
+
   describe("playerAdvantage", () => {
     it("returns null playerAdvantage when more than 2 teams are present", () => {
       const data = aFakeScoreProgressionWith({

--- a/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
+++ b/pages/src/components/stats/score-progression/tests/score-progression-presenter.test.ts
@@ -40,6 +40,7 @@ const BASE_INPUT = {
   durationMs: 600000,
   teamLines: [aFakeTeamLine("Eagle", "#f00", 0), aFakeTeamLine("Cobra", "#00f", 1)],
   playerAdvantage: null,
+  controlPeriods: [],
   ariaLabel: "test chart",
 };
 
@@ -260,6 +261,21 @@ describe("ScoreProgressionPresenter", () => {
       const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: null });
       expect(model.progressionViewModel.tooltipFormatter(5, "Eagle")).toEqual(["5", "Eagle"]);
       expect(model.progressionViewModel.tooltipFormatter(3, "Cobra")).toEqual(["3", "Cobra"]);
+    });
+  });
+
+  describe("progressionViewModel.controlPeriods", () => {
+    it("passes controlPeriods through to progressionViewModel", () => {
+      const { store, presenter } = makePresenter();
+      const controlPeriods = [{ startMs: 0, endMs: 5000, color: "#ff0000" }] as const;
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: null, controlPeriods });
+      expect(model.progressionViewModel.controlPeriods).toBe(controlPeriods);
+    });
+
+    it("passes empty controlPeriods when input has none", () => {
+      const { store, presenter } = makePresenter();
+      const model = presenter.present(store.getSnapshot(), { ...BASE_INPUT, scoreDelta: null });
+      expect(model.progressionViewModel.controlPeriods).toEqual([]);
     });
   });
 

--- a/pages/src/components/stats/score-progression/types.ts
+++ b/pages/src/components/stats/score-progression/types.ts
@@ -22,11 +22,18 @@ export interface PlayerAdvantageData {
   readonly maxScore: number;
 }
 
+export interface ObjectiveControlPeriodDisplay {
+  readonly startMs: number;
+  readonly endMs: number;
+  readonly color: string | null;
+}
+
 export interface ScoreProgressionViewData {
   readonly durationMs: number;
   readonly teamLines: readonly ScoreProgressionTeamLine[];
   readonly scoreDelta: ScoreDeltaData | null;
   readonly playerAdvantage: PlayerAdvantageData | null;
+  readonly controlPeriods: readonly ObjectiveControlPeriodDisplay[];
 }
 
 export type ChartType = "progression" | "delta";
@@ -47,6 +54,7 @@ export interface ScoreProgressionProgressionViewModel {
   readonly durationMs: number;
   readonly teamLines: readonly ScoreProgressionTeamLine[];
   readonly playerAdvantage: PlayerAdvantageData | null;
+  readonly controlPeriods: readonly ObjectiveControlPeriodDisplay[];
   readonly tooltipFormatter: (
     value: number | string | readonly (number | string)[] | undefined,
     name: string | number | undefined,

--- a/pages/src/components/stats/tests/match-stats.test.tsx
+++ b/pages/src/components/stats/tests/match-stats.test.tsx
@@ -226,6 +226,7 @@ describe("MatchStats", () => {
       teamLines: [],
       scoreDelta: null,
       playerAdvantage: null,
+      controlPeriods: [],
     };
     const baseProps = {
       data,


### PR DESCRIPTION
## Context

Part of a 5-PR plan to add score progression charts for objective Halo game modes (KOTH, Oddball, Strongholds, CTF). PRs 1–3 built the API layer: type-2 film scanning, objective control period detection, and analytics service integration.

## This change

Wires the `controlPeriods` data from the analytics API into the score progression chart UI:

- **`ObjectiveControlPeriodDisplay`** — new display-layer type in `types.ts` carrying `startMs`, `endMs`, and the resolved team color (or `null` for contested periods)
- **`score-progression-formatter.ts`** — `buildControlPeriods()` extracts periods from `objective-control` timelines and maps each `controllingTeamId` to the team's assigned color; returns `[]` for kill-race timelines
- **`ScoreProgressionViewData` / `ScoreProgressionProgressionViewModel`** — extended with `controlPeriods`; threaded through presenter → `create.tsx` → chart
- **`ProgressionChart`** — renders a `ReferenceArea` per period (at `fillOpacity: 0.12`) behind the team score lines; contested periods (`color: null`) are skipped, stable `startMs` key used per hardening guidelines
- Test coverage: formatter (empty, colored, null-color), presenter (threading), progression-chart (2/1/0 ReferenceArea cases), match-stats (type update)

All four objective modes use the existing step-line `AreaChart` — `ReferenceArea` is the only addition required; no new chart type needed.

## Subsequent work

PR 5: polish and edge cases (empty state handling, label/legend improvements if needed)