### PR TITLE
Add leaderboard ingestion observability logging

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -130,6 +130,7 @@ export class Server {
                   ["channelId", neatQueueConfig.ChannelId],
                 ]),
               );
+              throw error;
             }),
           );
         }

--- a/api/server.ts
+++ b/api/server.ts
@@ -119,7 +119,19 @@ export class Server {
         const { response, jobToComplete } = neatQueueService.handleRequest(interaction, neatQueueConfig);
 
         if (jobToComplete) {
-          ctx.waitUntil(jobToComplete());
+          ctx.waitUntil(
+            jobToComplete().catch((error: unknown) => {
+              services.logService.error(
+                error,
+                new Map([
+                  ["reason", "NeatQueue background job failed"],
+                  ["action", interaction.action],
+                  ["guildId", neatQueueConfig.GuildId],
+                  ["channelId", neatQueueConfig.ChannelId],
+                ]),
+              );
+            }),
+          );
         }
 
         return response;

--- a/api/server.ts
+++ b/api/server.ts
@@ -121,8 +121,9 @@ export class Server {
         if (jobToComplete) {
           ctx.waitUntil(
             jobToComplete().catch((error: unknown) => {
+              const normalizedError = error instanceof Error ? error : new Error(String(error));
               services.logService.error(
-                error,
+                normalizedError,
                 new Map([
                   ["reason", "NeatQueue background job failed"],
                   ["action", interaction.action],
@@ -130,7 +131,7 @@ export class Server {
                   ["channelId", neatQueueConfig.ChannelId],
                 ]),
               );
-              throw error;
+              throw normalizedError;
             }),
           );
         }

--- a/api/services/leaderboard/leaderboard.ts
+++ b/api/services/leaderboard/leaderboard.ts
@@ -50,6 +50,7 @@ export class LeaderboardService {
         "Leaderboard persistence skipped because series data is empty",
         new Map([
           ["guildId", request.guild],
+          ["channelId", request.channel],
           ["queueNumber", request.match_number.toString()],
         ]),
       );
@@ -61,6 +62,7 @@ export class LeaderboardService {
         "Leaderboard persistence skipped because winning team index is unresolved",
         new Map([
           ["guildId", request.guild],
+          ["channelId", request.channel],
           ["queueNumber", request.match_number.toString()],
           ["winningTeamIndex", request.winning_team_index.toString()],
         ]),
@@ -73,6 +75,7 @@ export class LeaderboardService {
         "Starting leaderboard persistence for completed series",
         new Map([
           ["guildId", request.guild],
+          ["channelId", request.channel],
           ["queueNumber", request.match_number.toString()],
           ["seriesMatchCount", series.length.toString()],
           ["queueChannelId", neatQueueConfig.ChannelId],

--- a/api/services/leaderboard/leaderboard.ts
+++ b/api/services/leaderboard/leaderboard.ts
@@ -45,11 +45,40 @@ export class LeaderboardService {
     series: MatchStats[];
     locale: string;
   }): Promise<void> {
-    if (series.length === 0 || request.winning_team_index === -1) {
+    if (series.length === 0) {
+      this.logService.info(
+        "Leaderboard persistence skipped because series data is empty",
+        new Map([
+          ["guildId", request.guild],
+          ["queueNumber", request.match_number.toString()],
+        ]),
+      );
+      return;
+    }
+
+    if (request.winning_team_index === -1) {
+      this.logService.info(
+        "Leaderboard persistence skipped because winning team index is unresolved",
+        new Map([
+          ["guildId", request.guild],
+          ["queueNumber", request.match_number.toString()],
+          ["winningTeamIndex", request.winning_team_index.toString()],
+        ]),
+      );
       return;
     }
 
     try {
+      this.logService.info(
+        "Starting leaderboard persistence for completed series",
+        new Map([
+          ["guildId", request.guild],
+          ["queueNumber", request.match_number.toString()],
+          ["seriesMatchCount", series.length.toString()],
+          ["queueChannelId", neatQueueConfig.ChannelId],
+        ]),
+      );
+
       const sortedSeries = [...series].sort((left, right) =>
         left.MatchInfo.StartTime.localeCompare(right.MatchInfo.StartTime),
       );
@@ -80,6 +109,17 @@ export class LeaderboardService {
       const associations = await this.databaseService.getDiscordAssociationsByXboxId(allXuids);
       const xuidToDiscordId = new Map(associations.map((association) => [association.XboxId, association.DiscordId]));
 
+      this.logService.debug(
+        "Resolved leaderboard identity mappings",
+        new Map([
+          ["guildId", request.guild],
+          ["queueNumber", request.match_number.toString()],
+          ["distinctXuidCount", allXuids.length.toString()],
+          ["gamertagMapCount", gamertagMap.size.toString()],
+          ["discordAssociationCount", associations.length.toString()],
+        ]),
+      );
+
       const { gamesRows, gamePlayerRows, seriesPlayerRows } = await this.buildLeaderboardRows({
         guildId: request.guild,
         queueNumber: request.match_number,
@@ -89,12 +129,32 @@ export class LeaderboardService {
         gamertagMap,
         xuidToDiscordId,
       });
+
+      this.logService.info(
+        "Prepared leaderboard row payloads",
+        new Map([
+          ["guildId", request.guild],
+          ["queueNumber", request.match_number.toString()],
+          ["gamesRowCount", gamesRows.length.toString()],
+          ["gamePlayerRowCount", gamePlayerRows.length.toString()],
+          ["seriesPlayerRowCount", seriesPlayerRows.length.toString()],
+        ]),
+      );
+
       await this.databaseService.upsertLeaderboardSeriesDataBatch({
         series: seriesRow,
         games: gamesRows,
         gamePlayers: gamePlayerRows,
         seriesPlayers: seriesPlayerRows,
       });
+
+      this.logService.info(
+        "Completed leaderboard persistence for series",
+        new Map([
+          ["guildId", request.guild],
+          ["queueNumber", request.match_number.toString()],
+        ]),
+      );
     } catch (error) {
       this.logService.warn(
         error,

--- a/api/services/leaderboard/tests/leaderboard.test.ts
+++ b/api/services/leaderboard/tests/leaderboard.test.ts
@@ -2,9 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
 import type { LeaderboardRankingRow } from "../../database/types/leaderboard_ranking_row";
-import { aFakeDatabaseServiceWith, aFakeLeaderboardConfigRow } from "../../database/fakes/database.fake";
+import {
+  aFakeDatabaseServiceWith,
+  aFakeLeaderboardConfigRow,
+  aFakeNeatQueueConfigRow,
+} from "../../database/fakes/database.fake";
 import { aFakeHaloServiceWith } from "../../halo/fakes/halo.fake";
+import { getMatchStats } from "../../halo/fakes/data";
 import { aFakeLogServiceWith } from "../../log/fakes/log.fake";
+import type { NeatQueueMatchCompletedRequest } from "../../neatqueue/types";
 import { LeaderboardService } from "../leaderboard";
 
 describe("LeaderboardService", () => {
@@ -194,5 +200,69 @@ describe("LeaderboardService", () => {
 
     expect(result.rows[0]?.gamertag).toBe("Bravo");
     expect(result.rows[0]?.metricValue).toBe(Number.MAX_VALUE);
+  });
+
+  it("skips persistence when no series matches are resolved", async () => {
+    const databaseService = aFakeDatabaseServiceWith();
+    const haloService = aFakeHaloServiceWith({ databaseService });
+    const logService = aFakeLogServiceWith();
+    const service = new LeaderboardService({ databaseService, haloService, logService });
+    const upsertSpy = vi.spyOn(databaseService, "upsertLeaderboardSeriesDataBatch");
+    const infoSpy = vi.spyOn(logService, "info");
+
+    const request: NeatQueueMatchCompletedRequest = {
+      action: "MATCH_COMPLETED",
+      guild: "guild-1",
+      channel: "channel-1",
+      queue: "ranked",
+      match_number: 42,
+      winning_team_index: 0,
+      teams: [],
+    };
+
+    await service.persistSeriesData({
+      request,
+      neatQueueConfig: aFakeNeatQueueConfigRow(),
+      series: [],
+      locale: "en-US",
+    });
+
+    expect(upsertSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(
+      "Leaderboard persistence skipped because series data is empty",
+      expect.any(Map),
+    );
+  });
+
+  it("skips persistence when winning team index is unresolved", async () => {
+    const databaseService = aFakeDatabaseServiceWith();
+    const haloService = aFakeHaloServiceWith({ databaseService });
+    const logService = aFakeLogServiceWith();
+    const service = new LeaderboardService({ databaseService, haloService, logService });
+    const upsertSpy = vi.spyOn(databaseService, "upsertLeaderboardSeriesDataBatch");
+    const infoSpy = vi.spyOn(logService, "info");
+
+    const request: NeatQueueMatchCompletedRequest = {
+      action: "MATCH_COMPLETED",
+      guild: "guild-1",
+      channel: "channel-1",
+      queue: "ranked",
+      match_number: 42,
+      winning_team_index: -1,
+      teams: [],
+    };
+
+    await service.persistSeriesData({
+      request,
+      neatQueueConfig: aFakeNeatQueueConfigRow(),
+      series: [Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf"))],
+      locale: "en-US",
+    });
+
+    expect(upsertSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(
+      "Leaderboard persistence skipped because winning team index is unresolved",
+      expect.any(Map),
+    );
   });
 });

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -17,6 +17,7 @@ import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import { getTeamName } from "@guilty-spark/shared/halo/team";
 import type { SeriesStartedPayload } from "@guilty-spark/shared/contracts/durable-objects/individual-tracker/nudge";
+import type { LiveTrackerRefreshResponse } from "@guilty-spark/shared/contracts/durable-objects/live-tracker/management";
 import type { DatabaseService } from "../database/database";
 import type { NeatQueueConfigRow } from "../database/types/neat_queue_config";
 import { NeatQueuePostSeriesDisplayMode } from "../database/types/neat_queue_config";
@@ -1243,7 +1244,16 @@ export class NeatQueueService {
         ]),
       );
     } catch (error) {
-      this.logService.info(error, new Map([["reason", "Failed to get series data from timeline"]]));
+      this.logService.info(
+        error,
+        new Map([
+          ["reason", "Failed to resolve series data for MATCH_COMPLETED"],
+          ["guildId", request.guild],
+          ["channelId", request.channel],
+          ["queueNumber", request.match_number.toString()],
+          ["seriesSource", seriesSource],
+        ]),
+      );
       errorOccurred = true;
 
       const handledError = error instanceof Error ? error : new Error(String(error));
@@ -1362,12 +1372,17 @@ export class NeatQueueService {
 
     const refreshResult = await this.liveTrackerService.refreshTracker(context, true);
     if (!isSuccessResponse(refreshResult)) {
+      const failureDetails = this.getLiveTrackerRefreshFailureDetails(refreshResult);
+      const logParams = new Map([
+        ["guildId", request.guild],
+        ["queueNumber", request.match_number.toString()],
+      ]);
+      for (const [key, value] of failureDetails) {
+        logParams.set(key, value);
+      }
       this.logService.warn(
         "Live tracker refresh failed for MATCH_COMPLETED; falling back to timeline resolution",
-        new Map([
-          ["guildId", request.guild],
-          ["queueNumber", request.match_number.toString()],
-        ]),
+        logParams,
       );
       return null;
     }
@@ -1420,6 +1435,17 @@ export class NeatQueueService {
     }
 
     return series.length > 0 ? series : null;
+  }
+
+  private getLiveTrackerRefreshFailureDetails(refreshResult: LiveTrackerRefreshResponse): Map<string, string> {
+    if ("error" in refreshResult) {
+      return new Map([
+        ["error", refreshResult.error],
+        ["message", refreshResult.message],
+      ]);
+    }
+
+    return new Map([["error", "refresh_unsuccessful_without_error_message"]]);
   }
 
   private async handlePostSeriesError(

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -1207,16 +1207,41 @@ export class NeatQueueService {
     request: NeatQueueMatchCompletedRequest,
     neatQueueConfig: NeatQueueConfigRow,
   ): Promise<void> {
+    this.logService.info(
+      "Starting NeatQueue MATCH_COMPLETED background job",
+      new Map([
+        ["guildId", request.guild],
+        ["channelId", request.channel],
+        ["queueNumber", request.match_number.toString()],
+        ["postSeriesMode", neatQueueConfig.PostSeriesMode],
+      ]),
+    );
+
     const timeline = await this.getTimeline(request, neatQueueConfig);
     timeline.push({ timestamp: new Date().toISOString(), event: request });
 
     let series: MatchStats[] = [];
     let errorOccurred = false;
+    let seriesSource = "timeline";
 
     try {
-      series =
-        (await this.resolveSeriesFromLiveTracker(request)) ??
-        (await this.getSeriesDataFromTimeline(timeline, neatQueueConfig));
+      const liveTrackerSeries = await this.resolveSeriesFromLiveTracker(request);
+      if (liveTrackerSeries != null) {
+        series = liveTrackerSeries;
+        seriesSource = "live-tracker";
+      } else {
+        series = await this.getSeriesDataFromTimeline(timeline, neatQueueConfig);
+      }
+
+      this.logService.info(
+        "Resolved series data for MATCH_COMPLETED",
+        new Map([
+          ["guildId", request.guild],
+          ["queueNumber", request.match_number.toString()],
+          ["seriesSource", seriesSource],
+          ["seriesMatchCount", series.length.toString()],
+        ]),
+      );
     } catch (error) {
       this.logService.info(error, new Map([["reason", "Failed to get series data from timeline"]]));
       errorOccurred = true;
@@ -1227,12 +1252,49 @@ export class NeatQueueService {
     }
 
     if (!errorOccurred && series.length > 0) {
+      this.logService.info(
+        "Posting series data and triggering leaderboard persistence",
+        new Map([
+          ["guildId", request.guild],
+          ["queueNumber", request.match_number.toString()],
+          ["postSeriesMode", neatQueueConfig.PostSeriesMode],
+          ["seriesMatchCount", series.length.toString()],
+        ]),
+      );
+
       const opts = { request, neatQueueConfig, series, timeline };
       await this.handlePostSeriesData(neatQueueConfig.PostSeriesMode, opts);
+
+      this.logService.info(
+        "Completed series post flow for MATCH_COMPLETED",
+        new Map([
+          ["guildId", request.guild],
+          ["queueNumber", request.match_number.toString()],
+          ["postSeriesMode", neatQueueConfig.PostSeriesMode],
+        ]),
+      );
+    } else if (!errorOccurred && series.length === 0) {
+      this.logService.warn(
+        "No series data resolved for MATCH_COMPLETED; leaderboard persistence will not run",
+        new Map([
+          ["guildId", request.guild],
+          ["queueNumber", request.match_number.toString()],
+          ["seriesSource", seriesSource],
+        ]),
+      );
     }
 
     const completedQueueState = await this.getQueueState(neatQueueConfig.GuildId, request.match_number);
     const allPlayerXuids = await this.extractXuidsWithFallback(completedQueueState.playersAssociationData);
+
+    this.logService.debug(
+      "Running MATCH_COMPLETED cleanup tasks",
+      new Map([
+        ["guildId", request.guild],
+        ["queueNumber", request.match_number.toString()],
+        ["resolvedXuidCount", allPlayerXuids.length.toString()],
+      ]),
+    );
 
     await Promise.all([
       this.nudgeIndividualTrackersForMatchCompletion(request, neatQueueConfig, allPlayerXuids),
@@ -1241,6 +1303,14 @@ export class NeatQueueService {
       this.deletePlayersMessageId(request, neatQueueConfig),
       this.haloService.updateDiscordAssociations(),
     ]);
+
+    this.logService.info(
+      "Completed NeatQueue MATCH_COMPLETED background job",
+      new Map([
+        ["guildId", request.guild],
+        ["queueNumber", request.match_number.toString()],
+      ]),
+    );
   }
 
   private async nudgeIndividualTrackersForMatchCompletion(
@@ -1279,11 +1349,26 @@ export class NeatQueueService {
     };
     const liveTrackerStatus = await this.liveTrackerService.getTrackerStatus(context);
     if (liveTrackerStatus?.state.status !== "active") {
+      this.logService.debug(
+        "Live tracker is not active for MATCH_COMPLETED; falling back to timeline resolution",
+        new Map([
+          ["guildId", request.guild],
+          ["queueNumber", request.match_number.toString()],
+          ["status", liveTrackerStatus?.state.status ?? "not_found"],
+        ]),
+      );
       return null;
     }
 
     const refreshResult = await this.liveTrackerService.refreshTracker(context, true);
     if (!isSuccessResponse(refreshResult)) {
+      this.logService.warn(
+        "Live tracker refresh failed for MATCH_COMPLETED; falling back to timeline resolution",
+        new Map([
+          ["guildId", request.guild],
+          ["queueNumber", request.match_number.toString()],
+        ]),
+      );
       return null;
     }
 

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -1223,14 +1223,14 @@ export class NeatQueueService {
 
     let series: MatchStats[] = [];
     let errorOccurred = false;
-    let seriesSource = "timeline";
+    let seriesSource = "live-tracker";
 
     try {
       const liveTrackerSeries = await this.resolveSeriesFromLiveTracker(request);
       if (liveTrackerSeries != null) {
         series = liveTrackerSeries;
-        seriesSource = "live-tracker";
       } else {
+        seriesSource = "timeline";
         series = await this.getSeriesDataFromTimeline(timeline, neatQueueConfig);
       }
 

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -1280,6 +1280,7 @@ export class NeatQueueService {
         "Completed series post flow for MATCH_COMPLETED",
         new Map([
           ["guildId", request.guild],
+          ["channelId", request.channel],
           ["queueNumber", request.match_number.toString()],
           ["postSeriesMode", neatQueueConfig.PostSeriesMode],
         ]),
@@ -1446,7 +1447,7 @@ export class NeatQueueService {
     if ("error" in refreshResult) {
       return new Map([
         ["error", refreshResult.error],
-        ["message", refreshResult.message],
+        ["refreshMessage", refreshResult.message],
       ]);
     }
 

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -1244,7 +1244,7 @@ export class NeatQueueService {
         ]),
       );
     } catch (error) {
-      this.logService.info(
+      this.logService.warn(
         error,
         new Map([
           ["reason", "Failed to resolve series data for MATCH_COMPLETED"],

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -1266,6 +1266,7 @@ export class NeatQueueService {
         "Posting series data and triggering leaderboard persistence",
         new Map([
           ["guildId", request.guild],
+          ["channelId", request.channel],
           ["queueNumber", request.match_number.toString()],
           ["postSeriesMode", neatQueueConfig.PostSeriesMode],
           ["seriesMatchCount", series.length.toString()],
@@ -1319,6 +1320,7 @@ export class NeatQueueService {
       "Completed NeatQueue MATCH_COMPLETED background job",
       new Map([
         ["guildId", request.guild],
+        ["channelId", request.channel],
         ["queueNumber", request.match_number.toString()],
       ]),
     );

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -1233,16 +1233,6 @@ export class NeatQueueService {
         seriesSource = "timeline";
         series = await this.getSeriesDataFromTimeline(timeline, neatQueueConfig);
       }
-
-      this.logService.info(
-        "Resolved series data for MATCH_COMPLETED",
-        new Map([
-          ["guildId", request.guild],
-          ["queueNumber", request.match_number.toString()],
-          ["seriesSource", seriesSource],
-          ["seriesMatchCount", series.length.toString()],
-        ]),
-      );
     } catch (error) {
       this.logService.warn(
         error,
@@ -1262,6 +1252,16 @@ export class NeatQueueService {
     }
 
     if (!errorOccurred && series.length > 0) {
+      this.logService.info(
+        "Resolved series data for MATCH_COMPLETED",
+        new Map([
+          ["guildId", request.guild],
+          ["channelId", request.channel],
+          ["queueNumber", request.match_number.toString()],
+          ["seriesSource", seriesSource],
+          ["seriesMatchCount", series.length.toString()],
+        ]),
+      );
       this.logService.info(
         "Posting series data and triggering leaderboard persistence",
         new Map([
@@ -1288,6 +1288,7 @@ export class NeatQueueService {
         "No series data resolved for MATCH_COMPLETED; leaderboard persistence will not run",
         new Map([
           ["guildId", request.guild],
+          ["channelId", request.channel],
           ["queueNumber", request.match_number.toString()],
           ["seriesSource", seriesSource],
         ]),
@@ -1363,6 +1364,7 @@ export class NeatQueueService {
         "Live tracker is not active for MATCH_COMPLETED; falling back to timeline resolution",
         new Map([
           ["guildId", request.guild],
+          ["channelId", request.channel],
           ["queueNumber", request.match_number.toString()],
           ["status", liveTrackerStatus?.state.status ?? "not_found"],
         ]),
@@ -1375,6 +1377,7 @@ export class NeatQueueService {
       const failureDetails = this.getLiveTrackerRefreshFailureDetails(refreshResult);
       const logParams = new Map([
         ["guildId", request.guild],
+        ["channelId", request.channel],
         ["queueNumber", request.match_number.toString()],
       ]);
       for (const [key, value] of failureDetails) {


### PR DESCRIPTION
## Context
Two leaderboard PRs have merged: the persistence foundation (`#759`) and query API/ranking work (`#780`). After merge, completed NeatQueue series were played but leaderboard rows were not observed in the database. This PR adds backend observability for the NeatQueue completion path and leaderboard persistence lifecycle so we can pinpoint whether writes are being skipped, failing, or completing.

## This PR
- Adds `waitUntil` failure capture in `/neatqueue` route handling:
  - logs uncaught background job failures with action/guild/channel context.
- Adds NeatQueue `MATCH_COMPLETED` flow tracing:
  - job start/end logs
  - series resolution source (`live-tracker` vs `timeline`) and resolved match count
  - explicit warning when no series data is resolved (and therefore persistence will not run)
  - logs around post-series processing and cleanup phases.
- Adds leaderboard persistence stage logging:
  - explicit skip logs for empty series and unresolved winner
  - start log for persistence run
  - identity resolution counts (xuid/gamertag/association)
  - prepared row counts (`games`, `gamePlayers`, `seriesPlayers`)
  - completion log after database upsert.
- Adds focused leaderboard service tests for persistence skip branches to anchor new behavior.

## Subsequent Work
- Observe production/staging logs for NeatQueue match completions and identify the first failing/skip stage.
- If logs show successful persistence but empty tables, add direct D1 verification logging around write/query boundaries.
- Based on findings, implement targeted fix (series resolution, payload shaping, or DB upsert path) in a follow-up PR.
