### PR TITLE
fix(individual-tracker): pending series shows teams-created time and sits at timeline end

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -2262,7 +2262,9 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
           startedAt,
           isActive: true,
         };
-        if (payload.startedAt != null && isParseableTimestamp(payload.startedAt)) {
+        if (payload.searchStartTime != null && isParseableTimestamp(payload.searchStartTime)) {
+          trackerState.searchStartTime = payload.searchStartTime;
+        } else if (payload.startedAt != null && isParseableTimestamp(payload.startedAt)) {
           trackerState.searchStartTime = payload.startedAt;
         }
         delete trackerState.preSeriesPlayerInfoLatestMatchId;

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -3725,6 +3725,44 @@ describe("IndividualTrackerDO", () => {
       expect(persisted.searchStartTime).toBe(startedAt);
     });
 
+    it("prefers payload searchStartTime over startedAt for match discovery while keeping startedAt for display", async () => {
+      const startedAt = "2026-07-25T12:00:00Z";
+      const searchStartTime = "2026-07-25T11:30:00Z";
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({ searchStartTime: "2026-01-01T00:00:00Z" }),
+      );
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", {
+          method: "POST",
+          body: JSON.stringify(aSeriesPayload({ startedAt, searchStartTime })),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.searchStartTime).toBe(searchStartTime);
+      expect(persisted.activeSeries?.startedAt).toBe(startedAt);
+    });
+
+    it("falls back to startedAt for searchStartTime when payload searchStartTime is unparseable", async () => {
+      const startedAt = "2026-07-25T12:00:00Z";
+      storageGetSpy.mockResolvedValue(
+        aFakeIndividualTrackerInternalStateWith({ searchStartTime: "2026-01-01T00:00:00Z" }),
+      );
+
+      const response = await individualTrackerDO.fetch(
+        new Request("http://do/nudge", {
+          method: "POST",
+          body: JSON.stringify(aSeriesPayload({ startedAt, searchStartTime: "not-a-valid-date" })),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.searchStartTime).toBe(startedAt);
+    });
+
     it("keeps existing searchStartTime when a started nudge omits startedAt", async () => {
       const previousSearchStartTime = "2026-01-01T00:00:00Z";
       storageGetSpy.mockResolvedValue(

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -679,13 +679,14 @@ export class NeatQueueService {
           this.buildSeriesPlayer(queueState.playersAssociationData[player.id], player.id, player.name),
         ),
       }));
+      const searchStartTime = this.resolveSeriesSearchStartTime(request);
       const seriesContext: SeriesStartedPayload = {
         type: "started",
         title,
         subtitle: `Queue #${request.match_number.toString()}`,
         guildIconUrl,
         startedAt: new Date().toISOString(),
-        searchStartTime: this.resolveSeriesSearchStartTime(request),
+        ...(searchStartTime != null ? { searchStartTime } : {}),
         teams: seriesTeams,
       };
       queueState.seriesContext = seriesContext;
@@ -723,7 +724,7 @@ export class NeatQueueService {
     }
   }
 
-  private resolveSeriesSearchStartTime(request: NeatQueueTeamsCreatedRequest): string {
+  private resolveSeriesSearchStartTime(request: NeatQueueTeamsCreatedRequest): string | undefined {
     const validTimestamps = request.teams
       .flatMap((team) => team.map((player) => player.timestamp))
       .map((value) => value.trim())
@@ -735,7 +736,7 @@ export class NeatQueueService {
       return new Date(Math.min(...validTimestamps)).toISOString();
     }
 
-    return new Date().toISOString();
+    return undefined;
   }
 
   private async fetchGuildDisplayInfo(guildId: string): Promise<{ title: string; guildIconUrl: string | null }> {

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -684,7 +684,8 @@ export class NeatQueueService {
         title,
         subtitle: `Queue #${request.match_number.toString()}`,
         guildIconUrl,
-        startedAt: this.resolveSeriesStartedAt(request),
+        startedAt: new Date().toISOString(),
+        searchStartTime: this.resolveSeriesSearchStartTime(request),
         teams: seriesTeams,
       };
       queueState.seriesContext = seriesContext;
@@ -722,7 +723,7 @@ export class NeatQueueService {
     }
   }
 
-  private resolveSeriesStartedAt(request: NeatQueueTeamsCreatedRequest): string {
+  private resolveSeriesSearchStartTime(request: NeatQueueTeamsCreatedRequest): string {
     const validTimestamps = request.teams
       .flatMap((team) => team.map((player) => player.timestamp))
       .map((value) => value.trim())

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -2260,7 +2260,7 @@ describe("NeatQueueService", () => {
 
       it("uses guild display name for title even when explicit team names are set", async () => {
         const teamsCreatedRequest = getFakeNeatQueueData("teamsCreated");
-        const expectedStartedAt = new Date(
+        const expectedSearchStartTime = new Date(
           teamsCreatedRequest.teams[0]?.[0]?.timestamp ?? "2026-01-01T00:00:00.000Z",
         ).toISOString();
         const team0Player = teamsCreatedRequest.teams[0]?.[0];
@@ -2289,10 +2289,11 @@ describe("NeatQueueService", () => {
         expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
         const [, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], SeriesStartedPayload];
         expect(payload.title).toBe("Test Server");
-        expect(payload.startedAt).toBe(expectedStartedAt);
+        expect(payload.startedAt).toBe(new Date(now).toISOString());
+        expect(payload.searchStartTime).toBe(expectedSearchStartTime);
       });
 
-      it("uses earliest valid player timestamp when earlier entries are invalid", async () => {
+      it("uses earliest valid player timestamp as searchStartTime when earlier entries are invalid", async () => {
         vi.setSystemTime(new Date("2026-07-17T10:00:00.000Z"));
 
         const teamsCreatedRequest = getFakeNeatQueueData("teamsCreated");
@@ -2321,7 +2322,8 @@ describe("NeatQueueService", () => {
 
         expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
         const [, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], SeriesStartedPayload];
-        expect(payload.startedAt).toBe("2026-07-17T09:58:00.000Z");
+        expect(payload.startedAt).toBe("2026-07-17T10:00:00.000Z");
+        expect(payload.searchStartTime).toBe("2026-07-17T09:58:00.000Z");
       });
 
       it("uses guild ID as title fallback when getGuild fails and team names are unavailable", async () => {

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -2326,6 +2326,35 @@ describe("NeatQueueService", () => {
         expect(payload.searchStartTime).toBe("2026-07-17T09:58:00.000Z");
       });
 
+      it("omits searchStartTime when no player timestamps are valid", async () => {
+        const teamsCreatedRequest = getFakeNeatQueueData("teamsCreated");
+        for (const team of teamsCreatedRequest.teams) {
+          for (const player of team) {
+            player.timestamp = "not-a-date";
+          }
+        }
+
+        (vi.spyOn(env.APP_DATA, "get") as MockInstance).mockResolvedValue(aFakeNeatQueueStateWith());
+        vi.spyOn(env.APP_DATA, "put").mockResolvedValue();
+        vi.spyOn(discordService, "getGuild").mockResolvedValue({
+          ...guild,
+          id: "guild-1",
+          name: "Test Server",
+          icon: null,
+        });
+        vi.spyOn(databaseService, "getGuildConfig").mockResolvedValue(
+          aFakeGuildConfigRow({ NeatQueueInformerLiveTracking: "N" }),
+        );
+
+        const { jobToComplete } = neatQueueService.handleRequest(teamsCreatedRequest, neatQueueConfig);
+        await jobToComplete?.();
+
+        expect(nudgeTrackersSpy).toHaveBeenCalledOnce();
+        const [, payload] = nudgeTrackersSpy.mock.calls[0] as [string[], SeriesStartedPayload];
+        expect(payload.searchStartTime).toBeUndefined();
+        expect(payload.startedAt).toBe(new Date(now).toISOString());
+      });
+
       it("uses guild ID as title fallback when getGuild fails and team names are unavailable", async () => {
         const teamsCreatedRequest = getFakeNeatQueueData("teamsCreated");
         teamsCreatedRequest.teams = [];

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
@@ -434,6 +434,33 @@ describe("buildViewerRenderModel", () => {
     }
   });
 
+  it("appends the pending active pre-series row after existing timeline matches", () => {
+    const view = aFakeTrackerViewStateWith({
+      matches: [aFakeTrackerMatchSummaryWith({ matchId: "m1" }), aFakeTrackerMatchSummaryWith({ matchId: "m2" })],
+      series: [],
+      hasActiveSeries: true,
+      activeSeriesContext: {
+        title: "Alpha vs Beta",
+        subtitle: "Bo5",
+        guildIconUrl: null,
+        startedAt: "2026-07-17T09:23:30.659Z",
+        teams: [],
+      },
+    });
+
+    const model = buildViewerRenderModel({ view });
+
+    expect(model.timeline).toHaveLength(3);
+    expect(model.timeline[0]?.type).toBe("match");
+    expect(model.timeline[1]?.type).toBe("match");
+    const last = model.timeline.at(-1);
+    expect(last?.type).toBe("series");
+    if (last?.type === "series") {
+      expect(last.series.isActive).toBe(true);
+      expect(last.series.matches).toHaveLength(0);
+    }
+  });
+
   it("replaces the pending pre-series row once active series match data is available", () => {
     const pendingView = aFakeTrackerViewStateWith({
       matches: [],

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -408,7 +408,7 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
     view.hasActiveSeries &&
     view.activeSeriesContext != null &&
     !timelineWithFallback.some((item) => item.type === "series" && item.series.isActive)
-      ? ([{ type: "series", series: toPendingActiveSeriesTab(view) }, ...timelineWithFallback] as ViewerTimelineItem[])
+      ? ([...timelineWithFallback, { type: "series", series: toPendingActiveSeriesTab(view) }] as ViewerTimelineItem[])
       : timelineWithFallback;
 
   const accumulated = accumulate(view.matches);

--- a/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/nudge.ts
@@ -16,6 +16,7 @@ export const seriesStartedPayloadSchema = z.object({
   subtitle: z.string(),
   guildIconUrl: z.string().nullable(),
   startedAt: z.string().optional(),
+  searchStartTime: z.string().optional(),
   teams: z.array(seriesTeamSchema),
 });
 export type SeriesStartedPayload = z.infer<typeof seriesStartedPayloadSchema>;


### PR DESCRIPTION
## Context

When a NeatQueue series starts, the individual tracker viewer shows a pending series row until the first match is discovered (after which the series anchors to that match). Two things were wrong with that pending row:

1. **Wrong start time.** `resolveSeriesStartedAt` (introduced in #717) derived `startedAt` from the minimum of all players' `timestamp` fields in the TEAMS_CREATED webhook — each player's *queue-join* time. Since players (and streamers starting trackers) join the queue well before teams are created, the displayed series start time read as roughly the tracker start / search start time. #750 additionally reused this value as the DO's `searchStartTime`, coupling the display value to the match-discovery window.
2. **Wrong timeline position.** The viewer *prepended* the pending series row to the timeline, so the newest item (the just-started series) appeared in the oldest position at the top, then jumped to the bottom once its first match anchored it. The timeline orders oldest → newest positionally (matches array order); no timestamp is consulted for ordering.

## This change

- `startedAt` on the series-started nudge payload is now the TEAMS_CREATED webhook receipt time — the actual NeatQueue series start — displayed until the first match arrives.
- A new optional `searchStartTime` payload field carries the earliest queue-join timestamp; the DO prefers it (falling back to `startedAt`) for its match-discovery window, preserving the wide-search buffer. When no valid player timestamps exist the field is omitted entirely.
- The pending active series row is now *appended* to the viewer timeline, matching oldest → newest ordering and the scroll-to-latest behavior.
- Regression tests cover the payload split, the DO preference/fallback ordering, the omission case, and the pending row's timeline position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)