### PR TITLE
fix(overlay): matchmaking series tab shows title + subtitle

### DIFF
--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -85,6 +85,10 @@ function getSeriesOutcomeColorHex(series: ViewerSeriesTab): string | undefined {
   return undefined;
 }
 
+function getSeriesTabLabel(series: ViewerSeriesTab): string {
+  return series.subtitle !== "" ? `${series.title} - ${series.subtitle}` : series.title;
+}
+
 export type MatchStatsState =
   | { readonly status: "loading" }
   | {
@@ -272,7 +276,7 @@ export class IndividualTrackerOverlayPresenter {
             type: "series",
             seriesId: item.series.id,
             index: seriesIdx--,
-            label: item.series.title,
+            label: getSeriesTabLabel(item.series),
             score: item.series.score,
             teamColor: getSeriesOutcomeColorHex(item.series),
             icons: item.series.iconMatches.map((match) => ({

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay-presenter.test.ts
@@ -192,6 +192,7 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(seriesTab.type).toBe("series");
     if (seriesTab.type === "series") {
       expect(seriesTab.seriesId).toBe("series-complete");
+      expect(seriesTab.label).toBe("Eagle vs Cobra - Best of 3");
       expect(seriesTab.icons).toEqual([
         { src: gameModeIconSrc(6), dimmed: false },
         { src: gameModeIconSrc(7), dimmed: false },
@@ -201,6 +202,25 @@ describe("individual-tracker-overlay-presenter", () => {
     expect(matchTab.type).toBe("match");
     if (matchTab.type === "match") {
       expect(matchTab.icon).toBe(gameModeIconSrc(8));
+    }
+  });
+
+  it("omits the subtitle from a matchmaking series tab's label when there is none", () => {
+    const completedSeries = aSeriesWith({
+      id: "series-no-subtitle",
+      isActive: false,
+      title: "Eagle vs Cobra",
+      subtitle: "",
+    });
+
+    const timeline: ViewerTimelineItem[] = [{ type: "series", series: completedSeries }];
+
+    const tabs = presenter.buildTabs(timeline);
+    const seriesTab = tabs.find((tab) => tab.type === "series" && tab.seriesId === "series-no-subtitle");
+
+    expect(seriesTab?.type).toBe("series");
+    if (seriesTab?.type === "series") {
+      expect(seriesTab.label).toBe("Eagle vs Cobra");
     }
   });
 


### PR DESCRIPTION
## Context

In the individual tracker overlay's matchmaking UI, a completed series in the bottom tab bar consolidates its matches into a single tab (with a per-match mode-icon strip and the already-present score). Its label was just the series title, dropping the subtitle (e.g. `Queue #1234`, `Best of 3`) entirely.

## This change

- Adds `getSeriesTabLabel`, used at the one call site that builds this consolidated tab: `${title} - ${subtitle}` when a subtitle exists, falling back to the title alone otherwise.
- Score is unaffected — it already renders as a separate field alongside the label.
- Regression tests: label includes the subtitle for the default case, and omits it (falls back to title only) when the series has no subtitle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)