### PR TITLE
feat(individual-tracker): prepopulate active series when starting mid-series

### DIFF
--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -1321,7 +1321,7 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       guildIconUrl: seriesSeed.guildIconUrl,
       teams: seriesSeed.teams,
       matchIds: [],
-      startedAt: seriesSeed.startedAt,
+      startedAt: isParseableTimestamp(seriesSeed.startedAt) ? seriesSeed.startedAt : new Date().toISOString(),
       isActive: true,
     };
 

--- a/api/durable-objects/individual-tracker/individual-tracker-do.ts
+++ b/api/durable-objects/individual-tracker/individual-tracker-do.ts
@@ -27,6 +27,7 @@ import {
   individualTrackerStartRequestSchema,
   individualTrackerStopContract,
   type IndividualTrackerDoState,
+  type IndividualTrackerSeriesSeed,
 } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/lifecycle";
 import {
   individualTrackerStatusContract,
@@ -1278,9 +1279,14 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
       },
     };
 
+    if (body.seriesSeed != null) {
+      await this.applySeriesSeed(trackerState, body.seriesSeed);
+    }
+
     await this.setState(trackerState);
     this.notifyUserTracker(trackerState);
-    await this.state.storage.setAlarm(addMilliseconds(new Date(), ALARM_INTERVAL_MS).getTime());
+    const firstAlarmDelayMs = body.seriesSeed != null ? 0 : ALARM_INTERVAL_MS;
+    await this.state.storage.setAlarm(addMilliseconds(new Date(), firstAlarmDelayMs).getTime());
 
     this.logService.info(
       "IndividualTracker: tracker started",
@@ -1288,11 +1294,72 @@ export class IndividualTrackerDO implements DurableObject, Rpc.DurableObjectBran
         ["userId", body.userId],
         ["trackerId", body.trackerId],
         ["gamertag", body.gamertag],
-        ["searchStartTime", body.searchStartTime],
+        ["searchStartTime", trackerState.searchStartTime],
+        ["seededSeries", String(body.seriesSeed != null)],
+        ["seededMatchCount", (body.seriesSeed?.matchIds.length ?? 0).toString()],
       ]),
     );
 
     return individualTrackerStartContract.toResponse({ success: true, state: this.sanitizeState(trackerState) });
