### PR TITLE
PR3: add leaderboard query API and ranking service tests

### DIFF
--- a/api/routes/stats/leaderboard.ts
+++ b/api/routes/stats/leaderboard.ts
@@ -1,0 +1,34 @@
+import { parseQueryParams } from "@guilty-spark/shared/base/request-parsing";
+import { errorContract } from "@guilty-spark/shared/contracts/error";
+import { leaderboardContract, leaderboardQuerySchema } from "@guilty-spark/shared/contracts/stats/leaderboard";
+import type { RoutesRegisterHandler } from "../base/types";
+
+export const leaderboardRoute: RoutesRegisterHandler = (router, installServices) => {
+  router.get("/api/stats/leaderboard", async (request, env: Env) => {
+    const services = installServices({ env });
+    const { leaderboardService, logService } = services;
+
+    try {
+      const url = new URL(request.url);
+      const queryParams = parseQueryParams(url, leaderboardQuerySchema, "Invalid query parameters");
+      if (!queryParams.success) {
+        return queryParams.response;
+      }
+
+      const { guildId, queueChannelId, window, metric, page, pageSize, minGamesPlayed } = queryParams.data;
+      const response = await leaderboardService.getLeaderboard({
+        guildId,
+        ...(queueChannelId != null ? { queueChannelId } : {}),
+        ...(window != null ? { window } : {}),
+        ...(metric != null ? { metric } : {}),
+        ...(page != null ? { page } : {}),
+        ...(pageSize != null ? { pageSize } : {}),
+        ...(minGamesPlayed != null ? { minGamesPlayed } : {}),
+      });
+      return leaderboardContract.toResponse(response, { noStore: true });
+    } catch (error) {
+      logService.error(error, new Map([["context", "Failed to resolve leaderboard route"]]));
+      return errorContract.toResponse({ error: "Failed to resolve leaderboard" }, { status: 500, noStore: true });
+    }
+  });
+};

--- a/api/routes/stats/stats.ts
+++ b/api/routes/stats/stats.ts
@@ -2,9 +2,11 @@ import type { RoutesRegisterHandler } from "../base/types";
 import { statsDiscordSeriesRoute } from "./discord-series";
 import { batchMatchAnalyticsRoute } from "./batch-analytics";
 import { seriesMatchesRoute } from "./series-matches";
+import { leaderboardRoute } from "./leaderboard";
 
 export const statsRoutesRegisterHandler: RoutesRegisterHandler = (router, installServices) => {
   statsDiscordSeriesRoute(router, installServices);
   batchMatchAnalyticsRoute(router, installServices);
   seriesMatchesRoute(router, installServices);
+  leaderboardRoute(router, installServices);
 };

--- a/api/routes/stats/tests/leaderboard.test.ts
+++ b/api/routes/stats/tests/leaderboard.test.ts
@@ -1,0 +1,98 @@
+import type { AutoRouterType } from "itty-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { leaderboardContract } from "@guilty-spark/shared/contracts/stats/leaderboard";
+import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
+import { createApiRouter } from "../../../base/router";
+import { aFakeEnvWith } from "../../../base/fakes/env.fake";
+import { installFakeServicesWith } from "../../../services/fakes/services";
+import { statsRoutesRegisterHandler } from "../stats";
+
+describe("/api/stats/leaderboard", () => {
+  let env: Env;
+  let router: AutoRouterType;
+
+  beforeEach(() => {
+    env = aFakeEnvWith();
+    router = createApiRouter();
+  });
+
+  it("returns 400 when required guildId is missing", async () => {
+    const services = installFakeServicesWith({ env });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(new Request("http://localhost/api/stats/leaderboard"), env)) as Response;
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns leaderboard payload and parses query options", async () => {
+    const services = installFakeServicesWith({ env });
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "guild-1",
+      queueChannelId: "queue-a",
+      window: LeaderboardWindow.OneMonth,
+      metric: LeaderboardMetric.Kills,
+      minGamesPlayed: 3,
+      page: 2,
+      pageSize: 10,
+      total: 1,
+      rows: [
+        {
+          rank: 11,
+          xboxXuid: "xuid-1",
+          discordUserId: "discord-1",
+          gamertag: "Alpha",
+          seriesPlayed: 4,
+          seriesWins: 3,
+          gamesPlayed: 9,
+          metricValue: 44,
+        },
+      ],
+    });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request(
+        "http://localhost/api/stats/leaderboard?guildId=guild-1&queueChannelId=queue-a&window=1M&metric=KILLS&page=2&pageSize=10&minGamesPlayed=3",
+      ),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(200);
+    const body = await leaderboardContract.fromResponse(response);
+    expect(body).toEqual({
+      guildId: "guild-1",
+      queueChannelId: "queue-a",
+      window: LeaderboardWindow.OneMonth,
+      metric: LeaderboardMetric.Kills,
+      minGamesPlayed: 3,
+      page: 2,
+      pageSize: 10,
+      total: 1,
+      rows: [
+        {
+          rank: 11,
+          xboxXuid: "xuid-1",
+          discordUserId: "discord-1",
+          gamertag: "Alpha",
+          seriesPlayed: 4,
+          seriesWins: 3,
+          gamesPlayed: 9,
+          metricValue: 44,
+        },
+      ],
+    });
+
+    expect(getLeaderboardSpy).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      queueChannelId: "queue-a",
+      window: LeaderboardWindow.OneMonth,
+      metric: LeaderboardMetric.Kills,
+      page: 2,
+      pageSize: 10,
+      minGamesPlayed: 3,
+    });
+  });
+});

--- a/api/routes/stats/tests/leaderboard.test.ts
+++ b/api/routes/stats/tests/leaderboard.test.ts
@@ -39,6 +39,19 @@ describe("/api/stats/leaderboard", () => {
     expect(response.status).toBe(400);
   });
 
