### PR TITLE
fix(follow): decode percent-encoded gamertag in /u/:gamertag routes

### DIFF
--- a/api/routes/user-tracker/follow.ts
+++ b/api/routes/user-tracker/follow.ts
@@ -7,7 +7,23 @@ import type { UserTrackerDO } from "../../durable-objects/user-tracker/user-trac
 import { emptyTrackerDirectory } from "../../durable-objects/user-tracker/types";
 import type { RoutesRegisterHandler } from "../base/types";
 
-const gamertagParamsSchema = z.object({ gamertag: z.string().min(1) });
+// itty-router captures path params straight from URL.pathname, which never decodes
+// percent-escapes (e.g. a gamertag containing a space arrives as "Foo%20Bar"). Decode here so
+// the shared schema covers both routes below; a malformed escape fails validation like any
+// other invalid gamertag rather than throwing.
+const gamertagParamsSchema = z.object({
+  gamertag: z
+    .string()
+    .min(1)
+    .transform((value, ctx) => {
+      try {
+        return decodeURIComponent(value);
+      } catch {
+        ctx.addIssue({ code: "custom", message: "Invalid gamertag encoding" });
+        return z.NEVER;
+      }
+    }),
+});
 
 function getUserTrackerStub(env: Env, userId: string): DurableObjectStub<UserTrackerDO> {
   const doId = env.USER_TRACKER_DO.idFromName(userId);

--- a/api/routes/user-tracker/tests/follow.test.ts
+++ b/api/routes/user-tracker/tests/follow.test.ts
@@ -218,7 +218,7 @@ describe("/u/:gamertag follow routes", () => {
       expect(res.status).toBe(426);
     });
 
-    it("decodes a percent-encoded gamertag containing a space before looking it up", async () => {
+    it("decodes a percent-encoded gamertag containing a space before looking it up (websocket route)", async () => {
       const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "CAP0 CRIMINI" });
       const userTrackerDo = aFakeUserTrackerDOWith();
       const localEnv = aFakeEnvWith({ USER_TRACKER_DO: aFakeDurableObjectNamespaceWith(userTrackerDo) });

--- a/api/routes/user-tracker/tests/follow.test.ts
+++ b/api/routes/user-tracker/tests/follow.test.ts
@@ -1,5 +1,7 @@
 import type { AutoRouterType } from "itty-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import type { TrackerDirectoryResponse } from "@guilty-spark/shared/contracts/individual-tracker/follow";
 import { withStreamerViewSettingsDefaults } from "@guilty-spark/shared/individual-tracker/streamer-view-settings";
 import { createApiRouter } from "../../../base/router";
@@ -7,6 +9,7 @@ import { aFakeDurableObjectNamespaceWith } from "../../../base/fakes/do.fake";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import { aFakeUserTrackerDOWith } from "../../../durable-objects/user-tracker/fakes/user-tracker-do.fake";
 import { aFakeLinkedIdentitiesRow } from "../../../services/database/fakes/database.fake";
+import type { DatabaseService } from "../../../services/database/database";
 import { installFakeServicesWith } from "../../../services/fakes/services";
 import { userTrackerRoutesRegisterHandler } from "../user-tracker";
 
@@ -131,6 +134,39 @@ describe("/u/:gamertag follow routes", () => {
       expect(parsedUrl.searchParams.get("userId")).toBe("user-1");
     });
 
+    it("decodes a percent-encoded gamertag containing a space before looking it up", async () => {
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "CAP0 CRIMINI" });
+      const userTrackerDo = aFakeUserTrackerDOWith({ viewStateResponse: { state: null } });
+      const localEnv = aFakeEnvWith({ USER_TRACKER_DO: aFakeDurableObjectNamespaceWith(userTrackerDo) });
+
+      let findByGamertagSpy: MockInstance<DatabaseService["findActiveXboxIdentityByGamertag"]> | null = null;
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env: localEnv });
+        findByGamertagSpy = vi
+          .spyOn(services.databaseService, "findActiveXboxIdentityByGamertag")
+          .mockResolvedValue(identity);
+        return services;
+      });
+      userTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/u/CAP0%20CRIMINI"), localEnv)) as Response;
+
+      expect(res.status).toBe(200);
+      expect(Preconditions.checkExists(findByGamertagSpy, "findByGamertag spy")).toHaveBeenCalledWith("CAP0 CRIMINI");
+    });
+
+    it("returns 400 when the gamertag contains a malformed percent-escape", async () => {
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env });
+        return services;
+      });
+      userTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(getRequest("/u/Bad%"), env)) as Response;
+
+      expect(res.status).toBe(400);
+    });
+
     it("returns an empty directory when UserTrackerDO has not built state yet", async () => {
       const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "EmptyTag" });
       const userTrackerDo = aFakeUserTrackerDOWith({ viewStateResponse: { state: null } });
