### PR TITLE
fix(viewer): mute lost series match icons regardless of active state

### DIFF
--- a/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
+++ b/pages/src/components/individual-tracker/viewer/individual-tracker-viewer.tsx
@@ -463,7 +463,7 @@ export function IndividualTrackerViewer({
                                   src={gameModeIconSrc(seriesMatch.gameVariantCategory)}
                                   alt={seriesMatch.gameModeName}
                                   className={classNames(styles.entryModeIcon, {
-                                    [styles.seriesModeIconMuted]: !series.isActive && seriesMatch.outcome === "Loss",
+                                    [styles.seriesModeIconMuted]: seriesMatch.outcome === "Loss",
                                   })}
                                 />
                               ))}

--- a/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
@@ -219,7 +219,7 @@ describe("IndividualTrackerViewer", () => {
     expect(screen.queryByText(/End time/)).not.toBeInTheDocument();
   });
 
-  it("does not mute a lost match's icon while its series is still active", () => {
+  it("mutes a lost match's icon while its series is still active", () => {
     const view = aFakeTrackerViewStateWith({
       matches: [
         aFakeTrackerMatchSummaryWith({
@@ -250,7 +250,7 @@ describe("IndividualTrackerViewer", () => {
 
     const icons = within(screen.getByLabelText("Series Ranked Series")).getAllByRole("img");
     expect(icons).toHaveLength(2);
-    expect(icons.every((icon) => !icon.className.includes("seriesModeIconMuted"))).toBe(true);
+    expect(icons.some((icon) => icon.className.includes("seriesModeIconMuted"))).toBe(true);
   });
 
   it("mutes a lost match's icon once its series has completed", () => {

--- a/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
+++ b/pages/src/components/individual-tracker/viewer/tests/individual-tracker-viewer.test.tsx
@@ -248,9 +248,10 @@ describe("IndividualTrackerViewer", () => {
 
     renderViewer(view);
 
-    const icons = within(screen.getByLabelText("Series Ranked Series")).getAllByRole("img");
-    expect(icons).toHaveLength(2);
-    expect(icons.some((icon) => icon.className.includes("seriesModeIconMuted"))).toBe(true);
+    const seriesEntry = within(screen.getByLabelText("Series Ranked Series"));
+    expect(seriesEntry.getAllByRole("img")).toHaveLength(2);
+    expect(seriesEntry.getByAltText("Slayer").className).not.toContain("seriesModeIconMuted");
+    expect(seriesEntry.getByAltText("Attrition").className).toContain("seriesModeIconMuted");
   });
 
   it("mutes a lost match's icon once its series has completed", () => {
@@ -276,9 +277,10 @@ describe("IndividualTrackerViewer", () => {
 
     renderViewer(view);
 
-    const icons = within(screen.getByLabelText("Series Completed Series")).getAllByRole("img");
-    expect(icons).toHaveLength(2);
-    expect(icons.some((icon) => icon.className.includes("seriesModeIconMuted"))).toBe(true);
+    const seriesEntry = within(screen.getByLabelText("Series Completed Series"));
+    expect(seriesEntry.getAllByRole("img")).toHaveLength(2);
+    expect(seriesEntry.getByAltText("Slayer").className).not.toContain("seriesModeIconMuted");
+    expect(seriesEntry.getByAltText("Attrition").className).toContain("seriesModeIconMuted");
   });
 
   it("marks only the most recent series as In progress when active context is missing", () => {


### PR DESCRIPTION
## Context
#774 fixed the overlay's incorrect dimming of lost-match icons during an active series. That fix also touched the tracker viewer's series icon strip (`individual-tracker-viewer.tsx`), which is shared by both the account owner's tracker page and the public `/u/:gamertag` follow page — but that shared component was reported as showing an in-progress series' lost-match icon at full opacity, which isn't the desired behavior there.

## This change
Only the overlay(s) should skip dimming while a series is in progress (there's no "historical" state to distinguish against). The plain viewer — used by both the tracker management page and the public follow page — should dim lost-match icons the same way whether the series is active or completed, matching the completed-series treatment. Reverts the `!series.isActive &&` condition added in #774 for this one component while keeping all of #774's overlay-specific fixes intact.

## Test plan
- [x] Updated regression test to assert muting still applies during an active series
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (full monorepo, 3326 tests)