### PR TITLE
fix(live-tracker): persist Discord associations discovered during live tracking

### DIFF
--- a/api/durable-objects/live-tracker/live-tracker-do.ts
+++ b/api/durable-objects/live-tracker/live-tracker-do.ts
@@ -1067,7 +1067,12 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
         true,
       );
 
+      const matchCountBefore = Object.keys(trackerState.discoveredMatches).length;
       await this.enrichAndMergeMatches(trackerState, matches);
+
+      if (Object.keys(trackerState.discoveredMatches).length > matchCountBefore) {
+        await this.persistDiscordAssociations();
+      }
 
       return Object.values(trackerState.discoveredMatches);
     } catch (error) {
@@ -1077,6 +1082,26 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
         return Object.values(trackerState.discoveredMatches);
       }
       throw error;
+    }
+  }
+
+  // getSeriesFromDiscordQueue's fuzzy team-position matching (run above) is the only way to
+  // identify a player whose Discord name doesn't resemble their gamertag and whose match history
+  // is private - but it only updates the in-memory userCache. doNotUpdateDiscordAssociations=true
+  // above skips the auto-persist on its no-match-found paths (this poll loop runs every ~3
+  // minutes for the whole match and would otherwise spam writes before any match exists to
+  // correlate against). A newly discovered match is exactly when that matching has fresh data to
+  // work with, so persist here - without this, any identity resolved during live tracking is
+  // discarded every cycle (clearUserCache runs before each fetch) and never reaches the database,
+  // so future series always start from scratch.
+  private async persistDiscordAssociations(): Promise<void> {
+    try {
+      await this.haloService.updateDiscordAssociations();
+    } catch (error) {
+      this.logService.warn(
+        "Failed to persist Discord associations discovered during live tracking",
+        new Map([["error", String(error)]]),
+      );
     }
   }
 

--- a/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
+++ b/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
@@ -871,6 +871,91 @@ describe("LiveTrackerDO", () => {
       expect(storagePutSpy).toHaveBeenCalledTimes(2);
     });
 
