### PR TITLE
fix(overlay): align stats panel headers with viewer and fix close button z-index

### DIFF
--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -106,6 +106,39 @@ function IndividualTrackerOverlayPageInternal({
 
   const overlayModel = useMemo(() => presenter.present(overlaySnapshot), [overlaySnapshot, presenter]);
   const overlayPresenter = useMemo(() => new IndividualTrackerOverlayPresenter(), []);
+  const selectedMatch = useMemo(() => {
+    if (model.renderModel == null || overlayModel.selectedMatchId == null) {
+      return null;
+    }
+
+    for (const item of model.renderModel.timeline) {
+      if (item.type === "match" && item.match.matchId === overlayModel.selectedMatchId) {
+        return item.match;
+      }
+
+      if (item.type === "series") {
+        const seriesMatch = item.series.matches.find((match) => match.matchId === overlayModel.selectedMatchId);
+        if (seriesMatch != null) {
+          return seriesMatch;
+        }
+      }
+    }
+
+    return null;
+  }, [model.renderModel, overlayModel.selectedMatchId]);
+  const selectedSeries = useMemo(() => {
+    if (model.renderModel == null || overlayModel.selectedSeriesId == null) {
+      return null;
+    }
+
+    for (const item of model.renderModel.timeline) {
+      if (item.type === "series" && item.series.id === overlayModel.selectedSeriesId) {
+        return item.series;
+      }
+    }
+
+    return null;
+  }, [model.renderModel, overlayModel.selectedSeriesId]);
   const selectedSeriesEntryState = useMemo(() => {
     if (overlayModel.selectedSeriesId == null) {
       return null;
@@ -167,6 +200,8 @@ function IndividualTrackerOverlayPageInternal({
             matchesLength={model.renderModel.accumulated.total}
             matchStatsPanelState={overlayModel.matchStatsPanelState}
             seriesStatsPanelState={selectedSeriesPanelState}
+            selectedMatch={selectedMatch}
+            selectedSeries={selectedSeries}
             selectedMatchId={overlayModel.selectedMatchId}
             selectedSeriesId={overlayModel.selectedSeriesId}
             showPreview={showPreview}

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.module.css
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.module.css
@@ -4,3 +4,33 @@
   overflow: hidden;
   position: fixed;
 }
+
+.seriesPanel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.headerVisuals {
+  align-items: center;
+  display: flex;
+  gap: var(--space-2);
+}
+
+.headerModeIcon {
+  filter: drop-shadow(0 2px 4px rgb(0 0 0 / 50%));
+  height: 1.75rem;
+  width: 1.75rem;
+}
+
+.seriesModeIcons {
+  display: flex;
+  flex-flow: row wrap;
+  gap: var(--space-1);
+  justify-content: flex-end;
+  max-width: 160px;
+}
+
+.seriesModeIconMuted {
+  filter: grayscale(100%) opacity(45%);
+}

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay.tsx
@@ -1,13 +1,20 @@
 import React, { useCallback, useMemo } from "react";
+import classNames from "classnames";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import { summarizeSeriesOutcome } from "@guilty-spark/shared/halo/match-enrichment";
 import { createStreamerOverlaySection } from "../../streamer-overlay/create";
 import { TopSection } from "../../streamer-overlay/top-section";
 import { TeamDetailsContent } from "../../streamer-overlay/team-details-content";
 import { StatsPanel } from "../viewer/stats-panel";
 import { SeriesStatsView } from "../../series-stats/series-stats";
+import { StatsHeader } from "../../stats/stats-header";
+import { OutcomeBadge } from "../../outcome-badge/outcome-badge";
 import { Alert } from "../../alert/alert";
 import { LoadingState } from "../../loading-state/loading-state";
-import type { MatchDetailsState, SeriesDetailsState } from "../viewer/types";
+import { gameModeIconSrc } from "../game-mode-icon";
+import { buildSeriesHeaderMetadata, seriesHeaderBackgroundStyle } from "../stats-panel-header";
+import { useRotatingBackgroundTick } from "../use-rotating-background-tick";
+import type { MatchDetailsState, SeriesDetailsState, ViewerMatchTab, ViewerSeriesTab } from "../viewer/types";
 import { OverlayStatsHighlights } from "./overlay-stats-highlights";
 import { MATCHMAKING_SUMMARY_TAB_SERIES_ID, type IndividualTrackerOverlayViewModel } from "./types";
 import styles from "./individual-tracker-overlay.module.css";
@@ -18,6 +25,8 @@ interface IndividualTrackerOverlayProps {
   readonly matchesLength: number;
   readonly matchStatsPanelState: MatchDetailsState | null;
   readonly seriesStatsPanelState: SeriesDetailsState | null;
+  readonly selectedMatch: ViewerMatchTab | null;
+  readonly selectedSeries: ViewerSeriesTab | null;
   readonly selectedMatchId: string | null;
   readonly selectedSeriesId: string | null;
   readonly showPreview?: boolean;
@@ -33,6 +42,8 @@ export function IndividualTrackerOverlay({
   matchesLength,
   matchStatsPanelState,
   seriesStatsPanelState,
+  selectedMatch,
+  selectedSeries,
   selectedMatchId,
   selectedSeriesId,
   showPreview = false,
@@ -42,6 +53,11 @@ export function IndividualTrackerOverlay({
   onDeselect,
 }: IndividualTrackerOverlayProps): React.ReactElement {
   const StreamerOverlaySection = useMemo(() => createStreamerOverlaySection(), []);
+  const {
+    tick: seriesBackgroundTick,
+    isTransitioning: isSeriesBackgroundTransitioning,
+    isGlitching: isSeriesBackgroundGlitching,
+  } = useRotatingBackgroundTick();
 
   const topSection = useMemo(() => {
     if (viewModel.topSection != null) {
@@ -143,32 +159,87 @@ export function IndividualTrackerOverlay({
 
       if (selectedTab?.type === "series") {
         if (selectedTab.seriesId === MATCHMAKING_SUMMARY_TAB_SERIES_ID && seriesStatsPanelState == null) {
-          return <StatsPanel state={matchStatsPanelState} />;
+          return <StatsPanel match={selectedMatch} state={matchStatsPanelState} />;
         }
 
         if (seriesStatsPanelState == null) {
           return null;
         }
 
+        let seriesBody: React.ReactElement;
         switch (seriesStatsPanelState.status) {
           case "loading": {
-            return <LoadingState text="Loading series stats..." />;
+            seriesBody = <LoadingState text="Loading series stats..." />;
+            break;
           }
           case "error": {
-            return <Alert variant="error">{seriesStatsPanelState.message}</Alert>;
+            seriesBody = <Alert variant="error">{seriesStatsPanelState.message}</Alert>;
+            break;
           }
           case "loaded": {
-            return <SeriesStatsView {...seriesStatsPanelState.viewModel} noGutter={true} />;
+            seriesBody = <SeriesStatsView {...seriesStatsPanelState.viewModel} noGutter={true} />;
+            break;
           }
           default: {
             throw new UnreachableError(seriesStatsPanelState);
           }
         }
+
+        return (
+          <div className={styles.seriesPanel}>
+            {selectedSeries != null && (
+              <StatsHeader
+                title={selectedSeries.title}
+                subtitle={selectedSeries.subtitle}
+                metadata={buildSeriesHeaderMetadata(selectedSeries)}
+                backgroundStyle={seriesHeaderBackgroundStyle(
+                  selectedSeries.matchBackgroundUrls,
+                  seriesBackgroundTick,
+                  isSeriesBackgroundTransitioning,
+                  isSeriesBackgroundGlitching,
+                )}
+                rightContent={
+                  <div className={styles.headerVisuals}>
+                    <div className={styles.seriesModeIcons}>
+                      {selectedSeries.iconMatches.map((seriesMatch, iconIndex) => (
+                        <img
+                          key={`${seriesMatch.matchId}:${iconIndex.toString()}`}
+                          src={gameModeIconSrc(seriesMatch.gameVariantCategory)}
+                          alt={seriesMatch.gameModeName}
+                          className={classNames(styles.headerModeIcon, {
+                            [styles.seriesModeIconMuted]: seriesMatch.outcome === "Loss",
+                          })}
+                        />
+                      ))}
+                    </div>
+                    <OutcomeBadge
+                      outcome={
+                        selectedSeries.isActive
+                          ? "In progress"
+                          : summarizeSeriesOutcome(selectedSeries.matches.map((seriesMatch) => seriesMatch.outcome))
+                      }
+                    />
+                  </div>
+                }
+              />
+            )}
+            {seriesBody}
+          </div>
+        );
       }
 
-      return <StatsPanel state={matchStatsPanelState} />;
+      return <StatsPanel match={selectedMatch} state={matchStatsPanelState} />;
     },
-    [matchStatsPanelState, seriesStatsPanelState, viewModel.tabs],
+    [
+      matchStatsPanelState,
+      seriesStatsPanelState,
+      selectedMatch,
+      selectedSeries,
+      seriesBackgroundTick,
+      isSeriesBackgroundTransitioning,
+      isSeriesBackgroundGlitching,
+      viewModel.tabs,
+    ],
   );
 
   return (

--- a/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
+++ b/pages/src/components/individual-tracker/overlay/tests/individual-tracker-overlay.test.tsx
@@ -30,6 +30,47 @@ function aRenderModel(
   return buildViewerRenderModel({ view: aFakeTrackerViewStateWith(overrides) });
 }
 
+function findTimelineMatch(
+  timeline: ReturnType<typeof buildViewerRenderModel>["timeline"],
+  matchId: string | null,
+): React.ComponentProps<typeof IndividualTrackerOverlay>["selectedMatch"] {
+  if (matchId == null) {
+    return null;
+  }
+
+  for (const item of timeline) {
+    if (item.type === "match" && item.match.matchId === matchId) {
+      return item.match;
+    }
+
+    if (item.type === "series") {
+      const seriesMatch = item.series.matches.find((match) => match.matchId === matchId);
+      if (seriesMatch != null) {
+        return seriesMatch;
+      }
+    }
+  }
+
+  return null;
+}
+
+function findTimelineSeries(
+  timeline: ReturnType<typeof buildViewerRenderModel>["timeline"],
+  seriesId: string | null,
+): React.ComponentProps<typeof IndividualTrackerOverlay>["selectedSeries"] {
+  if (seriesId == null) {
+    return null;
+  }
+
+  for (const item of timeline) {
+    if (item.type === "series" && item.series.id === seriesId) {
+      return item.series;
+    }
+  }
+
+  return null;
+}
+
 function aPropsWith(options?: {
   renderModel?: ReturnType<typeof buildViewerRenderModel>;
   streamerSettings?: StreamerViewSettings;
@@ -47,8 +88,11 @@ function aPropsWith(options?: {
   const streamerSettings = options?.streamerSettings;
   const matchStatsState = options?.matchStatsState ?? null;
   const selectedMatchId = options?.selectedMatchId ?? null;
+  const selectedSeriesId = options?.selectedSeriesId ?? null;
   const matchStatsByMatchId =
     selectedMatchId != null && matchStatsState != null ? new Map([[selectedMatchId, matchStatsState]]) : new Map();
+  const selectedMatch = findTimelineMatch(renderModel.timeline, selectedMatchId);
+  const selectedSeries = findTimelineSeries(renderModel.timeline, selectedSeriesId);
 
   return {
     viewModel: presenter.present({
@@ -60,14 +104,16 @@ function aPropsWith(options?: {
     isPanelOpen: presenter.isPanelOpen(
       selectedMatchId,
       matchStatsState,
-      options?.selectedSeriesId ?? null,
+      selectedSeriesId,
       options?.seriesStatsPanelState ?? null,
     ),
     matchesLength: renderModel.accumulated.total,
     matchStatsPanelState: options?.matchStatsPanelState ?? null,
     seriesStatsPanelState: options?.seriesStatsPanelState ?? null,
+    selectedMatch,
+    selectedSeries,
     selectedMatchId,
-    selectedSeriesId: options?.selectedSeriesId ?? null,
+    selectedSeriesId,
     onSelectMatch: options?.onSelectMatch ?? ((): void => undefined),
     onSelectSeries: options?.onSelectSeries ?? ((): void => undefined),
     onDeselect: options?.onDeselect ?? ((): void => undefined),

--- a/pages/src/components/individual-tracker/stats-panel-header.ts
+++ b/pages/src/components/individual-tracker/stats-panel-header.ts
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "react";
+import { isValid, parseISO } from "date-fns";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import type { StatsHeaderItem } from "../stats/stats-header";
 import type { ViewerMatchTab, ViewerSeriesTab } from "./viewer/types";
@@ -8,8 +9,8 @@ function formatDate(value: string | null): string {
     return "unknown";
   }
 
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? "unknown" : date.toLocaleString();
+  const date = parseISO(value);
+  return isValid(date) ? date.toLocaleString() : "unknown";
 }
 
 export function buildMatchHeaderTitle(match: ViewerMatchTab): string {

--- a/pages/src/components/individual-tracker/stats-panel-header.ts
+++ b/pages/src/components/individual-tracker/stats-panel-header.ts
@@ -1,0 +1,91 @@
+import type { CSSProperties } from "react";
+import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import type { StatsHeaderItem } from "../stats/stats-header";
+import type { ViewerMatchTab, ViewerSeriesTab } from "./viewer/types";
+
+function formatDate(value: string | null): string {
+  if (value == null || value === "") {
+    return "unknown";
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "unknown" : date.toLocaleString();
+}
+
+export function buildMatchHeaderTitle(match: ViewerMatchTab): string {
+  return `${match.gameModeName}: ${match.mapName}`;
+}
+
+export function buildMatchHeaderMetadata(match: ViewerMatchTab): StatsHeaderItem[] {
+  return [
+    { label: "Score", value: match.score },
+    { label: "Duration", value: match.duration },
+    { label: "End time", value: formatDate(match.endTime) },
+    { label: "Kills:Deaths:Assists (KDA)", value: match.killsDeathsAssistsKda },
+    { label: "Damage D:T (D/T)", value: match.damageDealtTakenRatio },
+  ];
+}
+
+export function buildSeriesHeaderMetadata(series: ViewerSeriesTab): StatsHeaderItem[] {
+  return [
+    { label: "Score", value: series.score },
+    { label: "Duration", value: series.duration },
+    series.isActive
+      ? { label: "Start time", value: formatDate(series.startTime) }
+      : { label: "End time", value: formatDate(series.endTime) },
+    { label: "Kills:Deaths:Assists (KDA)", value: series.killsDeathsAssistsKda },
+    { label: "Damage D:T (D/T)", value: series.damageDealtTakenRatio },
+  ];
+}
+
+export function matchHeaderBackgroundStyle(mapBackgroundUrl: string, fallbackThumbnailUrl?: string): CSSProperties {
+  if (mapBackgroundUrl !== "" && mapBackgroundUrl !== "data:,") {
+    return {
+      "--match-bg": `url(${mapBackgroundUrl})`,
+    } as CSSProperties;
+  }
+
+  if (fallbackThumbnailUrl != null && fallbackThumbnailUrl !== "" && fallbackThumbnailUrl !== "data:,") {
+    return {
+      "--match-bg": `url(${fallbackThumbnailUrl})`,
+    } as CSSProperties;
+  }
+
+  return {
+    "--match-bg": "linear-gradient(135deg, #0a0e14 0%, #1a1e24 100%)",
+  } as CSSProperties;
+}
+
+function getBackgroundAt(backgrounds: readonly string[], index: number): string {
+  return Preconditions.checkExists(backgrounds[index], "Expected series background at index");
+}
+
+export function seriesHeaderBackgroundStyle(
+  matchBackgroundUrls: readonly string[],
+  rotationTick: number,
+  isTransitioning: boolean,
+  isGlitching: boolean,
+): CSSProperties {
+  const backgrounds = matchBackgroundUrls.filter((url) => url !== "" && url !== "data:,");
+
+  if (backgrounds.length > 0) {
+    const currentIndex = rotationTick % backgrounds.length;
+    const previousIndex = (currentIndex - 1 + backgrounds.length) % backgrounds.length;
+    const currentBackground = getBackgroundAt(backgrounds, currentIndex);
+    const previousBackground = getBackgroundAt(backgrounds, previousIndex);
+
+    const baseBackground = isTransitioning && backgrounds.length > 1 ? previousBackground : currentBackground;
+    const overlayBackground = currentBackground;
+
+    return {
+      "--match-bg": `url(${baseBackground})`,
+      "--match-bg-next": `url(${overlayBackground})`,
+      "--match-bg-next-opacity": isTransitioning ? 1 : 0,
+      "--match-glitch-opacity": isGlitching && backgrounds.length > 1 ? 0.28 : 0,
+    } as CSSProperties;
+  }
+
+  return {
+    "--match-bg": "linear-gradient(135deg, #0a0e14 0%, #1a1e24 100%)",
+  } as CSSProperties;
+}

--- a/pages/src/components/individual-tracker/tests/stats-panel-header.test.ts
+++ b/pages/src/components/individual-tracker/tests/stats-panel-header.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMatchHeaderMetadata,
+  buildMatchHeaderTitle,
+  buildSeriesHeaderMetadata,
+  matchHeaderBackgroundStyle,
+  seriesHeaderBackgroundStyle,
+} from "../stats-panel-header";
+import type { ViewerMatchTab, ViewerSeriesTab } from "../viewer/types";
+
+function aMatchWith(overrides: Partial<ViewerMatchTab> = {}): ViewerMatchTab {
+  return {
+    matchId: "match-1",
+    mapName: "Live Fire",
+    mapBackgroundUrl: "https://example.com/live-fire.jpg",
+    gameVariantCategory: 6,
+    isMatchmaking: false,
+    gameModeName: "Slayer",
+    duration: "10m",
+    outcome: "Win",
+    score: "50:42",
+    killsDeathsAssistsKda: "10:7:4 (1.62)",
+    damageDealtTakenRatio: "4,200:3,900 (1.08)",
+    colorHex: undefined,
+    startTime: "2026-01-01T00:00:00.000Z",
+    endTime: "2026-01-01T00:10:00.000Z",
+    ...overrides,
+  };
+}
+
+function aSeriesWith(overrides: Partial<ViewerSeriesTab> = {}): ViewerSeriesTab {
+  return {
+    id: "series-1",
+    title: "Eagle vs Cobra",
+    subtitle: "Best of 3",
+    isActive: false,
+    teams: [],
+    matchBackgroundUrls: [],
+    score: "2:1",
+    duration: "30m",
+    killsDeathsAssistsKda: "20:14:9 (1.88)",
+    damageDealtTakenRatio: "11,200:9,500 (1.18)",
+    startTime: "2026-01-01T00:00:00.000Z",
+    endTime: "2026-01-01T00:30:00.000Z",
+    matches: [],
+    iconMatches: [],
+    colorHex: undefined,
+    ...overrides,
+  };
+}
+
+describe("buildMatchHeaderTitle", () => {
+  it("combines the game mode name and map name", () => {
+    expect(buildMatchHeaderTitle(aMatchWith({ gameModeName: "Slayer", mapName: "Aquarius" }))).toBe(
+      "Slayer: Aquarius",
+    );
+  });
+});
+
+describe("buildMatchHeaderMetadata", () => {
+  it("returns score, duration, end time, KDA, and D/T in order", () => {
+    const metadata = buildMatchHeaderMetadata(
+      aMatchWith({
+        score: "50:42",
+        duration: "10m",
+        endTime: "2026-01-01T00:10:00.000Z",
+        killsDeathsAssistsKda: "10:7:4 (1.62)",
+        damageDealtTakenRatio: "4,200:3,900 (1.08)",
+      }),
+    );
+
+    expect(metadata.map((item) => item.label)).toEqual([
+      "Score",
+      "Duration",
+      "End time",
+      "Kills:Deaths:Assists (KDA)",
+      "Damage D:T (D/T)",
+    ]);
+    expect(metadata[0]?.value).toBe("50:42");
+    expect(metadata[1]?.value).toBe("10m");
+    expect(metadata[3]?.value).toBe("10:7:4 (1.62)");
+    expect(metadata[4]?.value).toBe("4,200:3,900 (1.08)");
+  });
+
+  it("formats a valid end time as a locale string rather than the raw ISO value", () => {
+    const metadata = buildMatchHeaderMetadata(aMatchWith({ endTime: "2026-01-01T00:10:00.000Z" }));
+    const endTimeItem = metadata.find((item) => item.label === "End time");
+
+    expect(endTimeItem?.value).toBe(new Date("2026-01-01T00:10:00.000Z").toLocaleString());
+  });
+
+  it("shows unknown for an unparseable end time", () => {
+    const metadata = buildMatchHeaderMetadata(aMatchWith({ endTime: "not-a-date" }));
+    const endTimeItem = metadata.find((item) => item.label === "End time");
+
+    expect(endTimeItem?.value).toBe("unknown");
+  });
+});
+
+describe("buildSeriesHeaderMetadata", () => {
+  it("shows end time for a completed series", () => {
+    const metadata = buildSeriesHeaderMetadata(aSeriesWith({ isActive: false, endTime: "2026-01-01T00:30:00.000Z" }));
+
+    expect(metadata.map((item) => item.label)).toEqual([
+      "Score",
+      "Duration",
+      "End time",
+      "Kills:Deaths:Assists (KDA)",
+      "Damage D:T (D/T)",
+    ]);
+  });
+
+  it("shows start time instead of end time for an active series", () => {
+    const metadata = buildSeriesHeaderMetadata(
+      aSeriesWith({ isActive: true, startTime: "2026-01-01T00:00:00.000Z" }),
+    );
+
+    expect(metadata.map((item) => item.label)).toEqual([
+      "Score",
+      "Duration",
+      "Start time",
+      "Kills:Deaths:Assists (KDA)",
+      "Damage D:T (D/T)",
+    ]);
+    const startTimeItem = metadata.find((item) => item.label === "Start time");
+    expect(startTimeItem?.value).toBe(new Date("2026-01-01T00:00:00.000Z").toLocaleString());
+  });
+});
+
+describe("matchHeaderBackgroundStyle", () => {
+  it("uses the match background url when present", () => {
+    const style = matchHeaderBackgroundStyle("https://example.com/aquarius.jpg", undefined);
+    expect(style).toEqual({ "--match-bg": "url(https://example.com/aquarius.jpg)" });
+  });
+
+  it("falls back to the provided thumbnail url when the background is a blank placeholder", () => {
+    const style = matchHeaderBackgroundStyle("data:,", "https://example.com/fallback.jpg");
+    expect(style).toEqual({ "--match-bg": "url(https://example.com/fallback.jpg)" });
+  });
+
+  it("falls back to a gradient when neither background nor fallback is usable", () => {
+    const style = matchHeaderBackgroundStyle("", undefined);
+    expect(style).toEqual({ "--match-bg": "linear-gradient(135deg, #0a0e14 0%, #1a1e24 100%)" });
+  });
+});
+
+describe("seriesHeaderBackgroundStyle", () => {
+  it("returns a gradient when there are no usable backgrounds", () => {
+    const style = seriesHeaderBackgroundStyle([], 0, false, false);
+    expect(style).toEqual({ "--match-bg": "linear-gradient(135deg, #0a0e14 0%, #1a1e24 100%)" });
+  });
+
+  it("cycles through backgrounds based on the rotation tick, filtering blank placeholders", () => {
+    const backgrounds = ["data:,", "https://example.com/a.jpg", "https://example.com/b.jpg"];
+
+    const first = seriesHeaderBackgroundStyle(backgrounds, 0, false, false);
+    expect(first).toEqual({
+      "--match-bg": "url(https://example.com/a.jpg)",
+      "--match-bg-next": "url(https://example.com/a.jpg)",
+      "--match-bg-next-opacity": 0,
+      "--match-glitch-opacity": 0,
+    });
+
+    const second = seriesHeaderBackgroundStyle(backgrounds, 1, false, false);
+    expect(second).toEqual({
+      "--match-bg": "url(https://example.com/b.jpg)",
+      "--match-bg-next": "url(https://example.com/b.jpg)",
+      "--match-bg-next-opacity": 0,
+      "--match-glitch-opacity": 0,
+    });
+  });
+
+  it("shows the previous background as the base while transitioning, with the next fading in", () => {
+    const backgrounds = ["https://example.com/a.jpg", "https://example.com/b.jpg"];
+
+    const style = seriesHeaderBackgroundStyle(backgrounds, 1, true, false);
+
+    expect(style).toEqual({
+      "--match-bg": "url(https://example.com/a.jpg)",
+      "--match-bg-next": "url(https://example.com/b.jpg)",
+      "--match-bg-next-opacity": 1,
+      "--match-glitch-opacity": 0,
+    });
+  });
+
+  it("applies the glitch opacity only when glitching with more than one background", () => {
+    const backgrounds = ["https://example.com/a.jpg", "https://example.com/b.jpg"];
+
+    const glitching = seriesHeaderBackgroundStyle(backgrounds, 0, false, true);
+    expect(glitching).toMatchObject({ "--match-glitch-opacity": 0.28 });
+
+    const notGlitching = seriesHeaderBackgroundStyle(backgrounds, 0, false, false);
+    expect(notGlitching).toMatchObject({ "--match-glitch-opacity": 0 });
+
+    const singleBackgroundGlitching = seriesHeaderBackgroundStyle(["https://example.com/a.jpg"], 0, false, true);
+    expect(singleBackgroundGlitching).toMatchObject({ "--match-glitch-opacity": 0 });
+  });
+});

--- a/pages/src/components/individual-tracker/tests/stats-panel-header.test.ts
+++ b/pages/src/components/individual-tracker/tests/stats-panel-header.test.ts
@@ -51,9 +51,7 @@ function aSeriesWith(overrides: Partial<ViewerSeriesTab> = {}): ViewerSeriesTab 
 
 describe("buildMatchHeaderTitle", () => {
   it("combines the game mode name and map name", () => {
-    expect(buildMatchHeaderTitle(aMatchWith({ gameModeName: "Slayer", mapName: "Aquarius" }))).toBe(
-      "Slayer: Aquarius",
-    );
+    expect(buildMatchHeaderTitle(aMatchWith({ gameModeName: "Slayer", mapName: "Aquarius" }))).toBe("Slayer: Aquarius");
   });
 });
 
@@ -111,9 +109,7 @@ describe("buildSeriesHeaderMetadata", () => {
   });
 
   it("shows start time instead of end time for an active series", () => {
-    const metadata = buildSeriesHeaderMetadata(
-      aSeriesWith({ isActive: true, startTime: "2026-01-01T00:00:00.000Z" }),
-    );
+    const metadata = buildSeriesHeaderMetadata(aSeriesWith({ isActive: true, startTime: "2026-01-01T00:00:00.000Z" }));
 
     expect(metadata.map((item) => item.label)).toEqual([
       "Score",

--- a/pages/src/components/individual-tracker/tests/use-rotating-background-tick.test.ts
+++ b/pages/src/components/individual-tracker/tests/use-rotating-background-tick.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useRotatingBackgroundTick } from "../use-rotating-background-tick";
+
+describe("useRotatingBackgroundTick", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts at tick 0 with no transition or glitch in progress", () => {
+    const { result } = renderHook(() => useRotatingBackgroundTick());
+
+    expect(result.current).toEqual({ tick: 0, isTransitioning: false, isGlitching: false });
+  });
+
+  it("advances the tick and enters transition/glitch state once the rotation interval elapses", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useRotatingBackgroundTick());
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(result.current.tick).toBe(1);
+    expect(result.current.isTransitioning).toBe(true);
+    expect(result.current.isGlitching).toBe(true);
+  });
+
+  it("clears the glitch state before the transition state, matching their independent durations", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useRotatingBackgroundTick());
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(result.current.isGlitching).toBe(true);
+    expect(result.current.isTransitioning).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(260);
+    });
+    expect(result.current.isGlitching).toBe(false);
+    expect(result.current.isTransitioning).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(900 - 260);
+    });
+    expect(result.current.isTransitioning).toBe(false);
+  });
+
+  it("advances the tick again on each subsequent rotation interval", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useRotatingBackgroundTick());
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(result.current.tick).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(result.current.tick).toBe(2);
+  });
+
+  it("clears timers on unmount without throwing", () => {
+    vi.useFakeTimers();
+    const { unmount } = renderHook(() => useRotatingBackgroundTick());
+
+    expect(() => {
+      unmount();
+      vi.advanceTimersByTime(20_000);
+    }).not.toThrow();
+  });
+});

--- a/pages/src/components/individual-tracker/tests/use-rotating-background-tick.test.ts
+++ b/pages/src/components/individual-tracker/tests/use-rotating-background-tick.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
-import { act, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import { useRotatingBackgroundTick } from "../use-rotating-background-tick";
 
 describe("useRotatingBackgroundTick", () => {
   afterEach(() => {
+    cleanup();
     vi.useRealTimers();
   });
 

--- a/pages/src/components/individual-tracker/use-rotating-background-tick.ts
+++ b/pages/src/components/individual-tracker/use-rotating-background-tick.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from "react";
+
+const ROTATION_INTERVAL_MS = 10_000;
+const FADE_DURATION_MS = 900;
+const GLITCH_DURATION_MS = 260;
+
+export interface RotatingBackgroundTick {
+  readonly tick: number;
+  readonly isTransitioning: boolean;
+  readonly isGlitching: boolean;
+}
+
+// Drives the periodic crossfade/glitch used to cycle through a series' match backgrounds.
+// Runs unconditionally on an interval; callers with zero or one background simply see no
+// visible effect since seriesHeaderBackgroundStyle only animates when there's more than one.
+export function useRotatingBackgroundTick(): RotatingBackgroundTick {
+  const [tick, setTick] = useState(0);
+  const [isTransitioning, setIsTransitioning] = useState(false);
+  const [isGlitching, setIsGlitching] = useState(false);
+  const fadeTimeoutRef = useRef<number | null>(null);
+  const glitchTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    let rotationTimeoutId: number | null = null;
+
+    function rotate(): void {
+      setTick((current) => current + 1);
+      setIsTransitioning(true);
+      setIsGlitching(true);
+
+      if (fadeTimeoutRef.current != null) {
+        window.clearTimeout(fadeTimeoutRef.current);
+      }
+      if (glitchTimeoutRef.current != null) {
+        window.clearTimeout(glitchTimeoutRef.current);
+      }
+
+      fadeTimeoutRef.current = window.setTimeout(() => {
+        setIsTransitioning(false);
+      }, FADE_DURATION_MS);
+
+      glitchTimeoutRef.current = window.setTimeout(() => {
+        setIsGlitching(false);
+      }, GLITCH_DURATION_MS);
+
+      rotationTimeoutId = window.setTimeout(rotate, ROTATION_INTERVAL_MS);
+    }
+
+    rotationTimeoutId = window.setTimeout(rotate, ROTATION_INTERVAL_MS);
+
+    return (): void => {
+      if (rotationTimeoutId != null) {
+        window.clearTimeout(rotationTimeoutId);
+      }
+      if (fadeTimeoutRef.current != null) {
+        window.clearTimeout(fadeTimeoutRef.current);
+      }
+      if (glitchTimeoutRef.current != null) {
+        window.clearTimeout(glitchTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  return { tick, isTransitioning, isGlitching };
+}

--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
@@ -1,8 +1,8 @@
 import React from "react";
+import type { CSSProperties } from "react";
 import classNames from "classnames";
 import ReactTimeAgo from "react-time-ago";
 import { addMinutes, isValid, parseISO } from "date-fns";
-import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import type { TrackerStatus } from "@guilty-spark/shared/contracts/individual-tracker/tracker";
 import { summarizeSeriesOutcome } from "@guilty-spark/shared/halo/match-enrichment";
@@ -18,13 +18,17 @@ import { SeriesStatsView } from "../../series-stats/series-stats";
 import { PlayerPreSeriesInfo } from "../../player-pre-series-info/player-pre-series-info";
 import type { TrackerViewConnectionStatus } from "../../../services/individual-tracker/view-types";
 import { gameModeIconSrc } from "../game-mode-icon";
+import {
+  buildMatchHeaderMetadata,
+  buildMatchHeaderTitle,
+  buildSeriesHeaderMetadata,
+  matchHeaderBackgroundStyle,
+  seriesHeaderBackgroundStyle,
+} from "../stats-panel-header";
+import { useRotatingBackgroundTick } from "../use-rotating-background-tick";
 import { StatsHighlights } from "./stats-highlights";
 import type { IndividualTrackerViewerRenderModel, ViewerEntryState, ViewerTimelineItem } from "./types";
 import styles from "./individual-tracker-viewer.module.css";
-
-const SERIES_BACKGROUND_ROTATION_MS = 10_000;
-const SERIES_BACKGROUND_FADE_MS = 900;
-const SERIES_BACKGROUND_GLITCH_MS = 260;
 
 interface IndividualTrackerViewerProps {
   readonly renderModel: IndividualTrackerViewerRenderModel;
@@ -121,11 +125,6 @@ function parseDate(value: string | null): Date | null {
   return isValid(date) ? date : null;
 }
 
-function formatDate(value: string | null): string {
-  const date = parseDate(value);
-  return date == null ? "unknown" : date.toLocaleString();
-}
-
 function preSeriesStatusMessage(totalTrackedMatches: number): string {
   if (totalTrackedMatches === 0) {
     return "Series is active and waiting for the first tracked match.";
@@ -188,59 +187,13 @@ function connectionAwareNextUpdate(
   return nextUpdateContent(renderModel);
 }
 
-function getBackgroundAt(backgrounds: readonly string[], index: number): string {
-  return Preconditions.checkExists(backgrounds[index], "Expected series background at index");
-}
-
-function matchHeaderBackgroundStyle(
+function matchHeaderBackgroundStyleForEntry(
   mapBackgroundUrl: string,
   state: ViewerEntryState | undefined,
-): React.CSSProperties {
-  if (mapBackgroundUrl !== "" && mapBackgroundUrl !== "data:,") {
-    return {
-      "--match-bg": `url(${mapBackgroundUrl})`,
-    } as React.CSSProperties;
-  }
-
-  if (state?.kind === "match" && state.state.status === "loaded") {
-    return {
-      "--match-bg": `url(${state.state.gameMapThumbnailUrl})`,
-    } as React.CSSProperties;
-  }
-
-  return {
-    "--match-bg": "linear-gradient(135deg, #0a0e14 0%, #1a1e24 100%)",
-  } as React.CSSProperties;
-}
-
-function seriesHeaderBackgroundStyle(
-  matchBackgroundUrls: readonly string[],
-  rotationTick: number,
-  isTransitioning: boolean,
-  isGlitching: boolean,
-): React.CSSProperties {
-  const backgrounds = matchBackgroundUrls.filter((url) => url !== "" && url !== "data:,");
-
-  if (backgrounds.length > 0) {
-    const currentIndex = rotationTick % backgrounds.length;
-    const previousIndex = (currentIndex - 1 + backgrounds.length) % backgrounds.length;
-    const currentBackground = getBackgroundAt(backgrounds, currentIndex);
-    const previousBackground = getBackgroundAt(backgrounds, previousIndex);
-
-    const baseBackground = isTransitioning && backgrounds.length > 1 ? previousBackground : currentBackground;
-    const overlayBackground = currentBackground;
-
-    return {
-      "--match-bg": `url(${baseBackground})`,
-      "--match-bg-next": `url(${overlayBackground})`,
-      "--match-bg-next-opacity": isTransitioning ? 1 : 0,
-      "--match-glitch-opacity": isGlitching && backgrounds.length > 1 ? 0.28 : 0,
-    } as React.CSSProperties;
-  }
-
-  return {
-    "--match-bg": "linear-gradient(135deg, #0a0e14 0%, #1a1e24 100%)",
-  } as React.CSSProperties;
+): CSSProperties {
+  const fallback =
+    state?.kind === "match" && state.state.status === "loaded" ? state.state.gameMapThumbnailUrl : undefined;
+  return matchHeaderBackgroundStyle(mapBackgroundUrl, fallback);
 }
 
 export function IndividualTrackerViewer({
@@ -259,11 +212,11 @@ export function IndividualTrackerViewer({
   const nearLatestRef = React.useRef<boolean>(true);
   const [isNearLatestNow, setIsNearLatestNow] = React.useState(true);
   const [unseenEntries, setUnseenEntries] = React.useState(0);
-  const [seriesBackgroundTick, setSeriesBackgroundTick] = React.useState(0);
-  const [isSeriesBackgroundTransitioning, setIsSeriesBackgroundTransitioning] = React.useState(false);
-  const [isSeriesBackgroundGlitching, setIsSeriesBackgroundGlitching] = React.useState(false);
-  const seriesFadeTimeoutRef = React.useRef<number | null>(null);
-  const seriesGlitchTimeoutRef = React.useRef<number | null>(null);
+  const {
+    tick: seriesBackgroundTick,
+    isTransitioning: isSeriesBackgroundTransitioning,
+    isGlitching: isSeriesBackgroundGlitching,
+  } = useRotatingBackgroundTick();
 
   const { timeline } = renderModel;
 
@@ -303,44 +256,6 @@ export function IndividualTrackerViewer({
     }
     lastTimelineLengthRef.current = nextLength;
   }, [timeline.length, scrollToLatest]);
-
-  React.useEffect(() => {
-    const beginTransition = (): void => {
-      setSeriesBackgroundTick((current) => current + 1);
-      setIsSeriesBackgroundTransitioning(true);
-      setIsSeriesBackgroundGlitching(true);
-
-      if (seriesFadeTimeoutRef.current != null) {
-        window.clearTimeout(seriesFadeTimeoutRef.current);
-      }
-
-      if (seriesGlitchTimeoutRef.current != null) {
-        window.clearTimeout(seriesGlitchTimeoutRef.current);
-      }
-
-      seriesFadeTimeoutRef.current = window.setTimeout(() => {
-        setIsSeriesBackgroundTransitioning(false);
-      }, SERIES_BACKGROUND_FADE_MS);
-
-      seriesGlitchTimeoutRef.current = window.setTimeout(() => {
-        setIsSeriesBackgroundGlitching(false);
-      }, SERIES_BACKGROUND_GLITCH_MS);
-    };
-
-    const intervalId = window.setInterval(beginTransition, SERIES_BACKGROUND_ROTATION_MS);
-
-    return (): void => {
-      window.clearInterval(intervalId);
-
-      if (seriesFadeTimeoutRef.current != null) {
-        window.clearTimeout(seriesFadeTimeoutRef.current);
-      }
-
-      if (seriesGlitchTimeoutRef.current != null) {
-        window.clearTimeout(seriesGlitchTimeoutRef.current);
-      }
-    };
-  }, []);
 
   const statusBadge = getViewerStatusBadge(renderModel.status, connectionStatus);
   const canRefresh = statusBadge.tone === "active";
@@ -440,16 +355,10 @@ export function IndividualTrackerViewer({
                       aria-label={`Match ${match.gameModeName} on ${match.mapName}`}
                     >
                       <StatsHeader
-                        title={`${match.gameModeName}: ${match.mapName}`}
+                        title={buildMatchHeaderTitle(match)}
                         subtitle={match.subtitle}
-                        metadata={[
-                          { label: "Score", value: match.score },
-                          { label: "Duration", value: match.duration },
-                          { label: "End time", value: formatDate(match.endTime) },
-                          { label: "Kills:Deaths:Assists (KDA)", value: match.killsDeathsAssistsKda },
-                          { label: "Damage D:T (D/T)", value: match.damageDealtTakenRatio },
-                        ]}
-                        backgroundStyle={matchHeaderBackgroundStyle(match.mapBackgroundUrl, state)}
+                        metadata={buildMatchHeaderMetadata(match)}
+                        backgroundStyle={matchHeaderBackgroundStyleForEntry(match.mapBackgroundUrl, state)}
                         rightContent={
                           <div className={styles.entryHeaderRight}>
                             <div className={styles.entryHeaderVisuals}>
@@ -537,15 +446,7 @@ export function IndividualTrackerViewer({
                     <StatsHeader
                       title={series.title}
                       subtitle={series.subtitle}
-                      metadata={[
-                        { label: "Score", value: series.score },
-                        { label: "Duration", value: series.duration },
-                        series.isActive
-                          ? { label: "Start time", value: formatDate(series.startTime) }
-                          : { label: "End time", value: formatDate(series.endTime) },
-                        { label: "Kills:Deaths:Assists (KDA)", value: series.killsDeathsAssistsKda },
-                        { label: "Damage D:T (D/T)", value: series.damageDealtTakenRatio },
-                      ]}
+                      metadata={buildSeriesHeaderMetadata(series)}
                       backgroundStyle={seriesHeaderBackgroundStyle(
                         series.matchBackgroundUrls,
                         seriesBackgroundTick,

--- a/pages/src/components/individual-tracker/viewer/stats-panel.module.css
+++ b/pages/src/components/individual-tracker/viewer/stats-panel.module.css
@@ -1,3 +1,15 @@
 .wrapper {
   margin-bottom: var(--space-6);
 }
+
+.headerVisuals {
+  align-items: center;
+  display: flex;
+  gap: var(--space-2);
+}
+
+.headerModeIcon {
+  filter: drop-shadow(0 2px 4px rgb(0 0 0 / 50%));
+  height: 1.75rem;
+  width: 1.75rem;
+}

--- a/pages/src/components/individual-tracker/viewer/stats-panel.tsx
+++ b/pages/src/components/individual-tracker/viewer/stats-panel.tsx
@@ -3,15 +3,19 @@ import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { Alert } from "../../alert/alert";
 import { LoadingState } from "../../loading-state/loading-state";
 import { MatchStats } from "../../stats/match-stats";
+import { StatsHeader } from "../../stats/stats-header";
+import { OutcomeBadge } from "../../outcome-badge/outcome-badge";
 import { gameModeIconSrc } from "../game-mode-icon";
-import type { MatchDetailsState } from "./types";
+import { buildMatchHeaderMetadata, buildMatchHeaderTitle, matchHeaderBackgroundStyle } from "../stats-panel-header";
+import type { MatchDetailsState, ViewerMatchTab } from "./types";
 import styles from "./stats-panel.module.css";
 
 interface StatsPanelProps {
+  readonly match: ViewerMatchTab | null;
   readonly state: MatchDetailsState | null;
 }
 
-export function StatsPanel({ state }: StatsPanelProps): React.ReactElement | null {
+export function StatsPanel({ match, state }: StatsPanelProps): React.ReactElement | null {
   if (state == null) {
     return null;
   }
@@ -34,6 +38,24 @@ export function StatsPanel({ state }: StatsPanelProps): React.ReactElement | nul
     case "loaded": {
       return (
         <div className={styles.wrapper}>
+          {match != null && (
+            <StatsHeader
+              title={buildMatchHeaderTitle(match)}
+              subtitle={match.subtitle}
+              metadata={buildMatchHeaderMetadata(match)}
+              backgroundStyle={matchHeaderBackgroundStyle(match.mapBackgroundUrl, state.gameMapThumbnailUrl)}
+              rightContent={
+                <div className={styles.headerVisuals}>
+                  <img
+                    src={gameModeIconSrc(match.gameVariantCategory)}
+                    alt={match.gameModeName}
+                    className={styles.headerModeIcon}
+                  />
+                  <OutcomeBadge outcome={match.outcome} />
+                </div>
+              }
+            />
+          )}
           <MatchStats
             data={state.data}
             id={state.matchId}
@@ -52,6 +74,7 @@ export function StatsPanel({ state }: StatsPanelProps): React.ReactElement | nul
             swappedCrossTeamData={state.swappedCrossTeamKillMatrixData}
             killMatrixStatus={state.killMatrixStatus}
             scoreProgressionViewData={state.scoreProgressionViewData}
+            showHeader={false}
           />
         </div>
       );

--- a/pages/src/components/streamer-overlay/stats-panel/stats-panel.module.css
+++ b/pages/src/components/streamer-overlay/stats-panel/stats-panel.module.css
@@ -72,6 +72,7 @@
   right: var(--space-4);
   top: var(--space-4);
   transition: all var(--transition-fast);
+  z-index: 10;
 }
 
 .closeButton:hover {


### PR DESCRIPTION
## Context
The overlay's clickable match/series stats panel (opened by clicking the bottom tabs) had drifted out of sync with the individual tracker viewer's own header rendering — different content, layout, and background image — and its close button rendered behind the header instead of on top of it.

## This change
- Extracts the header title/metadata/background-style builders (`buildMatchHeaderTitle`, `buildMatchHeaderMetadata`, `buildSeriesHeaderMetadata`, `matchHeaderBackgroundStyle`, `seriesHeaderBackgroundStyle`) out of the viewer into a shared `stats-panel-header.ts` module, and refactors the viewer to use it (behavior-preserving, covered by its existing test suite).
- Extracts the rotating multi-background crossfade/glitch timer into a `useRotatingBackgroundTick` hook, reused by both the viewer and the overlay.
- Wires the overlay's match panel (`viewer/stats-panel.tsx`) and series panel (`individual-tracker-overlay.tsx`) to render a `StatsHeader` using the same builders, so header content/layout/background now match the viewer.
- Fixes the panel close button's z-index so it renders above the header's stacking context instead of behind it.

## Subsequent work
- A follow-up PR (`feat/overlay-stats-panel-header-alignment`, stacked on this branch) changes the series stats panel to reuse already-cached match stats instead of re-fetching them over the network.