### PR TITLE
fix(header): lazy-load profile menu with auth hint cookie on static routes

### DIFF
--- a/.claude/commands/copilot-loop.md
+++ b/.claude/commands/copilot-loop.md
@@ -1,6 +1,6 @@
 # Copilot Review Loop
 
-Processes the latest Copilot PR review: fixes valid issues, replies to all comments, resolves threads, requests a new review, then polls until clean. Poll state (PR, iteration, last review ID) is carried forward in the scheduled prompt string — no external storage needed. Keep the loop quiet. Emit the final report only when the review is clean.
+Processes the latest Copilot PR review: fixes valid issues — both inline comments and suppressed (low-confidence) comments buried in the review body — replies to all inline comments, resolves threads, requests a new review, then polls until clean. "Clean" means zero inline comments AND zero suppressed comments. Poll state (PR, iteration, last review ID) is carried forward in the scheduled prompt string — no external storage needed. Keep the loop quiet. Emit the final report only when the review is clean.
 
 ## Setup
 
@@ -37,11 +37,14 @@ if last:
     body = last.get('body') or ''
     print(last['id'], last['submitted_at'], last['commit_id'][:8])
     print('BODY_CLEAN:', 'generated no new comments' in body)
-    print('BODY:', body.replace('\n', ' ')[:500])
+    print('HAS_SUPPRESSED:', 'Suppressed comments' in body)
+    print('BODY:', body)
 else:
     print('NO_REVIEW')
 "
 ```
+
+Do not truncate `BODY` — the suppressed-comments section (if present) contains the finding text and code snippets needed in Step 4, and truncating can cut it off.
 
 **If `NO_REVIEW`:** on the first poll only (`iteration == 0`), request a review:
 
@@ -75,17 +78,28 @@ Fetch the review's inline comments:
 gh api "repos/{owner}/{repo}/pulls/{PR}/reviews/{REVIEW_ID}/comments"
 ```
 
-**Clean** if the JSON array is empty (`[]`), OR if `BODY_CLEAN: True` was printed in Step 1.
+**Clean** requires ALL of:
+
+- The inline comments JSON array is empty (`[]`), OR `BODY_CLEAN: True` was printed in Step 1.
+- `HAS_SUPPRESSED: False` was printed in Step 1 — a `<details><summary>Suppressed comments (N)</summary>` block in the body means Copilot found low-confidence issues it chose not to post as real review comments. These still need triage; do not treat the review as clean while this section is present.
 
 If clean: emit the final report and stop — do not reschedule.
 
 | Round | Finding | Status | How handled | Evidence |
 | ----- | ------- | ------ | ----------- | -------- |
 | 1 | ... | fixed/refuted | ... | thread id, commit SHA, or path |
+| 1 | ... (suppressed) | fixed/refuted | ... | commit SHA or path — no thread, suppressed comments have no comment ID |
 
-## Step 4 — Process each comment
+## Step 4 — Process each finding
 
-For each inline comment from the review:
+Process two sources of findings from this review:
+
+1. **Inline comments** — from the `gh api .../comments` call above. Each has a `COMMENT_ID` used later for replying/resolving.
+2. **Suppressed comments** — if `HAS_SUPPRESSED: True`, parse them out of the `BODY` text printed in Step 1. Each entry starts with a `**path/to/file.ts:LINE**` heading, followed by a `*` bullet with the finding text (sometimes noting "This issue also appears on line N of the same file") and a fenced code snippet for context.
+
+   Treat each `**path:line**` heading as one finding. These have **no comment ID** — there is no PR comment or thread behind them, so no reply/resolve step applies to them (see Step 5).
+
+For each finding (inline or suppressed):
 
 1. **Assess validity.** Read the referenced file and surrounding context. Is the concern real?
 
@@ -97,9 +111,9 @@ For each inline comment from the review:
 
 3. **If invalid/refuted:** Note the reason clearly. Do not make code changes for this comment.
 
-4. Add one row to the findings ledger for every comment you process. Include the review round, the finding, whether it was fixed or refuted, and how it was handled.
+4. Add one row to the findings ledger for every finding you process (inline or suppressed). Include the review round, the finding, whether it was fixed or refuted, and how it was handled — mark suppressed findings clearly (e.g. append "(suppressed)" to the finding text) since they skip the reply/resolve step.
 
-5. Commit all fixes together once all comments are processed:
+5. Commit all fixes together once all findings are processed:
 
    ```bash
    git add <changed files>
@@ -108,13 +122,13 @@ For each inline comment from the review:
 
 ## Step 5 — Push, reply, resolve, request
 
-Once all comments are addressed (or refuted):
+Once all findings are addressed (or refuted):
 
 ```bash
 git push
 ```
 
-**Reply in-thread to every comment** (include the fix commit SHA or the refutation reason):
+**Reply in-thread to every inline comment** (include the fix commit SHA or the refutation reason). Skip this for suppressed findings — they have no `COMMENT_ID` to reply to:
 
 ```bash
 gh api repos/{owner}/{repo}/pulls/{PR}/comments/{COMMENT_ID}/replies \
