### PR TITLE
fix(overlay): accumulated Series Stats ticker group for in-series rotation

### DIFF
--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -13,6 +13,8 @@ import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type { TickerMatchGroup, TickerStatRow } from "../../information-ticker/information-ticker";
 import { createMatchStatsFormatter } from "../../../controllers/stats/create";
+import { SeriesTeamStatsFormatter } from "../../../controllers/stats/series-team-stats-formatter";
+import { SeriesPlayerStatsFormatter } from "../../../controllers/stats/series-player-stats-formatter";
 import type { MatchStatsValues } from "../../../controllers/stats/types";
 import type { OverlayTab } from "../../streamer-overlay/tabs-bar";
 import type {
@@ -502,14 +504,21 @@ export class IndividualTrackerOverlayPresenter {
       matchmakingSummaryScore,
     });
     const trimmedTabs = this.trimTabsToMaxPreviousGames(tabs, this.getMaxPreviousGamesToShow(streamerSettings));
-    const loadedTickerGroups = this.buildTickerGroups(options.matchStatsByMatchId, trimmedTabs, {
+    const tickerFilterOptions: TickerFilterOptions = {
       trackedGamertag: renderModel.gamertag,
       includeOnlyTrackedPlayer: this.getIncludeOnlyTrackedPlayer(streamerSettings, activeSeries),
       applyPlayerPerspectiveTickerColors: activeSeries == null,
       selectedSlayerStats: this.getSelectedSlayerStats(streamerSettings),
       showObjectiveStats: this.getShowObjectiveStats(streamerSettings),
       medalRarityFilter: this.getMedalRarityFilter(streamerSettings),
-    });
+    };
+    const seriesStatsTickerGroup =
+      activeSeries != null
+        ? this.buildSeriesStatsTickerGroup(options.matchStatsByMatchId, activeSeries, tickerFilterOptions)
+        : null;
+    const matchTickerGroups = this.buildTickerGroups(options.matchStatsByMatchId, trimmedTabs, tickerFilterOptions);
+    const loadedTickerGroups =
+      seriesStatsTickerGroup != null ? [seriesStatsTickerGroup, ...matchTickerGroups] : matchTickerGroups;
     const tickerMatchGroups =
       loadedTickerGroups.length > 0
         ? loadedTickerGroups
@@ -656,6 +665,64 @@ export class IndividualTrackerOverlayPresenter {
     // If player is on team 0, playerTeamColor goes to team 0
     // If player is on team 1, playerTeamColor goes to team 1, enemyTeamColor to team 0
     return trackedPlayerTeamId === 0 ? [playerTeamColor, enemyTeamColor] : [enemyTeamColor, playerTeamColor];
+  }
+
+  private buildSeriesStatsTickerGroup(
+    matchStatsByMatchId: ReadonlyMap<string, MatchStatsState>,
+    activeSeries: ViewerSeriesTab,
+    filterOptions: TickerFilterOptions,
+  ): TickerMatchGroup | null {
+    const loadedStates = activeSeries.matches
+      .map((match) => matchStatsByMatchId.get(match.matchId))
+      .filter((state) => state?.status === "loaded");
+    if (loadedStates.length === 0) {
+      return null;
+    }
+    const [firstState] = loadedStates;
+
+    const playerMap = new Map<string, string>();
+    for (const state of loadedStates) {
+      for (const [xuid, gamertag] of state.playerMap) {
+        playerMap.set(xuid, gamertag);
+      }
+    }
+
+    const matches = loadedStates.map((state) => state.stats);
+    const teamData = new SeriesTeamStatsFormatter().getSeriesData(matches, playerMap, firstState.medalMetadata);
+    const playerData = new SeriesPlayerStatsFormatter().getSeriesData(matches, playerMap, firstState.medalMetadata);
+
+    const rows: TickerMatchGroup["rows"] = [
+      ...teamData.map((team) => ({
+        type: "team" as const,
+        teamId: team.teamId,
+        name: getTeamName(team.teamId),
+        stats: this.filterTickerStats(team.teamStats, filterOptions),
+        medals: this.filterTickerMedals(team.teamMedals, filterOptions.medalRarityFilter),
+      })),
+      ...playerData.flatMap((team) =>
+        team.players.map((player) => ({
+          type: "player" as const,
+          teamId: team.teamId,
+          name: player.name,
+          discordName: null,
+          gamertag: player.name,
+          stats: this.filterTickerStats(player.values, filterOptions),
+          medals: this.filterTickerMedals(player.medals, filterOptions.medalRarityFilter),
+        })),
+      ),
+    ];
+
+    const rowsWithColorSlots = this.applyTickerColorSlots(rows, filterOptions);
+    const filteredRows = this.filterRowsForTrackedPlayer(rowsWithColorSlots, filterOptions);
+    if (filteredRows.length === 0) {
+      return null;
+    }
+
+    return {
+      matchIndex: -1,
+      label: "Series Stats",
+      rows: filteredRows,
+    };
   }
 
   private buildTickerGroups(

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -674,7 +674,7 @@ export class IndividualTrackerOverlayPresenter {
   ): TickerMatchGroup | null {
     const loadedStates = activeSeries.matches
       .map((match) => matchStatsByMatchId.get(match.matchId))
-      .filter((state) => state?.status === "loaded");
+      .filter((state): state is Extract<MatchStatsState, { status: "loaded" }> => state?.status === "loaded");
     if (loadedStates.length === 0) {
       return null;
     }

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -979,6 +979,131 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(model.statsHighlights).toEqual([]);
   });
 