@@ -180,6 +216,27 @@ describe("/u/:gamertag follow routes", () => {
       const res = (await router.fetch(getRequest("/u/SomeTag/ws"), env)) as Response;
 
       expect(res.status).toBe(426);
+    });
+
+    it("decodes a percent-encoded gamertag containing a space before looking it up", async () => {
+      const identity = aFakeLinkedIdentitiesRow({ UserId: "user-1", Gamertag: "CAP0 CRIMINI" });
+      const userTrackerDo = aFakeUserTrackerDOWith();
+      const localEnv = aFakeEnvWith({ USER_TRACKER_DO: aFakeDurableObjectNamespaceWith(userTrackerDo) });
+
+      let findByGamertagSpy: MockInstance<DatabaseService["findActiveXboxIdentityByGamertag"]> | null = null;
+      const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => {
+        const services = installFakeServicesWith({ env: localEnv });
+        findByGamertagSpy = vi
+          .spyOn(services.databaseService, "findActiveXboxIdentityByGamertag")
+          .mockResolvedValue(identity);
+        return services;
+      });
+      userTrackerRoutesRegisterHandler(router, localInstallServices);
+
+      const res = (await router.fetch(wsRequest("/u/CAP0%20CRIMINI/ws"), localEnv)) as Response;
+
+      expect(res.headers.get("x-fake-upgrade")).toBe("websocket");
+      expect(Preconditions.checkExists(findByGamertagSpy, "findByGamertag spy")).toHaveBeenCalledWith("CAP0 CRIMINI");
     });
 
     it("forwards websocket upgrades to UserTrackerDO and passes userId in the internal request", async () => {


### PR DESCRIPTION
## Context

From the pasted console screenshot: `wss://api.guilty-spark.app/u/CAP0%20CRIMINI/ws` failed with a 404, and the pulled Cloudflare Worker logs (`api/test-results/message.txt`) confirm both `GET /u/CAP0%20CRIMINI` and `GET /u/CAP0%20CRIMINI/ws` consistently returned 404 across many repeated attempts.

Root cause: itty-router populates `request.params` straight from `URL.pathname.match(...)`, and `URL.pathname` never decodes percent-escapes (unlike `URLSearchParams`, which decodes automatically). So a gamertag containing a space — anything that needs URL-encoding — arrives at the route handler as the literal, still-encoded string `"CAP0%20CRIMINI"`, not `"CAP0 CRIMINI"`. That string is passed directly to `findActiveXboxIdentityByGamertag`, an exact-match DB query against the stored (unencoded) gamertag — which never matches, so the lookup returns `null` and the route 404s. This affects any player whose gamertag needs encoding (most commonly, contains a space), on both the directory fetch and the websocket upgrade route.

## This change

- Decodes the `gamertag` path param via a Zod `.transform` on the shared `gamertagParamsSchema`, so both `GET /u/:gamertag` and `GET /u/:gamertag/ws` are covered from one place.
- A malformed percent-escape (e.g. a stray `%`) now fails schema validation and returns the existing 400 "Invalid gamertag" response, rather than `decodeURIComponent` throwing an uncaught exception.
- Regression tests for both routes: a percent-encoded gamertag with a space is decoded before the DB lookup (verified via the lookup spy's call args, not just response status), and a malformed escape returns 400. Confirmed both decode tests fail without the fix.

## Note on the second symptom reported alongside this

The user also mentioned a different friend, also with a space in their gamertag, whose *login* (not the follow page) bounces back to the login page with the profile icon still showing logged-out. I traced the full OAuth/PKCE/redirect chain (start route → PKCE cookie → callback → session cookie) end-to-end and found no space-related defect there — every step already uses `URLSearchParams`/`URL` APIs that handle percent-encoding correctly, unlike the raw path-param extraction fixed here. I did not want to guess a fix for unconfirmed symptoms; happy to dig further with server logs from that specific login attempt if it's still reproducing after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)