### PR TITLE
fix(individual-tracker): include teamCount in DO view state for websocket broadcasts

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -2738,6 +2738,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         gameVariantCategory: summary.gameVariantCategory,
         outcome: summary.outcome,
         score: summary.score,
+        ...(summary.teamCount != null ? { teamCount: summary.teamCount } : {}),
         killsDeathsAssistsKda: summary.killsDeathsAssistsKda ?? UNKNOWN_KDA_DISPLAY,
         damageDealtTakenRatio: summary.damageDealtTakenRatio ?? UNKNOWN_DAMAGE_RATIO_DISPLAY,
         isMatchmaking: summary.isMatchmaking,

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -536,6 +536,7 @@ describe("IndividualTrackerDO", () => {
           "gameVariantCategory",
           "outcome",
           "score",
+          "teamCount",
           "killsDeathsAssistsKda",
           "damageDealtTakenRatio",
           "isMatchmaking",
@@ -3262,6 +3263,36 @@ describe("IndividualTrackerDO", () => {
       const parsed = trackerViewMessageContract.parse(Preconditions.checkExists(webSocketAdapter.broadcasts[0]));
       expect(parsed.type).toBe("view");
       expect(parsed.view.matches.some((m) => m.matchId === "new-match")).toBe(true);
+    });
+
+    it("includes teamCount in broadcast match summaries", async () => {
+      ownerClient.getPlayerMatches.mockResolvedValueOnce([]);
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({
+          matchIds: ["old-match"],
+          selectedMatchIds: ["old-match"],
+          discoveredMatches: {
+            "old-match": aFakeIndividualTrackerMatchSummaryWith({
+              matchId: "old-match",
+              teamCount: 3,
+              teamOutcomes: [2, 3],
+              kills: 10,
+              deaths: 7,
+              assists: 4,
+              damageDealt: 4200,
+              damageTaken: 3900,
+            }),
+          },
+        }),
+      );
+
+      const response = await individualTrackerDO.fetch(new Request("http://do/refresh", { method: "POST" }));
+
+      expect(response.status).toBe(200);
+      expect(webSocketAdapter.broadcasts).toHaveLength(1);
+      const parsed = trackerViewMessageContract.parse(Preconditions.checkExists(webSocketAdapter.broadcasts[0]));
+      const match = parsed.view.matches.find((m) => m.matchId === "old-match");
+      expect(match?.teamCount).toBe(3);
     });
 
     it("does not broadcast when a poll discovers no new match", async () => {


### PR DESCRIPTION
## Context

PR #758 introduced server-provided `teamCount` so the viewer only applies win/loss outcome colors to 2-team matches (excluding FFA). It updated the DO's match enrichment, the internal summary type, and the REST mapper (`toTrackerView`) — but the overlay is driven by websocket broadcasts, which are serialized by a separate path.

## This change

- Adds `teamCount` to the DO's `toViewState` match summary mapping — the serializer used by websocket broadcasts and the `/view-state` endpoint — mirroring the REST mapper. Without it, the viewer's `teamCount === 2` check always failed and all overlay outcome colors disappeared.
- Adds a regression test asserting a broadcast carries `teamCount` through from stored state (using a non-default value so enrichment defaults can't mask a regression).
- Updates the existing public-shape key-list test to include `teamCount`.

Note: match summaries persisted before #758 deployed lack `teamCount` in DO storage and remain uncolored until re-enriched; new and refreshed matches pick it up immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)