+  it("includes a series stats ticker group ahead of match groups when in an active series", () => {
+    const matchId = "series-match-1";
+    const activeSeries = aSeriesWith({
+      id: "series-active",
+      isActive: true,
+      matches: [aMatchWith({ matchId })],
+    });
+
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        hasActiveSeries: true,
+        activeSeriesContext: {
+          title: "Series",
+          subtitle: "Bo3",
+          teams: [],
+        },
+        timeline: [{ type: "series", series: activeSeries }],
+      }),
+      streamerSettings: undefined,
+      matchStatsByMatchId: new Map([
+        [
+          matchId,
+          {
+            status: "loaded" as const,
+            stats: aFakeMatchStatsWith({ MatchId: matchId }),
+            playerMap: new Map<string, string>([
+              ["1111111111", "TrackedPlayer"],
+              ["2222222222", "PlayerTwo"],
+              ["3333333333", "PlayerThree"],
+              ["4444444444", "PlayerFour"],
+            ]),
+            medalMetadata: aFakeMedalMetadata(),
+            analytics: null,
+            analyticsStatus: ComponentLoaderStatus.LOADED,
+          },
+        ],
+      ]),
+      selectedMatchId: null,
+    });
+
+    expect(model.tickerMatchGroups.length).toBeGreaterThanOrEqual(2);
+    const [seriesGroup, matchGroup] = model.tickerMatchGroups;
+    expect(seriesGroup.label).toBe("Series Stats");
+    expect(seriesGroup.matchIndex).toBe(-1);
+    expect(seriesGroup.rows.some((row) => row.type === "team")).toBe(true);
+    expect(seriesGroup.rows.some((row) => row.type === "player")).toBe(true);
+    expect(matchGroup.matchIndex).not.toBe(-1);
+  });
+
+  it("shows only the tracked player row in the series stats group when inSeriesMyStatsOnly is enabled", () => {
+    const matchId = "series-match-1";
+    const activeSeries = aSeriesWith({
+      id: "series-active",
+      isActive: true,
+      matches: [aMatchWith({ matchId })],
+    });
+
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        hasActiveSeries: true,
+        activeSeriesContext: {
+          title: "Series",
+          subtitle: "Bo3",
+          teams: [],
+        },
+        timeline: [{ type: "series", series: activeSeries }],
+      }),
+      streamerSettings: {
+        styleFlags: {
+          inSeriesMyStatsOnly: true,
+        },
+      } satisfies StreamerViewSettings,
+      matchStatsByMatchId: new Map([
+        [
+          matchId,
+          {
+            status: "loaded" as const,
+            stats: aFakeMatchStatsWith({ MatchId: matchId }),
+            playerMap: new Map<string, string>([
+              ["1111111111", "TrackedPlayer"],
+              ["2222222222", "PlayerTwo"],
+              ["3333333333", "PlayerThree"],
+              ["4444444444", "PlayerFour"],
+            ]),
+            medalMetadata: aFakeMedalMetadata(),
+            analytics: null,
+            analyticsStatus: ComponentLoaderStatus.LOADED,
+          },
+        ],
+      ]),
+      selectedMatchId: null,
+    });
+
+    const [seriesGroup] = model.tickerMatchGroups;
+    expect(seriesGroup.label).toBe("Series Stats");
+    expect(seriesGroup.rows).toHaveLength(1);
+    expect(seriesGroup.rows[0].type).toBe("player");
+    expect(seriesGroup.rows[0].name).toBe("TrackedPlayer");
+  });
+
+  it("omits the series stats group when no series match stats are loaded", () => {
+    const activeSeries = aSeriesWith({
+      id: "series-active",
+      isActive: true,
+      matches: [aMatchWith({ matchId: "series-match-1" })],
+    });
+
+    const model = presenter.present({
+      renderModel: aRenderModelWith({
+        hasActiveSeries: true,
+        activeSeriesContext: {
+          title: "Series",
+          subtitle: "Bo3",
+          teams: [],
+        },
+        timeline: [{ type: "series", series: activeSeries }],
+      }),
+      streamerSettings: undefined,
+      matchStatsByMatchId: new Map(),
+      selectedMatchId: null,
+    });
+
+    expect(model.tickerMatchGroups.some((group) => group.label === "Series Stats")).toBe(false);
+  });
+
   it("shows only the tracked player row in matchmaking ticker when matchmakingMyStatsOnly is enabled", () => {
     const matchId = "matchmaking-1";
 

--- a/pages/src/components/information-ticker/information-ticker.tsx
+++ b/pages/src/components/information-ticker/information-ticker.tsx
@@ -38,6 +38,10 @@ const InformationTickerComponent = function InformationTicker({
   onScrollComplete,
 }: InformationTickerProps): React.ReactElement {
   const [currentRowIndex, setCurrentRowIndex] = React.useState(0);
+  // Incremented on every completed cycle so the component re-renders even when the row/group
+  // index does not change (e.g. a single row in a single group). Without it the ScrollingContent
+  // effect never re-arms after its one-shot completion and the ticker freezes permanently.
+  const [, setCompletedCycleCount] = React.useState(0);
   const { rows } = currentMatchGroup;
   const hasRows = rows.length > 0;
   const safeRowIndex = hasRows ? Math.min(currentRowIndex, rows.length - 1) : 0;
@@ -72,6 +76,7 @@ const InformationTickerComponent = function InformationTicker({
     } else {
       // All rows complete, notify parent
       setCurrentRowIndex(0);
+      setCompletedCycleCount((count) => count + 1);
       onScrollComplete();
     }
   };

--- a/pages/src/components/information-ticker/tests/information-ticker-rotation.test.tsx
+++ b/pages/src/components/information-ticker/tests/information-ticker-rotation.test.tsx
@@ -7,9 +7,7 @@ import type { TickerMatchGroup } from "../information-ticker";
 import { InformationTicker } from "../information-ticker";
 
 vi.mock("../../icons/team-icon", () => ({
-  TeamIcon: ({ teamId }: { teamId: number }): React.ReactNode => (
-    <div data-testid={`team-icon-${teamId.toString()}`} />
-  ),
+  TeamIcon: ({ teamId }: { teamId: number }): React.ReactNode => <div data-testid={`team-icon-${teamId.toString()}`} />,
 }));
 
 // Uses the real ScrollingContent (unlike information-ticker.test.tsx which mocks it) so the

--- a/pages/src/components/information-ticker/tests/information-ticker-rotation.test.tsx
+++ b/pages/src/components/information-ticker/tests/information-ticker-rotation.test.tsx
@@ -1,0 +1,109 @@
+import "@testing-library/jest-dom/vitest";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import type { TeamColor } from "../../team-colors/team-colors";
+import type { TickerMatchGroup } from "../information-ticker";
+import { InformationTicker } from "../information-ticker";
+
+vi.mock("../../icons/team-icon", () => ({
+  TeamIcon: ({ teamId }: { teamId: number }): React.ReactNode => (
+    <div data-testid={`team-icon-${teamId.toString()}`} />
+  ),
+}));
+
+// Uses the real ScrollingContent (unlike information-ticker.test.tsx which mocks it) so the
+// cycle re-arming behaviour is exercised end to end via the non-overflow 10s timeout path.
+
+const teamColors: TeamColor[] = [
+  { id: "eagle", name: "Eagle", hex: "#0066CC" },
+  { id: "cobra", name: "Cobra", hex: "#CC0000" },
+];
+
+function aSingleRowGroup(): TickerMatchGroup {
+  return {
+    matchIndex: 0,
+    label: "Lattice",
+    rows: [
+      {
+        type: "player",
+        teamId: 0,
+        name: "TrackedPlayer",
+        stats: [{ name: "Kills", value: 14, bestInTeam: false, bestInMatch: false, display: "14" }],
+        medals: [],
+      },
+    ],
+  };
+}
+
+describe("InformationTicker rotation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    global.requestAnimationFrame = vi.fn(() => 0);
+    global.cancelAnimationFrame = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps completing cycles for a single-row group when the parent advance is a no-op", () => {
+    const onScrollComplete = vi.fn();
+
+    render(
+      <InformationTicker
+        currentMatchGroup={aSingleRowGroup()}
+        teamColors={teamColors}
+        onScrollComplete={onScrollComplete}
+      />,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(onScrollComplete).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(onScrollComplete).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(onScrollComplete).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps completing cycles when the parent re-renders with content-equal props", () => {
+    const onScrollComplete = vi.fn();
+
+    const { rerender } = render(
+      <InformationTicker
+        currentMatchGroup={aSingleRowGroup()}
+        teamColors={teamColors}
+        onScrollComplete={onScrollComplete}
+      />,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(onScrollComplete).toHaveBeenCalledTimes(1);
+
+    // Simulate a data refresh delivering a new-but-equal group (memo blocks the re-render)
+    rerender(
+      <InformationTicker
+        currentMatchGroup={aSingleRowGroup()}
+        teamColors={teamColors}
+        onScrollComplete={onScrollComplete}
+      />,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(onScrollComplete).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Context

On the user-level overlay (e.g. `/u/dreekzzzz/overlay`), the information ticker appeared permanently stationary while in a series — and stayed frozen even after a second match was played. Two distinct defects compound here:

1. **No series-overview group**: ticker groups were only built from *match* tabs, so in-series the rotation had one group per played match and nothing else — no accumulated series view (the live tracker overlay has one).
2. **Dead-state in the scroll cycle (root cause of the permanent freeze)**: `ScrollingContent`'s completion is one-shot — after it fires, nothing re-arms it unless a re-render recreates its children. With a single single-row group (e.g. one match + `inSeriesMyStatsOnly`), the group advance is a no-op and the row reset bails out (same value), so no re-render ever happens and the ticker dies. Worse, when new matches arrive later, the *current* group's content is unchanged, so `InformationTicker`'s deep-compare memo keeps blocking the re-render — the ticker stays frozen forever despite new groups existing.

## This change

- **Series Stats ticker group**: `buildSeriesStatsTickerGroup` prepends an accumulated group (`matchIndex: -1`, highlighting the series tab) when an active series has at least one match's stats loaded. Aggregation reuses the existing `SeriesTeamStatsFormatter`/`SeriesPlayerStatsFormatter` (same as the live tracker), with player maps merged across loaded matches, respecting all existing filters (slayer stats, objective stats, medal rarity, my-stats-only).
- **Cycle re-arm**: `InformationTicker` now increments a completed-cycle counter whenever a full row cycle finishes, forcing a re-render that recreates `ScrollingContent`'s children and restarts its timer chain — so the ticker keeps cycling even when the advance changes nothing, and picks up newly arrived groups on the next completion.
- Regression tests: a new rotation test file using the **real** `ScrollingContent` (the existing ticker tests mock it, which is why this never got caught) verifies repeated cycle completions for a single-row group and across content-equal re-renders; presenter tests cover the Series Stats group (ordering, my-stats-only, omission when stats unloaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)