### PR TITLE
fix(overlay): reuse cached match stats for the series stats panel instead of refetching

### DIFF
--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -83,19 +83,7 @@ function IndividualTrackerOverlayPageInternal({
       return;
     }
 
-    const matchIds = new Set<string>();
-    for (const item of model.renderModel.timeline) {
-      if (item.type === "match") {
-        matchIds.add(item.match.matchId);
-        continue;
-      }
-
-      for (const match of item.series.matches) {
-        matchIds.add(match.matchId);
-      }
-    }
-
-    presenter.preloadMatchStats([...matchIds]);
+    presenter.preloadTimelineMatchStats(model.renderModel.timeline);
   }, [model.renderModel, presenter]);
 
   const overlaySnapshot = useSyncExternalStore(
@@ -106,39 +94,20 @@ function IndividualTrackerOverlayPageInternal({
 
   const overlayModel = useMemo(() => presenter.present(overlaySnapshot), [overlaySnapshot, presenter]);
   const overlayPresenter = useMemo(() => new IndividualTrackerOverlayPresenter(), []);
-  const selectedMatch = useMemo(() => {
-    if (model.renderModel == null || overlayModel.selectedMatchId == null) {
-      return null;
-    }
-
-    for (const item of model.renderModel.timeline) {
-      if (item.type === "match" && item.match.matchId === overlayModel.selectedMatchId) {
-        return item.match;
-      }
-
-      if (item.type === "series") {
-        const seriesMatch = item.series.matches.find((match) => match.matchId === overlayModel.selectedMatchId);
-        if (seriesMatch != null) {
-          return seriesMatch;
-        }
-      }
-    }
-
-    return null;
-  }, [model.renderModel, overlayModel.selectedMatchId]);
-  const selectedSeries = useMemo(() => {
-    if (model.renderModel == null || overlayModel.selectedSeriesId == null) {
-      return null;
-    }
-
-    for (const item of model.renderModel.timeline) {
-      if (item.type === "series" && item.series.id === overlayModel.selectedSeriesId) {
-        return item.series;
-      }
-    }
-
-    return null;
-  }, [model.renderModel, overlayModel.selectedSeriesId]);
+  const selectedMatch = useMemo(
+    () =>
+      model.renderModel == null
+        ? null
+        : presenter.findSelectedMatch(model.renderModel.timeline, overlayModel.selectedMatchId),
+    [model.renderModel, overlayModel.selectedMatchId, presenter],
+  );
+  const selectedSeries = useMemo(
+    () =>
+      model.renderModel == null
+        ? null
+        : presenter.findSelectedSeries(model.renderModel.timeline, overlayModel.selectedSeriesId),
+    [model.renderModel, overlayModel.selectedSeriesId, presenter],
+  );
   const selectedSeriesPanelState = useMemo(
     () => presenter.buildSeriesStatsPanelState(selectedSeries, overlaySnapshot.matchStatsByMatchId),
     [presenter, selectedSeries, overlaySnapshot.matchStatsByMatchId],

--- a/pages/src/components/individual-tracker/overlay/create.tsx
+++ b/pages/src/components/individual-tracker/overlay/create.tsx
@@ -59,7 +59,7 @@ function IndividualTrackerOverlayPageInternal({
     [haloClient, medalMetadataResolver, matchAnalyticsService, store],
   );
 
-  const { snapshot, model, onRetry, onToggleEntry } = useIndividualTrackerViewer({
+  const { snapshot, model, onRetry } = useIndividualTrackerViewer({
     individualTrackerViewService,
     matchAnalyticsService,
     seriesMatchesService,
@@ -139,16 +139,9 @@ function IndividualTrackerOverlayPageInternal({
 
     return null;
   }, [model.renderModel, overlayModel.selectedSeriesId]);
-  const selectedSeriesEntryState = useMemo(() => {
-    if (overlayModel.selectedSeriesId == null) {
-      return null;
-    }
-
-    return model.entryStates.get(`series:${overlayModel.selectedSeriesId}`) ?? null;
-  }, [model.entryStates, overlayModel.selectedSeriesId]);
   const selectedSeriesPanelState = useMemo(
-    () => (selectedSeriesEntryState?.kind === "series" ? selectedSeriesEntryState.state : null),
-    [selectedSeriesEntryState],
+    () => presenter.buildSeriesStatsPanelState(selectedSeries, overlaySnapshot.matchStatsByMatchId),
+    [presenter, selectedSeries, overlaySnapshot.matchStatsByMatchId],
   );
   const overlayViewModel = useMemo(
     () =>
@@ -210,7 +203,7 @@ function IndividualTrackerOverlayPageInternal({
               presenter.selectMatch(matchId);
             }}
             onSelectSeries={(seriesId): void => {
-              presenter.selectSeriesAndToggleIfAvailable(model.renderModel?.timeline ?? null, seriesId, onToggleEntry);
+              presenter.selectSeries(seriesId);
             }}
             onDeselect={(): void => {
               presenter.deselect();

--- a/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
@@ -1,6 +1,7 @@
 import type { HaloInfiniteClient } from "halo-infinite-api";
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
 import { StatsController } from "../../../controllers/stats/stats-controller";
 import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPlayer } from "../../../controllers/stats/kill-matrix/types";
@@ -8,10 +9,18 @@ import { ComponentLoaderStatus } from "../../component-loader/component-loader";
 import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
-import type { MatchDetailsState, ViewerTimelineItem } from "../viewer/types";
+import type { MatchDetailsState, SeriesDetailsState, ViewerMatchTab, ViewerSeriesTab } from "../viewer/types";
 import { formatScoreProgression } from "../../stats/score-progression/score-progression-formatter";
+import { buildSeriesViewModel, type ResolvedSeriesMatch } from "../../series-stats/build-series-view-model";
+import type { SeriesStatsViewModel } from "../../series-stats/types";
+import { buildMatchHeaderTitle } from "../stats-panel-header";
 import type { MatchStatsState } from "./individual-tracker-overlay-presenter";
 import type { OverlayPageSnapshot, OverlayPageStore } from "./overlay-page-store";
+
+interface LoadedSeriesMatch {
+  readonly match: ViewerMatchTab;
+  readonly state: Extract<MatchStatsState, { status: "loaded" }>;
+}
 
 interface OverlayPagePresenterConfig {
   readonly store: OverlayPageStore;
@@ -74,24 +83,109 @@ export class OverlayPagePresenter {
     void this.loadMatchStatsAsync(matchId);
   }
 
-  public selectSeriesAndToggleIfAvailable(
-    timeline: readonly ViewerTimelineItem[] | null,
-    seriesId: string,
-    onToggleEntry: (item: ViewerTimelineItem) => void,
-  ): void {
+  public selectSeries(seriesId: string): void {
     this.config.store.setSelectedSeriesId(seriesId);
-    if (timeline == null) {
-      return;
-    }
-
-    const timelineItem = this.findSeriesInTimeline(timeline, seriesId);
-    if (timelineItem != null) {
-      onToggleEntry(timelineItem);
-    }
   }
 
   public deselect(): void {
     this.config.store.setSelectedMatchId(null);
+  }
+
+  public buildSeriesStatsPanelState(
+    series: ViewerSeriesTab | null,
+    matchStatsByMatchId: ReadonlyMap<string, MatchStatsState>,
+  ): SeriesDetailsState | null {
+    if (series == null || series.matches.length === 0) {
+      return null;
+    }
+
+    for (const match of series.matches) {
+      const state = matchStatsByMatchId.get(match.matchId);
+      if (state?.status === "error") {
+        return { status: "error", message: state.message };
+      }
+    }
+
+    const loadedMatches = this.toLoadedSeriesMatches(series, matchStatsByMatchId);
+    if (loadedMatches == null) {
+      return { status: "loading" };
+    }
+
+    return {
+      status: "loaded",
+      seriesId: series.id,
+      viewModel: this.buildSeriesViewModelFromCache(series, loadedMatches),
+    };
+  }
+
+  private toLoadedSeriesMatches(
+    series: ViewerSeriesTab,
+    matchStatsByMatchId: ReadonlyMap<string, MatchStatsState>,
+  ): readonly LoadedSeriesMatch[] | null {
+    const loaded: LoadedSeriesMatch[] = [];
+    for (const match of series.matches) {
+      const state = matchStatsByMatchId.get(match.matchId);
+      if (state?.status !== "loaded") {
+        return null;
+      }
+      loaded.push({ match, state });
+    }
+
+    return loaded;
+  }
+
+  private buildSeriesViewModelFromCache(
+    series: ViewerSeriesTab,
+    loadedMatches: readonly LoadedSeriesMatch[],
+  ): SeriesStatsViewModel {
+    const playerMap = new Map<string, string>();
+    const medalMetadata: MedalMetadata = {};
+    const analyticsByMatchId = new Map<string, MatchAnalytics>();
+    let analyticsStatus = ComponentLoaderStatus.LOADED;
+
+    for (const { match, state } of loadedMatches) {
+      for (const [xuid, gamertag] of state.playerMap) {
+        playerMap.set(xuid, gamertag);
+      }
+      Object.assign(medalMetadata, state.medalMetadata);
+      if (state.analytics != null) {
+        analyticsByMatchId.set(match.matchId, state.analytics);
+      }
+      if (state.analyticsStatus === ComponentLoaderStatus.LOADING) {
+        analyticsStatus = ComponentLoaderStatus.LOADING;
+      } else if (
+        state.analyticsStatus === ComponentLoaderStatus.ERROR &&
+        analyticsStatus === ComponentLoaderStatus.LOADED
+      ) {
+        analyticsStatus = ComponentLoaderStatus.ERROR;
+      }
+    }
+
+    const matches: ResolvedSeriesMatch[] = loadedMatches.map(({ match, state }) => ({
+      matchId: match.matchId,
+      gameTypeAndMap: buildMatchHeaderTitle(match),
+      gameVariantCategory: match.gameVariantCategory,
+      gameType: match.gameModeName,
+      gameMap: match.mapName,
+      gameMapThumbnailUrl: match.mapBackgroundUrl,
+      duration: match.duration,
+      gameScore: match.score,
+      gameSubScore: null,
+      startTime: match.startTime,
+      endTime: match.endTime,
+      rawMatch: state.stats,
+    }));
+
+    return buildSeriesViewModel({
+      series,
+      matches,
+      rawMatches: loadedMatches.map(({ state }) => state.stats),
+      medalMetadata,
+      playerMap,
+      teamColors: [getTeamColorOrDefault(undefined, 0), getTeamColorOrDefault(undefined, 1)],
+      analyticsByMatchId,
+      analyticsStatus,
+    });
   }
 
   public present(snapshot: OverlayPageSnapshot): OverlayPageViewModel {
@@ -248,15 +342,5 @@ export class OverlayPagePresenter {
         data[0]?.players.length ?? null,
       ),
     };
-  }
-
-  private findSeriesInTimeline(timeline: readonly ViewerTimelineItem[], seriesId: string): ViewerTimelineItem | null {
-    for (const item of timeline) {
-      if (item.type === "series" && item.series.id === seriesId) {
-        return item;
-      }
-    }
-
-    return null;
   }
 }

--- a/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/overlay-page-presenter.ts
@@ -9,7 +9,13 @@ import { ComponentLoaderStatus } from "../../component-loader/component-loader";
 import { getTeamColorOrDefault } from "../../team-colors/team-colors";
 import type { HaloMedalMetadataResolver } from "../../../services/halo/medal-metadata-resolver";
 import type { MatchAnalyticsService } from "../../../services/stats/match-analytics-types";
-import type { MatchDetailsState, SeriesDetailsState, ViewerMatchTab, ViewerSeriesTab } from "../viewer/types";
+import type {
+  MatchDetailsState,
+  SeriesDetailsState,
+  ViewerMatchTab,
+  ViewerSeriesTab,
+  ViewerTimelineItem,
+} from "../viewer/types";
 import { formatScoreProgression } from "../../stats/score-progression/score-progression-formatter";
 import { buildSeriesViewModel, type ResolvedSeriesMatch } from "../../series-stats/build-series-view-model";
 import type { SeriesStatsViewModel } from "../../series-stats/types";
@@ -72,6 +78,51 @@ export class OverlayPagePresenter {
     }
   }
 
+  public preloadTimelineMatchStats(timeline: readonly ViewerTimelineItem[]): void {
+    this.preloadMatchStats(this.collectTimelineMatchIds(timeline));
+  }
+
+  public findSelectedMatch(
+    timeline: readonly ViewerTimelineItem[],
+    selectedMatchId: string | null,
+  ): ViewerMatchTab | null {
+    if (selectedMatchId == null) {
+      return null;
+    }
+
+    for (const item of timeline) {
+      if (item.type === "match" && item.match.matchId === selectedMatchId) {
+        return item.match;
+      }
+
+      if (item.type === "series") {
+        const seriesMatch = item.series.matches.find((match) => match.matchId === selectedMatchId);
+        if (seriesMatch != null) {
+          return seriesMatch;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  public findSelectedSeries(
+    timeline: readonly ViewerTimelineItem[],
+    selectedSeriesId: string | null,
+  ): ViewerSeriesTab | null {
+    if (selectedSeriesId == null) {
+      return null;
+    }
+
+    for (const item of timeline) {
+      if (item.type === "series" && item.series.id === selectedSeriesId) {
+        return item.series;
+      }
+    }
+
+    return null;
+  }
+
   public selectMatch(matchId: string): void {
     this.config.store.setSelectedMatchId(matchId);
 
@@ -116,6 +167,22 @@ export class OverlayPagePresenter {
       seriesId: series.id,
       viewModel: this.buildSeriesViewModelFromCache(series, loadedMatches),
     };
+  }
+
+  private collectTimelineMatchIds(timeline: readonly ViewerTimelineItem[]): readonly string[] {
+    const matchIds = new Set<string>();
+    for (const item of timeline) {
+      if (item.type === "match") {
+        matchIds.add(item.match.matchId);
+        continue;
+      }
+
+      for (const match of item.series.matches) {
+        matchIds.add(match.matchId);
+      }
+    }
+
+    return [...matchIds];
   }
 
   private toLoadedSeriesMatches(

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
@@ -6,7 +6,7 @@ import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 import { aFakeHaloClientWith } from "../../../../services/fakes/halo-client.fake";
 import { HaloMedalMetadataResolver } from "../../../../services/halo/medal-metadata-resolver";
 import { aFakeMatchAnalyticsServiceWith } from "../../../../services/stats/fakes/match-analytics.fake";
-import type { ViewerMatchTab, ViewerSeriesTab } from "../../viewer/types";
+import type { ViewerMatchTab, ViewerSeriesTab, ViewerTimelineItem } from "../../viewer/types";
 import type { MatchStatsState } from "../individual-tracker-overlay-presenter";
 import { OverlayPagePresenter } from "../overlay-page-presenter";
 import { OverlayPageStore } from "../overlay-page-store";
@@ -108,6 +108,19 @@ function aMedalsMetadataFile(): Awaited<ReturnType<HaloInfiniteClient["getMedals
       },
     ],
   };
+}
+
+function aPresenter(): OverlayPagePresenter {
+  const store = new OverlayPageStore();
+  const haloClient = aFakeHaloClientWith({
+    getMatchStats: vi.fn(async () => Promise.resolve(aFakeMatchStatsWith())),
+  });
+  return new OverlayPagePresenter({
+    store,
+    haloClient,
+    medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
+    matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+  });
 }
 
 describe("OverlayPagePresenter", () => {
@@ -344,20 +357,91 @@ describe("OverlayPagePresenter", () => {
     unsubscribe();
   });
 
-  describe("buildSeriesStatsPanelState", () => {
-    function aPresenter(): OverlayPagePresenter {
+  describe("preloadTimelineMatchStats", () => {
+    it("preloads stats for standalone matches and matches nested inside series entries", async () => {
+      const getMatchStats = vi
+        .fn(async (matchId: string) => Promise.resolve(aFakeMatchStatsWith({ MatchId: matchId })))
+        .mockName("getMatchStats");
       const store = new OverlayPageStore();
       const haloClient = aFakeHaloClientWith({
-        getMatchStats: vi.fn(async () => Promise.resolve(aFakeMatchStatsWith())),
+        getMatchStats,
+        getUsers: vi.fn(async (xuids: string[]) => Promise.resolve(aUsersFor(xuids))),
       });
-      return new OverlayPagePresenter({
+      const presenter = new OverlayPagePresenter({
         store,
         haloClient,
         medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
         matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
       });
-    }
+      const timeline: readonly ViewerTimelineItem[] = [
+        { type: "match", match: aMatchTabWith({ matchId: "standalone-1" }) },
+        {
+          type: "series",
+          series: aSeriesTabWith({
+            matches: [aMatchTabWith({ matchId: "series-match-1" }), aMatchTabWith({ matchId: "series-match-2" })],
+          }),
+        },
+      ];
 
+      presenter.preloadTimelineMatchStats(timeline);
+
+      await waitFor(() => {
+        expect(store.getSnapshot().matchStatsByMatchId.get("standalone-1")?.status).toBe("loaded");
+        expect(store.getSnapshot().matchStatsByMatchId.get("series-match-1")?.status).toBe("loaded");
+        expect(store.getSnapshot().matchStatsByMatchId.get("series-match-2")?.status).toBe("loaded");
+      });
+      expect(getMatchStats).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("findSelectedMatch", () => {
+    it("returns null when no match is selected", () => {
+      expect(aPresenter().findSelectedMatch([], null)).toBeNull();
+    });
+
+    it("finds a standalone match tab by id", () => {
+      const match = aMatchTabWith({ matchId: "match-1" });
+      const timeline: readonly ViewerTimelineItem[] = [{ type: "match", match }];
+
+      expect(aPresenter().findSelectedMatch(timeline, "match-1")).toBe(match);
+    });
+
+    it("finds a match nested inside a series entry", () => {
+      const seriesMatch = aMatchTabWith({ matchId: "series-match-1" });
+      const timeline: readonly ViewerTimelineItem[] = [
+        { type: "series", series: aSeriesTabWith({ matches: [seriesMatch] }) },
+      ];
+
+      expect(aPresenter().findSelectedMatch(timeline, "series-match-1")).toBe(seriesMatch);
+    });
+
+    it("returns null when the selected match id isn't in the timeline", () => {
+      const timeline: readonly ViewerTimelineItem[] = [{ type: "match", match: aMatchTabWith({ matchId: "match-1" }) }];
+
+      expect(aPresenter().findSelectedMatch(timeline, "missing")).toBeNull();
+    });
+  });
+
+  describe("findSelectedSeries", () => {
+    it("returns null when no series is selected", () => {
+      expect(aPresenter().findSelectedSeries([], null)).toBeNull();
+    });
+
+    it("finds a series entry by id", () => {
+      const series = aSeriesTabWith({ id: "series-1" });
+      const timeline: readonly ViewerTimelineItem[] = [{ type: "series", series }];
+
+      expect(aPresenter().findSelectedSeries(timeline, "series-1")).toBe(series);
+    });
+
+    it("returns null when the selected series id isn't in the timeline", () => {
+      const timeline: readonly ViewerTimelineItem[] = [{ type: "series", series: aSeriesTabWith({ id: "series-1" }) }];
+
+      expect(aPresenter().findSelectedSeries(timeline, "missing")).toBeNull();
+    });
+  });
+
+  describe("buildSeriesStatsPanelState", () => {
     it("returns null when there is no selected series", () => {
       expect(aPresenter().buildSeriesStatsPanelState(null, new Map())).toBeNull();
     });

--- a/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
+++ b/pages/src/components/individual-tracker/overlay/tests/overlay-page-presenter.test.ts
@@ -6,9 +6,65 @@ import { aFakeMatchStatsWith } from "../../../../controllers/stats/fakes/data";
 import { aFakeHaloClientWith } from "../../../../services/fakes/halo-client.fake";
 import { HaloMedalMetadataResolver } from "../../../../services/halo/medal-metadata-resolver";
 import { aFakeMatchAnalyticsServiceWith } from "../../../../services/stats/fakes/match-analytics.fake";
-import type { ViewerTimelineItem } from "../../viewer/types";
+import type { ViewerMatchTab, ViewerSeriesTab } from "../../viewer/types";
+import type { MatchStatsState } from "../individual-tracker-overlay-presenter";
 import { OverlayPagePresenter } from "../overlay-page-presenter";
 import { OverlayPageStore } from "../overlay-page-store";
+
+function aMatchTabWith(overrides: Partial<ViewerMatchTab> = {}): ViewerMatchTab {
+  return {
+    matchId: "match-1",
+    mapName: "Live Fire",
+    mapBackgroundUrl: "https://example.com/live-fire.jpg",
+    gameVariantCategory: 6,
+    isMatchmaking: false,
+    gameModeName: "Slayer",
+    duration: "10m",
+    outcome: "Win",
+    score: "50:42",
+    killsDeathsAssistsKda: "10:7:4 (1.62)",
+    damageDealtTakenRatio: "4,200:3,900 (1.08)",
+    colorHex: undefined,
+    startTime: "2026-01-01T00:00:00.000Z",
+    endTime: "2026-01-01T00:10:00.000Z",
+    ...overrides,
+  };
+}
+
+function aSeriesTabWith(overrides: Partial<ViewerSeriesTab> = {}): ViewerSeriesTab {
+  return {
+    id: "series-1",
+    title: "Alpha vs Beta",
+    subtitle: "Best of 3",
+    isActive: false,
+    teams: [],
+    matchBackgroundUrls: [],
+    score: "1:0",
+    duration: "10m",
+    killsDeathsAssistsKda: "10:7:4 (1.62)",
+    damageDealtTakenRatio: "4,200:3,900 (1.08)",
+    startTime: "2026-01-01T00:00:00.000Z",
+    endTime: "2026-01-01T00:10:00.000Z",
+    matches: [],
+    iconMatches: [],
+    colorHex: undefined,
+    ...overrides,
+  };
+}
+
+function aLoadedMatchStatsStateWith(
+  overrides: Partial<Extract<MatchStatsState, { status: "loaded" }>> = {},
+): Extract<MatchStatsState, { status: "loaded" }> {
+  return {
+    status: "loaded",
+    stats: aFakeMatchStatsWith(),
+    playerMap: new Map(),
+    medalMetadata: {},
+    analytics: null,
+    analyticsStatus: ComponentLoaderStatus.LOADED,
+    ...overrides,
+  };
+}
 
 function aUsersFor(
   xuids: readonly string[],
@@ -246,7 +302,7 @@ describe("OverlayPagePresenter", () => {
     expect(getMatchStats).toHaveBeenCalledTimes(3);
   });
 
-  it("selects a series and toggles the matching timeline item when present", () => {
+  it("selects a series by id", () => {
     const store = new OverlayPageStore();
     const haloClient = aFakeHaloClientWith({
       getMatchStats: vi.fn(async () => Promise.resolve(aFakeMatchStatsWith())),
@@ -257,34 +313,10 @@ describe("OverlayPagePresenter", () => {
       medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
       matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
     });
-    const timeline: readonly ViewerTimelineItem[] = [
-      {
-        type: "series",
-        series: {
-          id: "series-1",
-          title: "Series 1",
-          subtitle: "Best of 1",
-          isActive: true,
-          teams: [],
-          matchBackgroundUrls: [],
-          score: "1:0",
-          duration: "10m",
-          killsDeathsAssistsKda: "10:7:4 (1.62)",
-          damageDealtTakenRatio: "4,200:3,900 (1.08)",
-          startTime: "2026-01-01T00:00:00.000Z",
-          endTime: "2026-01-01T00:10:00.000Z",
-          matches: [],
-          iconMatches: [],
-          colorHex: undefined,
-        },
-      },
-    ];
-    const onToggleEntry = vi.fn<(item: ViewerTimelineItem) => void>();
 
-    presenter.selectSeriesAndToggleIfAvailable(timeline, "series-1", onToggleEntry);
+    presenter.selectSeries("series-1");
 
     expect(store.getSnapshot().selectedSeriesId).toBe("series-1");
-    expect(onToggleEntry).toHaveBeenCalledOnce();
   });
 
   it("clears selection with a single store notification", () => {
@@ -301,7 +333,7 @@ describe("OverlayPagePresenter", () => {
     const listener = vi.fn<() => void>();
     const unsubscribe = store.subscribe(listener);
 
-    presenter.selectSeriesAndToggleIfAvailable(null, "series-1", vi.fn<(item: ViewerTimelineItem) => void>());
+    presenter.selectSeries("series-1");
     listener.mockClear();
 
     presenter.deselect();
@@ -310,5 +342,91 @@ describe("OverlayPagePresenter", () => {
     expect(store.getSnapshot().selectedMatchId).toBeNull();
     expect(store.getSnapshot().selectedSeriesId).toBeNull();
     unsubscribe();
+  });
+
+  describe("buildSeriesStatsPanelState", () => {
+    function aPresenter(): OverlayPagePresenter {
+      const store = new OverlayPageStore();
+      const haloClient = aFakeHaloClientWith({
+        getMatchStats: vi.fn(async () => Promise.resolve(aFakeMatchStatsWith())),
+      });
+      return new OverlayPagePresenter({
+        store,
+        haloClient,
+        medalMetadataResolver: new HaloMedalMetadataResolver(haloClient),
+        matchAnalyticsService: aFakeMatchAnalyticsServiceWith(),
+      });
+    }
+
+    it("returns null when there is no selected series", () => {
+      expect(aPresenter().buildSeriesStatsPanelState(null, new Map())).toBeNull();
+    });
+
+    it("returns null when the series has no matches yet", () => {
+      const series = aSeriesTabWith({ matches: [] });
+
+      expect(aPresenter().buildSeriesStatsPanelState(series, new Map())).toBeNull();
+    });
+
+    it("returns loading while any match's cached stats are still pending", () => {
+      const match = aMatchTabWith({ matchId: "match-1" });
+      const series = aSeriesTabWith({ matches: [match] });
+
+      expect(aPresenter().buildSeriesStatsPanelState(series, new Map())).toEqual({ status: "loading" });
+    });
+
+    it("returns the error message when a match's cached stats failed to load", () => {
+      const match = aMatchTabWith({ matchId: "match-1" });
+      const series = aSeriesTabWith({ matches: [match] });
+      const matchStatsByMatchId = new Map<string, MatchStatsState>([
+        ["match-1", { status: "error", message: "Failed to load match stats" }],
+      ]);
+
+      expect(aPresenter().buildSeriesStatsPanelState(series, matchStatsByMatchId)).toEqual({
+        status: "error",
+        message: "Failed to load match stats",
+      });
+    });
+
+    it("builds a loaded view model from cached match stats without any additional fetch", () => {
+      const matchOne = aMatchTabWith({ matchId: "match-1", mapName: "Live Fire" });
+      const matchTwo = aMatchTabWith({ matchId: "match-2", mapName: "Aquarius" });
+      const series = aSeriesTabWith({ title: "Alpha vs Beta", subtitle: "Best of 3", matches: [matchOne, matchTwo] });
+      const playerMap = new Map([
+        ["1111111111", "Alpha"],
+        ["2222222222", "Bravo"],
+        ["3333333333", "Charlie"],
+        ["4444444444", "Delta"],
+      ]);
+      const matchStatsByMatchId = new Map<string, MatchStatsState>([
+        [
+          "match-1",
+          aLoadedMatchStatsStateWith({
+            stats: aFakeMatchStatsWith({ MatchId: "match-1" }),
+            playerMap,
+            medalMetadata: { 1: { name: "Killing Spree", sortingWeight: 100 } },
+          }),
+        ],
+        [
+          "match-2",
+          aLoadedMatchStatsStateWith({
+            stats: aFakeMatchStatsWith({ MatchId: "match-2" }),
+            playerMap,
+            medalMetadata: { 2: { name: "Double Kill", sortingWeight: 50 } },
+          }),
+        ],
+      ]);
+
+      const state = aPresenter().buildSeriesStatsPanelState(series, matchStatsByMatchId);
+
+      expect(state?.status).toBe("loaded");
+      if (state?.status !== "loaded") {
+        throw new Error("expected loaded series stats state");
+      }
+      expect(state.seriesId).toBe("series-1");
+      expect(state.viewModel.title).toBe("Alpha vs Beta");
+      expect(state.viewModel.subtitle).toBe("Best of 3");
+      expect(state.viewModel.matchSummaries.map((summary) => summary.matchId)).toEqual(["match-1", "match-2"]);
+    });
   });
 });

--- a/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
+++ b/pages/src/components/individual-tracker/viewer/viewer-presenter.ts
@@ -1,7 +1,6 @@
 import type { MatchStats } from "halo-infinite-api";
 import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
-import { getTeamName } from "@guilty-spark/shared/halo/team";
 import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
 import type { SeriesMatchesResponse } from "@guilty-spark/shared/contracts/stats/series-matches";
 import type { TrackerViewState } from "@guilty-spark/shared/contracts/individual-tracker/view";
@@ -17,21 +16,13 @@ import type {
   TrackerViewSubscription,
 } from "../../../services/individual-tracker/view-types";
 import { isMatchStats } from "../../../controllers/stats/is-match-stats";
-import { calculateSeriesMetadata } from "../../../controllers/stats/series-metadata";
 import { StatsController } from "../../../controllers/stats/stats-controller";
-import { GAMES_SUFFIX_RE, KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import { KillMatrixFormatter } from "../../../controllers/stats/kill-matrix/kill-matrix-formatter";
 import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPlayer } from "../../../controllers/stats/kill-matrix/types";
 import { ComponentLoaderStatus } from "../../component-loader/component-loader";
 import { DEFAULT_TEAM_COLORS, getTeamColorOrDefault, type TeamColor } from "../../team-colors/team-colors";
-import { gameModeIconSrc } from "../game-mode-icon";
 import { getReconnectDelayMs } from "../../../services/base/reconnect-policy";
-import type {
-  SeriesMatchDetail,
-  SeriesMatchSummary,
-  SeriesStatsSummary,
-  SeriesStatsViewModel,
-  SeriesTeamCard,
-} from "../../series-stats/types";
+import { buildSeriesViewModel } from "../../series-stats/build-series-view-model";
 import { formatScoreProgression } from "../../stats/score-progression/score-progression-formatter";
 import { buildViewerRenderModel } from "./viewer-render-model";
 import type {
@@ -59,218 +50,7 @@ interface Config {
   readonly trackerId: string;
 }
 
-const WIN_OUTCOME = 2;
 const SERIES_MATCHES_BATCH_SIZE = 30;
-
-interface BuildSeriesViewModelArgs {
-  readonly series: ViewerSeriesTab;
-  readonly seriesData: SeriesMatchesResponse;
-  readonly rawMatches: readonly MatchStats[];
-  readonly medalMetadata: MedalMetadata;
-  readonly playerMap: Map<string, string>;
-  readonly teamColors: readonly TeamColor[];
-  readonly analyticsByMatchId: ReadonlyMap<string, MatchAnalytics>;
-  readonly analyticsStatus: ComponentLoaderStatus;
-}
-
-function getLatestRawMatch(rawMatches: readonly MatchStats[]): MatchStats | undefined {
-  let latest: MatchStats | undefined;
-  let latestTime = Number.NEGATIVE_INFINITY;
-
-  for (const match of rawMatches) {
-    const endTime = new Date(match.MatchInfo.EndTime).getTime();
-    if (!Number.isFinite(endTime)) {
-      continue;
-    }
-    if (endTime > latestTime) {
-      latest = match;
-      latestTime = endTime;
-    }
-  }
-
-  return latest;
-}
-
-function buildSeriesViewModel({
-  series,
-  seriesData,
-  rawMatches,
-  medalMetadata,
-  playerMap,
-  teamColors,
-  analyticsByMatchId,
-  analyticsStatus,
-}: BuildSeriesViewModelArgs): SeriesStatsViewModel {
-  // --- Series totals ---
-  const seriesController = new StatsController();
-  seriesController.loadSeries([...rawMatches], playerMap, medalMetadata);
-  const seriesTotals = seriesController.getSeriesStats();
-  const seriesPlayers = seriesController.getPlayers();
-  const playersByGamertag = new Map(seriesPlayers.map((player) => [player.gamertag, player]));
-  const resolvedSeriesPlayers = seriesTotals.playerData
-    .flatMap((teamData) =>
-      teamData.players.map((player) => playersByGamertag.get(player.name.replace(GAMES_SUFFIX_RE, ""))),
-    )
-    .filter((player): player is KillMatrixPlayer => player != null);
-  const orderedSeriesPlayers =
-    resolvedSeriesPlayers.length === seriesPlayers.length ? resolvedSeriesPlayers : seriesPlayers;
-  const playersByXuid = new Map(
-    seriesPlayers.map((player) => [player.xuid, { gamertag: player.gamertag, teamId: player.teamId }]),
-  );
-  const killMatrixFormatter = new KillMatrixFormatter();
-
-  const metadata = calculateSeriesMetadata(
-    seriesData.matches.map((m) => ({ startTime: m.startTime, endTime: m.endTime })),
-    series.score,
-  );
-
-  const seriesStats: SeriesStatsSummary = {
-    teamData: seriesTotals.teamData,
-    playerData: seriesTotals.playerData,
-    metadata,
-    teamColors,
-    killMatrixPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
-    transposedKillMatrixPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
-    crossTeamKillMatrixData: null,
-    swappedCrossTeamKillMatrixData: null,
-    killMatrixStatus: analyticsStatus,
-  };
-
-  // --- Match summaries (score cards) ---
-  const matchSummaries: SeriesMatchSummary[] = seriesData.matches.map((m) => {
-    let winningTeamColorHex: string | null = null;
-    if (isMatchStats(m.rawMatch)) {
-      const winningTeamIndex = m.rawMatch.Teams.findIndex((t) => t.Outcome === WIN_OUTCOME);
-      if (winningTeamIndex >= 0) {
-        winningTeamColorHex = getTeamColorOrDefault(teamColors[winningTeamIndex]?.id, winningTeamIndex).hex;
-      }
-    }
-    return {
-      matchId: m.matchId,
-      gameMapThumbnailUrl: m.gameMapThumbnailUrl,
-      gameModeIconUrl: gameModeIconSrc(m.gameVariantCategory),
-      gameModeAlt: m.gameType,
-      gameScore: m.gameScore,
-      gameSubScore: m.gameSubScore,
-      gameMap: m.gameMap,
-      winningTeamColorHex,
-    };
-  });
-
-  // --- Team cards (derived from the latest chronological match's team/player layout) ---
-  const lastRawMatch = getLatestRawMatch(rawMatches);
-  const teams: SeriesTeamCard[] =
-    lastRawMatch === undefined
-      ? []
-      : lastRawMatch.Teams.map((team, teamIndex) => ({
-          name: getTeamName(team.TeamId),
-          players: lastRawMatch.Players.filter(
-            (p) =>
-              p.PlayerType === 1 &&
-              p.ParticipationInfo.PresentAtBeginning &&
-              p.PlayerTeamStats.some((ts) => ts.TeamId === team.TeamId),
-          ).map((p) => playerMap.get(getPlayerXuid(p)) ?? "*Unknown*"),
-          teamColorHex: getTeamColorOrDefault(teamColors[teamIndex]?.id, teamIndex).hex,
-        }));
-
-  const matchKillMatrixRows = new Map<string, ReturnType<KillMatrixFormatter["present"]>>();
-
-  // --- Per-match detail sections ---
-  const matchDetails: SeriesMatchDetail[] = seriesData.matches.map((m, index) => {
-    const { rawMatch } = m;
-    let data = null;
-    let orderedPlayers: readonly KillMatrixPlayer[] | undefined = undefined;
-    const analytics = analyticsByMatchId.get(m.matchId) ?? null;
-    if (isMatchStats(rawMatch)) {
-      try {
-        const matchController = new StatsController();
-        matchController.loadMatch(rawMatch, playerMap, medalMetadata);
-        data = matchController.getMatchStats();
-
-        const matchPlayers = matchController.getPlayers();
-        const matchPlayersByGamertag = new Map(matchPlayers.map((player) => [player.gamertag, player]));
-        const resolvedPlayers = data
-          .flatMap((teamData) =>
-            teamData.players.map((player) => matchPlayersByGamertag.get(player.name.replace(GAMES_SUFFIX_RE, ""))),
-          )
-          .filter((player): player is KillMatrixPlayer => player != null);
-        orderedPlayers = resolvedPlayers.length === matchPlayers.length ? resolvedPlayers : matchPlayers;
-      } catch {
-        data = null;
-      }
-    }
-
-    const killMatrixRows = analytics != null ? killMatrixFormatter.present({ analytics, playersByXuid }) : null;
-    if (killMatrixRows != null) {
-      matchKillMatrixRows.set(m.matchId, killMatrixRows);
-    }
-    const crossTeam =
-      killMatrixRows != null
-        ? KillMatrixFormatter.buildCrossTeam(killMatrixRows, orderedPlayers ?? orderedSeriesPlayers)
-        : null;
-
-    return {
-      matchId: m.matchId,
-      data,
-      gameMapThumbnailUrl: m.gameMapThumbnailUrl,
-      gameModeIconUrl: gameModeIconSrc(m.gameVariantCategory),
-      gameModeAlt: m.gameType,
-      matchNumber: index + 1,
-      gameTypeAndMap: m.gameTypeAndMap,
-      duration: m.duration,
-      score: m.gameSubScore != null ? `${m.gameScore} (${m.gameSubScore})` : m.gameScore,
-      startTime: m.startTime,
-      endTime: m.endTime,
-      teamColors,
-      killMatrixPivotData:
-        killMatrixRows != null
-          ? KillMatrixFormatter.pivot(killMatrixRows, orderedPlayers ?? orderedSeriesPlayers)
-          : EMPTY_KILL_MATRIX_PIVOT_DATA,
-      transposedKillMatrixPivotData:
-        killMatrixRows != null
-          ? KillMatrixFormatter.transpose(killMatrixRows, orderedPlayers ?? orderedSeriesPlayers)
-          : EMPTY_KILL_MATRIX_PIVOT_DATA,
-      crossTeamKillMatrixData: crossTeam?.crossTeamData ?? null,
-      swappedCrossTeamKillMatrixData: crossTeam?.swappedCrossTeamData ?? null,
-      killMatrixStatus: analyticsStatus,
-      scoreProgressionViewData: formatScoreProgression(
-        analytics?.scoreProgression ?? null,
-        teamColors,
-        data?.[0]?.players.length ?? null,
-      ),
-    };
-  });
-
-  const aggregatedKillMatrixRows = KillMatrixFormatter.aggregate(
-    [...matchKillMatrixRows.values()].flatMap((rows) => rows),
-  );
-  const hasAggregatedKillMatrix = matchKillMatrixRows.size > 0;
-  const aggregatedCrossTeam = hasAggregatedKillMatrix
-    ? KillMatrixFormatter.buildCrossTeam(aggregatedKillMatrixRows, orderedSeriesPlayers)
-    : null;
-
-  const seriesStatsWithAnalytics: SeriesStatsSummary = {
-    ...seriesStats,
-    killMatrixPivotData: hasAggregatedKillMatrix
-      ? KillMatrixFormatter.pivot(aggregatedKillMatrixRows, orderedSeriesPlayers)
-      : EMPTY_KILL_MATRIX_PIVOT_DATA,
-    transposedKillMatrixPivotData: hasAggregatedKillMatrix
-      ? KillMatrixFormatter.transpose(aggregatedKillMatrixRows, orderedSeriesPlayers)
-      : EMPTY_KILL_MATRIX_PIVOT_DATA,
-    crossTeamKillMatrixData: aggregatedCrossTeam?.crossTeamData ?? null,
-    swappedCrossTeamKillMatrixData: aggregatedCrossTeam?.swappedCrossTeamData ?? null,
-  };
-
-  return {
-    title: series.title,
-    subtitle: series.subtitle,
-    seriesScore: series.score,
-    matchSummaries,
-    teams,
-    seriesStats: seriesStatsWithAnalytics,
-    matchDetails,
-  };
-}
 
 export class IndividualTrackerViewerPresenter {
   private readonly config: Config;
@@ -569,7 +349,7 @@ export class IndividualTrackerViewerPresenter {
       const teamColors = this.resolveTeamColors();
       const viewModel = buildSeriesViewModel({
         series,
-        seriesData: mergedSeriesData,
+        matches: mergedSeriesData.matches,
         rawMatches,
         medalMetadata,
         playerMap,
@@ -584,7 +364,7 @@ export class IndividualTrackerViewerPresenter {
       void this.fetchSeriesAnalyticsAsync({
         key,
         series,
-        seriesData: mergedSeriesData,
+        matches: mergedSeriesData.matches,
         rawMatches,
         medalMetadata,
         playerMap,
@@ -601,7 +381,7 @@ export class IndividualTrackerViewerPresenter {
   private async fetchSeriesAnalyticsAsync(args: {
     readonly key: string;
     readonly series: ViewerSeriesTab;
-    readonly seriesData: SeriesMatchesResponse;
+    readonly matches: SeriesMatchesResponse["matches"];
     readonly rawMatches: readonly MatchStats[];
     readonly medalMetadata: MedalMetadata;
     readonly playerMap: Map<string, string>;

--- a/pages/src/components/series-stats/build-series-view-model.ts
+++ b/pages/src/components/series-stats/build-series-view-model.ts
@@ -1,0 +1,254 @@
+import type { MatchStats } from "halo-infinite-api";
+import type { MedalMetadata } from "@guilty-spark/shared/halo/medals";
+import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
+import { getTeamName } from "@guilty-spark/shared/halo/team";
+import type { MatchAnalytics } from "@guilty-spark/shared/contracts/stats/match-analytics";
+import { isMatchStats } from "../../controllers/stats/is-match-stats";
+import { calculateSeriesMetadata } from "../../controllers/stats/series-metadata";
+import { StatsController } from "../../controllers/stats/stats-controller";
+import { GAMES_SUFFIX_RE, KillMatrixFormatter } from "../../controllers/stats/kill-matrix/kill-matrix-formatter";
+import { EMPTY_KILL_MATRIX_PIVOT_DATA, type KillMatrixPlayer } from "../../controllers/stats/kill-matrix/types";
+import type { ComponentLoaderStatus } from "../component-loader/component-loader";
+import { getTeamColorOrDefault, type TeamColor } from "../team-colors/team-colors";
+import { gameModeIconSrc } from "../individual-tracker/game-mode-icon";
+import { formatScoreProgression } from "../stats/score-progression/score-progression-formatter";
+import type {
+  SeriesMatchDetail,
+  SeriesMatchSummary,
+  SeriesStatsSummary,
+  SeriesStatsViewModel,
+  SeriesTeamCard,
+} from "./types";
+
+const WIN_OUTCOME = 2;
+
+export interface SeriesSummaryInput {
+  readonly title: string;
+  readonly subtitle: string;
+  readonly score: string;
+}
+
+export interface ResolvedSeriesMatch {
+  readonly matchId: string;
+  readonly gameTypeAndMap: string;
+  readonly gameVariantCategory: number;
+  readonly gameType: string;
+  readonly gameMap: string;
+  readonly gameMapThumbnailUrl: string;
+  readonly duration: string;
+  readonly gameScore: string;
+  readonly gameSubScore: string | null;
+  readonly startTime: string;
+  readonly endTime: string;
+  readonly rawMatch: unknown;
+}
+
+export interface BuildSeriesViewModelArgs {
+  readonly series: SeriesSummaryInput;
+  readonly matches: readonly ResolvedSeriesMatch[];
+  readonly rawMatches: readonly MatchStats[];
+  readonly medalMetadata: MedalMetadata;
+  readonly playerMap: Map<string, string>;
+  readonly teamColors: readonly TeamColor[];
+  readonly analyticsByMatchId: ReadonlyMap<string, MatchAnalytics>;
+  readonly analyticsStatus: ComponentLoaderStatus;
+}
+
+function getLatestRawMatch(rawMatches: readonly MatchStats[]): MatchStats | undefined {
+  let latest: MatchStats | undefined;
+  let latestTime = Number.NEGATIVE_INFINITY;
+
+  for (const match of rawMatches) {
+    const endTime = new Date(match.MatchInfo.EndTime).getTime();
+    if (!Number.isFinite(endTime)) {
+      continue;
+    }
+    if (endTime > latestTime) {
+      latest = match;
+      latestTime = endTime;
+    }
+  }
+
+  return latest;
+}
+
+export function buildSeriesViewModel({
+  series,
+  matches,
+  rawMatches,
+  medalMetadata,
+  playerMap,
+  teamColors,
+  analyticsByMatchId,
+  analyticsStatus,
+}: BuildSeriesViewModelArgs): SeriesStatsViewModel {
+  // --- Series totals ---
+  const seriesController = new StatsController();
+  seriesController.loadSeries([...rawMatches], playerMap, medalMetadata);
+  const seriesTotals = seriesController.getSeriesStats();
+  const seriesPlayers = seriesController.getPlayers();
+  const playersByGamertag = new Map(seriesPlayers.map((player) => [player.gamertag, player]));
+  const resolvedSeriesPlayers = seriesTotals.playerData
+    .flatMap((teamData) =>
+      teamData.players.map((player) => playersByGamertag.get(player.name.replace(GAMES_SUFFIX_RE, ""))),
+    )
+    .filter((player): player is KillMatrixPlayer => player != null);
+  const orderedSeriesPlayers =
+    resolvedSeriesPlayers.length === seriesPlayers.length ? resolvedSeriesPlayers : seriesPlayers;
+  const playersByXuid = new Map(
+    seriesPlayers.map((player) => [player.xuid, { gamertag: player.gamertag, teamId: player.teamId }]),
+  );
+  const killMatrixFormatter = new KillMatrixFormatter();
+
+  const metadata = calculateSeriesMetadata(
+    matches.map((m) => ({ startTime: m.startTime, endTime: m.endTime })),
+    series.score,
+  );
+
+  const seriesStats: SeriesStatsSummary = {
+    teamData: seriesTotals.teamData,
+    playerData: seriesTotals.playerData,
+    metadata,
+    teamColors,
+    killMatrixPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
+    transposedKillMatrixPivotData: EMPTY_KILL_MATRIX_PIVOT_DATA,
+    crossTeamKillMatrixData: null,
+    swappedCrossTeamKillMatrixData: null,
+    killMatrixStatus: analyticsStatus,
+  };
+
+  // --- Match summaries (score cards) ---
+  const matchSummaries: SeriesMatchSummary[] = matches.map((m) => {
+    let winningTeamColorHex: string | null = null;
+    if (isMatchStats(m.rawMatch)) {
+      const winningTeamIndex = m.rawMatch.Teams.findIndex((t) => t.Outcome === WIN_OUTCOME);
+      if (winningTeamIndex >= 0) {
+        winningTeamColorHex = getTeamColorOrDefault(teamColors[winningTeamIndex]?.id, winningTeamIndex).hex;
+      }
+    }
+    return {
+      matchId: m.matchId,
+      gameMapThumbnailUrl: m.gameMapThumbnailUrl,
+      gameModeIconUrl: gameModeIconSrc(m.gameVariantCategory),
+      gameModeAlt: m.gameType,
+      gameScore: m.gameScore,
+      gameSubScore: m.gameSubScore,
+      gameMap: m.gameMap,
+      winningTeamColorHex,
+    };
+  });
+
+  // --- Team cards (derived from the latest chronological match's team/player layout) ---
+  const lastRawMatch = getLatestRawMatch(rawMatches);
+  const teams: SeriesTeamCard[] =
+    lastRawMatch === undefined
+      ? []
+      : lastRawMatch.Teams.map((team, teamIndex) => ({
+          name: getTeamName(team.TeamId),
+          players: lastRawMatch.Players.filter(
+            (p) =>
+              p.PlayerType === 1 &&
+              p.ParticipationInfo.PresentAtBeginning &&
+              p.PlayerTeamStats.some((ts) => ts.TeamId === team.TeamId),
+          ).map((p) => playerMap.get(getPlayerXuid(p)) ?? "*Unknown*"),
+          teamColorHex: getTeamColorOrDefault(teamColors[teamIndex]?.id, teamIndex).hex,
+        }));
+
+  const matchKillMatrixRows = new Map<string, ReturnType<KillMatrixFormatter["present"]>>();
+
+  // --- Per-match detail sections ---
+  const matchDetails: SeriesMatchDetail[] = matches.map((m, index) => {
+    const { rawMatch } = m;
+    let data = null;
+    let orderedPlayers: readonly KillMatrixPlayer[] | undefined = undefined;
+    const analytics = analyticsByMatchId.get(m.matchId) ?? null;
+    if (isMatchStats(rawMatch)) {
+      try {
+        const matchController = new StatsController();
+        matchController.loadMatch(rawMatch, playerMap, medalMetadata);
+        data = matchController.getMatchStats();
+
+        const matchPlayers = matchController.getPlayers();
+        const matchPlayersByGamertag = new Map(matchPlayers.map((player) => [player.gamertag, player]));
+        const resolvedPlayers = data
+          .flatMap((teamData) =>
+            teamData.players.map((player) => matchPlayersByGamertag.get(player.name.replace(GAMES_SUFFIX_RE, ""))),
+          )
+          .filter((player): player is KillMatrixPlayer => player != null);
+        orderedPlayers = resolvedPlayers.length === matchPlayers.length ? resolvedPlayers : matchPlayers;
+      } catch {
+        data = null;
+      }
+    }
+
+    const killMatrixRows = analytics != null ? killMatrixFormatter.present({ analytics, playersByXuid }) : null;
+    if (killMatrixRows != null) {
+      matchKillMatrixRows.set(m.matchId, killMatrixRows);
+    }
+    const crossTeam =
+      killMatrixRows != null
+        ? KillMatrixFormatter.buildCrossTeam(killMatrixRows, orderedPlayers ?? orderedSeriesPlayers)
+        : null;
+
+    return {
+      matchId: m.matchId,
+      data,
+      gameMapThumbnailUrl: m.gameMapThumbnailUrl,
+      gameModeIconUrl: gameModeIconSrc(m.gameVariantCategory),
+      gameModeAlt: m.gameType,
+      matchNumber: index + 1,
+      gameTypeAndMap: m.gameTypeAndMap,
+      duration: m.duration,
+      score: m.gameSubScore != null ? `${m.gameScore} (${m.gameSubScore})` : m.gameScore,
+      startTime: m.startTime,
+      endTime: m.endTime,
+      teamColors,
+      killMatrixPivotData:
+        killMatrixRows != null
+          ? KillMatrixFormatter.pivot(killMatrixRows, orderedPlayers ?? orderedSeriesPlayers)
+          : EMPTY_KILL_MATRIX_PIVOT_DATA,
+      transposedKillMatrixPivotData:
+        killMatrixRows != null
+          ? KillMatrixFormatter.transpose(killMatrixRows, orderedPlayers ?? orderedSeriesPlayers)
+          : EMPTY_KILL_MATRIX_PIVOT_DATA,
+      crossTeamKillMatrixData: crossTeam?.crossTeamData ?? null,
+      swappedCrossTeamKillMatrixData: crossTeam?.swappedCrossTeamData ?? null,
+      killMatrixStatus: analyticsStatus,
+      scoreProgressionViewData: formatScoreProgression(
+        analytics?.scoreProgression ?? null,
+        teamColors,
+        data?.[0]?.players.length ?? null,
+      ),
+    };
+  });
+
+  const aggregatedKillMatrixRows = KillMatrixFormatter.aggregate(
+    [...matchKillMatrixRows.values()].flatMap((rows) => rows),
+  );
+  const hasAggregatedKillMatrix = matchKillMatrixRows.size > 0;
+  const aggregatedCrossTeam = hasAggregatedKillMatrix
+    ? KillMatrixFormatter.buildCrossTeam(aggregatedKillMatrixRows, orderedSeriesPlayers)
+    : null;
+
+  const seriesStatsWithAnalytics: SeriesStatsSummary = {
+    ...seriesStats,
+    killMatrixPivotData: hasAggregatedKillMatrix
+      ? KillMatrixFormatter.pivot(aggregatedKillMatrixRows, orderedSeriesPlayers)
+      : EMPTY_KILL_MATRIX_PIVOT_DATA,
+    transposedKillMatrixPivotData: hasAggregatedKillMatrix
+      ? KillMatrixFormatter.transpose(aggregatedKillMatrixRows, orderedSeriesPlayers)
+      : EMPTY_KILL_MATRIX_PIVOT_DATA,
+    crossTeamKillMatrixData: aggregatedCrossTeam?.crossTeamData ?? null,
+    swappedCrossTeamKillMatrixData: aggregatedCrossTeam?.swappedCrossTeamData ?? null,
+  };
+
+  return {
+    title: series.title,
+    subtitle: series.subtitle,
+    seriesScore: series.score,
+    matchSummaries,
+    teams,
+    seriesStats: seriesStatsWithAnalytics,
+    matchDetails,
+  };
+}


### PR DESCRIPTION
## Context
Stacked on #772. Together these two PRs fix the overlay's clickable stats panel: #772 aligns the header rendering with the viewer, this PR fixes the series stats data flow.

## This change
The overlay's series stats panel executed its own isolated fetch flow (`seriesMatchesService.getSeriesMatches` + medal metadata + analytics), re-fetching raw match data over the network even though every match in the series was already loaded client-side for the ticker/preview (`OverlayPagePresenter.preloadMatchStats`).

- Extracts the series view-model aggregation logic (`buildSeriesViewModel`) out of the viewer presenter into a shared `series-stats/build-series-view-model.ts` module, generalized to accept a plain list of resolved match summaries instead of a `SeriesMatchesResponse` from the network endpoint.
- Adds `OverlayPagePresenter.buildSeriesStatsPanelState`, which assembles the same view model directly from the overlay's cached per-match stats (merging player maps, medal metadata, and analytics across matches), with no additional fetch.
- Simplifies series selection (`selectSeries`) now that it no longer needs to trigger the viewer's network-based entry-expansion flow.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (full monorepo, 3311 tests)