+  }
+
+  private async applySeriesSeed(
+    trackerState: IndividualTrackerInternalState,
+    seriesSeed: IndividualTrackerSeriesSeed,
+  ): Promise<void> {
+    const seedSearchStartTime = seriesSeed.searchStartTime ?? seriesSeed.startedAt;
+    if (
+      isParseableTimestamp(seedSearchStartTime) &&
+      new Date(seedSearchStartTime) < new Date(trackerState.searchStartTime)
+    ) {
+      trackerState.searchStartTime = seedSearchStartTime;
+    }
+
+    trackerState.activeSeries = {
+      title: seriesSeed.title,
+      subtitle: seriesSeed.subtitle,
+      guildIconUrl: seriesSeed.guildIconUrl,
+      teams: seriesSeed.teams,
+      matchIds: [],
+      startedAt: seriesSeed.startedAt,
+      isActive: true,
+    };
+
+    if (seriesSeed.matchIds.length === 0) {
+      return;
+    }
+
+    try {
+      const hydrationResult = await this.hydrateMatchSummaries(trackerState, seriesSeed.matchIds);
+      if (!hydrationResult.success) {
+        this.logService.warn(
+          "IndividualTracker: series seed hydration failed, matches will be discovered by polling",
+          new Map([
+            ["trackerId", trackerState.trackerId],
+            ["failingIds", hydrationResult.failingIds.join(",")],
+          ]),
+        );
+        return;
+      }
+
+      this.mergeHydratedMatches(trackerState, hydrationResult.summaries);
+      const seededMatchIds = new Set(seriesSeed.matchIds);
+      for (const matchId of seriesSeed.matchIds) {
+        if (!trackerState.selectedMatchIds.includes(matchId)) {
+          trackerState.selectedMatchIds.push(matchId);
+        }
+      }
+      trackerState.selectedMatchIds.sort();
+      trackerState.activeSeries.matchIds = trackerState.matchIds.filter((id) => seededMatchIds.has(id));
+    } catch (error) {
+      this.logService.warn(
+        "IndividualTracker: series seed hydration errored, matches will be discovered by polling",
+        new Map([
+          ["trackerId", trackerState.trackerId],
+          ["error", String(error)],
+        ]),
+      );
+    }
   }
 
   private async handlePause(): Promise<Response> {

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -233,6 +233,155 @@ describe("IndividualTrackerDO", () => {
       expect(storageSetAlarmSpy).toHaveBeenCalled();
     });
 
+    it("seeds the active series and backdates searchStartTime when a series seed is provided", async () => {
+      const request = new Request("http://do/start", {
+        method: "POST",
+        body: JSON.stringify(
+          createMockStartRequest({
+            searchStartTime: "2024-11-26T12:00:00.000Z",
+            seriesSeed: {
+              title: "Test Server",
+              subtitle: "Queue #5",
+              guildIconUrl: null,
+              startedAt: "2024-11-26T10:00:00.000Z",
+              searchStartTime: "2024-11-26T09:30:00.000Z",
+              teams: [],
+              matchIds: [],
+            },
+          }),
+        ),
+      });
+
+      const response = await individualTrackerDO.fetch(request);
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries).toMatchObject({
+        title: "Test Server",
+        subtitle: "Queue #5",
+        startedAt: "2024-11-26T10:00:00.000Z",
+        isActive: true,
+        matchIds: [],
+      });
+      expect(persisted.searchStartTime).toBe("2024-11-26T09:30:00.000Z");
+    });
+
+    it("schedules an immediate alarm when a series seed is provided", async () => {
+      const request = new Request("http://do/start", {
+        method: "POST",
+        body: JSON.stringify(
+          createMockStartRequest({
+            seriesSeed: {
+              title: "Test Server",
+              subtitle: "Queue #5",
+              guildIconUrl: null,
+              startedAt: "2024-11-26T10:00:00.000Z",
+              teams: [],
+              matchIds: [],
+            },
+          }),
+        ),
+      });
+
+      await individualTrackerDO.fetch(request);
+
+      const alarmTime = Preconditions.checkExists(storageSetAlarmSpy.mock.calls[0]?.[0]);
+      expect(Number(alarmTime)).toBeLessThanOrEqual(Date.now() + 1000);
+    });
+
+    it("keeps the requested searchStartTime when the seed window is not earlier", async () => {
+      const request = new Request("http://do/start", {
+        method: "POST",
+        body: JSON.stringify(
+          createMockStartRequest({
+            searchStartTime: "2024-11-26T08:00:00.000Z",
+            seriesSeed: {
+              title: "Test Server",
+              subtitle: "Queue #5",
+              guildIconUrl: null,
+              startedAt: "2024-11-26T10:00:00.000Z",
+              teams: [],
+              matchIds: [],
+            },
+          }),
+        ),
+      });
+
+      await individualTrackerDO.fetch(request);
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.searchStartTime).toBe("2024-11-26T08:00:00.000Z");
+    });
+
+    it("hydrates and auto-selects seeded series matches", async () => {
+      ownerClient.getMatchStats.mockImplementation(async (matchId: string) => {
+        const startTime = matchId === "m1" ? "2024-11-26T10:10:00.000Z" : "2024-11-26T10:30:00.000Z";
+        return Promise.resolve(
+          aFakeMatchStatsWith({
+            MatchId: matchId,
+            MatchInfo: {
+              ...aFakeMatchStatsWith().MatchInfo,
+              StartTime: startTime,
+            },
+            Players: [aFakePlayerWith({ PlayerId: "test-xuid", Outcome: 2 })],
+          }),
+        );
+      });
+      const request = new Request("http://do/start", {
+        method: "POST",
+        body: JSON.stringify(
+          createMockStartRequest({
+            searchStartTime: "2024-11-26T12:00:00.000Z",
+            seriesSeed: {
+              title: "Test Server",
+              subtitle: "Queue #5",
+              guildIconUrl: null,
+              startedAt: "2024-11-26T10:00:00.000Z",
+              teams: [],
+              matchIds: ["m2", "m1"],
+            },
+          }),
+        ),
+      });
+
+      const response = await individualTrackerDO.fetch(request);
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.matchIds).toEqual(["m1", "m2"]);
+      expect(persisted.selectedMatchIds).toEqual(["m1", "m2"]);
+      expect(persisted.activeSeries?.matchIds).toEqual(["m1", "m2"]);
+      expect(persisted.discoveredMatches["m1"]?.startTime).toBe("2024-11-26T10:10:00.000Z");
+      expect(persisted.discoveredMatches["m2"]?.startTime).toBe("2024-11-26T10:30:00.000Z");
+    });
+
+    it("starts with the series seeded but no matches when hydration fails", async () => {
+      ownerClient.getMatchStats.mockRejectedValue(new Error("Halo API unavailable"));
+      const request = new Request("http://do/start", {
+        method: "POST",
+        body: JSON.stringify(
+          createMockStartRequest({
+            seriesSeed: {
+              title: "Test Server",
+              subtitle: "Queue #5",
+              guildIconUrl: null,
+              startedAt: "2024-11-26T10:00:00.000Z",
+              teams: [],
+              matchIds: ["m1"],
+            },
+          }),
+        ),
+      });
+
+      const response = await individualTrackerDO.fetch(request);
+
+      expect(response.status).toBe(200);
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries?.title).toBe("Test Server");
+      expect(persisted.matchIds).toEqual([]);
+      expect(persisted.selectedMatchIds).toEqual([]);
+    });
+
     it("notifies UserTrackerDO after start state is persisted", async () => {
       const userTrackerDo = aFakeUserTrackerDOWith();
       const userTrackerFetchSpy = vi.spyOn(userTrackerDo, "fetch");

--- a/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
+++ b/api/durable-objects/individual-tracker/tests/individual-tracker-do.test.ts
@@ -289,6 +289,30 @@ describe("IndividualTrackerDO", () => {
       expect(Number(alarmTime)).toBeLessThanOrEqual(Date.now() + 1000);
     });
 
+    it("normalizes an unparseable seed startedAt to a parseable timestamp", async () => {
+      const request = new Request("http://do/start", {
+        method: "POST",
+        body: JSON.stringify(
+          createMockStartRequest({
+            seriesSeed: {
+              title: "Test Server",
+              subtitle: "Queue #5",
+              guildIconUrl: null,
+              startedAt: "not-a-valid-date",
+              teams: [],
+              matchIds: [],
+            },
+          }),
+        ),
+      });
+
+      await individualTrackerDO.fetch(request);
+
+      const persisted = lastPersistedState(storagePutSpy);
+      expect(persisted.activeSeries?.startedAt).not.toBe("not-a-valid-date");
+      expect(Number.isNaN(Date.parse(persisted.activeSeries?.startedAt ?? ""))).toBe(false);
+    });
+
     it("keeps the requested searchStartTime when the seed window is not earlier", async () => {
       const request = new Request("http://do/start", {
         method: "POST",

--- a/api/individual-tracker/series-seed.ts
+++ b/api/individual-tracker/series-seed.ts
@@ -1,0 +1,72 @@
+import type { IndividualTrackerSeriesSeed } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/lifecycle";
+import type { LiveTrackerService } from "../services/live-tracker/live-tracker";
+import type { LogService } from "../services/log/types";
+import type { NeatQueueService } from "../services/neatqueue/neatqueue";
+import type { ActiveSeriesForPlayer } from "../services/neatqueue/types";
+
+export interface ResolveSeriesSeedOpts {
+  neatQueueService: NeatQueueService;
+  liveTrackerService: LiveTrackerService;
+  logService: LogService;
+  xuid: string;
+  gamertag: string;
+}
+
+async function resolveSeriesMatchIds(
+  opts: ResolveSeriesSeedOpts,
+  activeSeries: ActiveSeriesForPlayer,
+): Promise<string[]> {
+  const { liveTrackerService, logService } = opts;
+
+  try {
+    const status = await liveTrackerService.getTrackerStatusByQueue(activeSeries.guildId, activeSeries.queueNumber);
+    if (status == null || status.state.status === "stopped") {
+      return [];
+    }
+
+    return [...status.state.matchIds];
+  } catch (error) {
+    logService.warn(
+      "resolveSeriesSeed: failed to fetch live tracker matches, seeding series without matches",
+      new Map([
+        ["guildId", activeSeries.guildId],
+        ["queueNumber", activeSeries.queueNumber.toString()],
+        ["error", String(error)],
+      ]),
+    );
+    return [];
+  }
+}
+
+export async function resolveSeriesSeed(opts: ResolveSeriesSeedOpts): Promise<IndividualTrackerSeriesSeed | null> {
+  const { neatQueueService, logService, xuid, gamertag } = opts;
+
+  try {
+    const activeSeries = await neatQueueService.findActiveSeriesForPlayer(xuid, gamertag);
+    if (activeSeries == null) {
+      return null;
+    }
+
+    const matchIds = await resolveSeriesMatchIds(opts, activeSeries);
+    const { seriesContext } = activeSeries;
+
+    return {
+      title: seriesContext.title,
+      subtitle: seriesContext.subtitle,
+      guildIconUrl: seriesContext.guildIconUrl,
+      startedAt: seriesContext.startedAt ?? new Date().toISOString(),
+      ...(seriesContext.searchStartTime != null ? { searchStartTime: seriesContext.searchStartTime } : {}),
+      teams: seriesContext.teams,
+      matchIds,
+    };
+  } catch (error) {
+    logService.warn(
+      "resolveSeriesSeed: failed to resolve active series, starting tracker without seed",
+      new Map([
+        ["gamertag", gamertag],
+        ["error", String(error)],
+      ]),
+    );
+    return null;
+  }
+}

--- a/api/individual-tracker/tests/series-seed.test.ts
+++ b/api/individual-tracker/tests/series-seed.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import type { LiveTrackerService } from "../../services/live-tracker/live-tracker";
+import { aFakeLiveTrackerServiceWith } from "../../services/live-tracker/fakes/live-tracker.fake";
+import { aFakeLiveTrackerStateWith } from "../../durable-objects/live-tracker/fakes/live-tracker-do.fake";
+import type { LogService } from "../../services/log/types";
+import { aFakeLogServiceWith } from "../../services/log/fakes/log.fake";
+import type { NeatQueueService } from "../../services/neatqueue/neatqueue";
+import { aFakeNeatQueueServiceWith } from "../../services/neatqueue/fakes/neatqueue.fake";
+import type { ActiveSeriesForPlayer } from "../../services/neatqueue/types";
+import { resolveSeriesSeed } from "../series-seed";
+
+function anActiveSeriesForPlayerWith(overrides: Partial<ActiveSeriesForPlayer> = {}): ActiveSeriesForPlayer {
+  return {
+    guildId: "guild-1",
+    queueNumber: 5,
+    seriesContext: {
+      type: "started",
+      title: "Test Server",
+      subtitle: "Queue #5",
+      guildIconUrl: "https://cdn.example.com/icon.webp",
+      startedAt: "2026-08-01T10:00:00.000Z",
+      searchStartTime: "2026-08-01T09:30:00.000Z",
+      teams: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("resolveSeriesSeed()", () => {
+  let neatQueueService: NeatQueueService;
+  let liveTrackerService: LiveTrackerService;
+  let logService: LogService;
+  let findActiveSeriesSpy: MockInstance<typeof neatQueueService.findActiveSeriesForPlayer>;
+  let getStatusSpy: MockInstance<typeof liveTrackerService.getTrackerStatusByQueue>;
+
+  const resolve = async (): Promise<ReturnType<typeof resolveSeriesSeed>> =>
+    resolveSeriesSeed({ neatQueueService, liveTrackerService, logService, xuid: "xuid-1", gamertag: "Chief" });
+
+  beforeEach(() => {
+    neatQueueService = aFakeNeatQueueServiceWith();
+    liveTrackerService = aFakeLiveTrackerServiceWith();
+    logService = aFakeLogServiceWith();
+    findActiveSeriesSpy = vi.spyOn(neatQueueService, "findActiveSeriesForPlayer").mockResolvedValue(null);
+    getStatusSpy = vi.spyOn(liveTrackerService, "getTrackerStatusByQueue").mockResolvedValue(null);
+  });
+
+  it("returns null when the player has no active series", async () => {
+    await expect(resolve()).resolves.toBeNull();
+    expect(findActiveSeriesSpy).toHaveBeenCalledWith("xuid-1", "Chief");
+    expect(getStatusSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns a seed with live tracker match ids when the live tracker is active", async () => {
+    findActiveSeriesSpy.mockResolvedValue(anActiveSeriesForPlayerWith());
+    getStatusSpy.mockResolvedValue({
+      state: aFakeLiveTrackerStateWith({ status: "active", matchIds: ["m1", "m2"] }),
+    });
+
+    const seed = await resolve();
+
+    expect(getStatusSpy).toHaveBeenCalledWith("guild-1", 5);
+    expect(seed).toEqual({
+      title: "Test Server",
+      subtitle: "Queue #5",
+      guildIconUrl: "https://cdn.example.com/icon.webp",
+      startedAt: "2026-08-01T10:00:00.000Z",
+      searchStartTime: "2026-08-01T09:30:00.000Z",
+      teams: [],
+      matchIds: ["m1", "m2"],
+    });
+  });
+
+  it("returns a seed without matches when no live tracker exists for the queue", async () => {
+    findActiveSeriesSpy.mockResolvedValue(anActiveSeriesForPlayerWith());
+    getStatusSpy.mockResolvedValue(null);
+
+    const seed = await resolve();
+
+    expect(seed?.matchIds).toEqual([]);
+  });
+
+  it("returns a seed without matches when the live tracker is stopped", async () => {
+    findActiveSeriesSpy.mockResolvedValue(anActiveSeriesForPlayerWith());
+    getStatusSpy.mockResolvedValue({
+      state: aFakeLiveTrackerStateWith({ status: "stopped", matchIds: ["m1"] }),
+    });
+
+    const seed = await resolve();
+
+    expect(seed?.matchIds).toEqual([]);
+  });
+
+  it("returns a seed with matches from a paused live tracker", async () => {
+    findActiveSeriesSpy.mockResolvedValue(anActiveSeriesForPlayerWith());
+    getStatusSpy.mockResolvedValue({
+      state: aFakeLiveTrackerStateWith({ status: "paused", matchIds: ["m1"] }),
+    });
+
+    const seed = await resolve();
+
+    expect(seed?.matchIds).toEqual(["m1"]);
+  });
+
+  it("returns a seed without matches when the live tracker status lookup throws", async () => {
+    findActiveSeriesSpy.mockResolvedValue(anActiveSeriesForPlayerWith());
+    getStatusSpy.mockRejectedValue(new Error("DO unavailable"));
+
+    const seed = await resolve();
+
+    expect(seed?.matchIds).toEqual([]);
+  });
+
+  it("omits searchStartTime when the series context does not include one", async () => {
+    findActiveSeriesSpy.mockResolvedValue(
+      anActiveSeriesForPlayerWith({
+        seriesContext: {
+          type: "started",
+          title: "Test Server",
+          subtitle: "Queue #5",
+          guildIconUrl: null,
+          startedAt: "2026-08-01T10:00:00.000Z",
+          teams: [],
+        },
+      }),
+    );
+
+    const seed = await resolve();
+
+    expect(seed).not.toHaveProperty("searchStartTime");
+  });
+
+  it("returns null without throwing when the active series lookup fails", async () => {
+    findActiveSeriesSpy.mockRejectedValue(new Error("KV unavailable"));
+
+    await expect(resolve()).resolves.toBeNull();
+  });
+});

--- a/api/routes/individual-tracker/manage.ts
+++ b/api/routes/individual-tracker/manage.ts
@@ -45,6 +45,7 @@ import {
 import type { LogService } from "../../services/log/types";
 import type { CreateTrackerOptions } from "../../services/individual-tracker/types";
 import { toTracker } from "../../individual-tracker/mapper";
+import { resolveSeriesSeed } from "../../individual-tracker/series-seed";
 import type { RoutesRegisterHandler } from "../base/types";
 import { requireSession } from "../base/require-session";
 
@@ -266,7 +267,7 @@ async function refreshTrackerDo(env: Env, userId: string, trackerId: string): Pr
 export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
   router.post("/api/individual-tracker/manage/start", async (request, env: Env) => {
     const services = installServices({ env });
-    const { authService, individualTrackerService, logService } = services;
+    const { authService, individualTrackerService, liveTrackerService, logService, neatQueueService } = services;
 
     try {
       const auth = await requireSession(request, authService);
@@ -298,6 +299,14 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
         throw error;
       }
 
+      const seriesSeed = await resolveSeriesSeed({
+        neatQueueService,
+        liveTrackerService,
+        logService,
+        xuid: tracker.Xuid,
+        gamertag: tracker.Gamertag,
+      });
+
       const startRequest: IndividualTrackerStartRequest = {
         userId: auth.session.userId,
         trackerId: tracker.TrackerId,
@@ -305,6 +314,7 @@ export const trackerManageRoutesRegisterHandler: RoutesRegisterHandler = (router
         gamertag: tracker.Gamertag,
         searchStartTime: parsed.data.searchStartTime ?? new Date().toISOString(),
         idleTimeoutHours: parsed.data.idleTimeoutHours ?? DEFAULT_IDLE_TIMEOUT_HOURS,
+        ...(seriesSeed != null ? { seriesSeed } : {}),
       };
 
       const state = await startTrackerDo(env, startRequest);

--- a/api/routes/individual-tracker/tests/manage.test.ts
+++ b/api/routes/individual-tracker/tests/manage.test.ts
@@ -26,6 +26,7 @@ import {
   aFakeUserTrackerDOWith,
   type FakeUserTrackerDO,
 } from "../../../durable-objects/user-tracker/fakes/user-tracker-do.fake";
+import { aFakeLiveTrackerStateWith } from "../../../durable-objects/live-tracker/fakes/live-tracker-do.fake";
 import { aFakeIndividualTrackersRow } from "../../../services/database/fakes/database.fake";
 import { installFakeServicesWith } from "../../../services/fakes/services";
 import type { IndividualTrackerService } from "../../../services/individual-tracker/individual-tracker";
@@ -115,6 +116,109 @@ describe("/api/individual-tracker manage routes", () => {
     expect(body.tracker.gamertag).toBe("ResolvedTag");
     expect(body.tracker.status).toBe("active");
     expect(startSpy).toHaveBeenCalledWith("http://do/start", expect.objectContaining({ method: "POST" }));
+  });
+
+  it("attaches a series seed to the DO start request when the player is in an active series", async () => {
+    const doStub = aFakeIndividualTrackerDOWith({
+      startResponse: {
+        success: true,
+        state: aFakeIndividualTrackerStateWith({ trackerId: "new-tracker", gamertag: "ResolvedTag" }),
+      },
+    });
+    const startSpy: MockInstance<FakeIndividualTrackerDO["fetch"]> = vi.spyOn(doStub, "fetch");
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+
+    const row = aFakeIndividualTrackersRow({
+      TrackerId: "new-tracker",
+      Gamertag: "ResolvedTag",
+      Xuid: "xuid-1",
+      Status: "active",
+    });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env: localEnv });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith());
+      vi.spyOn(services.individualTrackerService, "createTracker").mockResolvedValue(row);
+      vi.spyOn(services.neatQueueService, "findActiveSeriesForPlayer").mockResolvedValue({
+        guildId: "guild-1",
+        queueNumber: 5,
+        seriesContext: {
+          type: "started",
+          title: "Test Server",
+          subtitle: "Queue #5",
+          guildIconUrl: null,
+          startedAt: "2026-08-01T10:00:00.000Z",
+          searchStartTime: "2026-08-01T09:30:00.000Z",
+          teams: [],
+        },
+      });
+      vi.spyOn(services.liveTrackerService, "getTrackerStatusByQueue").mockResolvedValue({
+        state: aFakeLiveTrackerStateWith({ status: "active", matchIds: ["m1", "m2"] }),
+      });
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(
+      postRequest("/api/individual-tracker/manage/start", { gamertag: "ResolvedTag", xuid: "xuid-1" }),
+      localEnv,
+    )) as Response;
+
+    expect(res.status).toBe(200);
+    const startCall = startSpy.mock.calls.find(([url]) => url === "http://do/start");
+    const rawStartBody = Preconditions.checkExists(startCall?.[1]?.body);
+    if (typeof rawStartBody !== "string") {
+      throw new Error("Expected DO start request body to be a JSON string");
+    }
+    const startBody = JSON.parse(rawStartBody) as Record<string, unknown>;
+    expect(startBody["seriesSeed"]).toEqual({
+      title: "Test Server",
+      subtitle: "Queue #5",
+      guildIconUrl: null,
+      startedAt: "2026-08-01T10:00:00.000Z",
+      searchStartTime: "2026-08-01T09:30:00.000Z",
+      teams: [],
+      matchIds: ["m1", "m2"],
+    });
+  });
+
+  it("starts without a series seed when the player has no active series", async () => {
+    const doStub = aFakeIndividualTrackerDOWith({
+      startResponse: {
+        success: true,
+        state: aFakeIndividualTrackerStateWith({ trackerId: "new-tracker", gamertag: "ResolvedTag" }),
+      },
+    });
+    const startSpy: MockInstance<FakeIndividualTrackerDO["fetch"]> = vi.spyOn(doStub, "fetch");
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(doStub) });
+
+    const row = aFakeIndividualTrackersRow({
+      TrackerId: "new-tracker",
+      Gamertag: "ResolvedTag",
+      Xuid: "xuid-1",
+      Status: "active",
+    });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+      const services = installFakeServicesWith({ env: localEnv });
+      vi.spyOn(services.authService, "validateSession").mockResolvedValue(aFakeAuthSessionWith());
+      vi.spyOn(services.individualTrackerService, "createTracker").mockResolvedValue(row);
+      vi.spyOn(services.neatQueueService, "findActiveSeriesForPlayer").mockResolvedValue(null);
+      return services;
+    });
+    individualTrackerRoutesRegisterHandler(router, localInstallServices);
+
+    const res = (await router.fetch(
+      postRequest("/api/individual-tracker/manage/start", { gamertag: "ResolvedTag", xuid: "xuid-1" }),
+      localEnv,
+    )) as Response;
+
+    expect(res.status).toBe(200);
+    const startCall = startSpy.mock.calls.find(([url]) => url === "http://do/start");
+    const rawStartBody = Preconditions.checkExists(startCall?.[1]?.body);
+    if (typeof rawStartBody !== "string") {
+      throw new Error("Expected DO start request body to be a JSON string");
+    }
+    const startBody = JSON.parse(rawStartBody) as Record<string, unknown>;
+    expect(startBody).not.toHaveProperty("seriesSeed");
   });
 
   it("returns 429 on start when the user is at the tracker limit", async () => {

--- a/api/services/live-tracker/live-tracker.ts
+++ b/api/services/live-tracker/live-tracker.ts
@@ -580,8 +580,28 @@ export class LiveTrackerService {
     return liveTrackerSeriesDataContract.fromResponse(response);
   }
 
+  /**
+   * Gets the status of a live tracker by its queue identity, without requiring a full context
+   */
+  async getTrackerStatusByQueue(guildId: string, queueNumber: number): Promise<LiveTrackerStatusResponse | null> {
+    const doStub = this.getDurableObjectStubForQueue(guildId, queueNumber);
+    const response = await doStub.fetch("http://do/status", {
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    return liveTrackerStatusContract.fromResponse(response);
+  }
+
   private getDurableObjectStub(context: LiveTrackerContext): DurableObjectStub<LiveTrackerDO> {
-    const doId = this.env.LIVE_TRACKER_DO.idFromName(`${context.guildId}:${context.queueNumber.toString()}`);
+    return this.getDurableObjectStubForQueue(context.guildId, context.queueNumber);
+  }
+
+  private getDurableObjectStubForQueue(guildId: string, queueNumber: number): DurableObjectStub<LiveTrackerDO> {
+    const doId = this.env.LIVE_TRACKER_DO.idFromName(`${guildId}:${queueNumber.toString()}`);
 
     return this.env.LIVE_TRACKER_DO.get(doId);
   }

--- a/api/services/live-tracker/tests/live-tracker.test.ts
+++ b/api/services/live-tracker/tests/live-tracker.test.ts
@@ -535,6 +535,40 @@ describe("LiveTrackerService", () => {
     });
   });
 
+  describe("getTrackerStatusByQueue", () => {
+    it("gets tracker status by queue identity successfully", async () => {
+      const mockResponse: LiveTrackerStatusResponse = {
+        state: state,
+      };
+
+      fetch.mockResolvedValue(
+        aFakeResponseWith({
+          json: vi.fn().mockResolvedValue(mockResponse),
+        }),
+      );
+
+      const result = await service.getTrackerStatusByQueue(liveTrackerContext.guildId, liveTrackerContext.queueNumber);
+
+      expect(result).toEqual(mockResponse);
+      expect(fetch).toHaveBeenCalledWith("http://do/status", {
+        method: "GET",
+      });
+    });
+
+    it("returns null when DO returns non-ok response", async () => {
+      fetch.mockResolvedValue(
+        aFakeResponseWith({
+          ok: false,
+          status: 404,
+        }),
+      );
+
+      const result = await service.getTrackerStatusByQueue(liveTrackerContext.guildId, liveTrackerContext.queueNumber);
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe("repostTracker", () => {
     it("reposts a tracker successfully", async () => {
       const mockResponse: LiveTrackerRepostResponse = {

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -726,11 +726,11 @@ export class NeatQueueService {
   }
 
   async findActiveSeriesForPlayer(xuid: string, gamertag: string): Promise<ActiveSeriesForPlayer | null> {
-    const { keys } = await this.env.APP_DATA.list({ prefix: "neatqueue:state:" });
+    const stateKeys = await this.listQueueStateKeys();
     let latest: ActiveSeriesForPlayer | null = null;
 
-    for (const key of keys) {
-      const candidate = await this.getActiveSeriesCandidate(key.name, xuid, gamertag);
+    for (const stateKey of stateKeys) {
+      const candidate = await this.getActiveSeriesCandidate(stateKey, xuid, gamertag);
       if (candidate == null) {
         continue;
       }
@@ -743,13 +743,29 @@ export class NeatQueueService {
     return latest;
   }
 
+  private async listQueueStateKeys(): Promise<string[]> {
+    const names: string[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const result = await this.env.APP_DATA.list({
+        prefix: "neatqueue:state:",
+        ...(cursor !== undefined ? { cursor } : {}),
+      });
+      names.push(...result.keys.map((key) => key.name));
+      cursor = result.list_complete ? undefined : result.cursor;
+    } while (cursor !== undefined);
+
+    return names;
+  }
+
   private async getActiveSeriesCandidate(
     stateKey: string,
     xuid: string,
     gamertag: string,
   ): Promise<ActiveSeriesForPlayer | null> {
     const [, , guildId, queueNumber] = stateKey.split(":");
-    if (guildId == null || queueNumber == null) {
+    if (guildId == null || guildId === "" || queueNumber == null || !/^\d+$/.test(queueNumber)) {
       return null;
     }
 

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -47,6 +47,7 @@ import { buildDiscordSeriesRenderDataFromMatches } from "../discord/discord-seri
 import type { SeriesPlayer, SeriesTeam } from "../../durable-objects/individual-tracker/types";
 import type { IndividualTrackerService } from "../individual-tracker/individual-tracker";
 import type {
+  ActiveSeriesForPlayer,
   VerifyNeatQueueResponse,
   NeatQueueRequest,
   NeatQueueMatchCompletedRequest,
@@ -722,6 +723,57 @@ export class NeatQueueService {
         ]),
       );
     }
+  }
+
+  async findActiveSeriesForPlayer(xuid: string, gamertag: string): Promise<ActiveSeriesForPlayer | null> {
+    const { keys } = await this.env.APP_DATA.list({ prefix: "neatqueue:state:" });
+    let latest: ActiveSeriesForPlayer | null = null;
+
+    for (const key of keys) {
+      const candidate = await this.getActiveSeriesCandidate(key.name, xuid, gamertag);
+      if (candidate == null) {
+        continue;
+      }
+
+      if (latest == null || (candidate.seriesContext.startedAt ?? "") > (latest.seriesContext.startedAt ?? "")) {
+        latest = candidate;
+      }
+    }
+
+    return latest;
+  }
+
+  private async getActiveSeriesCandidate(
+    stateKey: string,
+    xuid: string,
+    gamertag: string,
+  ): Promise<ActiveSeriesForPlayer | null> {
+    const [, , guildId, queueNumber] = stateKey.split(":");
+    if (guildId == null || queueNumber == null) {
+      return null;
+    }
+
+    const state = await this.env.APP_DATA.get<NeatQueueState>(stateKey, { type: "json" });
+    if (state?.seriesContext == null) {
+      return null;
+    }
+
+    if (!this.isPlayerInAssociationData(state.playersAssociationData, xuid, gamertag)) {
+      return null;
+    }
+
+    return { guildId, queueNumber: Number(queueNumber), seriesContext: state.seriesContext };
+  }
+
+  private isPlayerInAssociationData(
+    playersAssociationData: Record<string, PlayerAssociationData>,
+    xuid: string,
+    gamertag: string,
+  ): boolean {
+    const normalizedGamertag = gamertag.toLowerCase();
+    return Object.values(playersAssociationData).some(
+      (player) => player.xboxId === xuid || player.gamertag?.toLowerCase() === normalizedGamertag,
+    );
   }
 
   private resolveSeriesSearchStartTime(request: NeatQueueTeamsCreatedRequest): string | undefined {

--- a/api/services/neatqueue/tests/find-active-series.test.ts
+++ b/api/services/neatqueue/tests/find-active-series.test.ts
@@ -106,6 +106,46 @@ describe("NeatQueueService.findActiveSeriesForPlayer()", () => {
     expect(result).toBeNull();
   });
 
+  it("follows KV list pagination across multiple pages", async () => {
+    const association = {
+      "discord-1": aFakePlayerAssociationDataWith({ discordId: "discord-1", xboxId: "xuid-1" }),
+    };
+    listSpy.mockImplementation(async (options?: KVNamespaceListOptions): Promise<KVNamespaceListResult<unknown>> => {
+      if (options?.cursor === "page-2") {
+        return Promise.resolve(listResultWith(["neatqueue:state:guild-2:9"]));
+      }
+      return Promise.resolve({
+        list_complete: false,
+        cursor: "page-2",
+        keys: [{ name: "neatqueue:state:guild-1:5" }],
+        cacheStatus: null,
+      });
+    });
+    getSpy.mockImplementation(async (key: string) => {
+      if (key === "neatqueue:state:guild-2:9") {
+        return Promise.resolve(
+          aFakeNeatQueueStateWith({ seriesContext: aSeriesContextWith(), playersAssociationData: association }),
+        );
+      }
+      return Promise.resolve(aFakeNeatQueueStateWith());
+    });
+
+    const result = await neatQueueService.findActiveSeriesForPlayer("xuid-1", "Chief");
+
+    expect(listSpy).toHaveBeenCalledTimes(2);
+    expect(listSpy).toHaveBeenCalledWith({ prefix: "neatqueue:state:", cursor: "page-2" });
+    expect(result?.guildId).toBe("guild-2");
+  });
+
+  it("ignores queue state keys with a non-numeric queue number", async () => {
+    listSpy.mockResolvedValue(listResultWith(["neatqueue:state:guild-1:not-a-number"]));
+
+    const result = await neatQueueService.findActiveSeriesForPlayer("xuid-1", "Chief");
+
+    expect(result).toBeNull();
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
   it("picks the most recently started series when the player is in multiple", async () => {
     listSpy.mockResolvedValue(listResultWith(["neatqueue:state:guild-1:5", "neatqueue:state:guild-2:9"]));
     const association = {

--- a/api/services/neatqueue/tests/find-active-series.test.ts
+++ b/api/services/neatqueue/tests/find-active-series.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import type { SeriesStartedPayload } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
+import { aFakeEnvWith } from "../../../base/fakes/env.fake";
+import type { NeatQueueService } from "../neatqueue";
+import { aFakeNeatQueueServiceWith } from "../fakes/neatqueue.fake";
+import { aFakeNeatQueueStateWith, aFakePlayerAssociationDataWith } from "../fakes/data";
+import type { NeatQueueState } from "../types";
+
+function aSeriesContextWith(overrides: Partial<SeriesStartedPayload> = {}): SeriesStartedPayload {
+  return {
+    type: "started",
+    title: "Test Server",
+    subtitle: "Queue #5",
+    guildIconUrl: null,
+    startedAt: "2026-08-01T10:00:00.000Z",
+    searchStartTime: "2026-08-01T09:30:00.000Z",
+    teams: [],
+    ...overrides,
+  };
+}
+
+describe("NeatQueueService.findActiveSeriesForPlayer()", () => {
+  let env: Env;
+  let neatQueueService: NeatQueueService;
+  let listSpy: MockInstance<typeof env.APP_DATA.list>;
+  let getSpy: MockInstance<(key: string, opts: { type: "json" }) => Promise<NeatQueueState | null>>;
+
+  const listResultWith = (names: string[]): Awaited<ReturnType<typeof env.APP_DATA.list>> => ({
+    list_complete: true as const,
+    keys: names.map((name) => ({ name })),
+    cacheStatus: null,
+  });
+
+  beforeEach(() => {
+    env = aFakeEnvWith();
+    neatQueueService = aFakeNeatQueueServiceWith({ env });
+    listSpy = vi.spyOn(env.APP_DATA, "list").mockResolvedValue(listResultWith([]));
+    getSpy = vi.spyOn(env.APP_DATA, "get");
+  });
+
+  it("returns null when no queue states exist", async () => {
+    const result = await neatQueueService.findActiveSeriesForPlayer("xuid-1", "Chief");
+
+    expect(listSpy).toHaveBeenCalledWith({ prefix: "neatqueue:state:" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when queue states have no series context", async () => {
+    listSpy.mockResolvedValue(listResultWith(["neatqueue:state:guild-1:5"]));
+    getSpy.mockResolvedValue(aFakeNeatQueueStateWith());
+
+    const result = await neatQueueService.findActiveSeriesForPlayer("xuid-1", "Chief");
+
+    expect(result).toBeNull();
+  });
+
+  it("finds the active series when the player xuid is in the association data", async () => {
+    listSpy.mockResolvedValue(listResultWith(["neatqueue:state:guild-1:5"]));
+    const state: NeatQueueState = aFakeNeatQueueStateWith({
+      seriesContext: aSeriesContextWith(),
+      playersAssociationData: {
+        "discord-1": aFakePlayerAssociationDataWith({ discordId: "discord-1", xboxId: "xuid-1" }),
+      },
+    });
+    getSpy.mockResolvedValue(state);
+
+    const result = await neatQueueService.findActiveSeriesForPlayer("xuid-1", "Chief");
+
+    expect(result).toEqual({
+      guildId: "guild-1",
+      queueNumber: 5,
+      seriesContext: state.seriesContext,
+    });
+  });
+
+  it("matches by gamertag case-insensitively when xuid does not match", async () => {
+    listSpy.mockResolvedValue(listResultWith(["neatqueue:state:guild-1:5"]));
+    getSpy.mockResolvedValue(
+      aFakeNeatQueueStateWith({
+        seriesContext: aSeriesContextWith(),
+        playersAssociationData: {
+          "discord-1": aFakePlayerAssociationDataWith({ discordId: "discord-1", xboxId: null, gamertag: "CHIEF" }),
+        },
+      }),
+    );
+
+    const result = await neatQueueService.findActiveSeriesForPlayer("xuid-1", "chief");
+
+    expect(result?.guildId).toBe("guild-1");
+  });
+
+  it("returns null when the player is not in any active series", async () => {
+    listSpy.mockResolvedValue(listResultWith(["neatqueue:state:guild-1:5"]));
+    getSpy.mockResolvedValue(
+      aFakeNeatQueueStateWith({
+        seriesContext: aSeriesContextWith(),
+        playersAssociationData: {
+          "discord-1": aFakePlayerAssociationDataWith({ discordId: "discord-1", xboxId: "other-xuid" }),
+        },
+      }),
+    );
+
+    const result = await neatQueueService.findActiveSeriesForPlayer("xuid-1", "Chief");
+
+    expect(result).toBeNull();
+  });
+
+  it("picks the most recently started series when the player is in multiple", async () => {
+    listSpy.mockResolvedValue(listResultWith(["neatqueue:state:guild-1:5", "neatqueue:state:guild-2:9"]));
+    const association = {
+      "discord-1": aFakePlayerAssociationDataWith({ discordId: "discord-1", xboxId: "xuid-1" }),
+    };
+    getSpy.mockImplementation(async (key: string) => {
+      if (key === "neatqueue:state:guild-1:5") {
+        return Promise.resolve(
+          aFakeNeatQueueStateWith({
+            seriesContext: aSeriesContextWith({ startedAt: "2026-08-01T08:00:00.000Z" }),
+            playersAssociationData: association,
+          }),
+        );
+      }
+      return Promise.resolve(
+        aFakeNeatQueueStateWith({
+          seriesContext: aSeriesContextWith({ startedAt: "2026-08-01T11:00:00.000Z" }),
+          playersAssociationData: association,
+        }),
+      );
+    });
+
+    const result = await neatQueueService.findActiveSeriesForPlayer("xuid-1", "Chief");
+
+    expect(result?.guildId).toBe("guild-2");
+    expect(result?.queueNumber).toBe(9);
+  });
+});

--- a/api/services/neatqueue/types.ts
+++ b/api/services/neatqueue/types.ts
@@ -125,6 +125,12 @@ export interface NeatQueueState {
   seriesContext?: SeriesStartedPayload;
 }
 
+export interface ActiveSeriesForPlayer {
+  guildId: string;
+  queueNumber: number;
+  seriesContext: SeriesStartedPayload;
+}
+
 export interface FetchedPlayersData {
   associationData: Record<string, PlayerAssociationData>;
   embedData: PlayersEmbedData;

--- a/shared/src/contracts/durable-objects/individual-tracker/lifecycle.ts
+++ b/shared/src/contracts/durable-objects/individual-tracker/lifecycle.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { defineContract } from "../../base";
 import { trackerStateSchema } from "../../individual-tracker/tracker";
+import { trackerSeriesTeamSchema } from "../../individual-tracker/view";
 
 // hasActiveSeries is optional here because old persisted DO state may predate the field.
 // trackerStateSchema marks it required (suitable for fresh API responses).
@@ -9,6 +10,17 @@ export const individualTrackerStateSchema = trackerStateSchema.extend({
 });
 export type IndividualTrackerDoState = z.infer<typeof individualTrackerStateSchema>;
 
+export const individualTrackerSeriesSeedSchema = z.object({
+  title: z.string(),
+  subtitle: z.string(),
+  guildIconUrl: z.string().nullable(),
+  startedAt: z.string(),
+  searchStartTime: z.string().optional(),
+  teams: z.array(trackerSeriesTeamSchema),
+  matchIds: z.array(z.string()),
+});
+export type IndividualTrackerSeriesSeed = z.infer<typeof individualTrackerSeriesSeedSchema>;
+
 export const individualTrackerStartRequestSchema = z.object({
   userId: z.string(),
   trackerId: z.string(),
@@ -16,6 +28,7 @@ export const individualTrackerStartRequestSchema = z.object({
   gamertag: z.string(),
   searchStartTime: z.string(),
   idleTimeoutHours: z.number(),
+  seriesSeed: individualTrackerSeriesSeedSchema.optional(),
 });
 export type IndividualTrackerStartRequest = z.infer<typeof individualTrackerStartRequestSchema>;
 


### PR DESCRIPTION
## Context

Individual trackers are sometimes started after a NeatQueue TEAMS_CREATED event has already fired — or part-way through an active series. Until now, such a tracker knew nothing about the in-flight series: the series-started nudge had already been broadcast before the tracker existed, so the overlay showed no series context and none of the series' earlier matches.

## This change

The start-tracker flow now aligns a mid-series start with the series in progress:

- **`NeatQueueService.findActiveSeriesForPlayer(xuid, gamertag)`** scans active queue states (`neatqueue:state:*` in KV — deleted on series completion, 1-day TTL) for a `seriesContext` whose players include the new tracker's player, matching on `xboxId` with a case-insensitive gamertag fallback. The most recently started series wins if several match.
- **`LiveTrackerService.getTrackerStatusByQueue(guildId, queueNumber)`** fetches the live tracker state by queue identity, exposing the `matchIds` discovered so far.
- **`resolveSeriesSeed`** (new `api/individual-tracker/series-seed.ts`) combines the two into an optional `seriesSeed` on the DO start request: series title/subtitle/teams/startedAt, the series search window, and live-tracker match ids (active or paused trackers; empty when no live tracker runs — per design decision, the series still seeds and polling discovers the matches).
- **`IndividualTrackerDO.handleStart`** applies the seed: sets `activeSeries`, backdates `searchStartTime` to the series search window (only when earlier than the requested window), hydrates and auto-selects the seeded matches via the existing `hydrateMatchSummaries`/`mergeHydratedMatches` machinery, and schedules an immediate first poll. Hydration failures log a warning and degrade gracefully — the backdated search window means polling discovers the matches instead.
- Seeding is fail-open at every layer: any resolution error starts the tracker exactly as before, without a seed.

Covers both scenarios: series started with no matches yet (series context only), and series with matches already played (context + hydrated, auto-selected matches).

## Note on size

805 lines total, of which ~500 are tests (lookup, resolver, DO seeding, route wiring, live tracker status). Production code is ~280 lines. Happy to split into two PRs (resolution plumbing / DO seeding) if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)