### PR TITLE
fix(overlay): pre-series rank info in ticker and dimmed lost series match icons

### DIFF
--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -49,6 +49,17 @@ const DIFFICULTY_RANGE = new Map<number, readonly [number, number]>([
   [3, [200, Infinity]],
 ]);
 
+interface PreSeriesRankInfo {
+  readonly currentRank?: number | null;
+  readonly currentRankTier?: string | null;
+  readonly currentRankSubTier?: number | null;
+  readonly currentRankMeasurementMatchesRemaining?: number | null;
+  readonly currentRankInitialMeasurementMatches?: number | null;
+  readonly allTimePeakRank?: number | null;
+  readonly esra?: number | null;
+  readonly lastRankedGamePlayed?: string | null;
+}
+
 interface TickerFilterOptions {
   readonly trackedGamertag: string;
   readonly includeOnlyTrackedPlayer: boolean;
@@ -254,8 +265,6 @@ export class IndividualTrackerOverlayPresenter {
           return [];
         }
 
-        const isMatchmakingSeries = item.series.matches.every((match) => match.isMatchmaking);
-
         return [
           {
             type: "series",
@@ -266,7 +275,7 @@ export class IndividualTrackerOverlayPresenter {
             teamColor: getSeriesOutcomeColorHex(item.series),
             icons: item.series.matches.map((match) => ({
               src: gameModeIconSrc(match.gameVariantCategory),
-              dimmed: isMatchmakingSeries && match.outcome === "Loss",
+              dimmed: match.outcome === "Loss",
             })),
           },
         ];
@@ -299,6 +308,90 @@ export class IndividualTrackerOverlayPresenter {
     }
 
     return selectedSeriesId != null && seriesEntryState != null;
+  }
+
+  private hasPreSeriesRankData(info: PreSeriesRankInfo): boolean {
+    return info.currentRank != null || info.allTimePeakRank != null || info.esra != null;
+  }
+
+  private buildNoRankDataStats(): MatchStatsValues[] {
+    return [
+      {
+        name: "Player information",
+        value: 0,
+        bestInTeam: false,
+        bestInMatch: false,
+        display: "No data",
+      },
+    ];
+  }
+
+  private buildPreSeriesRankStats(info: PreSeriesRankInfo): MatchStatsValues[] {
+    const currentRankDisplay =
+      info.currentRank != null && info.currentRank > 0 ? info.currentRank.toLocaleString() : "Unranked";
+    const peakRankDisplay = info.allTimePeakRank != null ? info.allTimePeakRank.toLocaleString() : "-";
+    const esraDisplay = info.esra != null ? Math.round(info.esra).toLocaleString() : "-";
+    let lastRankedDisplay = "-";
+    if (info.lastRankedGamePlayed != null) {
+      const ago = differenceInHours(new Date(), new Date(info.lastRankedGamePlayed));
+      lastRankedDisplay = ago < 1 ? "Less than an hour ago" : timeAgo.format(new Date(info.lastRankedGamePlayed));
+    }
+
+    return [
+      {
+        name: "Current rank",
+        value: info.currentRank ?? 0,
+        bestInTeam: false,
+        bestInMatch: false,
+        display: currentRankDisplay,
+        icon: createElement(RankIcon, {
+          rankTier: info.currentRankTier ?? null,
+          subTier: info.currentRankSubTier ?? null,
+          measurementMatchesRemaining: info.currentRankMeasurementMatchesRemaining ?? null,
+          initialMeasurementMatches: info.currentRankInitialMeasurementMatches ?? null,
+          size: "x-small",
+        }),
+      },
+      {
+        name: "Peak rank",
+        value: info.allTimePeakRank ?? 0,
+        bestInTeam: false,
+        bestInMatch: false,
+        display: peakRankDisplay,
+        icon:
+          info.allTimePeakRank != null
+            ? createElement(RankIcon, {
+                ...getRankTierFromCsr(info.allTimePeakRank),
+                measurementMatchesRemaining: null,
+                initialMeasurementMatches: null,
+                size: "x-small",
+              })
+            : undefined,
+      },
+      {
+        name: "ESRA",
+        value: info.esra ?? 0,
+        bestInTeam: false,
+        bestInMatch: false,
+        display: esraDisplay,
+        icon:
+          info.esra != null
+            ? createElement(RankIcon, {
+                ...getRankTierFromCsr(Math.round(info.esra)),
+                measurementMatchesRemaining: null,
+                initialMeasurementMatches: null,
+                size: "x-small",
+              })
+            : undefined,
+      },
+      {
+        name: "Last ranked match played",
+        value: info.lastRankedGamePlayed != null ? new Date(info.lastRankedGamePlayed).getTime() : 0,
+        bestInTeam: false,
+        bestInMatch: false,
+        display: lastRankedDisplay,
+      },
+    ];
   }
 
   public buildPreSeriesTickerGroup(options: {
@@ -337,71 +430,7 @@ export class IndividualTrackerOverlayPresenter {
         return createPlaceholderStats();
       }
 
-      const currentRankDisplay =
-        info.currentRank != null && info.currentRank > 0 ? info.currentRank.toLocaleString() : "Unranked";
-      const peakRankDisplay = info.allTimePeakRank != null ? info.allTimePeakRank.toLocaleString() : "-";
-      const esraDisplay = info.esra != null ? Math.round(info.esra).toLocaleString() : "-";
-      let lastRankedDisplay = "-";
-      if (info.lastRankedGamePlayed != null) {
-        const ago = differenceInHours(new Date(), new Date(info.lastRankedGamePlayed));
-        lastRankedDisplay = ago < 1 ? "Less than an hour ago" : timeAgo.format(new Date(info.lastRankedGamePlayed));
-      }
-
-      return [
-        {
-          name: "Current rank",
-          value: info.currentRank ?? 0,
-          bestInTeam: false,
-          bestInMatch: false,
-          display: currentRankDisplay,
-          icon: createElement(RankIcon, {
-            rankTier: info.currentRankTier,
-            subTier: info.currentRankSubTier,
-            measurementMatchesRemaining: info.currentRankMeasurementMatchesRemaining,
-            initialMeasurementMatches: info.currentRankInitialMeasurementMatches,
-            size: "x-small",
-          }),
-        },
-        {
-          name: "Peak rank",
-          value: info.allTimePeakRank ?? 0,
-          bestInTeam: false,
-          bestInMatch: false,
-          display: peakRankDisplay,
-          icon:
-            info.allTimePeakRank != null
-              ? createElement(RankIcon, {
-                  ...getRankTierFromCsr(info.allTimePeakRank),
-                  measurementMatchesRemaining: null,
-                  initialMeasurementMatches: null,
-                  size: "x-small",
-                })
-              : undefined,
-        },
-        {
-          name: "ESRA",
-          value: info.esra ?? 0,
-          bestInTeam: false,
-          bestInMatch: false,
-          display: esraDisplay,
-          icon:
-            info.esra != null
-              ? createElement(RankIcon, {
-                  ...getRankTierFromCsr(Math.round(info.esra)),
-                  measurementMatchesRemaining: null,
-                  initialMeasurementMatches: null,
-                  size: "x-small",
-                })
-              : undefined,
-        },
-        {
-          name: "Last ranked match played",
-          value: info.lastRankedGamePlayed != null ? new Date(info.lastRankedGamePlayed).getTime() : 0,
-          bestInTeam: false,
-          bestInMatch: false,
-          display: lastRankedDisplay,
-        },
-      ];
+      return this.buildPreSeriesRankStats(info);
     };
 
     // Case 1: Pre-series with active series that has teams (series exists but no matches yet)
@@ -410,18 +439,7 @@ export class IndividualTrackerOverlayPresenter {
       const seriesLabel = activeSeries.title || "Series Info";
       const rows: TickerStatRow[] = [];
 
-      // Add each team and its players
       for (const team of activeSeries.teams) {
-        // Add team row
-        rows.push({
-          type: "team",
-          teamId: team.id,
-          name: team.name,
-          stats: createPlaceholderStats(),
-          medals: [],
-        });
-
-        // Add each player in the team
         for (const player of team.players) {
           rows.push({
             type: "player",
@@ -429,7 +447,9 @@ export class IndividualTrackerOverlayPresenter {
             discordName: player.discordName,
             gamertag: player.gamertag,
             name: player.discordName ?? player.gamertag,
-            stats: createPlaceholderStats(),
+            stats: this.hasPreSeriesRankData(player)
+              ? this.buildPreSeriesRankStats(player)
+              : this.buildNoRankDataStats(),
             medals: [],
           });
         }

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -335,7 +335,7 @@ describe("individual-tracker-overlay-presenter", () => {
     }
   });
 
-  it("dims lost icons only for matchmaking series tabs", () => {
+  it("dims lost icons for both matchmaking and custom series tabs", () => {
     const timeline: ViewerTimelineItem[] = [
       {
         type: "series",
@@ -376,7 +376,7 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(customTab?.type).toBe("series");
     if (customTab?.type === "series") {
       expect(customTab.icons).toEqual([
-        { src: gameModeIconSrc(6), dimmed: false },
+        { src: gameModeIconSrc(6), dimmed: true },
         { src: gameModeIconSrc(6), dimmed: false },
       ]);
     }
@@ -495,7 +495,7 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(groups).toHaveLength(0);
   });
 
-  it("shows series with teams and players when pre-series with active teams", () => {
+  it("shows per-player rank info rows when pre-series with active teams", () => {
     const groups = presenter.buildPreSeriesTickerGroup({
       showTicker: true,
       showPreSeriesInfo: true,
@@ -508,14 +508,23 @@ describe("individual-tracker-overlay-presenter", () => {
             id: 0,
             name: "Eagle",
             players: [
-              { discordName: "DiscordPlayer1", gamertag: "Player1" },
+              {
+                discordName: "DiscordPlayer1",
+                gamertag: "Player1",
+                currentRank: 1550,
+                currentRankTier: "Diamond",
+                currentRankSubTier: 2,
+                allTimePeakRank: 1625,
+                esra: 1502.4,
+                lastRankedGamePlayed: "2026-01-01T00:00:00.000Z",
+              },
               { discordName: null, gamertag: "Player2" },
             ],
           },
           {
             id: 1,
             name: "Cobra",
-            players: [{ discordName: "DiscordPlayer3", gamertag: "Player3" }],
+            players: [{ discordName: "DiscordPlayer3", gamertag: "Player3", esra: 1400 }],
           },
         ],
       }),
@@ -527,17 +536,37 @@ describe("individual-tracker-overlay-presenter", () => {
 
     expect(groups).toHaveLength(1);
     expect(groups[0].label).toBe("Eagle vs Cobra");
-    expect(groups[0].rows).toHaveLength(5); // 2 teams + 3 players
-    expect(groups[0].rows[0]?.type).toBe("team");
-    expect(groups[0].rows[0]?.name).toBe("Eagle");
-    expect(groups[0].rows[1]?.type).toBe("player");
-    expect(groups[0].rows[1]?.gamertag).toBe("Player1");
-    expect(groups[0].rows[2]?.type).toBe("player");
-    expect(groups[0].rows[2]?.gamertag).toBe("Player2");
-    expect(groups[0].rows[3]?.type).toBe("team");
-    expect(groups[0].rows[3]?.name).toBe("Cobra");
-    expect(groups[0].rows[4]?.type).toBe("player");
-    expect(groups[0].rows[4]?.gamertag).toBe("Player3");
+    expect(groups[0].rows).toHaveLength(3);
+
+    const [playerWithData, playerWithoutData, opposingPlayer] = groups[0].rows;
+    expect(playerWithData.type).toBe("player");
+    expect(playerWithData.teamId).toBe(0);
+    expect(playerWithData.gamertag).toBe("Player1");
+    expect(playerWithData.stats.map((stat) => stat.name)).toEqual([
+      "Current rank",
+      "Peak rank",
+      "ESRA",
+      "Last ranked match played",
+    ]);
+    expect(playerWithData.stats[0].display).toBe("1,550");
+    expect(playerWithData.stats[1].display).toBe("1,625");
+    expect(playerWithData.stats[2].display).toBe("1,502");
+
+    expect(playerWithoutData.gamertag).toBe("Player2");
+    expect(playerWithoutData.stats).toEqual([
+      {
+        name: "Player information",
+        value: 0,
+        bestInTeam: false,
+        bestInMatch: false,
+        display: "No data",
+      },
+    ]);
+
+    expect(opposingPlayer.teamId).toBe(1);
+    expect(opposingPlayer.gamertag).toBe("Player3");
+    expect(opposingPlayer.stats[2].name).toBe("ESRA");
+    expect(opposingPlayer.stats[2].display).toBe("1,400");
   });
 
   it("uses pre-series player info in matchmaking pre-series ticker when available", () => {


### PR DESCRIPTION
## Context

Two user-level overlay behaviors that were intended but not working:

1. **Pre-series ticker**: when a series has started but no matches have been played, the information ticker is supposed to show each player's pre-series info (current rank, peak rank, ESRA, last ranked match) — mirroring the live tracker overlay. Instead it showed `<team icon> <player> Matches: -` because the series-with-teams branch of `buildPreSeriesTickerGroup` used hardcoded placeholder stats, even though the rank data is present on `activeSeries.teams[].players` (the viewer's pre-series table renders the same data).
2. **Series match icon fade**: series tabs in the matchmaking overlay UI show a mode icon per match played, and lost matches were supposed to render faded. The `dimmed` flag (from #657) was gated on `isMatchmakingSeries` — every NeatQueue series is custom games, so the gate never passed and all icons rendered at full opacity. The view and CSS (`tabIconDimmed`) already support dimming; the live tracker overlay dims losses unconditionally.

## This change

- Extracts the tracked-player rank-stat building into `buildPreSeriesRankStats` and reuses it per series player, mirroring the live tracker overlay's pre-series rows (including a "No data" row for players with no rank data). Team header rows with placeholder stats are removed, matching the live tracker's player-rows-only pre-series ticker.
- Drops the `isMatchmakingSeries` gate: series tab icons dim on `outcome === "Loss"` for matchmaking and custom series alike.
- Tests updated: per-player rank rows (with data, without data, opposing team), and loss dimming for custom series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)