+  it("returns 400 when pageSize exceeds the maximum", async () => {
+    const services = installFakeServicesWith({ env });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request("http://localhost/api/stats/leaderboard?guildId=guild-1&pageSize=101"),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(400);
+  });
+
   it("returns leaderboard payload and parses query options", async () => {
     const services = installFakeServicesWith({ env });
     const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({

--- a/api/routes/stats/tests/leaderboard.test.ts
+++ b/api/routes/stats/tests/leaderboard.test.ts
@@ -26,6 +26,19 @@ describe("/api/stats/leaderboard", () => {
     expect(response.status).toBe(400);
   });
 
+  it("returns 400 when numeric query params contain non-digit characters", async () => {
+    const services = installFakeServicesWith({ env });
+    const localInstallServices = vi.fn<typeof installFakeServicesWith>(() => services);
+    statsRoutesRegisterHandler(router, localInstallServices);
+
+    const response = (await router.fetch(
+      new Request("http://localhost/api/stats/leaderboard?guildId=guild-1&page=10abc"),
+      env,
+    )) as Response;
+
+    expect(response.status).toBe(400);
+  });
+
   it("returns leaderboard payload and parses query options", async () => {
     const services = installFakeServicesWith({ env });
     const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({

--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -945,7 +945,7 @@ export class DatabaseService {
       }
       case LeaderboardMetric.DamageRatio: {
         metricSql =
-          "CASE WHEN SUM(gp.DamageTaken) = 0 THEN CASE WHEN SUM(gp.DamageDealt) = 0 THEN 0 ELSE 1e309 END ELSE CAST(SUM(gp.DamageDealt) AS REAL) / SUM(gp.DamageTaken) END";
+          "CASE WHEN SUM(gp.DamageTaken) = 0 THEN CASE WHEN SUM(gp.DamageDealt) = 0 THEN 0 ELSE 1.7976931348623157e308 END ELSE CAST(SUM(gp.DamageDealt) AS REAL) / SUM(gp.DamageTaken) END";
         break;
       }
       case LeaderboardMetric.PersonalScore: {

--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -31,29 +31,6 @@ export interface LeaderboardRankingRow {
   MetricValue: number;
 }
 
-export interface LeaderboardSeriesPlayerFactRow {
-  XboxXuid: string;
-  DiscordUserId: string | null;
-  Gamertag: string;
-  SeriesWon: number;
-  GamesPlayedCount: number;
-}
-
-export interface LeaderboardGamePlayerFactRow {
-  XboxXuid: string;
-  DiscordUserId: string | null;
-  Gamertag: string;
-  Kills: number;
-  Deaths: number;
-  Assists: number;
-  Kda: number;
-  Accuracy: number;
-  DamageDealt: number;
-  DamageTaken: number;
-  PersonalScore: number;
-  QueueNumber: number;
-}
-
 interface LeaderboardRankingsQuery {
   guildId: string;
   queueChannelId: string | null;
@@ -769,84 +746,6 @@ export class DatabaseService {
     const query = "SELECT * FROM LeaderboardSeries WHERE GuildId = ? AND QueueNumber = ?";
     const stmt = this.DB.prepare(query).bind(guildId, queueNumber);
     return await stmt.first<LeaderboardSeriesRow>();
-  }
-
-  async getLeaderboardSeriesPlayerFacts({
-    guildId,
-    queueChannelId,
-    startEpochSeconds,
-  }: {
-    guildId: string;
-    queueChannelId: string | null;
-    startEpochSeconds: number;
-  }): Promise<LeaderboardSeriesPlayerFactRow[]> {
-    const bindings: (string | number)[] = [guildId, startEpochSeconds];
-    let query = `
-      SELECT
-        sp.XboxXuid AS XboxXuid,
-        sp.DiscordUserId AS DiscordUserId,
-        sp.GamertagSnapshot AS Gamertag,
-        sp.SeriesWon AS SeriesWon,
-        sp.GamesPlayedCount AS GamesPlayedCount
-      FROM LeaderboardSeriesPlayers sp
-      INNER JOIN LeaderboardSeries s
-        ON s.GuildId = sp.GuildId
-        AND s.QueueNumber = sp.QueueNumber
-      WHERE s.GuildId = ?
-        AND s.CompletedAt >= ?
-    `;
-
-    if (queueChannelId != null) {
-      query += " AND s.QueueChannelId = ?";
-      bindings.push(queueChannelId);
-    }
-
-    const stmt = this.DB.prepare(query).bind(...bindings);
-    const response = await stmt.all<LeaderboardSeriesPlayerFactRow>();
-    return response.results;
-  }
-
-  async getLeaderboardGamePlayerFacts({
-    guildId,
-    queueChannelId,
-    startEpochSeconds,
-  }: {
-    guildId: string;
-    queueChannelId: string | null;
-    startEpochSeconds: number;
-  }): Promise<LeaderboardGamePlayerFactRow[]> {
-    const bindings: (string | number)[] = [guildId, startEpochSeconds];
-    let query = `
-      SELECT
-        gp.XboxXuid AS XboxXuid,
-        gp.DiscordUserId AS DiscordUserId,
-        gp.GamertagSnapshot AS Gamertag,
-        gp.Kills AS Kills,
-        gp.Deaths AS Deaths,
-        gp.Assists AS Assists,
-        gp.Kda AS Kda,
-        gp.Accuracy AS Accuracy,
-        gp.DamageDealt AS DamageDealt,
-        gp.DamageTaken AS DamageTaken,
-        gp.PersonalScore AS PersonalScore,
-        gp.QueueNumber AS QueueNumber
-      FROM LeaderboardGamePlayers gp
-      INNER JOIN LeaderboardGames g
-        ON g.GuildId = gp.GuildId
-        AND g.QueueNumber = gp.QueueNumber
-        AND g.MatchId = gp.MatchId
-      WHERE gp.GuildId = ?
-        AND g.EndedAt >= ?
-    `;
-
-    if (queueChannelId != null) {
-      query += " AND gp.QueueChannelId = ?";
-      bindings.push(queueChannelId);
-    }
-
-    const stmt = this.DB.prepare(query).bind(...bindings);
-    const response = await stmt.all<LeaderboardGamePlayerFactRow>();
-    return response.results;
   }
 
   async getLeaderboardSeriesWinRateRankings({

--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -1,5 +1,6 @@
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import { LeaderboardWindow, LeaderboardMetric } from "@guilty-spark/shared/halo/leaderboard";
 import { SESSION_COOKIE_MAX_AGE_SECONDS } from "../auth/session-manager";
 import type { DiscordAssociationsRow } from "./types/discord_associations";
 import type { GuildConfigRow } from "./types/guild_config";
@@ -18,7 +19,6 @@ import type { LeaderboardGamesRow } from "./types/leaderboard_games";
 import type { LeaderboardGamePlayersRow } from "./types/leaderboard_game_players";
 import type { LeaderboardRankingRow } from "./types/leaderboard_ranking_row";
 import type { LeaderboardConfigRow } from "./types/leaderboard_config";
-import { LeaderboardWindow, LeaderboardMetric } from "./types/leaderboard_config";
 
 const DEFAULT_LEADERBOARD_ENABLED_WINDOWS_JSON = '["1W","1M","3M","6M","12M"]';
 

--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -16,20 +16,11 @@ import type { LeaderboardSeriesRow } from "./types/leaderboard_series";
 import type { LeaderboardSeriesPlayersRow } from "./types/leaderboard_series_players";
 import type { LeaderboardGamesRow } from "./types/leaderboard_games";
 import type { LeaderboardGamePlayersRow } from "./types/leaderboard_game_players";
+import type { LeaderboardRankingRow } from "./types/leaderboard_ranking_row";
 import type { LeaderboardConfigRow } from "./types/leaderboard_config";
 import { LeaderboardWindow, LeaderboardMetric } from "./types/leaderboard_config";
 
 const DEFAULT_LEADERBOARD_ENABLED_WINDOWS_JSON = '["1W","1M","3M","6M","12M"]';
-
-export interface LeaderboardRankingRow {
-  XboxXuid: string;
-  DiscordUserId: string | null;
-  Gamertag: string;
-  SeriesPlayed: number;
-  SeriesWins: number;
-  GamesPlayed: number;
-  MetricValue: number;
-}
 
 interface LeaderboardRankingsQuery {
   guildId: string;

--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -758,31 +758,66 @@ export class DatabaseService {
   }: LeaderboardRankingsQuery): Promise<{ total: number; rows: LeaderboardRankingRow[] }> {
     const aggregateSql = `
       SELECT
-        sp.XboxXuid AS XboxXuid,
-        MAX(sp.DiscordUserId) AS DiscordUserId,
-        MAX(sp.GamertagSnapshot) AS Gamertag,
-        COUNT(*) AS SeriesPlayed,
-        SUM(sp.SeriesWon) AS SeriesWins,
-        SUM(sp.GamesPlayedCount) AS GamesPlayed,
-        CAST(SUM(sp.SeriesWon) AS REAL) / COUNT(*) AS MetricValue
-      FROM LeaderboardSeriesPlayers sp
-      INNER JOIN LeaderboardSeries s
-        ON s.GuildId = sp.GuildId
-        AND s.QueueNumber = sp.QueueNumber
-      WHERE s.GuildId = ?
-        AND s.CompletedAt >= ?
-        AND (? IS NULL OR s.QueueChannelId = ?)
-      GROUP BY sp.XboxXuid
-      HAVING SUM(sp.GamesPlayedCount) >= ?
+        stats.XboxXuid AS XboxXuid,
+        identity.DiscordUserId AS DiscordUserId,
+        identity.GamertagSnapshot AS Gamertag,
+        stats.SeriesPlayed AS SeriesPlayed,
+        stats.SeriesWins AS SeriesWins,
+        stats.GamesPlayed AS GamesPlayed,
+        CAST(stats.SeriesWins AS REAL) / stats.SeriesPlayed AS MetricValue
+      FROM (
+        SELECT
+          sp.XboxXuid AS XboxXuid,
+          COUNT(*) AS SeriesPlayed,
+          SUM(sp.SeriesWon) AS SeriesWins,
+          SUM(sp.GamesPlayedCount) AS GamesPlayed
+        FROM LeaderboardSeriesPlayers sp
+        INNER JOIN LeaderboardSeries s
+          ON s.GuildId = sp.GuildId
+          AND s.QueueNumber = sp.QueueNumber
+        WHERE s.GuildId = ?
+          AND s.CompletedAt >= ?
+          AND (? IS NULL OR s.QueueChannelId = ?)
+        GROUP BY sp.XboxXuid
+        HAVING SUM(sp.GamesPlayedCount) >= ?
+      ) stats
+      INNER JOIN (
+        SELECT ranked.XboxXuid, ranked.DiscordUserId, ranked.GamertagSnapshot
+        FROM (
+          SELECT
+            sp.XboxXuid AS XboxXuid,
+            sp.DiscordUserId AS DiscordUserId,
+            sp.GamertagSnapshot AS GamertagSnapshot,
+            ROW_NUMBER() OVER (
+              PARTITION BY sp.XboxXuid
+              ORDER BY s.CompletedAt DESC, sp.CreatedAt DESC
+            ) AS RowNumber
+          FROM LeaderboardSeriesPlayers sp
+          INNER JOIN LeaderboardSeries s
+            ON s.GuildId = sp.GuildId
+            AND s.QueueNumber = sp.QueueNumber
+          WHERE s.GuildId = ?
+            AND s.CompletedAt >= ?
+            AND (? IS NULL OR s.QueueChannelId = ?)
+        ) ranked
+        WHERE ranked.RowNumber = 1
+      ) identity
+        ON identity.XboxXuid = stats.XboxXuid
     `;
 
-    const countStmt = this.DB.prepare(`SELECT COUNT(*) AS Total FROM (${aggregateSql}) agg`).bind(
+    const bindings = [
       guildId,
       startEpochSeconds,
       queueChannelId,
       queueChannelId,
       minGamesPlayed,
-    );
+      guildId,
+      startEpochSeconds,
+      queueChannelId,
+      queueChannelId,
+    ] as const;
+
+    const countStmt = this.DB.prepare(`SELECT COUNT(*) AS Total FROM (${aggregateSql}) agg`).bind(...bindings);
     const countRow = await countStmt.first<{ Total: number }>();
 
     const rowsStmt = this.DB.prepare(
@@ -791,7 +826,7 @@ export class DatabaseService {
         ORDER BY agg.MetricValue DESC, agg.SeriesWins DESC, agg.GamesPlayed DESC, agg.Gamertag ASC
         LIMIT ? OFFSET ?
       `,
-    ).bind(guildId, startEpochSeconds, queueChannelId, queueChannelId, minGamesPlayed, limit, offset);
+    ).bind(...bindings, limit, offset);
     const rowsResponse = await rowsStmt.all<LeaderboardRankingRow>();
 
     return {
@@ -858,32 +893,87 @@ export class DatabaseService {
 
     const aggregateSql = `
       SELECT
-        gp.XboxXuid AS XboxXuid,
-        MAX(gp.DiscordUserId) AS DiscordUserId,
-        MAX(gp.GamertagSnapshot) AS Gamertag,
-        COUNT(DISTINCT gp.QueueNumber) AS SeriesPlayed,
-        0 AS SeriesWins,
-        COUNT(*) AS GamesPlayed,
-        ${metricSql} AS MetricValue
-      FROM LeaderboardGamePlayers gp
-      INNER JOIN LeaderboardGames g
-        ON g.GuildId = gp.GuildId
-        AND g.QueueNumber = gp.QueueNumber
-        AND g.MatchId = gp.MatchId
-      WHERE gp.GuildId = ?
-        AND g.EndedAt >= ?
-        AND (? IS NULL OR gp.QueueChannelId = ?)
-      GROUP BY gp.XboxXuid
-      HAVING COUNT(*) >= ?
+        stats.XboxXuid AS XboxXuid,
+        identity.DiscordUserId AS DiscordUserId,
+        identity.GamertagSnapshot AS Gamertag,
+        COALESCE(seriesStats.SeriesPlayed, stats.SeriesPlayed) AS SeriesPlayed,
+        COALESCE(seriesStats.SeriesWins, 0) AS SeriesWins,
+        stats.GamesPlayed AS GamesPlayed,
+        stats.MetricValue AS MetricValue
+      FROM (
+        SELECT
+          gp.XboxXuid AS XboxXuid,
+          COUNT(DISTINCT gp.QueueNumber) AS SeriesPlayed,
+          COUNT(*) AS GamesPlayed,
+          ${metricSql} AS MetricValue
+        FROM LeaderboardGamePlayers gp
+        INNER JOIN LeaderboardGames g
+          ON g.GuildId = gp.GuildId
+          AND g.QueueNumber = gp.QueueNumber
+          AND g.MatchId = gp.MatchId
+        WHERE gp.GuildId = ?
+          AND g.EndedAt >= ?
+          AND (? IS NULL OR gp.QueueChannelId = ?)
+        GROUP BY gp.XboxXuid
+        HAVING COUNT(*) >= ?
+      ) stats
+      LEFT JOIN (
+        SELECT
+          sp.XboxXuid AS XboxXuid,
+          COUNT(*) AS SeriesPlayed,
+          SUM(sp.SeriesWon) AS SeriesWins
+        FROM LeaderboardSeriesPlayers sp
+        INNER JOIN LeaderboardSeries s
+          ON s.GuildId = sp.GuildId
+          AND s.QueueNumber = sp.QueueNumber
+        WHERE s.GuildId = ?
+          AND s.CompletedAt >= ?
+          AND (? IS NULL OR s.QueueChannelId = ?)
+        GROUP BY sp.XboxXuid
+      ) seriesStats
+        ON seriesStats.XboxXuid = stats.XboxXuid
+      INNER JOIN (
+        SELECT ranked.XboxXuid, ranked.DiscordUserId, ranked.GamertagSnapshot
+        FROM (
+          SELECT
+            gp.XboxXuid AS XboxXuid,
+            gp.DiscordUserId AS DiscordUserId,
+            gp.GamertagSnapshot AS GamertagSnapshot,
+            ROW_NUMBER() OVER (
+              PARTITION BY gp.XboxXuid
+              ORDER BY g.EndedAt DESC, gp.CreatedAt DESC
+            ) AS RowNumber
+          FROM LeaderboardGamePlayers gp
+          INNER JOIN LeaderboardGames g
+            ON g.GuildId = gp.GuildId
+            AND g.QueueNumber = gp.QueueNumber
+            AND g.MatchId = gp.MatchId
+          WHERE gp.GuildId = ?
+            AND g.EndedAt >= ?
+            AND (? IS NULL OR gp.QueueChannelId = ?)
+        ) ranked
+        WHERE ranked.RowNumber = 1
+      ) identity
+        ON identity.XboxXuid = stats.XboxXuid
     `;
 
-    const countStmt = this.DB.prepare(`SELECT COUNT(*) AS Total FROM (${aggregateSql}) agg`).bind(
+    const bindings = [
       guildId,
       startEpochSeconds,
       queueChannelId,
       queueChannelId,
       minGamesPlayed,
-    );
+      guildId,
+      startEpochSeconds,
+      queueChannelId,
+      queueChannelId,
+      guildId,
+      startEpochSeconds,
+      queueChannelId,
+      queueChannelId,
+    ] as const;
+
+    const countStmt = this.DB.prepare(`SELECT COUNT(*) AS Total FROM (${aggregateSql}) agg`).bind(...bindings);
     const countRow = await countStmt.first<{ Total: number }>();
 
     const rowsStmt = this.DB.prepare(
@@ -892,7 +982,7 @@ export class DatabaseService {
         ORDER BY agg.MetricValue DESC, agg.GamesPlayed DESC, agg.Gamertag ASC
         LIMIT ? OFFSET ?
       `,
-    ).bind(guildId, startEpochSeconds, queueChannelId, queueChannelId, minGamesPlayed, limit, offset);
+    ).bind(...bindings, limit, offset);
     const rowsResponse = await rowsStmt.all<LeaderboardRankingRow>();
 
     return {

--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -1,4 +1,5 @@
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { SESSION_COOKIE_MAX_AGE_SECONDS } from "../auth/session-manager";
 import type { DiscordAssociationsRow } from "./types/discord_associations";
 import type { GuildConfigRow } from "./types/guild_config";
@@ -19,6 +20,48 @@ import type { LeaderboardConfigRow } from "./types/leaderboard_config";
 import { LeaderboardWindow, LeaderboardMetric } from "./types/leaderboard_config";
 
 const DEFAULT_LEADERBOARD_ENABLED_WINDOWS_JSON = '["1W","1M","3M","6M","12M"]';
+
+export interface LeaderboardRankingRow {
+  XboxXuid: string;
+  DiscordUserId: string | null;
+  Gamertag: string;
+  SeriesPlayed: number;
+  SeriesWins: number;
+  GamesPlayed: number;
+  MetricValue: number;
+}
+
+export interface LeaderboardSeriesPlayerFactRow {
+  XboxXuid: string;
+  DiscordUserId: string | null;
+  Gamertag: string;
+  SeriesWon: number;
+  GamesPlayedCount: number;
+}
+
+export interface LeaderboardGamePlayerFactRow {
+  XboxXuid: string;
+  DiscordUserId: string | null;
+  Gamertag: string;
+  Kills: number;
+  Deaths: number;
+  Assists: number;
+  Kda: number;
+  Accuracy: number;
+  DamageDealt: number;
+  DamageTaken: number;
+  PersonalScore: number;
+  QueueNumber: number;
+}
+
+interface LeaderboardRankingsQuery {
+  guildId: string;
+  queueChannelId: string | null;
+  startEpochSeconds: number;
+  minGamesPlayed: number;
+  limit: number;
+  offset: number;
+}
 
 export interface DatabaseServiceOpts {
   env: Env;
@@ -726,6 +769,237 @@ export class DatabaseService {
     const query = "SELECT * FROM LeaderboardSeries WHERE GuildId = ? AND QueueNumber = ?";
     const stmt = this.DB.prepare(query).bind(guildId, queueNumber);
     return await stmt.first<LeaderboardSeriesRow>();
+  }
+
+  async getLeaderboardSeriesPlayerFacts({
+    guildId,
+    queueChannelId,
+    startEpochSeconds,
+  }: {
+    guildId: string;
+    queueChannelId: string | null;
+    startEpochSeconds: number;
+  }): Promise<LeaderboardSeriesPlayerFactRow[]> {
+    const bindings: (string | number)[] = [guildId, startEpochSeconds];
+    let query = `
+      SELECT
+        sp.XboxXuid AS XboxXuid,
+        sp.DiscordUserId AS DiscordUserId,
+        sp.GamertagSnapshot AS Gamertag,
+        sp.SeriesWon AS SeriesWon,
+        sp.GamesPlayedCount AS GamesPlayedCount
+      FROM LeaderboardSeriesPlayers sp
+      INNER JOIN LeaderboardSeries s
+        ON s.GuildId = sp.GuildId
+        AND s.QueueNumber = sp.QueueNumber
+      WHERE s.GuildId = ?
+        AND s.CompletedAt >= ?
+    `;
+
+    if (queueChannelId != null) {
+      query += " AND s.QueueChannelId = ?";
+      bindings.push(queueChannelId);
+    }
+
+    const stmt = this.DB.prepare(query).bind(...bindings);
+    const response = await stmt.all<LeaderboardSeriesPlayerFactRow>();
+    return response.results;
+  }
+
+  async getLeaderboardGamePlayerFacts({
+    guildId,
+    queueChannelId,
+    startEpochSeconds,
+  }: {
+    guildId: string;
+    queueChannelId: string | null;
+    startEpochSeconds: number;
+  }): Promise<LeaderboardGamePlayerFactRow[]> {
+    const bindings: (string | number)[] = [guildId, startEpochSeconds];
+    let query = `
+      SELECT
+        gp.XboxXuid AS XboxXuid,
+        gp.DiscordUserId AS DiscordUserId,
+        gp.GamertagSnapshot AS Gamertag,
+        gp.Kills AS Kills,
+        gp.Deaths AS Deaths,
+        gp.Assists AS Assists,
+        gp.Kda AS Kda,
+        gp.Accuracy AS Accuracy,
+        gp.DamageDealt AS DamageDealt,
+        gp.DamageTaken AS DamageTaken,
+        gp.PersonalScore AS PersonalScore,
+        gp.QueueNumber AS QueueNumber
+      FROM LeaderboardGamePlayers gp
+      INNER JOIN LeaderboardGames g
+        ON g.GuildId = gp.GuildId
+        AND g.QueueNumber = gp.QueueNumber
+        AND g.MatchId = gp.MatchId
+      WHERE gp.GuildId = ?
+        AND g.EndedAt >= ?
+    `;
+
+    if (queueChannelId != null) {
+      query += " AND gp.QueueChannelId = ?";
+      bindings.push(queueChannelId);
+    }
+
+    const stmt = this.DB.prepare(query).bind(...bindings);
+    const response = await stmt.all<LeaderboardGamePlayerFactRow>();
+    return response.results;
+  }
+
+  async getLeaderboardSeriesWinRateRankings({
+    guildId,
+    queueChannelId,
+    startEpochSeconds,
+    minGamesPlayed,
+    limit,
+    offset,
+  }: LeaderboardRankingsQuery): Promise<{ total: number; rows: LeaderboardRankingRow[] }> {
+    const aggregateSql = `
+      SELECT
+        sp.XboxXuid AS XboxXuid,
+        MAX(sp.DiscordUserId) AS DiscordUserId,
+        MAX(sp.GamertagSnapshot) AS Gamertag,
+        COUNT(*) AS SeriesPlayed,
+        SUM(sp.SeriesWon) AS SeriesWins,
+        SUM(sp.GamesPlayedCount) AS GamesPlayed,
+        CAST(SUM(sp.SeriesWon) AS REAL) / COUNT(*) AS MetricValue
+      FROM LeaderboardSeriesPlayers sp
+      INNER JOIN LeaderboardSeries s
+        ON s.GuildId = sp.GuildId
+        AND s.QueueNumber = sp.QueueNumber
+      WHERE s.GuildId = ?
+        AND s.CompletedAt >= ?
+        AND (? IS NULL OR s.QueueChannelId = ?)
+      GROUP BY sp.XboxXuid
+      HAVING SUM(sp.GamesPlayedCount) >= ?
+    `;
+
+    const countStmt = this.DB.prepare(`SELECT COUNT(*) AS Total FROM (${aggregateSql}) agg`).bind(
+      guildId,
+      startEpochSeconds,
+      queueChannelId,
+      queueChannelId,
+      minGamesPlayed,
+    );
+    const countRow = await countStmt.first<{ Total: number }>();
+
+    const rowsStmt = this.DB.prepare(
+      `
+        SELECT * FROM (${aggregateSql}) agg
+        ORDER BY agg.MetricValue DESC, agg.SeriesWins DESC, agg.GamesPlayed DESC, agg.Gamertag ASC
+        LIMIT ? OFFSET ?
+      `,
+    ).bind(guildId, startEpochSeconds, queueChannelId, queueChannelId, minGamesPlayed, limit, offset);
+    const rowsResponse = await rowsStmt.all<LeaderboardRankingRow>();
+
+    return {
+      total: countRow?.Total ?? 0,
+      rows: rowsResponse.results,
+    };
+  }
+
+  async getLeaderboardStatMetricRankings({
+    guildId,
+    queueChannelId,
+    startEpochSeconds,
+    minGamesPlayed,
+    limit,
+    offset,
+    metric,
+  }: LeaderboardRankingsQuery & { metric: Exclude<LeaderboardMetric, LeaderboardMetric.SeriesWinRate> }): Promise<{
+    total: number;
+    rows: LeaderboardRankingRow[];
+  }> {
+    let metricSql = "SUM(gp.PersonalScore)";
+    switch (metric) {
+      case LeaderboardMetric.Kills: {
+        metricSql = "SUM(gp.Kills)";
+        break;
+      }
+      case LeaderboardMetric.Deaths: {
+        metricSql = "SUM(gp.Deaths)";
+        break;
+      }
+      case LeaderboardMetric.Assists: {
+        metricSql = "SUM(gp.Assists)";
+        break;
+      }
+      case LeaderboardMetric.Kda: {
+        metricSql = "AVG(gp.Kda)";
+        break;
+      }
+      case LeaderboardMetric.Accuracy: {
+        metricSql = "AVG(gp.Accuracy)";
+        break;
+      }
+      case LeaderboardMetric.DamageDealt: {
+        metricSql = "SUM(gp.DamageDealt)";
+        break;
+      }
+      case LeaderboardMetric.DamageTaken: {
+        metricSql = "SUM(gp.DamageTaken)";
+        break;
+      }
+      case LeaderboardMetric.DamageRatio: {
+        metricSql =
+          "CASE WHEN SUM(gp.DamageTaken) = 0 THEN CASE WHEN SUM(gp.DamageDealt) = 0 THEN 0 ELSE 1e309 END ELSE CAST(SUM(gp.DamageDealt) AS REAL) / SUM(gp.DamageTaken) END";
+        break;
+      }
+      case LeaderboardMetric.PersonalScore: {
+        metricSql = "SUM(gp.PersonalScore)";
+        break;
+      }
+      default: {
+        throw new UnreachableError(metric);
+      }
+    }
+
+    const aggregateSql = `
+      SELECT
+        gp.XboxXuid AS XboxXuid,
+        MAX(gp.DiscordUserId) AS DiscordUserId,
+        MAX(gp.GamertagSnapshot) AS Gamertag,
+        COUNT(DISTINCT gp.QueueNumber) AS SeriesPlayed,
+        0 AS SeriesWins,
+        COUNT(*) AS GamesPlayed,
+        ${metricSql} AS MetricValue
+      FROM LeaderboardGamePlayers gp
+      INNER JOIN LeaderboardGames g
+        ON g.GuildId = gp.GuildId
+        AND g.QueueNumber = gp.QueueNumber
+        AND g.MatchId = gp.MatchId
+      WHERE gp.GuildId = ?
+        AND g.EndedAt >= ?
+        AND (? IS NULL OR gp.QueueChannelId = ?)
+      GROUP BY gp.XboxXuid
+      HAVING COUNT(*) >= ?
+    `;
+
+    const countStmt = this.DB.prepare(`SELECT COUNT(*) AS Total FROM (${aggregateSql}) agg`).bind(
+      guildId,
+      startEpochSeconds,
+      queueChannelId,
+      queueChannelId,
+      minGamesPlayed,
+    );
+    const countRow = await countStmt.first<{ Total: number }>();
+
+    const rowsStmt = this.DB.prepare(
+      `
+        SELECT * FROM (${aggregateSql}) agg
+        ORDER BY agg.MetricValue DESC, agg.GamesPlayed DESC, agg.Gamertag ASC
+        LIMIT ? OFFSET ?
+      `,
+    ).bind(guildId, startEpochSeconds, queueChannelId, queueChannelId, minGamesPlayed, limit, offset);
+    const rowsResponse = await rowsStmt.all<LeaderboardRankingRow>();
+
+    return {
+      total: countRow?.Total ?? 0,
+      rows: rowsResponse.results,
+    };
   }
 
   async getUserSession(sessionId: string): Promise<UserSessionsRow | null> {

--- a/api/services/database/fakes/database.fake.ts
+++ b/api/services/database/fakes/database.fake.ts
@@ -1,3 +1,4 @@
+import { LeaderboardWindow, LeaderboardMetric } from "@guilty-spark/shared/halo/leaderboard";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import type { DatabaseServiceOpts } from "../database";
 import { DatabaseService } from "../database";
@@ -15,7 +16,6 @@ import type { IndividualTrackerGamesRow } from "../types/individual_tracker_game
 import type { StreamerViewSettingsRow } from "../types/streamer_view_settings";
 import type { IndividualTrackersRow } from "../types/individual_trackers";
 import type { LeaderboardConfigRow } from "../types/leaderboard_config";
-import { LeaderboardWindow, LeaderboardMetric } from "../types/leaderboard_config";
 import type { LeaderboardSeriesRow } from "../types/leaderboard_series";
 import type { LeaderboardSeriesPlayersRow } from "../types/leaderboard_series_players";
 import type { LeaderboardGamesRow } from "../types/leaderboard_games";

--- a/api/services/database/tests/database.test.ts
+++ b/api/services/database/tests/database.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
 import { aFakeEnvWith, fakeD1Response, FakePreparedStatement } from "../../../base/fakes/env.fake";
 import { SESSION_COOKIE_MAX_AGE_SECONDS } from "../../auth/session-manager";
 import { DatabaseService } from "../database";
@@ -27,7 +28,6 @@ import type { LinkedIdentitiesRow } from "../types/linked_identities";
 import type { IndividualTrackerProfilesRow } from "../types/individual_tracker_profiles";
 import type { IndividualTrackerGamesRow } from "../types/individual_tracker_games";
 import type { StreamerViewSettingsRow } from "../types/streamer_view_settings";
-import { LeaderboardMetric, LeaderboardWindow } from "../types/leaderboard_config";
 
 describe("Database Service", () => {
   let env: Env;

--- a/api/services/database/types/leaderboard_config.ts
+++ b/api/services/database/types/leaderboard_config.ts
@@ -1,5 +1,5 @@
-export { LeaderboardWindow, LeaderboardMetric } from "@guilty-spark/shared/halo/leaderboard";
 import type { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
+export { LeaderboardWindow, LeaderboardMetric } from "@guilty-spark/shared/halo/leaderboard";
 
 export interface LeaderboardConfigRow {
   GuildId: string;

--- a/api/services/database/types/leaderboard_config.ts
+++ b/api/services/database/types/leaderboard_config.ts
@@ -1,23 +1,5 @@
-export enum LeaderboardWindow {
-  OneWeek = "1W",
-  OneMonth = "1M",
-  ThreeMonths = "3M",
-  SixMonths = "6M",
-  TwelveMonths = "12M",
-}
-
-export enum LeaderboardMetric {
-  SeriesWinRate = "SERIES_WIN_RATE",
-  Kills = "KILLS",
-  Deaths = "DEATHS",
-  Assists = "ASSISTS",
-  Kda = "KDA",
-  Accuracy = "ACCURACY",
-  DamageDealt = "DAMAGE_DEALT",
-  DamageTaken = "DAMAGE_TAKEN",
-  DamageRatio = "DAMAGE_RATIO",
-  PersonalScore = "PERSONAL_SCORE",
-}
+export { LeaderboardWindow, LeaderboardMetric } from "@guilty-spark/shared/halo/leaderboard";
+import type { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
 
 export interface LeaderboardConfigRow {
   GuildId: string;

--- a/api/services/database/types/leaderboard_config.ts
+++ b/api/services/database/types/leaderboard_config.ts
@@ -1,5 +1,4 @@
 import type { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
-export { LeaderboardWindow, LeaderboardMetric } from "@guilty-spark/shared/halo/leaderboard";
 
 export interface LeaderboardConfigRow {
   GuildId: string;

--- a/api/services/database/types/leaderboard_ranking_row.ts
+++ b/api/services/database/types/leaderboard_ranking_row.ts
@@ -1,0 +1,9 @@
+export interface LeaderboardRankingRow {
+  XboxXuid: string;
+  DiscordUserId: string | null;
+  Gamertag: string;
+  SeriesPlayed: number;
+  SeriesWins: number;
+  GamesPlayed: number;
+  MetricValue: number;
+}

--- a/api/services/leaderboard/leaderboard.ts
+++ b/api/services/leaderboard/leaderboard.ts
@@ -133,23 +133,25 @@ export class LeaderboardService {
     const offset = (resolvedPage - 1) * resolvedPageSize;
     const startEpochSeconds = this.getWindowStartEpochSeconds(resolvedWindow);
 
-    const allRows =
+    const rankings =
       resolvedMetric === LeaderboardMetric.SeriesWinRate
-        ? await this.getSeriesWinRateRows({
+        ? await this.databaseService.getLeaderboardSeriesWinRateRankings({
             guildId,
             queueChannelId: queueChannelId ?? null,
             startEpochSeconds,
             minGamesPlayed: resolvedMinGamesPlayed,
+            limit: resolvedPageSize,
+            offset,
           })
-        : await this.getMetricRows({
+        : await this.databaseService.getLeaderboardStatMetricRankings({
             guildId,
             queueChannelId: queueChannelId ?? null,
             startEpochSeconds,
             minGamesPlayed: resolvedMinGamesPlayed,
+            limit: resolvedPageSize,
+            offset,
             metric: resolvedMetric,
           });
-
-    const pagedRows = allRows.slice(offset, offset + resolvedPageSize);
 
     return {
       guildId,
@@ -159,252 +161,26 @@ export class LeaderboardService {
       minGamesPlayed: resolvedMinGamesPlayed,
       page: resolvedPage,
       pageSize: resolvedPageSize,
-      total: allRows.length,
-      rows: pagedRows.map((row, index) => ({
+      total: rankings.total,
+      rows: rankings.rows.map((row, index) => ({
         rank: offset + index + 1,
-        xboxXuid: row.xboxXuid,
-        discordUserId: row.discordUserId,
-        gamertag: row.gamertag,
-        seriesPlayed: row.seriesPlayed,
-        seriesWins: row.seriesWins,
-        gamesPlayed: row.gamesPlayed,
-        metricValue: row.metricValue,
+        xboxXuid: row.XboxXuid,
+        discordUserId: row.DiscordUserId,
+        gamertag: row.Gamertag,
+        seriesPlayed: row.SeriesPlayed,
+        seriesWins: row.SeriesWins,
+        gamesPlayed: row.GamesPlayed,
+        metricValue: this.toFiniteMetricValue(row.MetricValue),
       })),
     };
   }
 
-  private async getSeriesWinRateRows({
-    guildId,
-    queueChannelId,
-    startEpochSeconds,
-    minGamesPlayed,
-  }: {
-    guildId: string;
-    queueChannelId: string | null;
-    startEpochSeconds: number;
-    minGamesPlayed: number;
-  }): Promise<
-    {
-      xboxXuid: string;
-      discordUserId: string | null;
-      gamertag: string;
-      seriesPlayed: number;
-      seriesWins: number;
-      gamesPlayed: number;
-      metricValue: number;
-    }[]
-  > {
-    const facts = await this.databaseService.getLeaderboardSeriesPlayerFacts({
-      guildId,
-      queueChannelId,
-      startEpochSeconds,
-    });
-    const byXuid = new Map<
-      string,
-      {
-        xboxXuid: string;
-        discordUserId: string | null;
-        gamertag: string;
-        seriesPlayed: number;
-        seriesWins: number;
-        gamesPlayed: number;
-      }
-    >();
-
-    for (const fact of facts) {
-      const existing = byXuid.get(fact.XboxXuid);
-      if (existing == null) {
-        byXuid.set(fact.XboxXuid, {
-          xboxXuid: fact.XboxXuid,
-          discordUserId: fact.DiscordUserId,
-          gamertag: fact.Gamertag,
-          seriesPlayed: 1,
-          seriesWins: fact.SeriesWon,
-          gamesPlayed: fact.GamesPlayedCount,
-        });
-        continue;
-      }
-
-      existing.discordUserId = existing.discordUserId ?? fact.DiscordUserId;
-      existing.gamertag = fact.Gamertag;
-      existing.seriesPlayed += 1;
-      existing.seriesWins += fact.SeriesWon;
-      existing.gamesPlayed += fact.GamesPlayedCount;
+  private toFiniteMetricValue(metricValue: number): number {
+    if (Number.isFinite(metricValue)) {
+      return metricValue;
     }
 
-    return [...byXuid.values()]
-      .filter((row) => row.gamesPlayed >= minGamesPlayed)
-      .map((row) => ({
-        ...row,
-        metricValue: row.seriesPlayed === 0 ? 0 : row.seriesWins / row.seriesPlayed,
-      }))
-      .sort((left, right) => {
-        if (right.metricValue !== left.metricValue) {
-          return right.metricValue - left.metricValue;
-        }
-
-        if (right.seriesWins !== left.seriesWins) {
-          return right.seriesWins - left.seriesWins;
-        }
-
-        if (right.gamesPlayed !== left.gamesPlayed) {
-          return right.gamesPlayed - left.gamesPlayed;
-        }
-
-        return left.gamertag.localeCompare(right.gamertag);
-      });
-  }
-
-  private async getMetricRows({
-    guildId,
-    queueChannelId,
-    startEpochSeconds,
-    minGamesPlayed,
-    metric,
-  }: {
-    guildId: string;
-    queueChannelId: string | null;
-    startEpochSeconds: number;
-    minGamesPlayed: number;
-    metric: Exclude<LeaderboardMetric, LeaderboardMetric.SeriesWinRate>;
-  }): Promise<
-    {
-      xboxXuid: string;
-      discordUserId: string | null;
-      gamertag: string;
-      seriesPlayed: number;
-      seriesWins: number;
-      gamesPlayed: number;
-      metricValue: number;
-    }[]
-  > {
-    const facts = await this.databaseService.getLeaderboardGamePlayerFacts({
-      guildId,
-      queueChannelId,
-      startEpochSeconds,
-    });
-    const byXuid = new Map<
-      string,
-      {
-        xboxXuid: string;
-        discordUserId: string | null;
-        gamertag: string;
-        seriesNumbers: Set<number>;
-        gamesPlayed: number;
-        kills: number;
-        deaths: number;
-        assists: number;
-        kdaSum: number;
-        accuracySum: number;
-        damageDealt: number;
-        damageTaken: number;
-        personalScore: number;
-      }
-    >();
-
-    for (const fact of facts) {
-      const existing = byXuid.get(fact.XboxXuid);
-      if (existing == null) {
-        byXuid.set(fact.XboxXuid, {
-          xboxXuid: fact.XboxXuid,
-          discordUserId: fact.DiscordUserId,
-          gamertag: fact.Gamertag,
-          seriesNumbers: new Set([fact.QueueNumber]),
-          gamesPlayed: 1,
-          kills: fact.Kills,
-          deaths: fact.Deaths,
-          assists: fact.Assists,
-          kdaSum: fact.Kda,
-          accuracySum: fact.Accuracy,
-          damageDealt: fact.DamageDealt,
-          damageTaken: fact.DamageTaken,
-          personalScore: fact.PersonalScore,
-        });
-        continue;
-      }
-
-      existing.discordUserId = existing.discordUserId ?? fact.DiscordUserId;
-      existing.gamertag = fact.Gamertag;
-      existing.seriesNumbers.add(fact.QueueNumber);
-      existing.gamesPlayed += 1;
-      existing.kills += fact.Kills;
-      existing.deaths += fact.Deaths;
-      existing.assists += fact.Assists;
-      existing.kdaSum += fact.Kda;
-      existing.accuracySum += fact.Accuracy;
-      existing.damageDealt += fact.DamageDealt;
-      existing.damageTaken += fact.DamageTaken;
-      existing.personalScore += fact.PersonalScore;
-    }
-
-    const rows = [...byXuid.values()]
-      .filter((row) => row.gamesPlayed >= minGamesPlayed)
-      .map((row) => {
-        let metricValue = row.personalScore;
-        switch (metric) {
-          case LeaderboardMetric.Kills: {
-            metricValue = row.kills;
-            break;
-          }
-          case LeaderboardMetric.Deaths: {
-            metricValue = row.deaths;
-            break;
-          }
-          case LeaderboardMetric.Assists: {
-            metricValue = row.assists;
-            break;
-          }
-          case LeaderboardMetric.Kda: {
-            metricValue = row.kdaSum / row.gamesPlayed;
-            break;
-          }
-          case LeaderboardMetric.Accuracy: {
-            metricValue = row.accuracySum / row.gamesPlayed;
-            break;
-          }
-          case LeaderboardMetric.DamageDealt: {
-            metricValue = row.damageDealt;
-            break;
-          }
-          case LeaderboardMetric.DamageTaken: {
-            metricValue = row.damageTaken;
-            break;
-          }
-          case LeaderboardMetric.DamageRatio: {
-            metricValue = getSafeRatioValue(row.damageDealt, row.damageTaken);
-            break;
-          }
-          case LeaderboardMetric.PersonalScore: {
-            metricValue = row.personalScore;
-            break;
-          }
-          default: {
-            throw new UnreachableError(metric);
-          }
-        }
-
-        return {
-          xboxXuid: row.xboxXuid,
-          discordUserId: row.discordUserId,
-          gamertag: row.gamertag,
-          seriesPlayed: row.seriesNumbers.size,
-          seriesWins: 0,
-          gamesPlayed: row.gamesPlayed,
-          metricValue,
-        };
-      });
-
-    return rows.sort((left, right) => {
-      if (right.metricValue !== left.metricValue) {
-        return right.metricValue - left.metricValue;
-      }
-
-      if (right.gamesPlayed !== left.gamesPlayed) {
-        return right.gamesPlayed - left.gamesPlayed;
-      }
-
-      return left.gamertag.localeCompare(right.gamertag);
-    });
+    return Number.MAX_VALUE;
   }
 
   private getWindowStartEpochSeconds(window: LeaderboardWindow): number {

--- a/api/services/leaderboard/leaderboard.ts
+++ b/api/services/leaderboard/leaderboard.ts
@@ -1,8 +1,12 @@
 import type { MatchStats } from "halo-infinite-api";
+import { sub } from "date-fns";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { getDurationInSeconds } from "@guilty-spark/shared/halo/duration";
 import { getSafeRatioValue } from "@guilty-spark/shared/halo/stat-formatting";
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
+import type { LeaderboardResponse } from "@guilty-spark/shared/contracts/stats/leaderboard";
+import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
 import type { DatabaseService } from "../database/database";
 import type { LeaderboardSeriesRow } from "../database/types/leaderboard_series";
 import type { LeaderboardSeriesPlayersRow } from "../database/types/leaderboard_series_players";
@@ -100,6 +104,331 @@ export class LeaderboardService {
           ["reason", "Failed to persist leaderboard series data"],
         ]),
       );
+    }
+  }
+
+  async getLeaderboard({
+    guildId,
+    queueChannelId,
+    window,
+    metric,
+    page,
+    pageSize,
+    minGamesPlayed,
+  }: {
+    guildId: string;
+    queueChannelId?: string;
+    window?: LeaderboardWindow;
+    metric?: LeaderboardMetric;
+    page?: number;
+    pageSize?: number;
+    minGamesPlayed?: number;
+  }): Promise<LeaderboardResponse> {
+    const config = await this.databaseService.getLeaderboardConfig(guildId, true);
+    const resolvedWindow = window ?? config.DefaultWindow;
+    const resolvedMetric = metric ?? config.DefaultMetric;
+    const resolvedMinGamesPlayed = minGamesPlayed ?? config.MinGamesPlayed;
+    const resolvedPage = Math.max(1, page ?? 1);
+    const resolvedPageSize = Math.min(100, Math.max(1, pageSize ?? 25));
+    const offset = (resolvedPage - 1) * resolvedPageSize;
+    const startEpochSeconds = this.getWindowStartEpochSeconds(resolvedWindow);
+
+    const allRows =
+      resolvedMetric === LeaderboardMetric.SeriesWinRate
+        ? await this.getSeriesWinRateRows({
+            guildId,
+            queueChannelId: queueChannelId ?? null,
+            startEpochSeconds,
+            minGamesPlayed: resolvedMinGamesPlayed,
+          })
+        : await this.getMetricRows({
+            guildId,
+            queueChannelId: queueChannelId ?? null,
+            startEpochSeconds,
+            minGamesPlayed: resolvedMinGamesPlayed,
+            metric: resolvedMetric,
+          });
+
+    const pagedRows = allRows.slice(offset, offset + resolvedPageSize);
+
+    return {
+      guildId,
+      queueChannelId: queueChannelId ?? null,
+      window: resolvedWindow,
+      metric: resolvedMetric,
+      minGamesPlayed: resolvedMinGamesPlayed,
+      page: resolvedPage,
+      pageSize: resolvedPageSize,
+      total: allRows.length,
+      rows: pagedRows.map((row, index) => ({
+        rank: offset + index + 1,
+        xboxXuid: row.xboxXuid,
+        discordUserId: row.discordUserId,
+        gamertag: row.gamertag,
+        seriesPlayed: row.seriesPlayed,
+        seriesWins: row.seriesWins,
+        gamesPlayed: row.gamesPlayed,
+        metricValue: row.metricValue,
+      })),
+    };
+  }
+
+  private async getSeriesWinRateRows({
+    guildId,
+    queueChannelId,
+    startEpochSeconds,
+    minGamesPlayed,
+  }: {
+    guildId: string;
+    queueChannelId: string | null;
+    startEpochSeconds: number;
+    minGamesPlayed: number;
+  }): Promise<
+    {
+      xboxXuid: string;
+      discordUserId: string | null;
+      gamertag: string;
+      seriesPlayed: number;
+      seriesWins: number;
+      gamesPlayed: number;
+      metricValue: number;
+    }[]
+  > {
+    const facts = await this.databaseService.getLeaderboardSeriesPlayerFacts({
+      guildId,
+      queueChannelId,
+      startEpochSeconds,
+    });
+    const byXuid = new Map<
+      string,
+      {
+        xboxXuid: string;
+        discordUserId: string | null;
+        gamertag: string;
+        seriesPlayed: number;
+        seriesWins: number;
+        gamesPlayed: number;
+      }
+    >();
+
+    for (const fact of facts) {
+      const existing = byXuid.get(fact.XboxXuid);
+      if (existing == null) {
+        byXuid.set(fact.XboxXuid, {
+          xboxXuid: fact.XboxXuid,
+          discordUserId: fact.DiscordUserId,
+          gamertag: fact.Gamertag,
+          seriesPlayed: 1,
+          seriesWins: fact.SeriesWon,
+          gamesPlayed: fact.GamesPlayedCount,
+        });
+        continue;
+      }
+
+      existing.discordUserId = existing.discordUserId ?? fact.DiscordUserId;
+      existing.gamertag = fact.Gamertag;
+      existing.seriesPlayed += 1;
+      existing.seriesWins += fact.SeriesWon;
+      existing.gamesPlayed += fact.GamesPlayedCount;
+    }
+
+    return [...byXuid.values()]
+      .filter((row) => row.gamesPlayed >= minGamesPlayed)
+      .map((row) => ({
+        ...row,
+        metricValue: row.seriesPlayed === 0 ? 0 : row.seriesWins / row.seriesPlayed,
+      }))
+      .sort((left, right) => {
+        if (right.metricValue !== left.metricValue) {
+          return right.metricValue - left.metricValue;
+        }
+
+        if (right.seriesWins !== left.seriesWins) {
+          return right.seriesWins - left.seriesWins;
+        }
+
+        if (right.gamesPlayed !== left.gamesPlayed) {
+          return right.gamesPlayed - left.gamesPlayed;
+        }
+
+        return left.gamertag.localeCompare(right.gamertag);
+      });
+  }
+
+  private async getMetricRows({
+    guildId,
+    queueChannelId,
+    startEpochSeconds,
+    minGamesPlayed,
+    metric,
+  }: {
+    guildId: string;
+    queueChannelId: string | null;
+    startEpochSeconds: number;
+    minGamesPlayed: number;
+    metric: Exclude<LeaderboardMetric, LeaderboardMetric.SeriesWinRate>;
+  }): Promise<
+    {
+      xboxXuid: string;
+      discordUserId: string | null;
+      gamertag: string;
+      seriesPlayed: number;
+      seriesWins: number;
+      gamesPlayed: number;
+      metricValue: number;
+    }[]
+  > {
+    const facts = await this.databaseService.getLeaderboardGamePlayerFacts({
+      guildId,
+      queueChannelId,
+      startEpochSeconds,
+    });
+    const byXuid = new Map<
+      string,
+      {
+        xboxXuid: string;
+        discordUserId: string | null;
+        gamertag: string;
+        seriesNumbers: Set<number>;
+        gamesPlayed: number;
+        kills: number;
+        deaths: number;
+        assists: number;
+        kdaSum: number;
+        accuracySum: number;
+        damageDealt: number;
+        damageTaken: number;
+        personalScore: number;
+      }
+    >();
+
+    for (const fact of facts) {
+      const existing = byXuid.get(fact.XboxXuid);
+      if (existing == null) {
+        byXuid.set(fact.XboxXuid, {
+          xboxXuid: fact.XboxXuid,
+          discordUserId: fact.DiscordUserId,
+          gamertag: fact.Gamertag,
+          seriesNumbers: new Set([fact.QueueNumber]),
+          gamesPlayed: 1,
+          kills: fact.Kills,
+          deaths: fact.Deaths,
+          assists: fact.Assists,
+          kdaSum: fact.Kda,
+          accuracySum: fact.Accuracy,
+          damageDealt: fact.DamageDealt,
+          damageTaken: fact.DamageTaken,
+          personalScore: fact.PersonalScore,
+        });
+        continue;
+      }
+
+      existing.discordUserId = existing.discordUserId ?? fact.DiscordUserId;
+      existing.gamertag = fact.Gamertag;
+      existing.seriesNumbers.add(fact.QueueNumber);
+      existing.gamesPlayed += 1;
+      existing.kills += fact.Kills;
+      existing.deaths += fact.Deaths;
+      existing.assists += fact.Assists;
+      existing.kdaSum += fact.Kda;
+      existing.accuracySum += fact.Accuracy;
+      existing.damageDealt += fact.DamageDealt;
+      existing.damageTaken += fact.DamageTaken;
+      existing.personalScore += fact.PersonalScore;
+    }
+
+    const rows = [...byXuid.values()]
+      .filter((row) => row.gamesPlayed >= minGamesPlayed)
+      .map((row) => {
+        let metricValue = row.personalScore;
+        switch (metric) {
+          case LeaderboardMetric.Kills: {
+            metricValue = row.kills;
+            break;
+          }
+          case LeaderboardMetric.Deaths: {
+            metricValue = row.deaths;
+            break;
+          }
+          case LeaderboardMetric.Assists: {
+            metricValue = row.assists;
+            break;
+          }
+          case LeaderboardMetric.Kda: {
+            metricValue = row.kdaSum / row.gamesPlayed;
+            break;
+          }
+          case LeaderboardMetric.Accuracy: {
+            metricValue = row.accuracySum / row.gamesPlayed;
+            break;
+          }
+          case LeaderboardMetric.DamageDealt: {
+            metricValue = row.damageDealt;
+            break;
+          }
+          case LeaderboardMetric.DamageTaken: {
+            metricValue = row.damageTaken;
+            break;
+          }
+          case LeaderboardMetric.DamageRatio: {
+            metricValue = getSafeRatioValue(row.damageDealt, row.damageTaken);
+            break;
+          }
+          case LeaderboardMetric.PersonalScore: {
+            metricValue = row.personalScore;
+            break;
+          }
+          default: {
+            throw new UnreachableError(metric);
+          }
+        }
+
+        return {
+          xboxXuid: row.xboxXuid,
+          discordUserId: row.discordUserId,
+          gamertag: row.gamertag,
+          seriesPlayed: row.seriesNumbers.size,
+          seriesWins: 0,
+          gamesPlayed: row.gamesPlayed,
+          metricValue,
+        };
+      });
+
+    return rows.sort((left, right) => {
+      if (right.metricValue !== left.metricValue) {
+        return right.metricValue - left.metricValue;
+      }
+
+      if (right.gamesPlayed !== left.gamesPlayed) {
+        return right.gamesPlayed - left.gamesPlayed;
+      }
+
+      return left.gamertag.localeCompare(right.gamertag);
+    });
+  }
+
+  private getWindowStartEpochSeconds(window: LeaderboardWindow): number {
+    const now = new Date();
+
+    switch (window) {
+      case LeaderboardWindow.OneWeek: {
+        return Math.floor(sub(now, { weeks: 1 }).getTime() / 1000);
+      }
+      case LeaderboardWindow.OneMonth: {
+        return Math.floor(sub(now, { months: 1 }).getTime() / 1000);
+      }
+      case LeaderboardWindow.ThreeMonths: {
+        return Math.floor(sub(now, { months: 3 }).getTime() / 1000);
+      }
+      case LeaderboardWindow.SixMonths: {
+        return Math.floor(sub(now, { months: 6 }).getTime() / 1000);
+      }
+      case LeaderboardWindow.TwelveMonths: {
+        return Math.floor(sub(now, { months: 12 }).getTime() / 1000);
+      }
+      default: {
+        throw new UnreachableError(window);
+      }
     }
   }
 

--- a/api/services/leaderboard/tests/leaderboard.test.ts
+++ b/api/services/leaderboard/tests/leaderboard.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
 import type { LeaderboardRankingRow } from "../../database/database";
@@ -55,6 +55,10 @@ describe("LeaderboardService", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(nowIso));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("uses config defaults and ranks by series win rate", async () => {

--- a/api/services/leaderboard/tests/leaderboard.test.ts
+++ b/api/services/leaderboard/tests/leaderboard.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
-import type { LeaderboardRankingRow } from "../../database/database";
+import type { LeaderboardRankingRow } from "../../database/types/leaderboard_ranking_row";
 import { aFakeDatabaseServiceWith, aFakeLeaderboardConfigRow } from "../../database/fakes/database.fake";
 import { aFakeHaloServiceWith } from "../../halo/fakes/halo.fake";
 import { aFakeLogServiceWith } from "../../log/fakes/log.fake";

--- a/api/services/leaderboard/tests/leaderboard.test.ts
+++ b/api/services/leaderboard/tests/leaderboard.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
-import type { LeaderboardGamePlayerFactRow, LeaderboardSeriesPlayerFactRow } from "../../database/database";
+import type { LeaderboardRankingRow } from "../../database/database";
 import { aFakeDatabaseServiceWith, aFakeLeaderboardConfigRow } from "../../database/fakes/database.fake";
 import { aFakeHaloServiceWith } from "../../halo/fakes/halo.fake";
 import { aFakeLogServiceWith } from "../../log/fakes/log.fake";
@@ -10,86 +10,45 @@ import { LeaderboardService } from "../leaderboard";
 describe("LeaderboardService", () => {
   const nowIso = "2026-08-11T12:00:00.000Z";
 
-  const seriesFacts: LeaderboardSeriesPlayerFactRow[] = [
+  const seriesRankingRows: LeaderboardRankingRow[] = [
     {
       XboxXuid: "xuid-1",
       DiscordUserId: "discord-1",
       Gamertag: "Alpha",
-      SeriesWon: 1,
-      GamesPlayedCount: 3,
-    },
-    {
-      XboxXuid: "xuid-1",
-      DiscordUserId: "discord-1",
-      Gamertag: "Alpha",
-      SeriesWon: 1,
-      GamesPlayedCount: 2,
+      SeriesPlayed: 2,
+      SeriesWins: 2,
+      GamesPlayed: 5,
+      MetricValue: 1,
     },
     {
       XboxXuid: "xuid-2",
       DiscordUserId: "discord-2",
       Gamertag: "Bravo",
-      SeriesWon: 1,
-      GamesPlayedCount: 1,
-    },
-    {
-      XboxXuid: "xuid-2",
-      DiscordUserId: "discord-2",
-      Gamertag: "Bravo",
-      SeriesWon: 0,
-      GamesPlayedCount: 1,
-    },
-    {
-      XboxXuid: "xuid-3",
-      DiscordUserId: "discord-3",
-      Gamertag: "Charlie",
-      SeriesWon: 0,
-      GamesPlayedCount: 1,
+      SeriesPlayed: 2,
+      SeriesWins: 1,
+      GamesPlayed: 2,
+      MetricValue: 0.5,
     },
   ];
 
-  const gameFacts: LeaderboardGamePlayerFactRow[] = [
+  const killsRankingRows: LeaderboardRankingRow[] = [
     {
       XboxXuid: "xuid-1",
       DiscordUserId: "discord-1",
       Gamertag: "Alpha",
-      Kills: 5,
-      Deaths: 4,
-      Assists: 2,
-      Kda: 1.75,
-      Accuracy: 45,
-      DamageDealt: 4200,
-      DamageTaken: 2000,
-      PersonalScore: 2000,
-      QueueNumber: 10,
-    },
-    {
-      XboxXuid: "xuid-1",
-      DiscordUserId: "discord-1",
-      Gamertag: "Alpha",
-      Kills: 10,
-      Deaths: 6,
-      Assists: 5,
-      Kda: 2.5,
-      Accuracy: 48,
-      DamageDealt: 5200,
-      DamageTaken: 2500,
-      PersonalScore: 3000,
-      QueueNumber: 11,
+      SeriesPlayed: 2,
+      SeriesWins: 0,
+      GamesPlayed: 2,
+      MetricValue: 15,
     },
     {
       XboxXuid: "xuid-2",
       DiscordUserId: "discord-2",
       Gamertag: "Bravo",
-      Kills: 20,
-      Deaths: 11,
-      Assists: 1,
-      Kda: 1.9,
-      Accuracy: 38,
-      DamageDealt: 8000,
-      DamageTaken: 0,
-      PersonalScore: 4500,
-      QueueNumber: 12,
+      SeriesPlayed: 1,
+      SeriesWins: 0,
+      GamesPlayed: 1,
+      MetricValue: 20,
     },
   ];
 
@@ -112,9 +71,10 @@ describe("LeaderboardService", () => {
         MinGamesPlayed: 2,
       }),
     );
-    const getSeriesFactsSpy = vi
-      .spyOn(databaseService, "getLeaderboardSeriesPlayerFacts")
-      .mockResolvedValue(seriesFacts);
+    const getSeriesRankingsSpy = vi.spyOn(databaseService, "getLeaderboardSeriesWinRateRankings").mockResolvedValue({
+      total: 2,
+      rows: seriesRankingRows,
+    });
 
     const result = await service.getLeaderboard({ guildId: "guild-1" });
 
@@ -127,11 +87,14 @@ describe("LeaderboardService", () => {
       [2, "Bravo", 0.5],
     ]);
 
-    expect(getSeriesFactsSpy).toHaveBeenCalledTimes(1);
-    const [seriesFactArgs] = Preconditions.checkExists(getSeriesFactsSpy.mock.calls[0]);
-    expect(seriesFactArgs.guildId).toBe("guild-1");
-    expect(seriesFactArgs.queueChannelId).toBeNull();
-    expect(seriesFactArgs.startEpochSeconds).toBeGreaterThan(0);
+    expect(getSeriesRankingsSpy).toHaveBeenCalledTimes(1);
+    const [seriesRankingArgs] = Preconditions.checkExists(getSeriesRankingsSpy.mock.calls[0]);
+    expect(seriesRankingArgs.guildId).toBe("guild-1");
+    expect(seriesRankingArgs.queueChannelId).toBeNull();
+    expect(seriesRankingArgs.startEpochSeconds).toBeGreaterThan(0);
+    expect(seriesRankingArgs.minGamesPlayed).toBe(2);
+    expect(seriesRankingArgs.limit).toBe(25);
+    expect(seriesRankingArgs.offset).toBe(0);
   });
 
   it("supports queue scope and pagination for stat metrics", async () => {
@@ -148,7 +111,10 @@ describe("LeaderboardService", () => {
         MinGamesPlayed: 0,
       }),
     );
-    const getGameFactsSpy = vi.spyOn(databaseService, "getLeaderboardGamePlayerFacts").mockResolvedValue(gameFacts);
+    const getMetricRankingsSpy = vi.spyOn(databaseService, "getLeaderboardStatMetricRankings").mockResolvedValue({
+      total: 2,
+      rows: [Preconditions.checkExists(killsRankingRows[0])],
+    });
 
     const result = await service.getLeaderboard({
       guildId: "guild-1",
@@ -176,14 +142,18 @@ describe("LeaderboardService", () => {
       },
     ]);
 
-    expect(getGameFactsSpy).toHaveBeenCalledTimes(1);
-    const [gameFactArgs] = Preconditions.checkExists(getGameFactsSpy.mock.calls[0]);
-    expect(gameFactArgs.guildId).toBe("guild-1");
-    expect(gameFactArgs.queueChannelId).toBe("queue-a");
-    expect(gameFactArgs.startEpochSeconds).toBeGreaterThan(0);
+    expect(getMetricRankingsSpy).toHaveBeenCalledTimes(1);
+    const [metricRankingArgs] = Preconditions.checkExists(getMetricRankingsSpy.mock.calls[0]);
+    expect(metricRankingArgs.guildId).toBe("guild-1");
+    expect(metricRankingArgs.queueChannelId).toBe("queue-a");
+    expect(metricRankingArgs.startEpochSeconds).toBeGreaterThan(0);
+    expect(metricRankingArgs.minGamesPlayed).toBe(1);
+    expect(metricRankingArgs.limit).toBe(1);
+    expect(metricRankingArgs.offset).toBe(1);
+    expect(metricRankingArgs.metric).toBe(LeaderboardMetric.Kills);
   });
 
-  it("computes infinite damage ratio when damage taken is zero", async () => {
+  it("clamps non-finite metric values to a JSON-safe maximum", async () => {
     const databaseService = aFakeDatabaseServiceWith();
     const haloService = aFakeHaloServiceWith({ databaseService });
     const logService = aFakeLogServiceWith();
@@ -197,7 +167,20 @@ describe("LeaderboardService", () => {
         MinGamesPlayed: 0,
       }),
     );
-    vi.spyOn(databaseService, "getLeaderboardGamePlayerFacts").mockResolvedValue(gameFacts);
+    vi.spyOn(databaseService, "getLeaderboardStatMetricRankings").mockResolvedValue({
+      total: 1,
+      rows: [
+        {
+          XboxXuid: "xuid-2",
+          DiscordUserId: "discord-2",
+          Gamertag: "Bravo",
+          SeriesPlayed: 1,
+          SeriesWins: 0,
+          GamesPlayed: 1,
+          MetricValue: Number.POSITIVE_INFINITY,
+        },
+      ],
+    });
 
     const result = await service.getLeaderboard({
       guildId: "guild-1",
@@ -206,6 +189,6 @@ describe("LeaderboardService", () => {
     });
 
     expect(result.rows[0]?.gamertag).toBe("Bravo");
-    expect(result.rows[0]?.metricValue).toBe(Number.POSITIVE_INFINITY);
+    expect(result.rows[0]?.metricValue).toBe(Number.MAX_VALUE);
   });
 });

--- a/api/services/leaderboard/tests/leaderboard.test.ts
+++ b/api/services/leaderboard/tests/leaderboard.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
+import type { LeaderboardGamePlayerFactRow, LeaderboardSeriesPlayerFactRow } from "../../database/database";
+import { aFakeDatabaseServiceWith, aFakeLeaderboardConfigRow } from "../../database/fakes/database.fake";
+import { aFakeHaloServiceWith } from "../../halo/fakes/halo.fake";
+import { aFakeLogServiceWith } from "../../log/fakes/log.fake";
+import { LeaderboardService } from "../leaderboard";
+
+describe("LeaderboardService", () => {
+  const nowIso = "2026-08-11T12:00:00.000Z";
+
+  const seriesFacts: LeaderboardSeriesPlayerFactRow[] = [
+    {
+      XboxXuid: "xuid-1",
+      DiscordUserId: "discord-1",
+      Gamertag: "Alpha",
+      SeriesWon: 1,
+      GamesPlayedCount: 3,
+    },
+    {
+      XboxXuid: "xuid-1",
+      DiscordUserId: "discord-1",
+      Gamertag: "Alpha",
+      SeriesWon: 1,
+      GamesPlayedCount: 2,
+    },
+    {
+      XboxXuid: "xuid-2",
+      DiscordUserId: "discord-2",
+      Gamertag: "Bravo",
+      SeriesWon: 1,
+      GamesPlayedCount: 1,
+    },
+    {
+      XboxXuid: "xuid-2",
+      DiscordUserId: "discord-2",
+      Gamertag: "Bravo",
+      SeriesWon: 0,
+      GamesPlayedCount: 1,
+    },
+    {
+      XboxXuid: "xuid-3",
+      DiscordUserId: "discord-3",
+      Gamertag: "Charlie",
+      SeriesWon: 0,
+      GamesPlayedCount: 1,
+    },
+  ];
+
+  const gameFacts: LeaderboardGamePlayerFactRow[] = [
+    {
+      XboxXuid: "xuid-1",
+      DiscordUserId: "discord-1",
+      Gamertag: "Alpha",
+      Kills: 5,
+      Deaths: 4,
+      Assists: 2,
+      Kda: 1.75,
+      Accuracy: 45,
+      DamageDealt: 4200,
+      DamageTaken: 2000,
+      PersonalScore: 2000,
+      QueueNumber: 10,
+    },
+    {
+      XboxXuid: "xuid-1",
+      DiscordUserId: "discord-1",
+      Gamertag: "Alpha",
+      Kills: 10,
+      Deaths: 6,
+      Assists: 5,
+      Kda: 2.5,
+      Accuracy: 48,
+      DamageDealt: 5200,
+      DamageTaken: 2500,
+      PersonalScore: 3000,
+      QueueNumber: 11,
+    },
+    {
+      XboxXuid: "xuid-2",
+      DiscordUserId: "discord-2",
+      Gamertag: "Bravo",
+      Kills: 20,
+      Deaths: 11,
+      Assists: 1,
+      Kda: 1.9,
+      Accuracy: 38,
+      DamageDealt: 8000,
+      DamageTaken: 0,
+      PersonalScore: 4500,
+      QueueNumber: 12,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(nowIso));
+  });
+
+  it("uses config defaults and ranks by series win rate", async () => {
+    const databaseService = aFakeDatabaseServiceWith();
+    const haloService = aFakeHaloServiceWith({ databaseService });
+    const logService = aFakeLogServiceWith();
+    const service = new LeaderboardService({ databaseService, haloService, logService });
+
+    vi.spyOn(databaseService, "getLeaderboardConfig").mockResolvedValue(
+      aFakeLeaderboardConfigRow({
+        GuildId: "guild-1",
+        DefaultMetric: LeaderboardMetric.SeriesWinRate,
+        DefaultWindow: LeaderboardWindow.ThreeMonths,
+        MinGamesPlayed: 2,
+      }),
+    );
+    const getSeriesFactsSpy = vi
+      .spyOn(databaseService, "getLeaderboardSeriesPlayerFacts")
+      .mockResolvedValue(seriesFacts);
+
+    const result = await service.getLeaderboard({ guildId: "guild-1" });
+
+    expect(result.metric).toBe(LeaderboardMetric.SeriesWinRate);
+    expect(result.window).toBe(LeaderboardWindow.ThreeMonths);
+    expect(result.minGamesPlayed).toBe(2);
+    expect(result.total).toBe(2);
+    expect(result.rows.map((row) => [row.rank, row.gamertag, row.metricValue])).toEqual([
+      [1, "Alpha", 1],
+      [2, "Bravo", 0.5],
+    ]);
+
+    expect(getSeriesFactsSpy).toHaveBeenCalledTimes(1);
+    const [seriesFactArgs] = Preconditions.checkExists(getSeriesFactsSpy.mock.calls[0]);
+    expect(seriesFactArgs.guildId).toBe("guild-1");
+    expect(seriesFactArgs.queueChannelId).toBeNull();
+    expect(seriesFactArgs.startEpochSeconds).toBeGreaterThan(0);
+  });
+
+  it("supports queue scope and pagination for stat metrics", async () => {
+    const databaseService = aFakeDatabaseServiceWith();
+    const haloService = aFakeHaloServiceWith({ databaseService });
+    const logService = aFakeLogServiceWith();
+    const service = new LeaderboardService({ databaseService, haloService, logService });
+
+    vi.spyOn(databaseService, "getLeaderboardConfig").mockResolvedValue(
+      aFakeLeaderboardConfigRow({
+        GuildId: "guild-1",
+        DefaultMetric: LeaderboardMetric.SeriesWinRate,
+        DefaultWindow: LeaderboardWindow.ThreeMonths,
+        MinGamesPlayed: 0,
+      }),
+    );
+    const getGameFactsSpy = vi.spyOn(databaseService, "getLeaderboardGamePlayerFacts").mockResolvedValue(gameFacts);
+
+    const result = await service.getLeaderboard({
+      guildId: "guild-1",
+      queueChannelId: "queue-a",
+      metric: LeaderboardMetric.Kills,
+      window: LeaderboardWindow.OneMonth,
+      minGamesPlayed: 1,
+      page: 2,
+      pageSize: 1,
+    });
+
+    expect(result.metric).toBe(LeaderboardMetric.Kills);
+    expect(result.window).toBe(LeaderboardWindow.OneMonth);
+    expect(result.total).toBe(2);
+    expect(result.rows).toEqual([
+      {
+        rank: 2,
+        xboxXuid: "xuid-1",
+        discordUserId: "discord-1",
+        gamertag: "Alpha",
+        seriesPlayed: 2,
+        seriesWins: 0,
+        gamesPlayed: 2,
+        metricValue: 15,
+      },
+    ]);
+
+    expect(getGameFactsSpy).toHaveBeenCalledTimes(1);
+    const [gameFactArgs] = Preconditions.checkExists(getGameFactsSpy.mock.calls[0]);
+    expect(gameFactArgs.guildId).toBe("guild-1");
+    expect(gameFactArgs.queueChannelId).toBe("queue-a");
+    expect(gameFactArgs.startEpochSeconds).toBeGreaterThan(0);
+  });
+
+  it("computes infinite damage ratio when damage taken is zero", async () => {
+    const databaseService = aFakeDatabaseServiceWith();
+    const haloService = aFakeHaloServiceWith({ databaseService });
+    const logService = aFakeLogServiceWith();
+    const service = new LeaderboardService({ databaseService, haloService, logService });
+
+    vi.spyOn(databaseService, "getLeaderboardConfig").mockResolvedValue(
+      aFakeLeaderboardConfigRow({
+        GuildId: "guild-1",
+        DefaultMetric: LeaderboardMetric.SeriesWinRate,
+        DefaultWindow: LeaderboardWindow.ThreeMonths,
+        MinGamesPlayed: 0,
+      }),
+    );
+    vi.spyOn(databaseService, "getLeaderboardGamePlayerFacts").mockResolvedValue(gameFacts);
+
+    const result = await service.getLeaderboard({
+      guildId: "guild-1",
+      metric: LeaderboardMetric.DamageRatio,
+      minGamesPlayed: 1,
+    });
+
+    expect(result.rows[0]?.gamertag).toBe("Bravo");
+    expect(result.rows[0]?.metricValue).toBe(Number.POSITIVE_INFINITY);
+  });
+});

--- a/shared/src/contracts/stats/leaderboard.ts
+++ b/shared/src/contracts/stats/leaderboard.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import { defineContract } from "../base";
+import { LeaderboardMetric, LeaderboardWindow } from "../../halo/leaderboard";
+
+const positiveIntString = z
+  .string()
+  .transform((raw) => Number.parseInt(raw, 10))
+  .pipe(z.number().int().positive());
+
+const nonNegativeIntString = z
+  .string()
+  .transform((raw) => Number.parseInt(raw, 10))
+  .pipe(z.number().int().nonnegative());
+
+export const leaderboardQuerySchema = z.object({
+  guildId: z.string().min(1),
+  queueChannelId: z.string().min(1).optional(),
+  window: z.enum(LeaderboardWindow).optional(),
+  metric: z.enum(LeaderboardMetric).optional(),
+  page: positiveIntString.optional(),
+  pageSize: positiveIntString.optional(),
+  minGamesPlayed: nonNegativeIntString.optional(),
+});
+
+export type LeaderboardQuery = z.infer<typeof leaderboardQuerySchema>;
+
+export const leaderboardContract = defineContract(
+  z.object({
+    guildId: z.string(),
+    queueChannelId: z.string().nullable(),
+    window: z.enum(LeaderboardWindow),
+    metric: z.enum(LeaderboardMetric),
+    minGamesPlayed: z.number().int().nonnegative(),
+    page: z.number().int().positive(),
+    pageSize: z.number().int().positive(),
+    total: z.number().int().nonnegative(),
+    rows: z.array(
+      z.object({
+        rank: z.number().int().positive(),
+        xboxXuid: z.string(),
+        discordUserId: z.string().nullable(),
+        gamertag: z.string(),
+        seriesPlayed: z.number().int().nonnegative(),
+        seriesWins: z.number().int().nonnegative(),
+        gamesPlayed: z.number().int().nonnegative(),
+        metricValue: z.number(),
+      }),
+    ),
+  }),
+);
+
+export type LeaderboardResponse = z.infer<typeof leaderboardContract.schema>;

--- a/shared/src/contracts/stats/leaderboard.ts
+++ b/shared/src/contracts/stats/leaderboard.ts
@@ -20,7 +20,7 @@ export const leaderboardQuerySchema = z.object({
   window: z.enum(LeaderboardWindow).optional(),
   metric: z.enum(LeaderboardMetric).optional(),
   page: positiveIntString.optional(),
-  pageSize: positiveIntString.optional(),
+  pageSize: positiveIntString.pipe(z.number().int().max(100)).optional(),
   minGamesPlayed: nonNegativeIntString.optional(),
 });
 

--- a/shared/src/contracts/stats/leaderboard.ts
+++ b/shared/src/contracts/stats/leaderboard.ts
@@ -4,12 +4,14 @@ import { LeaderboardMetric, LeaderboardWindow } from "../../halo/leaderboard";
 
 const positiveIntString = z
   .string()
-  .transform((raw) => Number.parseInt(raw, 10))
+  .regex(/^\d+$/)
+  .transform((raw) => Number(raw))
   .pipe(z.number().int().positive());
 
 const nonNegativeIntString = z
   .string()
-  .transform((raw) => Number.parseInt(raw, 10))
+  .regex(/^\d+$/)
+  .transform((raw) => Number(raw))
   .pipe(z.number().int().nonnegative());
 
 export const leaderboardQuerySchema = z.object({

--- a/shared/src/contracts/stats/leaderboard.ts
+++ b/shared/src/contracts/stats/leaderboard.ts
@@ -6,13 +6,13 @@ const positiveIntString = z
   .string()
   .regex(/^\d+$/)
   .transform((raw) => Number(raw))
-  .pipe(z.number().int().positive());
+  .pipe(z.number().int().positive().max(Number.MAX_SAFE_INTEGER));
 
 const nonNegativeIntString = z
   .string()
   .regex(/^\d+$/)
   .transform((raw) => Number(raw))
-  .pipe(z.number().int().nonnegative());
+  .pipe(z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER));
 
 export const leaderboardQuerySchema = z.object({
   guildId: z.string().min(1),

--- a/shared/src/halo/leaderboard.ts
+++ b/shared/src/halo/leaderboard.ts
@@ -1,0 +1,20 @@
+export enum LeaderboardWindow {
+  OneWeek = "1W",
+  OneMonth = "1M",
+  ThreeMonths = "3M",
+  SixMonths = "6M",
+  TwelveMonths = "12M",
+}
+
+export enum LeaderboardMetric {
+  SeriesWinRate = "SERIES_WIN_RATE",
+  Kills = "KILLS",
+  Deaths = "DEATHS",
+  Assists = "ASSISTS",
+  Kda = "KDA",
+  Accuracy = "ACCURACY",
+  DamageDealt = "DAMAGE_DEALT",
+  DamageTaken = "DAMAGE_TAKEN",
+  DamageRatio = "DAMAGE_RATIO",
+  PersonalScore = "PERSONAL_SCORE",
+}


### PR DESCRIPTION
## Context
This leaderboard initiative adds durable NeatQueue-based rankings for both Discord and web surfaces, with canonical XUID identity, queue-aware scoping, rolling windows, and configurable visibility thresholds. PR1 and PR2 established schema/data-access and ingestion. This PR advances PR3 by introducing the read/query API surface and ranking aggregation behavior so consumers can fetch ranked leaderboard data by scope, window, and metric.

## This PR
- Adds shared leaderboard enums and typed read contract for query/response payloads.
- Adds a new stats route: GET /api/stats/leaderboard with validated query parsing and typed no-store response handling.
- Registers leaderboard route in the stats route bundle.
- Adds leaderboard service query behavior with:
  - config-driven defaults (window/metric/min-games)
  - server-wide or queue-specific scope
  - metric selection and ranking logic
  - pagination metadata and rank numbering
- Adds database query helpers used by leaderboard reads for series-level and game-level fact retrieval.
- Adds tests for:
  - route validation and success payload wiring
  - service-level ranking correctness for default behavior, win-rate ranking, scoped stat ranking + pagination, and damage-ratio edge handling.
- Revalidated quality gate with npm run done.

## Subsequent Work
- Expand PR3 service coverage for additional metric families and min-games boundary scenarios.
- Decide whether SQL ranking helper methods should be retained or pruned in favor of service-side aggregation-only approach.
- Continue with PR4 Discord /leaderboard show command and interactive embed controls after PR3 closes.
