### PR TITLE
feat(neatqueue): daily scheduled cleanup of stale NeatQueue configs

### DIFF
--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -206,6 +206,14 @@ export class DatabaseService {
     return results;
   }
 
+  async getAllNeatQueueConfigs(): Promise<NeatQueueConfigRow[]> {
+    const query = "SELECT * FROM NeatQueueConfig";
+    const stmt = this.DB.prepare(query);
+    const { results } = await stmt.all<NeatQueueConfigRow>();
+
+    return results;
+  }
+
   async upsertNeatQueueConfig(config: NeatQueueConfigRow): Promise<void> {
     const query = `
       INSERT INTO NeatQueueConfig (GuildId, ChannelId, WebhookSecret, ResultsChannelId, PostSeriesMode, PostSeriesChannelId) VALUES (?, ?, ?, ?, ?, ?)

--- a/api/services/database/tests/database.test.ts
+++ b/api/services/database/tests/database.test.ts
@@ -4,6 +4,7 @@ import { SESSION_COOKIE_MAX_AGE_SECONDS } from "../../auth/session-manager";
 import { DatabaseService } from "../database";
 import {
   aFakeDiscordAssociationsRow,
+  aFakeNeatQueueConfigRow,
   aFakeUserSessionsRow,
   aFakeUserCredentialsRow,
   aFakeLinkedIdentitiesRow,
@@ -394,6 +395,22 @@ describe("Database Service", () => {
       const results = await databaseService.findNeatQueueConfig({});
 
       expect(results).toEqual([]);
+    });
+  });
+
+  describe("getAllNeatQueueConfigs()", () => {
+    it("returns every NeatQueueConfig row", async () => {
+      const config1 = aFakeNeatQueueConfigRow({ GuildId: "guild-1", ChannelId: "channel-1" });
+      const config2 = aFakeNeatQueueConfigRow({ GuildId: "guild-2", ChannelId: "channel-2" });
+
+      const fakePreparedStatement = new FakePreparedStatement();
+      const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      vi.spyOn(fakePreparedStatement, "all").mockResolvedValue({ ...fakeD1Response, results: [config1, config2] });
+
+      const results = await databaseService.getAllNeatQueueConfigs();
+
+      expect(prepareSpy).toHaveBeenCalledWith("SELECT * FROM NeatQueueConfig");
+      expect(results).toEqual([config1, config2]);
     });
   });
 

--- a/api/services/neatqueue/stale-config-cleanup.ts
+++ b/api/services/neatqueue/stale-config-cleanup.ts
@@ -1,0 +1,130 @@
+import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import type { DatabaseService } from "../database/database";
+import type { NeatQueueConfigRow } from "../database/types/neat_queue_config";
+import type { DiscordService } from "../discord/discord";
+import { DiscordError } from "../discord/discord-error";
+import type { LogService } from "../log/types";
+
+export interface StaleNeatQueueConfigCleanupOpts {
+  databaseService: DatabaseService;
+  discordService: DiscordService;
+  logService: LogService;
+}
+
+type QueueChannelStatus = "exists" | "deleted" | "inaccessible" | "unknown";
+
+export class StaleNeatQueueConfigCleanup {
+  private readonly databaseService: DatabaseService;
+  private readonly discordService: DiscordService;
+  private readonly logService: LogService;
+  private readonly guildAccessCache = new Map<string, boolean>();
+
+  constructor({ databaseService, discordService, logService }: StaleNeatQueueConfigCleanupOpts) {
+    this.databaseService = databaseService;
+    this.discordService = discordService;
+    this.logService = logService;
+  }
+
+  async execute(): Promise<void> {
+    const configs = await this.databaseService.getAllNeatQueueConfigs();
+    let deletedCount = 0;
+
+    for (const config of configs) {
+      const isStale = await this.isConfigStale(config);
+      if (!isStale) {
+        continue;
+      }
+
+      await this.databaseService.deleteNeatQueueConfig(config.GuildId, config.ChannelId);
+      deletedCount += 1;
+      this.logService.info(
+        "StaleNeatQueueConfigCleanup: deleted stale config",
+        new Map([
+          ["guildId", config.GuildId],
+          ["channelId", config.ChannelId],
+        ]),
+      );
+    }
+
+    this.logService.info(
+      "StaleNeatQueueConfigCleanup: completed",
+      new Map([
+        ["totalConfigs", configs.length.toString()],
+        ["deletedConfigs", deletedCount.toString()],
+      ]),
+    );
+  }
+
+  private async isConfigStale(config: NeatQueueConfigRow): Promise<boolean> {
+    const status = await this.getQueueChannelStatus(config);
+
+    switch (status) {
+      case "exists": {
+        return false;
+      }
+      case "deleted": {
+        return true;
+      }
+      case "inaccessible": {
+        return this.isBotRemovedFromGuild(config.GuildId);
+      }
+      case "unknown": {
+        return false;
+      }
+      default: {
+        throw new UnreachableError(status);
+      }
+    }
+  }
+
+  private async getQueueChannelStatus(config: NeatQueueConfigRow): Promise<QueueChannelStatus> {
+    try {
+      await this.discordService.getChannel(config.ChannelId);
+      return "exists";
+    } catch (error) {
+      if (error instanceof DiscordError && error.httpStatus === 404) {
+        return "deleted";
+      }
+      if (error instanceof DiscordError && error.httpStatus === 403) {
+        return "inaccessible";
+      }
+
+      this.logService.warn(
+        "StaleNeatQueueConfigCleanup: unexpected error fetching queue channel, keeping config",
+        new Map([
+          ["guildId", config.GuildId],
+          ["channelId", config.ChannelId],
+          ["error", String(error)],
+        ]),
+      );
+      return "unknown";
+    }
+  }
+
+  private async isBotRemovedFromGuild(guildId: string): Promise<boolean> {
+    const cached = this.guildAccessCache.get(guildId);
+    if (cached != null) {
+      return cached;
+    }
+
+    let removed = false;
+    try {
+      await this.discordService.getGuild(guildId);
+    } catch (error) {
+      if (error instanceof DiscordError && (error.httpStatus === 404 || error.httpStatus === 403)) {
+        removed = true;
+      } else {
+        this.logService.warn(
+          "StaleNeatQueueConfigCleanup: unexpected error fetching guild, keeping config",
+          new Map([
+            ["guildId", guildId],
+            ["error", String(error)],
+          ]),
+        );
+      }
+    }
+
+    this.guildAccessCache.set(guildId, removed);
+    return removed;
+  }
+}

--- a/api/services/neatqueue/stale-config-cleanup.ts
+++ b/api/services/neatqueue/stale-config-cleanup.ts
@@ -107,24 +107,24 @@ export class StaleNeatQueueConfigCleanup {
       return cached;
     }
 
-    let removed = false;
     try {
       await this.discordService.getGuild(guildId);
+      this.guildAccessCache.set(guildId, false);
+      return false;
     } catch (error) {
       if (error instanceof DiscordError && (error.httpStatus === 404 || error.httpStatus === 403)) {
-        removed = true;
-      } else {
-        this.logService.warn(
-          "StaleNeatQueueConfigCleanup: unexpected error fetching guild, keeping config",
-          new Map([
-            ["guildId", guildId],
-            ["error", String(error)],
-          ]),
-        );
+        this.guildAccessCache.set(guildId, true);
+        return true;
       }
-    }
 
-    this.guildAccessCache.set(guildId, removed);
-    return removed;
+      this.logService.warn(
+        "StaleNeatQueueConfigCleanup: unexpected error fetching guild, keeping config",
+        new Map([
+          ["guildId", guildId],
+          ["error", String(error)],
+        ]),
+      );
+      return false;
+    }
   }
 }

--- a/api/services/neatqueue/tests/stale-config-cleanup.test.ts
+++ b/api/services/neatqueue/tests/stale-config-cleanup.test.ts
@@ -127,6 +127,23 @@ describe("StaleNeatQueueConfigCleanup", () => {
     expect(deleteConfigSpy).toHaveBeenCalledWith("guild-kicked", "channel-2");
   });
 
+  it("does not cache an unexpected guild error as a definitive answer", async () => {
+    getAllConfigsSpy.mockResolvedValue([
+      aFakeNeatQueueConfigRow({ GuildId: "guild-flaky", ChannelId: "channel-1" }),
+      aFakeNeatQueueConfigRow({ GuildId: "guild-flaky", ChannelId: "channel-2" }),
+    ]);
+    getChannelSpy.mockRejectedValue(new DiscordError(403, { code: 50001, message: "Missing Access" }));
+    getGuildSpy
+      .mockRejectedValueOnce(new DiscordError(500, { code: 0, message: "Internal Server Error" }))
+      .mockRejectedValueOnce(new DiscordError(403, { code: 50001, message: "Missing Access" }));
+
+    await cleanup.execute();
+
+    expect(getGuildSpy).toHaveBeenCalledTimes(2);
+    expect(deleteConfigSpy).toHaveBeenCalledTimes(1);
+    expect(deleteConfigSpy).toHaveBeenCalledWith("guild-flaky", "channel-2");
+  });
+
   it("processes remaining configs independently when one is stale", async () => {
     getAllConfigsSpy.mockResolvedValue([
       aFakeNeatQueueConfigRow({ GuildId: "guild-1", ChannelId: "channel-gone" }),

--- a/api/services/neatqueue/tests/stale-config-cleanup.test.ts
+++ b/api/services/neatqueue/tests/stale-config-cleanup.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import type { APIChannel } from "discord-api-types/v10";
+import type { DatabaseService } from "../../database/database";
+import { aFakeDatabaseServiceWith, aFakeNeatQueueConfigRow } from "../../database/fakes/database.fake";
+import type { DiscordService } from "../../discord/discord";
+import { aFakeDiscordServiceWith } from "../../discord/fakes/discord.fake";
+import { guild } from "../../discord/fakes/data";
+import { DiscordError } from "../../discord/discord-error";
+import type { LogService } from "../../log/types";
+import { aFakeLogServiceWith } from "../../log/fakes/log.fake";
+import { StaleNeatQueueConfigCleanup } from "../stale-config-cleanup";
+
+function aChannel(id: string): APIChannel {
+  return {
+    id,
+    name: "queue-channel",
+    type: 0,
+    position: 0,
+  };
+}
+
+describe("StaleNeatQueueConfigCleanup", () => {
+  let databaseService: DatabaseService;
+  let discordService: DiscordService;
+  let logService: LogService;
+  let cleanup: StaleNeatQueueConfigCleanup;
+  let getAllConfigsSpy: MockInstance<typeof databaseService.getAllNeatQueueConfigs>;
+  let deleteConfigSpy: MockInstance<typeof databaseService.deleteNeatQueueConfig>;
+  let getChannelSpy: MockInstance<typeof discordService.getChannel>;
+  let getGuildSpy: MockInstance<typeof discordService.getGuild>;
+
+  beforeEach(() => {
+    databaseService = aFakeDatabaseServiceWith();
+    discordService = aFakeDiscordServiceWith();
+    logService = aFakeLogServiceWith();
+    cleanup = new StaleNeatQueueConfigCleanup({ databaseService, discordService, logService });
+
+    getAllConfigsSpy = vi.spyOn(databaseService, "getAllNeatQueueConfigs").mockResolvedValue([]);
+    deleteConfigSpy = vi.spyOn(databaseService, "deleteNeatQueueConfig").mockResolvedValue();
+    getChannelSpy = vi.spyOn(discordService, "getChannel").mockResolvedValue(aChannel("channel-1"));
+    getGuildSpy = vi.spyOn(discordService, "getGuild").mockResolvedValue(guild);
+  });
+
+  it("makes no discord calls when no configs exist", async () => {
+    await cleanup.execute();
+
+    expect(getChannelSpy).not.toHaveBeenCalled();
+    expect(deleteConfigSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps configs whose queue channel exists", async () => {
+    getAllConfigsSpy.mockResolvedValue([aFakeNeatQueueConfigRow({ GuildId: "guild-1", ChannelId: "channel-1" })]);
+
+    await cleanup.execute();
+
+    expect(getChannelSpy).toHaveBeenCalledWith("channel-1");
+    expect(deleteConfigSpy).not.toHaveBeenCalled();
+  });
+
+  it("deletes configs whose queue channel returns 404", async () => {
+    getAllConfigsSpy.mockResolvedValue([aFakeNeatQueueConfigRow({ GuildId: "guild-1", ChannelId: "channel-gone" })]);
+    getChannelSpy.mockRejectedValue(new DiscordError(404, { code: 10003, message: "Unknown Channel" }));
+
+    await cleanup.execute();
+
+    expect(deleteConfigSpy).toHaveBeenCalledTimes(1);
+    expect(deleteConfigSpy).toHaveBeenCalledWith("guild-1", "channel-gone");
+    expect(getGuildSpy).not.toHaveBeenCalled();
+  });
+
+  it("deletes configs when the channel is inaccessible and the bot is no longer in the guild", async () => {
+    getAllConfigsSpy.mockResolvedValue([aFakeNeatQueueConfigRow({ GuildId: "guild-kicked", ChannelId: "channel-1" })]);
+    getChannelSpy.mockRejectedValue(new DiscordError(403, { code: 50001, message: "Missing Access" }));
+    getGuildSpy.mockRejectedValue(new DiscordError(403, { code: 50001, message: "Missing Access" }));
+
+    await cleanup.execute();
+
+    expect(getGuildSpy).toHaveBeenCalledWith("guild-kicked");
+    expect(deleteConfigSpy).toHaveBeenCalledTimes(1);
+    expect(deleteConfigSpy).toHaveBeenCalledWith("guild-kicked", "channel-1");
+  });
+
+  it("keeps configs when the channel is inaccessible but the bot is still in the guild", async () => {
+    getAllConfigsSpy.mockResolvedValue([aFakeNeatQueueConfigRow({ GuildId: "guild-1", ChannelId: "channel-hidden" })]);
+    getChannelSpy.mockRejectedValue(new DiscordError(403, { code: 50001, message: "Missing Access" }));
+
+    await cleanup.execute();
+
+    expect(getGuildSpy).toHaveBeenCalledWith("guild-1");
+    expect(deleteConfigSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps configs when fetching the queue channel fails with an unexpected error", async () => {
+    getAllConfigsSpy.mockResolvedValue([aFakeNeatQueueConfigRow({ GuildId: "guild-1", ChannelId: "channel-1" })]);
+    getChannelSpy.mockRejectedValue(new DiscordError(500, { code: 0, message: "Internal Server Error" }));
+
+    await cleanup.execute();
+
+    expect(deleteConfigSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps configs when the guild check fails with an unexpected error", async () => {
+    getAllConfigsSpy.mockResolvedValue([aFakeNeatQueueConfigRow({ GuildId: "guild-1", ChannelId: "channel-1" })]);
+    getChannelSpy.mockRejectedValue(new DiscordError(403, { code: 50001, message: "Missing Access" }));
+    getGuildSpy.mockRejectedValue(new DiscordError(500, { code: 0, message: "Internal Server Error" }));
+
+    await cleanup.execute();
+
+    expect(deleteConfigSpy).not.toHaveBeenCalled();
+  });
+
+  it("checks guild access once per guild across multiple inaccessible configs", async () => {
+    getAllConfigsSpy.mockResolvedValue([
+      aFakeNeatQueueConfigRow({ GuildId: "guild-kicked", ChannelId: "channel-1" }),
+      aFakeNeatQueueConfigRow({ GuildId: "guild-kicked", ChannelId: "channel-2" }),
+    ]);
+    getChannelSpy.mockRejectedValue(new DiscordError(403, { code: 50001, message: "Missing Access" }));
+    getGuildSpy.mockRejectedValue(new DiscordError(404, { code: 10004, message: "Unknown Guild" }));
+
+    await cleanup.execute();
+
+    expect(getGuildSpy).toHaveBeenCalledTimes(1);
+    expect(getGuildSpy).toHaveBeenCalledWith("guild-kicked");
+    expect(deleteConfigSpy).toHaveBeenCalledTimes(2);
+    expect(deleteConfigSpy).toHaveBeenCalledWith("guild-kicked", "channel-1");
+    expect(deleteConfigSpy).toHaveBeenCalledWith("guild-kicked", "channel-2");
+  });
+
+  it("processes remaining configs independently when one is stale", async () => {
+    getAllConfigsSpy.mockResolvedValue([
+      aFakeNeatQueueConfigRow({ GuildId: "guild-1", ChannelId: "channel-gone" }),
+      aFakeNeatQueueConfigRow({ GuildId: "guild-2", ChannelId: "channel-alive" }),
+    ]);
+    getChannelSpy.mockImplementation(async (channelId: string) => {
+      if (channelId === "channel-gone") {
+        return Promise.reject(new DiscordError(404, { code: 10003, message: "Unknown Channel" }));
+      }
+      return Promise.resolve(aChannel(channelId));
+    });
+
+    await cleanup.execute();
+
+    expect(deleteConfigSpy).toHaveBeenCalledTimes(1);
+    expect(deleteConfigSpy).toHaveBeenCalledWith("guild-1", "channel-gone");
+  });
+});

--- a/api/worker.ts
+++ b/api/worker.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/cloudflare";
 import { installServices } from "./services/install";
 import { createApiRouter } from "./base/router";
 import { Server } from "./server";
+import { StaleNeatQueueConfigCleanup } from "./services/neatqueue/stale-config-cleanup";
 
 // Export Durable Object classes
 export { LiveTrackerDO } from "./durable-objects/live-tracker/live-tracker-do";
@@ -43,5 +44,10 @@ export default Sentry.withSentry(
   }),
   {
     fetch: server.router.fetch,
+    scheduled: async (_controller: ScheduledController, env: Env): Promise<void> => {
+      const { databaseService, discordService, logService } = installServices({ env });
+      const cleanup = new StaleNeatQueueConfigCleanup({ databaseService, discordService, logService });
+      await cleanup.execute();
+    },
   },
 );

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -6,6 +6,11 @@
   "compatibility_date": "2026-02-28",
   "upload_source_maps": true,
 
+  // Daily cleanup of NeatQueue configs whose queue channel no longer exists
+  "triggers": {
+    "crons": ["43 15 * * *"],
+  },
+
   // KV namespaces for development
   "kv_namespaces": [
     {


### PR DESCRIPTION
## Context

Servers set up NeatQueue configurations and later delete the queue channels (or remove the bot entirely), leaving `NeatQueueConfig` rows pointing at channels and servers that no longer exist. These stale rows accumulate indefinitely since nothing cleans them up.

## This change

Adds a daily Cloudflare scheduled task that removes configs whose queue channel is gone:

- **Cron trigger** (`43 15 * * *` UTC, daily) in `wrangler.jsonc` — `triggers` is an inheritable key, so staging and production both get it from the single top-level entry.
- **`scheduled` handler** in `worker.ts` (Sentry-wrapped alongside `fetch`), which installs services per run and executes the cleanup.
- **`StaleNeatQueueConfigCleanup`** service (`api/services/neatqueue/stale-config-cleanup.ts`): iterates all configs, checks the queue channel via the Discord API, and deletes a config when:
  - the channel returns **404 Unknown Channel** (definitively deleted), or
  - the channel returns **403** *and* a guild-level check confirms the bot is no longer in the server (covers configs pointing at unknown servers).

  Ambiguous cases keep the config: a 403 where the bot is still in the guild (channel merely hidden), and any unexpected error (rate limits, 5xx) — logged as warnings. Guild-access checks are cached per run so multiple configs in one kicked guild cost a single API call. Only the queue channel (the config's identity) is checked; results/post-series channels are ignored.
- **`getAllNeatQueueConfigs()`** added to `DatabaseService`.
- Tests cover: empty table, channel exists, 404 delete, 403+kicked delete, 403+still-in-guild keep, unexpected channel/guild errors keep, per-guild cache, and independent processing across configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)