### PR TITLE
Individual tracker: exclude FFA from series and use server teamCount

### DIFF
--- a/api/durable-objects/individual-tracker/fakes/individual-tracker-do.fake.ts
+++ b/api/durable-objects/individual-tracker/fakes/individual-tracker-do.fake.ts
@@ -54,6 +54,7 @@ export function aFakeIndividualTrackerMatchSummaryWith(
     gameVariantCategory: 6,
     outcome: "Win",
     score: "50:42",
+    teamCount: 2,
     killsDeathsAssistsKda: "10:7:4 (1.62)",
     damageDealtTakenRatio: "4,200:3,900 (1.08)",
     isMatchmaking: false,

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -383,6 +383,10 @@ function isEligibleForActiveSeries(
     return false;
   }
 
+  if (summary.teamOutcomes?.length !== 2) {
+    return false;
+  }
+
   const expectedRosters = getExpectedSeriesTeamRosters(activeSeries.teams);
   if (expectedRosters == null) {
     return true;
@@ -998,6 +1002,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
     }
 
     summary.score = buildMatchScore(matchStats);
+    summary.teamCount = matchStats.Teams.length;
     const trackedPlayerSummaryStats = computeTrackedPlayerSummaryStats(matchStats, trackedXuid);
     summary.killsDeathsAssistsKda = trackedPlayerSummaryStats.killsDeathsAssistsKda;
     summary.damageDealtTakenRatio = trackedPlayerSummaryStats.damageDealtTakenRatio;
@@ -1736,6 +1741,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         gameVariantCategory: matchStats.MatchInfo.GameVariantCategory,
         outcome,
         score: buildMatchScore(matchStats),
+        teamCount: matchStats.Teams.length,
         ...computeTrackedPlayerSummaryStats(matchStats, getPlayerXuid(playerEntry)),
         isMatchmaking: matchStats.MatchInfo.Playlist != null,
         ...(matchmakingPlaylist != null ? { matchmakingPlaylist } : {}),

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -2340,6 +2340,87 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.activeSeries?.matchIds).toEqual([]);
     });
 