@@ -124,7 +138,7 @@ gh api repos/{owner}/{repo}/pulls/{PR}/comments/{COMMENT_ID}/replies \
   -X POST -f body="Not actioned: <reason why the concern doesn't apply>."
 ```
 
-**Resolve every unresolved Copilot thread** via GraphQL. First get thread node IDs, including the author of the first comment so you can filter to Copilot-owned threads only:
+**Resolve every unresolved Copilot thread** via GraphQL (inline comments only — suppressed findings have no thread). First get thread node IDs, including the author of the first comment so you can filter to Copilot-owned threads only:
 
 ```bash
 gh api graphql -f query='
@@ -171,3 +185,4 @@ manage_schedule(action: 'create', interval: '1m',
 - Owner: `davidhouweling`, Repo: `guilty-spark`
 - ESLint rules to watch for: `strict-boolean-expressions`, `no-unnecessary-condition` — avoid redundant null checks and `??` on non-nullable types
 - Always check `isResolved` before resolving a thread to avoid double-resolve errors
+- Fixing a suppressed comment can surface a *new* suppressed comment on a later review (e.g. fixing one flagged pattern in a file can expose an adjacent one Copilot previously deprioritized) — this is expected; keep looping until a review has neither inline nor suppressed comments

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -1,11 +1,11 @@
 ---
 agent: agent
-description: "Process the latest Copilot PR review: fix valid issues, reply to all comments, resolve threads, request a new review, poll every minute for up to 15 minutes, and reschedule itself with /after until the review is clean."
+description: "Process the latest Copilot PR review: fix valid issues (including suppressed low-confidence comments buried in the review body), reply to all inline comments, resolve threads, request a new review, poll every minute for up to 15 minutes, and reschedule itself with /after until the review has neither inline nor suppressed comments."
 ---
 
 Run one iteration of the Copilot review loop on the current PR in the GitHub Copilot CLI interactive session. From the VS Code integrated terminal, start that session with `copilot`. Experimental scheduling must be enabled first with `/experimental on` or `--experimental`.
 
-Keep the loop quiet. Each `/after` invocation runs in a fresh stateless context — only `/tmp/copilot-loop-{PR}.txt` persists across runs (line 1: `pollingStartedAt` ISO timestamp; line 2: `lastProcessedReviewId`). The findings ledger lives in session memory and is lost between invocations; rebuild it from git log if needed. Emit the final report only when the review is clean. Poll every 1 minute for up to 15 minutes, then fall back to 10 minutes.
+Keep the loop quiet. Each `/after` invocation runs in a fresh stateless context — only `/tmp/copilot-loop-{PR}.txt` persists across runs (line 1: `pollingStartedAt` ISO timestamp; line 2: `lastProcessedReviewId`). The findings ledger lives in session memory and is lost between invocations; rebuild it from git log if needed. Emit the final report only when the review is clean — meaning zero inline comments AND zero suppressed comments. Poll every 1 minute for up to 15 minutes, then fall back to 10 minutes.
 
 ## Step 1 — Identify the PR
 
@@ -27,11 +27,14 @@ if last:
     body = last.get('body') or ''
     print(last['id'], last['submitted_at'], last['commit_id'][:8])
     print('BODY_CLEAN:', 'generated no new comments' in body)
-    print('BODY:', body.replace('\n', ' ')[:500])
+    print('HAS_SUPPRESSED:', 'Suppressed comments' in body)
+    print('BODY:', body)
 else:
     print('NO_REVIEW')
 "
 ```
+
+Do not truncate `BODY` — the suppressed-comments section (if present) contains the finding text and code snippets needed in Step 4, and truncating can cut it off.
 
 If `NO_REVIEW`: on the first poll (temp file does not yet exist), request a review and initialize the temp file:
 
@@ -91,7 +94,11 @@ for c in reversed(comments):
 
 Clean if the body contains any of: `clean`, `no issues`, `good to merge`, `no new comments`, `all.*tests pass`.
 
-If clean: do not schedule another run. Delete the temp file:
+**Check 3 — suppressed comments in the review body:**
+
+Clean if `HAS_SUPPRESSED: False` was printed in Step 2. A `<details><summary>Suppressed comments (N)</summary>` block in the body means Copilot found low-confidence issues it chose not to post as real review comments — these still need triage, so do not treat the review as clean while this section is present.
+
+The review is clean only if Checks 1, 2, and 3 all pass. If clean: do not schedule another run. Delete the temp file:
 
 ```bash
 rm -f /tmp/copilot-loop-{PR}.txt
@@ -99,13 +106,19 @@ rm -f /tmp/copilot-loop-{PR}.txt
 
 Emit the final report:
 
-| Round | Finding | Status        | How handled | Evidence                       |
-| ----- | ------- | ------------- | ----------- | ------------------------------ |
-| 1     | ...     | fixed/refuted | ...         | thread id, commit SHA, or path |
+| Round | Finding          | Status        | How handled | Evidence                       |
+| ----- | ---------------- | ------------- | ----------- | ------------------------------ |
+| 1     | ...              | fixed/refuted | ...         | thread id, commit SHA, or path |
+| 1     | ... (suppressed) | fixed/refuted | ...         | commit SHA or path — no thread |
 
-## Step 4 — Process each inline comment
+## Step 4 — Process each finding
 
-For each comment:
+Process two sources of findings from this review:
+
+1. **Inline comments** — from the `gh api .../comments` call in Check 1. Each has a `COMMENT_ID` used later for replying/resolving.
+2. **Suppressed comments** — if `HAS_SUPPRESSED: True`, parse them out of the `BODY` text printed in Step 2. Each entry starts with a `**path/to/file.ts:LINE**` heading, followed by a `*` bullet with the finding text (sometimes noting "This issue also appears on line N of the same file") and a fenced code snippet for context. Treat each `**path:line**` heading as one finding. These have **no comment ID** — there is no PR comment or thread behind them, so no reply/resolve step applies to them (see Step 5).
+
+For each finding (inline or suppressed):
 
 1. **Assess validity.** Read the referenced file and surrounding context. Is the concern real?
 
@@ -117,9 +130,9 @@ For each comment:
 
 3. **If invalid/refuted:** Note the reason. No code changes.
 
-4. Add one row to the findings ledger for every comment you process. Include the review round, the finding, whether it was fixed or refuted, and how it was handled.
+4. Add one row to the findings ledger for every finding you process (inline or suppressed). Include the review round, the finding, whether it was fixed or refuted, and how it was handled — mark suppressed findings clearly (e.g. append "(suppressed)" to the finding text) since they skip the reply/resolve step.
 
-5. Commit all fixes together once all comments are processed:
+5. Commit all fixes together once all findings are processed:
 
    ```bash
    git add <changed files>
@@ -132,7 +145,7 @@ For each comment:
 git push
 ```
 
-**Reply in-thread to every comment:**
+**Reply in-thread to every inline comment** (skip this for suppressed findings — they have no `COMMENT_ID`):
 
 ```bash
 gh api repos/{owner}/{repo}/pulls/{PR}/comments/{COMMENT_ID}/replies \
@@ -142,7 +155,7 @@ gh api repos/{owner}/{repo}/pulls/{PR}/comments/{COMMENT_ID}/replies \
   -X POST -f body="Not actioned: <reason>."
 ```
 
-**Resolve every unresolved Copilot thread.** Get thread node IDs, including the author of the first comment so you can filter to Copilot-owned threads only:
+**Resolve every unresolved Copilot thread** (inline comments only — suppressed findings have no thread). Get thread node IDs, including the author of the first comment so you can filter to Copilot-owned threads only:
 
 ```bash
 gh api graphql -f query='
@@ -192,3 +205,4 @@ Then schedule the next iteration with `/after 1m #copilot-loop.prompt.md`. On su
 - Commit message: `fix(scope): description`
 - ESLint rules to watch: `strict-boolean-expressions`, `no-unnecessary-condition`
 - Always check `isResolved` before resolving a thread to avoid errors
+- Fixing a suppressed comment can surface a *new* suppressed comment on a later review (e.g. fixing one flagged pattern in a file can expose an adjacent one Copilot previously deprioritized) — this is expected; keep looping until a review has neither inline nor suppressed comments

--- a/.github/prompts/copilot-loop.prompt.md
+++ b/.github/prompts/copilot-loop.prompt.md
@@ -205,4 +205,4 @@ Then schedule the next iteration with `/after 1m #copilot-loop.prompt.md`. On su
 - Commit message: `fix(scope): description`
 - ESLint rules to watch: `strict-boolean-expressions`, `no-unnecessary-condition`
 - Always check `isResolved` before resolving a thread to avoid errors
-- Fixing a suppressed comment can surface a *new* suppressed comment on a later review (e.g. fixing one flagged pattern in a file can expose an adjacent one Copilot previously deprioritized) — this is expected; keep looping until a review has neither inline nor suppressed comments
+- Fixing a suppressed comment can surface a _new_ suppressed comment on a later review (e.g. fixing one flagged pattern in a file can expose an adjacent one Copilot previously deprioritized) — this is expected; keep looping until a review has neither inline nor suppressed comments

--- a/api/services/auth/session-manager.ts
+++ b/api/services/auth/session-manager.ts
@@ -1,6 +1,8 @@
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 
 const SESSION_COOKIE_NAME = "auth-session";
+const SESSION_HINT_COOKIE_NAME = "auth-presence";
+const SESSION_HINT_COOKIE_VALUE = "1";
 const PKCE_COOKIE_NAME = "auth-pkce-state";
 export const SESSION_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60; // 30 days
 const PKCE_COOKIE_MAX_AGE_SECONDS = 10 * 60;
@@ -107,12 +109,39 @@ export class SessionManager {
     response.headers.append("Set-Cookie", cookieValue);
   }
 
+  public setReadableCookie(
+    response: Response,
+    cookieName: string,
+    value: string,
+    expiresAt: number,
+    maxAgeSeconds = SESSION_COOKIE_MAX_AGE_SECONDS,
+    sameSite: "Lax" | "Strict" = "Strict",
+  ): void {
+    const expiresDate = new Date(expiresAt);
+    const cookieValue = `${cookieName}=${value}; Path=/; Secure; SameSite=${sameSite}; Max-Age=${maxAgeSeconds.toString()}; Expires=${expiresDate.toUTCString()}`;
+
+    response.headers.append("Set-Cookie", cookieValue);
+  }
+
+  public clearReadableCookie(response: Response, cookieName: string, sameSite: "Lax" | "Strict" = "Strict"): void {
+    const cookieValue = `${cookieName}=; Path=/; Secure; SameSite=${sameSite}; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+
+    response.headers.append("Set-Cookie", cookieValue);
+  }
+
   /**
    * Set a signed session token in an HttpOnly, Secure, SameSite cookie.
    */
   public setSessionCookie(response: Response, token: string): void {
     const expiresAt = Date.now() + SESSION_COOKIE_MAX_AGE_SECONDS * 1000;
     this.setCookie(response, SESSION_COOKIE_NAME, token, expiresAt);
+    this.setReadableCookie(
+      response,
+      SESSION_HINT_COOKIE_NAME,
+      SESSION_HINT_COOKIE_VALUE,
+      expiresAt,
+      SESSION_COOKIE_MAX_AGE_SECONDS,
+    );
   }
 
   /**
@@ -120,6 +149,7 @@ export class SessionManager {
    */
   public clearSessionCookie(response: Response): void {
     this.clearCookie(response, SESSION_COOKIE_NAME);
+    this.clearReadableCookie(response, SESSION_HINT_COOKIE_NAME);
   }
 
   public setPkceStateCookie(response: Response, token: string): void {

--- a/api/services/auth/session-manager.ts
+++ b/api/services/auth/session-manager.ts
@@ -109,7 +109,7 @@ export class SessionManager {
     response.headers.append("Set-Cookie", cookieValue);
   }
 
-  public setReadableCookie(
+  private setReadableCookie(
     response: Response,
     cookieName: string,
     value: string,
@@ -123,7 +123,7 @@ export class SessionManager {
     response.headers.append("Set-Cookie", cookieValue);
   }
 
-  public clearReadableCookie(response: Response, cookieName: string, sameSite: "Lax" | "Strict" = "Strict"): void {
+  private clearReadableCookie(response: Response, cookieName: string, sameSite: "Lax" | "Strict" = "Strict"): void {
     const cookieValue = `${cookieName}=; Path=/; Secure; SameSite=${sameSite}; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT`;
 
     response.headers.append("Set-Cookie", cookieValue);

--- a/api/services/auth/tests/session-manager.test.ts
+++ b/api/services/auth/tests/session-manager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { SessionManager } from "../session-manager";
 
 describe("SessionManager", () => {
@@ -55,8 +56,14 @@ describe("SessionManager", () => {
     manager.setSessionCookie(response, "test-token");
 
     const setCookies = response.headers.getSetCookie();
-    const sessionCookie = setCookies.find((cookie) => cookie.startsWith("auth-session="));
-    const presenceCookie = setCookies.find((cookie) => cookie.startsWith("auth-presence="));
+    const sessionCookie = Preconditions.checkExists(
+      setCookies.find((cookie) => cookie.startsWith("auth-session=")),
+      "auth-session cookie",
+    );
+    const presenceCookie = Preconditions.checkExists(
+      setCookies.find((cookie) => cookie.startsWith("auth-presence=")),
+      "auth-presence cookie",
+    );
 
     expect(sessionCookie).toContain("auth-session=test-token");
     expect(sessionCookie).toContain("HttpOnly");
@@ -79,8 +86,14 @@ describe("SessionManager", () => {
     manager.clearSessionCookie(response);
 
     const setCookies = response.headers.getSetCookie();
-    const sessionCookie = setCookies.find((cookie) => cookie.startsWith("auth-session="));
-    const presenceCookie = setCookies.find((cookie) => cookie.startsWith("auth-presence="));
+    const sessionCookie = Preconditions.checkExists(
+      setCookies.find((cookie) => cookie.startsWith("auth-session=")),
+      "auth-session cookie",
+    );
+    const presenceCookie = Preconditions.checkExists(
+      setCookies.find((cookie) => cookie.startsWith("auth-presence=")),
+      "auth-presence cookie",
+    );
 
     expect(sessionCookie).toContain("Max-Age=0");
     expect(sessionCookie).toContain("Expires=Thu, 01 Jan 1970");

--- a/api/services/auth/tests/session-manager.test.ts
+++ b/api/services/auth/tests/session-manager.test.ts
@@ -54,14 +54,21 @@ describe("SessionManager", () => {
     const response = new Response();
     manager.setSessionCookie(response, "test-token");
 
-    const setCookie = response.headers.get("Set-Cookie");
-    expect(setCookie).toContain("auth-session=test-token");
-    expect(setCookie).toContain("auth-presence=1");
-    expect(setCookie).toContain("HttpOnly");
-    expect(setCookie).toContain("Secure");
-    expect(setCookie).toContain("SameSite=Strict");
-    expect(setCookie).toContain("Path=/");
-    expect(setCookie).toContain("Max-Age=2592000");
+    const setCookies = response.headers.getSetCookie();
+    const sessionCookie = setCookies.find((cookie) => cookie.startsWith("auth-session="));
+    const presenceCookie = setCookies.find((cookie) => cookie.startsWith("auth-presence="));
+
+    expect(sessionCookie).toContain("auth-session=test-token");
+    expect(sessionCookie).toContain("HttpOnly");
+    expect(sessionCookie).toContain("Secure");
+    expect(sessionCookie).toContain("SameSite=Strict");
+    expect(sessionCookie).toContain("Path=/");
+    expect(sessionCookie).toContain("Max-Age=2592000");
+
+    expect(presenceCookie).toContain("auth-presence=1");
+    expect(presenceCookie).not.toContain("HttpOnly");
+    expect(presenceCookie).toContain("Secure");
+    expect(presenceCookie).toContain("SameSite=Strict");
   });
 
   it("clears session cookie on logout", () => {
@@ -71,11 +78,14 @@ describe("SessionManager", () => {
     const response = new Response();
     manager.clearSessionCookie(response);
 
-    const setCookie = response.headers.get("Set-Cookie");
-    expect(setCookie).toContain("auth-session=");
-    expect(setCookie).toContain("auth-presence=");
-    expect(setCookie).toContain("Max-Age=0");
-    expect(setCookie).toContain("Expires=Thu, 01 Jan 1970");
+    const setCookies = response.headers.getSetCookie();
+    const sessionCookie = setCookies.find((cookie) => cookie.startsWith("auth-session="));
+    const presenceCookie = setCookies.find((cookie) => cookie.startsWith("auth-presence="));
+
+    expect(sessionCookie).toContain("Max-Age=0");
+    expect(sessionCookie).toContain("Expires=Thu, 01 Jan 1970");
+    expect(presenceCookie).toContain("Max-Age=0");
+    expect(presenceCookie).toContain("Expires=Thu, 01 Jan 1970");
   });
 
   it("extracts session token from request cookies", () => {

--- a/api/services/auth/tests/session-manager.test.ts
+++ b/api/services/auth/tests/session-manager.test.ts
@@ -56,6 +56,7 @@ describe("SessionManager", () => {
 
     const setCookie = response.headers.get("Set-Cookie");
     expect(setCookie).toContain("auth-session=test-token");
+    expect(setCookie).toContain("auth-presence=1");
     expect(setCookie).toContain("HttpOnly");
     expect(setCookie).toContain("Secure");
     expect(setCookie).toContain("SameSite=Strict");
@@ -72,6 +73,7 @@ describe("SessionManager", () => {
 
     const setCookie = response.headers.get("Set-Cookie");
     expect(setCookie).toContain("auth-session=");
+    expect(setCookie).toContain("auth-presence=");
     expect(setCookie).toContain("Max-Age=0");
     expect(setCookie).toContain("Expires=Thu, 01 Jan 1970");
   });

--- a/pages/src/components/header/header.astro
+++ b/pages/src/components/header/header.astro
@@ -4,7 +4,6 @@ import Logo from "../logo/logo.astro";
 import Container from "../container/container.astro";
 import { SUPPORT_SERVER_URL, GITHUB_URL, API_HOST } from "../../constants";
 import { ProfileMenu } from "./profile-menu";
-import { ProfileAvatar } from "./profile-avatar";
 import styles from "./header.module.css";
 import profileMenuStyles from "./profile-menu.module.css";
 
@@ -15,9 +14,10 @@ interface NavLink {
 
 interface Props {
   readonly hasAuthSessionCookie?: boolean;
+  readonly hasAuthHintCookie?: boolean;
 }
 
-const { hasAuthSessionCookie = false } = Astro.props;
+const { hasAuthSessionCookie = false, hasAuthHintCookie = false } = Astro.props;
 
 const navLinks: NavLink[] = [
   { href: "/discord-commands", label: "Commands" },
@@ -26,6 +26,10 @@ const navLinks: NavLink[] = [
   { href: "/faq", label: "FAQ" },
 ];
 const signInLinkClassName = [styles.iconLink, profileMenuStyles.profileIconButton].join(" ");
+const iconLinkClassName = styles.iconLink;
+const expectAuthenticated = hasAuthSessionCookie || hasAuthHintCookie;
+const profileSlotId = "profile-menu-slot";
+const profileTemplateId = "profile-menu-template";
 ---
 
 <nav id="halo-nav" class={styles.haloNav} aria-label="Primary">
@@ -86,24 +90,56 @@ const signInLinkClassName = [styles.iconLink, profileMenuStyles.profileIconButto
             ></path>
           </svg>
         </a>
-        {
-          hasAuthSessionCookie ? (
-            <ProfileMenu
-              client:load
-              apiHost={API_HOST}
-              iconLinkClassName={styles.iconLink}
-              expectAuthenticated={hasAuthSessionCookie}
-            />
-          ) : (
-            <a href="/login" class={signInLinkClassName} aria-label="Sign in" title="Sign in">
-              <ProfileAvatar />
-            </a>
-          )
-        }
+        <div
+          id={profileSlotId}
+          data-expect-authenticated={String(expectAuthenticated)}
+        >
+          <a href="/login" class={signInLinkClassName} aria-label="Sign in" title="Sign in">
+            <span class={profileMenuStyles.profileAvatar} aria-hidden="true">
+              <span class={profileMenuStyles.profileAvatarGeneric}>
+                <span class={profileMenuStyles.avatarHead}></span>
+                <span class={profileMenuStyles.avatarBody}></span>
+              </span>
+            </span>
+          </a>
+        </div>
       </div>
     </div>
   </Container>
 </nav>
+
+<template id={profileTemplateId}>
+  <ProfileMenu
+    client:load
+    apiHost={API_HOST}
+    iconLinkClassName={iconLinkClassName}
+    signInLinkClassName={signInLinkClassName}
+  />
+</template>
+
+<script type="module">
+  const profileSlot = document.getElementById("profile-menu-slot");
+  if (!(profileSlot instanceof HTMLElement)) {
+    throw new Error("Profile menu slot not found");
+  }
+
+  const expectAuthenticated = profileSlot.dataset.expectAuthenticated === "true";
+
+  const hasAuthPresenceCookie = document.cookie
+    .split(";")
+    .map((cookie) => cookie.trim())
+    .some((cookie) => cookie === "auth-presence=1");
+
+  const shouldHydrateProfileMenu = expectAuthenticated || hasAuthPresenceCookie;
+  if (shouldHydrateProfileMenu) {
+    const profileTemplate = document.getElementById("profile-menu-template");
+    if (!(profileTemplate instanceof HTMLTemplateElement)) {
+      throw new Error("Profile menu template not found");
+    }
+
+    profileSlot.replaceChildren(profileTemplate.content.cloneNode(true));
+  }
+</script>
 
 <script>
   // Mobile menu toggle

--- a/pages/src/components/header/header.astro
+++ b/pages/src/components/header/header.astro
@@ -113,24 +113,24 @@ const profileTemplateId = "profile-menu-template";
 <script type="module" define:vars={{ profileSlotId, profileTemplateId }}>
   const profileSlot = document.getElementById(profileSlotId);
   if (!(profileSlot instanceof HTMLElement)) {
-    throw new Error("Profile menu slot not found");
-  }
+    console.error("Profile menu slot not found; keeping the logged-out fallback.");
+  } else {
+    const expectAuthenticated = profileSlot.dataset.expectAuthenticated === "true";
 
-  const expectAuthenticated = profileSlot.dataset.expectAuthenticated === "true";
+    const hasAuthPresenceCookie = document.cookie
+      .split(";")
+      .map((cookie) => cookie.trim())
+      .some((cookie) => cookie === "auth-presence=1");
 
-  const hasAuthPresenceCookie = document.cookie
-    .split(";")
-    .map((cookie) => cookie.trim())
-    .some((cookie) => cookie === "auth-presence=1");
-
-  const shouldHydrateProfileMenu = expectAuthenticated || hasAuthPresenceCookie;
-  if (shouldHydrateProfileMenu) {
-    const profileTemplate = document.getElementById(profileTemplateId);
-    if (!(profileTemplate instanceof HTMLTemplateElement)) {
-      throw new Error("Profile menu template not found");
+    const shouldHydrateProfileMenu = expectAuthenticated || hasAuthPresenceCookie;
+    if (shouldHydrateProfileMenu) {
+      const profileTemplate = document.getElementById(profileTemplateId);
+      if (!(profileTemplate instanceof HTMLTemplateElement)) {
+        console.error("Profile menu template not found; keeping the logged-out fallback.");
+      } else {
+        profileSlot.replaceChildren(profileTemplate.content.cloneNode(true));
+      }
     }
-
-    profileSlot.replaceChildren(profileTemplate.content.cloneNode(true));
   }
 </script>
 

--- a/pages/src/components/header/header.astro
+++ b/pages/src/components/header/header.astro
@@ -4,6 +4,7 @@ import Logo from "../logo/logo.astro";
 import Container from "../container/container.astro";
 import { SUPPORT_SERVER_URL, GITHUB_URL, API_HOST } from "../../constants";
 import { ProfileMenu } from "./profile-menu";
+import { ProfileAvatar } from "./profile-avatar";
 import styles from "./header.module.css";
 import profileMenuStyles from "./profile-menu.module.css";
 
@@ -92,12 +93,7 @@ const profileTemplateId = "profile-menu-template";
         </a>
         <div id={profileSlotId} data-expect-authenticated={String(expectAuthenticated)}>
           <a href="/login" class={signInLinkClassName} aria-label="Sign in" title="Sign in">
-            <span class={profileMenuStyles.profileAvatar} aria-hidden="true">
-              <span class={profileMenuStyles.profileAvatarGeneric}>
-                <span class={profileMenuStyles.avatarHead}></span>
-                <span class={profileMenuStyles.avatarBody}></span>
-              </span>
-            </span>
+            <ProfileAvatar />
           </a>
         </div>
       </div>

--- a/pages/src/components/header/header.astro
+++ b/pages/src/components/header/header.astro
@@ -90,10 +90,7 @@ const profileTemplateId = "profile-menu-template";
             ></path>
           </svg>
         </a>
-        <div
-          id={profileSlotId}
-          data-expect-authenticated={String(expectAuthenticated)}
-        >
+        <div id={profileSlotId} data-expect-authenticated={String(expectAuthenticated)}>
           <a href="/login" class={signInLinkClassName} aria-label="Sign in" title="Sign in">
             <span class={profileMenuStyles.profileAvatar} aria-hidden="true">
               <span class={profileMenuStyles.profileAvatarGeneric}>
@@ -117,8 +114,8 @@ const profileTemplateId = "profile-menu-template";
   />
 </template>
 
-<script type="module">
-  const profileSlot = document.getElementById("profile-menu-slot");
+<script type="module" define:vars={{ profileSlotId, profileTemplateId }}>
+  const profileSlot = document.getElementById(profileSlotId);
   if (!(profileSlot instanceof HTMLElement)) {
     throw new Error("Profile menu slot not found");
   }
@@ -132,7 +129,7 @@ const profileTemplateId = "profile-menu-template";
 
   const shouldHydrateProfileMenu = expectAuthenticated || hasAuthPresenceCookie;
   if (shouldHydrateProfileMenu) {
-    const profileTemplate = document.getElementById("profile-menu-template");
+    const profileTemplate = document.getElementById(profileTemplateId);
     if (!(profileTemplate instanceof HTMLTemplateElement)) {
       throw new Error("Profile menu template not found");
     }

--- a/pages/src/components/header/profile-menu.tsx
+++ b/pages/src/components/header/profile-menu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import classNames from "classnames";
 import type { SessionResponse } from "@guilty-spark/shared/contracts/auth/session";
 import { Dropdown } from "../dropdown/dropdown";
@@ -17,11 +17,9 @@ export function ProfileMenu({ apiHost, iconLinkClassName, signInLinkClassName }:
   const [authService, setAuthService] = useState<AuthService | null>(null);
   const [session, setSession] = useState<SessionResponse | null>(null);
   const [avatarFailed, setAvatarFailed] = useState(false);
-  const isDisposedRef = useRef(false);
-
   useEffect(() => {
-    isDisposedRef.current = false;
-    const isDisposed = (): boolean => isDisposedRef.current;
+    let isCancelled = false;
+    const isDisposed = (): boolean => isCancelled;
 
     async function installAndLoadSession(): Promise<void> {
       try {
@@ -49,7 +47,7 @@ export function ProfileMenu({ apiHost, iconLinkClassName, signInLinkClassName }:
     void installAndLoadSession();
 
     return (): void => {
-      isDisposedRef.current = true;
+      isCancelled = true;
     };
   }, [apiHost]);
 

--- a/pages/src/components/header/profile-menu.tsx
+++ b/pages/src/components/header/profile-menu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import classNames from "classnames";
 import type { SessionResponse } from "@guilty-spark/shared/contracts/auth/session";
 import { Dropdown } from "../dropdown/dropdown";
@@ -10,50 +10,55 @@ import styles from "./profile-menu.module.css";
 interface ProfileMenuProps {
   readonly apiHost: string;
   readonly iconLinkClassName?: string;
-  readonly expectAuthenticated?: boolean;
+  readonly signInLinkClassName?: string;
 }
 
 export function ProfileMenu({
   apiHost,
   iconLinkClassName,
-  expectAuthenticated = false,
+  signInLinkClassName,
 }: ProfileMenuProps): React.ReactElement {
   const [authService, setAuthService] = useState<AuthService | null>(null);
   const [session, setSession] = useState<SessionResponse | null>(null);
   const [avatarFailed, setAvatarFailed] = useState(false);
+  const isDisposedRef = useRef(false);
 
   useEffect(() => {
-    let isCancelled = false;
+    isDisposedRef.current = false;
+    const isDisposed = (): boolean => isDisposedRef.current;
 
-    installAuthService(apiHost)
-      .then((service): Promise<SessionResponse> | undefined => {
-        if (isCancelled) {
-          return undefined;
-        }
-        setAuthService(service);
-        return service.getSession();
-      })
-      .then((resolvedSession) => {
-        if (isCancelled || resolvedSession == null) {
+    async function installAndLoadSession(): Promise<void> {
+      try {
+        const service = await installAuthService(apiHost);
+        if (isDisposed()) {
           return;
         }
+        setAuthService(service);
+
+        const resolvedSession = await service.getSession();
+        if (isDisposed()) {
+          return;
+        }
+
         setAvatarFailed(false);
         setSession(resolvedSession);
-      })
-      .catch(() => {
-        if (!isCancelled) {
-          setSession({ authenticated: false });
+      } catch {
+        if (isDisposed()) {
+          return;
         }
-      });
+        setSession({ authenticated: false });
+      }
+    }
+
+    void installAndLoadSession();
 
     return (): void => {
-      isCancelled = true;
+      isDisposedRef.current = true;
     };
   }, [apiHost]);
 
   const hasAuthenticatedSession = session?.authenticated === true;
-  const isLoadingExpectedSession = expectAuthenticated && session == null;
-  const showDropdown = hasAuthenticatedSession || isLoadingExpectedSession;
+  const showDropdown = hasAuthenticatedSession || session == null;
   const avatarUrl = hasAuthenticatedSession && !avatarFailed ? (session.avatarUrl ?? null) : null;
 
   const avatar = (
@@ -66,10 +71,11 @@ export function ProfileMenu({
   );
 
   const profileButtonClassName = classNames(styles.profileIconButton, iconLinkClassName);
+  const signInClassName = signInLinkClassName ?? profileButtonClassName;
 
   if (!showDropdown) {
     return (
-      <a href="/login" className={profileButtonClassName} aria-label="Sign in" title="Sign in">
+      <a href="/login" className={signInClassName} aria-label="Sign in" title="Sign in">
         {avatar}
       </a>
     );

--- a/pages/src/components/header/profile-menu.tsx
+++ b/pages/src/components/header/profile-menu.tsx
@@ -13,11 +13,7 @@ interface ProfileMenuProps {
   readonly signInLinkClassName?: string;
 }
 
-export function ProfileMenu({
-  apiHost,
-  iconLinkClassName,
-  signInLinkClassName,
-}: ProfileMenuProps): React.ReactElement {
+export function ProfileMenu({ apiHost, iconLinkClassName, signInLinkClassName }: ProfileMenuProps): React.ReactElement {
   const [authService, setAuthService] = useState<AuthService | null>(null);
   const [session, setSession] = useState<SessionResponse | null>(null);
   const [avatarFailed, setAvatarFailed] = useState(false);

--- a/pages/src/components/header/tests/profile-menu.test.tsx
+++ b/pages/src/components/header/tests/profile-menu.test.tsx
@@ -52,10 +52,10 @@ describe("ProfileMenu", () => {
     expect(signIn.className).not.toBe("iconLink");
   });
 
-  it("renders a direct sign-in link after expected auth resolves unauthenticated", async () => {
+  it("renders a direct sign-in link after unauthenticated session resolves", async () => {
     installWithSession({ authenticated: false });
 
-    render(<ProfileMenu apiHost="https://api.example.com" expectAuthenticated />);
+    render(<ProfileMenu apiHost="https://api.example.com" />);
 
     const signIn = await screen.findByRole("link", { name: "Sign in" });
     expect(signIn).toHaveAttribute("href", "/login");

--- a/pages/src/layouts/layout.astro
+++ b/pages/src/layouts/layout.astro
@@ -17,6 +17,7 @@ const {
 } = Astro.props;
 
 const hasAuthSessionCookie = Astro.cookies.has("auth-session");
+const hasAuthHintCookie = Astro.cookies.has("auth-presence");
 ---
 
 <!doctype html>
@@ -91,7 +92,7 @@ const hasAuthSessionCookie = Astro.cookies.has("auth-session");
     <title>{title}</title>
   </head>
   <body>
-    <Header hasAuthSessionCookie={hasAuthSessionCookie} />
+    <Header hasAuthSessionCookie={hasAuthSessionCookie} hasAuthHintCookie={hasAuthHintCookie} />
     <main>
       <slot />
     </main>


### PR DESCRIPTION
## Context
Users could be authenticated but still see a logged-out header on static pages (notably `/`) because those pages are prerendered and cannot reliably read per-request session cookies at render time. The previous optimization to avoid unnecessary client auth checks then made this mismatch more visible.

## This change
- Adds a non-sensitive `auth-presence=1` hint cookie alongside the existing HttpOnly `auth-session` cookie lifecycle:
  - set when session cookie is set
  - cleared when session cookie is cleared
- Keeps `auth-session` as HttpOnly/Secure/SameSite and never exposes token material to JavaScript.
- Refactors header auth UX to Astro-style lazy hydration:
  - render a static logged-out avatar fallback in the header
  - keep a dormant `<template>` containing `ProfileMenu` island markup
  - run a small module script that only injects/hydrates `ProfileMenu` when either server expectation or `auth-presence` indicates likely auth
- Preserves exact logged-out avatar visuals by using the same avatar CSS structure in the fallback as `ProfileMenu`.
- Cleans up `ProfileMenu` by removing now-redundant `expectAuthenticated` prop, while preserving loading/transition behavior.

## Test plan
- [x] `runTests` for `api/services/auth/tests/session-manager.test.ts`
- [x] `runTests` for `pages/src/components/header/tests/profile-menu.test.tsx`
- [x] `npm run build` in `pages`