+    it("persists Discord associations when a new match is discovered during refresh", async () => {
+      const trackerState = createMockTrackerState();
+      trackerState.lastMessageState = {
+        matchCount: 0,
+        substitutionCount: 0,
+      };
+      trackerState.discoveredMatches = {};
+      const eightPlayerSetup = createEightPlayerSetup();
+      trackerState.teams = eightPlayerSetup.teams;
+      trackerState.players = eightPlayerSetup.players;
+      storageGetSpy.mockResolvedValue(trackerState);
+
+      const mockMatches = [Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"))];
+      vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue(mockMatches);
+      vi.spyOn(services.haloService, "getSeriesScore").mockReturnValue("1:0");
+      vi.spyOn(services.haloService, "getGameTypeAndMap").mockResolvedValue("Slayer on Aquarius");
+      vi.spyOn(haloDuration, "getReadableDuration").mockReturnValue("5:00");
+      vi.spyOn(services.haloService, "getMatchScore").mockReturnValue({ gameScore: "50:49", gameSubScore: null });
+      vi.spyOn(services.discordService, "createMessage").mockResolvedValue({
+        ...apiMessage,
+        id: "new-refresh-message-id",
+      });
+      vi.spyOn(services.discordService, "deleteMessage").mockResolvedValue(undefined);
+      const updateDiscordAssociationsSpy = vi
+        .spyOn(services.haloService, "updateDiscordAssociations")
+        .mockResolvedValue();
+
+      const response = await liveTrackerDO.fetch(new Request("http://do/refresh", { method: "POST" }));
+
+      expect(response.status).toBe(200);
+      expect(updateDiscordAssociationsSpy).toHaveBeenCalledOnce();
+    });
+
+    it("does not persist Discord associations when no new match is discovered during refresh", async () => {
+      const trackerState = createMockTrackerState();
+      trackerState.lastMessageState = {
+        matchCount: 0,
+        substitutionCount: 0,
+      };
+      trackerState.discoveredMatches = {};
+      storageGetSpy.mockResolvedValue(trackerState);
+
+      vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
+      vi.spyOn(services.haloService, "getSeriesScore").mockReturnValue("0:0");
+      vi.spyOn(services.discordService, "editMessage").mockResolvedValue(apiMessage);
+      const updateDiscordAssociationsSpy = vi
+        .spyOn(services.haloService, "updateDiscordAssociations")
+        .mockResolvedValue();
+
+      const response = await liveTrackerDO.fetch(new Request("http://do/refresh", { method: "POST" }));
+
+      expect(response.status).toBe(200);
+      expect(updateDiscordAssociationsSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not fail the refresh when persisting Discord associations errors", async () => {
+      const trackerState = createMockTrackerState();
+      trackerState.lastMessageState = {
+        matchCount: 0,
+        substitutionCount: 0,
+      };
+      trackerState.discoveredMatches = {};
+      const eightPlayerSetup = createEightPlayerSetup();
+      trackerState.teams = eightPlayerSetup.teams;
+      trackerState.players = eightPlayerSetup.players;
+      storageGetSpy.mockResolvedValue(trackerState);
+
+      const mockMatches = [Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"))];
+      vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue(mockMatches);
+      vi.spyOn(services.haloService, "getSeriesScore").mockReturnValue("1:0");
+      vi.spyOn(services.haloService, "getGameTypeAndMap").mockResolvedValue("Slayer on Aquarius");
+      vi.spyOn(haloDuration, "getReadableDuration").mockReturnValue("5:00");
+      vi.spyOn(services.haloService, "getMatchScore").mockReturnValue({ gameScore: "50:49", gameSubScore: null });
+      vi.spyOn(services.discordService, "createMessage").mockResolvedValue({
+        ...apiMessage,
+        id: "new-refresh-message-id",
+      });
+      vi.spyOn(services.discordService, "deleteMessage").mockResolvedValue(undefined);
+      vi.spyOn(services.haloService, "updateDiscordAssociations").mockRejectedValue(new Error("D1 unavailable"));
+
+      const response = await liveTrackerDO.fetch(new Request("http://do/refresh", { method: "POST" }));
+
+      expect(response.status).toBe(200);
+    });
+
     it("edits existing message during refresh when no new content is detected", async () => {
       const trackerState = createMockTrackerState();
       trackerState.lastMessageState = {


### PR DESCRIPTION
## Context

For a player whose Discord username doesn't resemble their gamertag and whose match history is private (`GamesRetrievable` stuck at `NO`), the only identification path is `fuzzyMatchTeam` — it correlates a Discord user to an Xbox player by **team position in an actual played match** rather than the player's own hidden history, with a `HISTORICAL_MATCH_BOOST` (+0.4) that reinforces a previously-guessed identity across matches. This logic runs inside `HaloService.getSeriesFromDiscordQueue`, but only updates the in-memory `userCache` — persisting to the `DiscordAssociations` table is the caller's responsibility via `updateDiscordAssociations()`.

Every caller does this **except** the live tracker DO:
- `/stats neatqueue` command → calls it after `getSeriesFromDiscordQueue` ✅
- NeatQueue match-completed webhook (`matchCompletedJob`) → calls it in its final `Promise.all` ✅
- Live tracker DO (`fetchAndMergeSeriesData`) → passes `doNotUpdateDiscordAssociations: true` and never calls it itself ❌

The live tracker DO also calls `clearUserCache()` before every poll (every ~3 minutes for the whole match). So any identity resolved via fuzzy team-position matching during live tracking was discarded every single cycle and never reached the database. Guilds with live tracking enabled would never persist an identification made this way — every new series started from scratch, re-deriving the same low-confidence match, and the pre-series "Players in queue" post (a plain DB read, no fuzzy matching of its own) kept showing "Not Connected" for that player indefinitely.

## This change

- `fetchAndMergeSeriesData` now calls a new `persistDiscordAssociations()` helper whenever a poll discovers at least one new match — the point at which `fuzzyMatchUnassociatedUsers` has fresh team-position data to correlate against. This mirrors the once-per-match cadence the webhook flow already uses, rather than persisting unconditionally on every ~3 minute poll tick (which would spam writes for the whole match duration, and is presumably why `doNotUpdateDiscordAssociations: true` was passed in the first place).
- The persist is wrapped in try/catch and logged on failure — a DB hiccup here shouldn't break the live tracker's own update flow.
- Regression tests: persists on new-match discovery, does not persist when no new match is found, and does not fail the refresh if persisting errors. Confirmed the first test fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)