+    it("does not attach a discovered custom match to active series when match stats have more than two teams", async () => {
+      ownerClient.getPlayerMatches
+        .mockResolvedValueOnce([aFakePlayerMatch("match-new", "2024-11-26T11:30:00.000Z", 2)])
+        .mockResolvedValueOnce([]);
+      ownerClient.getMatchStats.mockResolvedValueOnce(
+        aFakeMatchStatsWith({
+          Teams: [
+            aFakeTeamWith({ TeamId: 0, Outcome: 2 }),
+            aFakeTeamWith({ TeamId: 1, Outcome: 3 }),
+            aFakeTeamWith({ TeamId: 2, Outcome: 3 }),
+          ],
+        }),
+      );
+
+      const activeSeries: ActiveSeries = {
+        title: "Active Series",
+        subtitle: "Customs",
+        guildIconUrl: null,
+        teams: [],
+        matchIds: [],
+        startedAt: "2024-11-26T11:00:00.000Z",
+        isActive: true,
+      };
+
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          searchStartTime: "2024-11-26T11:00:00.000Z",
+          matchIds: [],
+          discoveredMatches: {},
+          activeSeries,
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries?.matchIds).toEqual([]);
+      expect(persisted.matchIds).toContain("match-new");
+      expect(persisted.discoveredMatches["match-new"]?.teamOutcomes).toEqual([2, 3, 3]);
+    });
+
+    it("does not attach a discovered custom match to active series when match stats have zero teams", async () => {
+      ownerClient.getPlayerMatches
+        .mockResolvedValueOnce([aFakePlayerMatch("match-new", "2024-11-26T11:30:00.000Z", 2)])
+        .mockResolvedValueOnce([]);
+      ownerClient.getMatchStats.mockResolvedValueOnce(
+        aFakeMatchStatsWith({
+          Teams: [],
+        }),
+      );
+
+      const activeSeries: ActiveSeries = {
+        title: "Active Series",
+        subtitle: "Customs",
+        guildIconUrl: null,
+        teams: [],
+        matchIds: [],
+        startedAt: "2024-11-26T11:00:00.000Z",
+        isActive: true,
+      };
+
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          startTime: now.toISOString(),
+          searchStartTime: "2024-11-26T11:00:00.000Z",
+          matchIds: [],
+          discoveredMatches: {},
+          activeSeries,
+        }),
+      );
+
+      await individualTrackerDO.alarm();
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries?.matchIds).toEqual([]);
+      expect(persisted.matchIds).toContain("match-new");
+      expect(persisted.discoveredMatches["match-new"]?.teamOutcomes).toEqual([]);
+      expect(persisted.discoveredMatches["match-new"]?.teamCount).toBe(0);
+    });
+
     it("falls back to an empty score and re-enriches on the next poll when getMatchStats fails", async () => {
       ownerClient.getPlayerMatches
         .mockResolvedValueOnce([aFakePlayerMatch("match-new", "2024-11-26T11:30:00.000Z", 2)])

--- a/api/durable-objects/individual-tracker/types.ts
+++ b/api/durable-objects/individual-tracker/types.ts
@@ -28,6 +28,7 @@ export interface IndividualTrackerMatchSummary {
   gameVariantCategory: number;
   outcome: NormalizedMatchOutcome;
   score: string;
+  teamCount?: number;
   killsDeathsAssistsKda?: string;
   damageDealtTakenRatio?: string;
   kills?: number;

--- a/api/individual-tracker/mapper.ts
+++ b/api/individual-tracker/mapper.ts
@@ -168,6 +168,7 @@ export function toTrackerView(
             gameVariantCategory: match.gameVariantCategory,
             outcome: match.outcome,
             score: match.score,
+            ...(match.teamCount != null ? { teamCount: match.teamCount } : {}),
             killsDeathsAssistsKda: match.killsDeathsAssistsKda,
             damageDealtTakenRatio: match.damageDealtTakenRatio,
             isMatchmaking: match.isMatchmaking,

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
@@ -121,11 +121,11 @@ describe("buildViewerRenderModel", () => {
     expect.assertions(5);
     const view = aFakeTrackerViewStateWith({
       matches: [
-        aFakeTrackerMatchSummaryWith({ matchId: "m1", outcome: "Win" }),
-        aFakeTrackerMatchSummaryWith({ matchId: "m2", outcome: "Loss" }),
-        aFakeTrackerMatchSummaryWith({ matchId: "m3", outcome: "Tie" }),
-        aFakeTrackerMatchSummaryWith({ matchId: "m4", outcome: "DNF" }),
-        aFakeTrackerMatchSummaryWith({ matchId: "m5", outcome: "Unknown" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m1", outcome: "Win", teamCount: 2 }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m2", outcome: "Loss", teamCount: 2 }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m3", outcome: "Tie", teamCount: 2 }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m4", outcome: "DNF", teamCount: 2 }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m5", outcome: "Unknown", teamCount: 2 }),
       ],
     });
 
@@ -143,7 +143,7 @@ describe("buildViewerRenderModel", () => {
   it("keeps Unknown outcome neutral with no colour", () => {
     expect.assertions(2);
     const view = aFakeTrackerViewStateWith({
-      matches: [aFakeTrackerMatchSummaryWith({ matchId: "m1", outcome: "Unknown" })],
+      matches: [aFakeTrackerMatchSummaryWith({ matchId: "m1", outcome: "Unknown", teamCount: 2 })],
     });
 
     const model = buildViewerRenderModel({ view });
@@ -151,6 +151,50 @@ describe("buildViewerRenderModel", () => {
     const [first] = model.timeline;
     if (first.type === "match") {
       expect(first.match.outcome).toBe("Unknown");
+      expect(first.match.colorHex).toBeUndefined();
+    }
+  });
+
+  it("keeps non-2-team summaries neutral with no colour", () => {
+    expect.assertions(2);
+    const view = aFakeTrackerViewStateWith({
+      matches: [
+        aFakeTrackerMatchSummaryWith({
+          matchId: "m-ffa",
+          outcome: "Win",
+          teamCount: 4,
+          isMatchmaking: true,
+        }),
+      ],
+    });
+
+    const model = buildViewerRenderModel({ view });
+
+    const [first] = model.timeline;
+    if (first.type === "match") {
+      expect(first.match.outcome).toBe("Win");
+      expect(first.match.colorHex).toBeUndefined();
+    }
+  });
+
+  it("keeps zero-team summaries neutral with no colour", () => {
+    expect.assertions(2);
+    const view = aFakeTrackerViewStateWith({
+      matches: [
+        aFakeTrackerMatchSummaryWith({
+          matchId: "m-ffa-zero",
+          outcome: "Win",
+          teamCount: 0,
+          isMatchmaking: true,
+        }),
+      ],
+    });
+
+    const model = buildViewerRenderModel({ view });
+
+    const [first] = model.timeline;
+    if (first.type === "match") {
+      expect(first.match.outcome).toBe("Win");
       expect(first.match.colorHex).toBeUndefined();
     }
   });
@@ -191,8 +235,8 @@ describe("buildViewerRenderModel", () => {
     expect.assertions(2);
     const view = aFakeTrackerViewStateWith({
       matches: [
-        aFakeTrackerMatchSummaryWith({ matchId: "m1", outcome: "Win" }),
-        aFakeTrackerMatchSummaryWith({ matchId: "m2", outcome: "Loss" }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m1", outcome: "Win", teamCount: 2 }),
+        aFakeTrackerMatchSummaryWith({ matchId: "m2", outcome: "Loss", teamCount: 2 }),
       ],
     });
 

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -211,6 +211,7 @@ function toReadableDurationOrUnknown(startTime: string, endTime: string): string
 function toMatchTab(summary: TrackerMatchSummary, teamHex: string, enemyHex: string): ViewerMatchTab {
   const outcome = normalizeOutcomeString(summary.outcome);
   const duration = toReadableDurationOrUnknown(summary.startTime, summary.endTime);
+  const colorHex = summary.teamCount === 2 ? getOutcomeColor(outcome, teamHex, enemyHex) : undefined;
 
   return {
     matchId: summary.matchId,
@@ -227,7 +228,7 @@ function toMatchTab(summary: TrackerMatchSummary, teamHex: string, enemyHex: str
     score: summary.score,
     killsDeathsAssistsKda: summary.killsDeathsAssistsKda,
     damageDealtTakenRatio: summary.damageDealtTakenRatio,
-    colorHex: getOutcomeColor(outcome, teamHex, enemyHex),
+    colorHex,
     startTime: summary.startTime,
     endTime: summary.endTime,
   };

--- a/pages/src/services/individual-tracker/fakes/view.fake.ts
+++ b/pages/src/services/individual-tracker/fakes/view.fake.ts
@@ -28,6 +28,7 @@ interface FakeMatchOverrides {
   readonly mapBackgroundUrl?: string;
   readonly outcome?: TrackerMatchSummary["outcome"];
   readonly score?: string;
+  readonly teamCount?: number;
   readonly killsDeathsAssistsKda?: string;
   readonly damageDealtTakenRatio?: string;
   readonly isMatchmaking?: boolean;
@@ -47,6 +48,7 @@ export function aFakeTrackerMatchSummaryWith(overrides: FakeMatchOverrides = {})
     gameVariantCategory: overrides.gameVariantCategory ?? 6,
     outcome: overrides.outcome ?? "Win",
     score: overrides.score ?? "50:42",
+    teamCount: overrides.teamCount ?? 2,
     killsDeathsAssistsKda: overrides.killsDeathsAssistsKda ?? "10:7:4 (1.62)",
     damageDealtTakenRatio: overrides.damageDealtTakenRatio ?? "4,200:3,900 (1.08)",
     isMatchmaking: overrides.isMatchmaking ?? false,

--- a/shared/src/contracts/individual-tracker/tests/view.test.ts
+++ b/shared/src/contracts/individual-tracker/tests/view.test.ts
@@ -160,6 +160,23 @@ describe("trackerViewContract", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts a zero teamCount in match summaries", () => {
+    const result = trackerViewContract.safeParse({
+      ...validResponse,
+      view: {
+        ...validResponse.view,
+        matches: [
+          {
+            ...validResponse.view.matches[0],
+            teamCount: 0,
+          },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it("rejects an unknown status", () => {
     const result = trackerViewContract.safeParse({
       ...validResponse,

--- a/shared/src/contracts/individual-tracker/view.ts
+++ b/shared/src/contracts/individual-tracker/view.ts
@@ -18,6 +18,7 @@ export const trackerMatchSummarySchema = z.object({
   mapBackgroundUrl: z.string().optional(),
   outcome: trackerMatchOutcomeSchema,
   score: z.string(),
+  teamCount: z.number().int().positive().optional(),
   killsDeathsAssistsKda: z.string(),
   damageDealtTakenRatio: z.string(),
   isMatchmaking: z.boolean(),

--- a/shared/src/contracts/individual-tracker/view.ts
+++ b/shared/src/contracts/individual-tracker/view.ts
@@ -18,7 +18,7 @@ export const trackerMatchSummarySchema = z.object({
   mapBackgroundUrl: z.string().optional(),
   outcome: trackerMatchOutcomeSchema,
   score: z.string(),
-  teamCount: z.number().int().positive().optional(),
+  teamCount: z.number().int().min(0).optional(),
   killsDeathsAssistsKda: z.string(),
   damageDealtTakenRatio: z.string(),
   isMatchmaking: z.boolean(),


### PR DESCRIPTION
## Context
Individual tracker series handling and viewer presentation were previously tuned to team-v-team assumptions. We needed to keep existing 2-team behavior, prevent free-for-all style matches from joining in-series state, and avoid frontend inference based on score formatting.

## This PR
- Adds server-computed teamCount to individual tracker match summaries and propagates it from Durable Object state through API mapping to the viewer contract.
- Prevents active series attachment for discovered matches unless they are non-matchmaking and exactly 2-team (which excludes FFA and other non-2-team customs from in-series flow).
- Updates viewer match color logic to use server-provided teamCount rather than score parsing.
- Adds focused regressions for:
  - 3-team and 0-team discovered custom matches not attaching to active series.
  - non-2-team and 0-team viewer entries remaining color-neutral.
- Updates related fakes and test fixtures to include teamCount.

Validation:
- npx vitest run api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts shared/src/contracts/individual-tracker/tests/view.test.ts
- npx vitest run api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts

## Subsequent Work
- Optionally introduce an explicit teamType field (for example ffa, team, unknown) if we want display/policy decisions beyond count-based gating.
