### PR TITLE
fix(individual-tracker): dedupe rematch icons in series icon strips

### DIFF
--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -275,7 +275,7 @@ export class IndividualTrackerOverlayPresenter {
             label: item.series.title,
             score: item.series.score,
             teamColor: getSeriesOutcomeColorHex(item.series),
-            icons: item.series.matches.map((match) => ({
+            icons: item.series.iconMatches.map((match) => ({
               src: gameModeIconSrc(match.gameVariantCategory),
               dimmed: match.outcome === "Loss",
             })),
@@ -610,6 +610,7 @@ export class IndividualTrackerOverlayPresenter {
       startTime: "",
       endTime: "",
       matches: [],
+      iconMatches: [],
       colorHex: undefined,
     };
   }

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -76,6 +76,7 @@ function aSeriesWith(overrides: Partial<ViewerSeriesTab> = {}): ViewerSeriesTab 
     startTime: overrides.startTime ?? "2026-01-01T00:00:00.000Z",
     endTime: overrides.endTime ?? "2026-01-01T00:30:00.000Z",
     matches,
+    iconMatches: overrides.iconMatches ?? matches,
     colorHex: overrides.colorHex,
   };
 }
@@ -378,6 +379,36 @@ describe("individual-tracker-overlay-presenter", () => {
       expect(customTab.icons).toEqual([
         { src: gameModeIconSrc(6), dimmed: true },
         { src: gameModeIconSrc(6), dimmed: false },
+      ]);
+    }
+  });
+
+  it("builds the consolidated series tab's icons from iconMatches, not the full matches list", () => {
+    const fullMatches = [
+      aMatchWith({ matchId: "m1", gameVariantCategory: 6 }),
+      aMatchWith({ matchId: "m2", gameVariantCategory: 7 }),
+      aMatchWith({ matchId: "m3", gameVariantCategory: 7 }),
+    ];
+    const timeline: ViewerTimelineItem[] = [
+      {
+        type: "series",
+        series: aSeriesWith({
+          id: "series-rematch",
+          isActive: false,
+          matches: fullMatches,
+          iconMatches: [fullMatches[0], fullMatches[2]],
+        }),
+      },
+    ];
+
+    const tabs = presenter.buildTabs(timeline);
+    const seriesTab = tabs.find((tab) => tab.type === "series" && tab.seriesId === "series-rematch");
+
+    expect(seriesTab?.type).toBe("series");
+    if (seriesTab?.type === "series") {
+      expect(seriesTab.icons).toEqual([
+        { src: gameModeIconSrc(6), dimmed: false },
+        { src: gameModeIconSrc(7), dimmed: false },
       ]);
     }
   });

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
@@ -274,6 +274,7 @@ describe("OverlayPagePresenter", () => {
           startTime: "2026-01-01T00:00:00.000Z",
           endTime: "2026-01-01T00:10:00.000Z",
           matches: [],
+          iconMatches: [],
           colorHex: undefined,
         },
       },

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
@@ -556,7 +556,7 @@ export function IndividualTrackerViewer({
                         <div className={styles.entryHeaderRight}>
                           <div className={styles.entryHeaderVisuals}>
                             <div className={styles.seriesModeIcons}>
-                              {series.matches.map((seriesMatch, iconIndex) => (
+                              {series.iconMatches.map((seriesMatch, iconIndex) => (
                                 <img
                                   key={`${seriesMatch.matchId}:${iconIndex.toString()}`}
                                   src={gameModeIconSrc(seriesMatch.gameVariantCategory)}

--- a/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
@@ -131,11 +131,15 @@ describe("IndividualTrackerViewer", () => {
       matches: [
         aFakeTrackerMatchSummaryWith({
           matchId: "m-1",
+          mapAssetId: "map-asset-1",
+          gameVariantCategory: 6,
           killsDeathsAssistsKda: "11:8:4 (1.54)",
           damageDealtTakenRatio: "4,400:3,900 (1.13)",
         }),
         aFakeTrackerMatchSummaryWith({
           matchId: "m-2",
+          mapAssetId: "map-asset-2",
+          gameVariantCategory: 7,
           killsDeathsAssistsKda: "9:7:5 (1.52)",
           damageDealtTakenRatio: "3,800:3,600 (1.06)",
         }),
@@ -159,6 +163,36 @@ describe("IndividualTrackerViewer", () => {
     expect(screen.getByText("20:15:9 (1.53)")).toBeInTheDocument();
     expect(screen.getByText("8,200:7,500 (1.09)")).toBeInTheDocument();
     expect(screen.getByText(/End time/)).toBeInTheDocument();
+  });
+
+  it("collapses a consecutive same-map/mode rematch to one icon in the series header", () => {
+    const view = aFakeTrackerViewStateWith({
+      matches: [
+        aFakeTrackerMatchSummaryWith({
+          matchId: "m-1",
+          startTime: "2100-01-01T00:00:00.000Z",
+          mapAssetId: "map-asset-1",
+          gameVariantCategory: 6,
+        }),
+        aFakeTrackerMatchSummaryWith({
+          matchId: "m-2",
+          startTime: "2100-01-01T00:10:00.000Z",
+          mapAssetId: "map-asset-1",
+          gameVariantCategory: 6,
+        }),
+      ],
+      series: [
+        aFakeTrackerSeriesGroupWith({
+          matchIds: ["m-1", "m-2"],
+          title: "Rematch Series",
+          score: "0:1",
+        }),
+      ],
+    });
+
+    renderViewer(view);
+
+    expect(within(screen.getByLabelText("Series Rematch Series")).getAllByRole("img")).toHaveLength(1);
   });
 
   it("renders In progress for an active series", () => {

--- a/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
+++ b/pages/src/components/individual-tracker/viewer/tests/viewer-render-model.test.ts
@@ -70,6 +70,75 @@ describe("buildViewerRenderModel", () => {
     }
   });
 
+  it("collapses a consecutive same-map/mode rematch to its final game in iconMatches, keeping matches intact", () => {
+    expect.assertions(2);
+    const view = aFakeTrackerViewStateWith({
+      matches: [
+        aFakeTrackerMatchSummaryWith({
+          matchId: "m1",
+          startTime: "2100-01-01T00:00:00.000Z",
+          mapAssetId: "map-a",
+          gameVariantCategory: 6,
+        }),
+        aFakeTrackerMatchSummaryWith({
+          matchId: "m2",
+          startTime: "2100-01-01T00:10:00.000Z",
+          mapAssetId: "map-b",
+          gameVariantCategory: 7,
+        }),
+        aFakeTrackerMatchSummaryWith({
+          matchId: "m3",
+          startTime: "2100-01-01T00:20:00.000Z",
+          mapAssetId: "map-b",
+          gameVariantCategory: 7,
+        }),
+      ],
+      series: [aFakeTrackerSeriesGroupWith({ id: "s1", matchIds: ["m1", "m2", "m3"] })],
+    });
+
+    const model = buildViewerRenderModel({ view });
+
+    const [first] = model.timeline;
+    if (first.type === "series") {
+      expect(first.series.matches.map((m) => m.matchId)).toEqual(["m1", "m2", "m3"]);
+      expect(first.series.iconMatches.map((m) => m.matchId)).toEqual(["m1", "m3"]);
+    }
+  });
+
+  it("does not collapse matches on the same map/mode when they are not consecutive", () => {
+    expect.assertions(1);
+    const view = aFakeTrackerViewStateWith({
+      matches: [
+        aFakeTrackerMatchSummaryWith({
+          matchId: "m1",
+          startTime: "2100-01-01T00:00:00.000Z",
+          mapAssetId: "map-a",
+          gameVariantCategory: 6,
+        }),
+        aFakeTrackerMatchSummaryWith({
+          matchId: "m2",
+          startTime: "2100-01-01T00:10:00.000Z",
+          mapAssetId: "map-b",
+          gameVariantCategory: 7,
+        }),
+        aFakeTrackerMatchSummaryWith({
+          matchId: "m3",
+          startTime: "2100-01-01T00:20:00.000Z",
+          mapAssetId: "map-a",
+          gameVariantCategory: 6,
+        }),
+      ],
+      series: [aFakeTrackerSeriesGroupWith({ id: "s1", matchIds: ["m1", "m2", "m3"] })],
+    });
+
+    const model = buildViewerRenderModel({ view });
+
+    const [first] = model.timeline;
+    if (first.type === "series") {
+      expect(first.series.iconMatches.map((m) => m.matchId)).toEqual(["m1", "m2", "m3"]);
+    }
+  });
+
   it("derives series start and end times from the actual chronological bounds", () => {
     expect.assertions(2);
     const view = aFakeTrackerViewStateWith({

--- a/pages/src/components/individual-tracker/viewer/types.ts
+++ b/pages/src/components/individual-tracker/viewer/types.ts
@@ -45,6 +45,10 @@ export interface ViewerSeriesTab {
   readonly startTime: string;
   readonly endTime: string;
   readonly matches: readonly ViewerMatchTab[];
+  // Same-map/mode consecutive rematches collapsed to their final (actual) game, mirroring the
+  // score's collapseSequentialSeriesEntries rule. Icon strips use this; the expanded per-match
+  // list still uses `matches` so every individual game remains browsable.
+  readonly iconMatches: readonly ViewerMatchTab[];
   readonly colorHex: string | undefined;
 }
 

--- a/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-render-model.ts
@@ -5,7 +5,11 @@ import type {
 } from "@guilty-spark/shared/contracts/individual-tracker/view";
 import { getGameModeName } from "@guilty-spark/shared/halo/game-variants";
 import { getDurationInIsoString, getReadableDuration } from "@guilty-spark/shared/halo/duration";
-import { normalizeOutcomeString, getOutcomeColor } from "@guilty-spark/shared/halo/match-enrichment";
+import {
+  normalizeOutcomeString,
+  getOutcomeColor,
+  collapseSequentialSeriesEntries,
+} from "@guilty-spark/shared/halo/match-enrichment";
 import { differenceInSeconds, isValid, parseISO } from "date-fns";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { getTeamColorOrDefault } from "../../team-colors/team-colors";
@@ -188,8 +192,17 @@ function toPendingActiveSeriesTab(view: TrackerViewState): ViewerSeriesTab {
     startTime: activeSeriesContext.startedAt ?? view.lastUpdateTime,
     endTime: "",
     matches: [],
+    iconMatches: [],
     colorHex: undefined,
   };
+}
+
+function toIconMatches(
+  seriesMatches: readonly ViewerMatchTab[],
+  seriesSummaries: readonly TrackerMatchSummary[],
+): ViewerMatchTab[] {
+  const survivingMatchIds = new Set(collapseSequentialSeriesEntries(seriesSummaries).map((summary) => summary.matchId));
+  return seriesMatches.filter((match) => survivingMatchIds.has(match.matchId));
 }
 
 function toReadableDurationOrUnknown(startTime: string, endTime: string): string {
@@ -369,6 +382,7 @@ export function buildViewerRenderModel(options: BuildViewerRenderModelOptions): 
         startTime: seriesStartTime,
         endTime: seriesEndTime,
         matches: seriesMatches,
+        iconMatches: toIconMatches(seriesMatches, seriesSummaries),
         colorHex: undefined,
       };
       const seriesWithPreSeriesData: ViewerSeriesTab =

--- a/pages/src/components/individual-tracker/viewer/viewer-tabs.tsx
+++ b/pages/src/components/individual-tracker/viewer/viewer-tabs.tsx
@@ -47,7 +47,7 @@ function SeriesTab({ series, selected, onSelect }: SeriesTabProps): React.ReactE
       <span className={styles.tabSeriesTitle}>{series.title}</span>
       <span className={styles.tabScore}>{series.score}</span>
       <div className={styles.tabIcons}>
-        {series.matches.map((match) => (
+        {series.iconMatches.map((match) => (
           <img key={match.matchId} className={styles.tabIcon} src={gameModeIconSrc(match.gameVariantCategory)} alt="" />
         ))}
       </div>


### PR DESCRIPTION
## Context

Series score computation already collapses consecutive same-map/mode rematches down to the final (actual) game, via `collapseSequentialSeriesEntries` — used by `computeSeriesTeamWins` for scoring and `getDefaultSeriesGroupSubtitle` for Best-of inference. The per-series icon strips that summarize a series never applied the same rule, so a chalked/restarted game still rendered its own icon alongside the real outcome, inflating the icon count beyond the actual game count the score reflects.

Three icon-rendering spots were affected, all deriving from the same underlying series match list:
- The individual tracker viewer's tab bar (`viewer-tabs.tsx`)
- The individual tracker viewer's series entry header (`individual-tracker-viewer.tsx`, `.seriesModeIcons`)
- The overlay's consolidated matchmaking series tab (`individual-tracker-overlay-presenter.ts`, `buildTabs`)

## This change

- Adds `ViewerSeriesTab.iconMatches` — computed once in `viewer-render-model.ts` by reusing `collapseSequentialSeriesEntries` on the series' match summaries (same signature: map asset/version + game variant category, only collapses *consecutive* matches, keeping the later one) — then filtering the already-built match tabs down to the surviving ids, preserving display order.
- Points all three icon-rendering call sites at `iconMatches` instead of `matches`.
- `matches` itself, and everything derived from it elsewhere (expanded per-match browsing when a series entry is opened, match count, score, aggregate stats), is untouched — every individual game, including a chalked one, is still viewable on its own. Only the icon summary dedupes, matching the ask: still show individual matches, just not duplicated in the icon strips.

## Tests

- `viewer-render-model.test.ts`: collapses a consecutive same-map/mode pair to the final game in `iconMatches` while `matches` stays intact; does *not* collapse a same-map/mode pair that isn't consecutive (a real coincidental map repeat later in the series).
- `individual-tracker-overlay-presenter.test.ts`: consolidated matchmaking series tab icons reflect `iconMatches`, not the full `matches` list.
- `individual-tracker-viewer.test.tsx`: a render-level regression — a consecutive same-map/mode rematch now renders one icon in the series header (this exact scenario existed by coincidence in an existing generic test using identical fixture defaults for two matches; retargeted that test's fixture data since its intent was unrelated to dedup, and added a dedicated test for the dedup behavior itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)