### PR TITLE
Fix D1 SQL variable limit in leaderboard persistence

### DIFF
--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -21,6 +21,7 @@ import type { LeaderboardRankingRow } from "./types/leaderboard_ranking_row";
 import type { LeaderboardConfigRow } from "./types/leaderboard_config";
 
 const DEFAULT_LEADERBOARD_ENABLED_WINDOWS_JSON = '["1W","1M","3M","6M","12M"]';
+const SQLITE_MAX_VARIABLES = 999;
 
 interface LeaderboardRankingsQuery {
   guildId: string;
@@ -441,9 +442,8 @@ export class DatabaseService {
       return;
     }
 
-    const sqliteMaxVariables = 999;
     const variablesPerRow = 26;
-    const maxRowsPerStatement = Math.floor(sqliteMaxVariables / variablesPerRow);
+    const maxRowsPerStatement = Math.floor(SQLITE_MAX_VARIABLES / variablesPerRow);
     const statements: D1PreparedStatement[] = [];
 
     for (let start = 0; start < players.length; start += maxRowsPerStatement) {
@@ -546,18 +546,9 @@ export class DatabaseService {
     );
     statements.push(upsertSeriesStmt);
 
-    const seriesPlayerXuids = [...new Set(normalizedSeriesPlayers.map((player) => player.XboxXuid))];
-    const deleteSeriesPlayersStmt =
-      seriesPlayerXuids.length === 0
-        ? this.DB.prepare("DELETE FROM LeaderboardSeriesPlayers WHERE GuildId = ? AND QueueNumber = ?").bind(
-            series.GuildId,
-            series.QueueNumber,
-          )
-        : this.DB.prepare(
-            `DELETE FROM LeaderboardSeriesPlayers WHERE GuildId = ? AND QueueNumber = ? AND XboxXuid NOT IN (${seriesPlayerXuids
-              .map(() => "?")
-              .join(",")})`,
-          ).bind(series.GuildId, series.QueueNumber, ...seriesPlayerXuids);
+    const deleteSeriesPlayersStmt = this.DB.prepare(
+      "DELETE FROM LeaderboardSeriesPlayers WHERE GuildId = ? AND QueueNumber = ?",
+    ).bind(series.GuildId, series.QueueNumber);
     statements.push(deleteSeriesPlayersStmt);
 
     const deleteGamesStmt = this.DB.prepare("DELETE FROM LeaderboardGames WHERE GuildId = ? AND QueueNumber = ?").bind(
@@ -567,39 +558,44 @@ export class DatabaseService {
     statements.push(deleteGamesStmt);
 
     if (normalizedGames.length > 0) {
-      const gamesPlaceholders = normalizedGames.map(() => "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").join(",");
-      const upsertGamesStmt = this.DB.prepare(
-        `
+      const variablesPerRow = 15;
+      const maxRowsPerStatement = Math.floor(SQLITE_MAX_VARIABLES / variablesPerRow);
+
+      for (let start = 0; start < normalizedGames.length; start += maxRowsPerStatement) {
+        const chunk = normalizedGames.slice(start, start + maxRowsPerStatement);
+        const gamesPlaceholders = chunk.map(() => "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").join(",");
+        const upsertGamesStmt = this.DB.prepare(
+          `
       INSERT INTO LeaderboardGames (MatchId, GuildId, QueueNumber, QueueChannelId, GameIndexInSeries, GameVariantCategory, ModeName, MapName, MapAssetId, MapVersionId, Team0Score, Team1Score, StartedAt, EndedAt, CreatedAt)
       VALUES ${gamesPlaceholders}
       ON CONFLICT(GuildId, QueueNumber, MatchId) DO UPDATE SET QueueChannelId=excluded.QueueChannelId, GameIndexInSeries=excluded.GameIndexInSeries, GameVariantCategory=excluded.GameVariantCategory, ModeName=excluded.ModeName, MapName=excluded.MapName, MapAssetId=excluded.MapAssetId, MapVersionId=excluded.MapVersionId, Team0Score=excluded.Team0Score, Team1Score=excluded.Team1Score, StartedAt=excluded.StartedAt, EndedAt=excluded.EndedAt
     `,
-      ).bind(
-        ...normalizedGames.flatMap((game) => [
-          game.MatchId,
-          game.GuildId,
-          game.QueueNumber,
-          game.QueueChannelId,
-          game.GameIndexInSeries,
-          game.GameVariantCategory,
-          game.ModeName,
-          game.MapName,
-          game.MapAssetId,
-          game.MapVersionId,
-          game.Team0Score,
-          game.Team1Score,
-          game.StartedAt,
-          game.EndedAt,
-          game.CreatedAt,
-        ]),
-      );
-      statements.push(upsertGamesStmt);
+        ).bind(
+          ...chunk.flatMap((game) => [
+            game.MatchId,
+            game.GuildId,
+            game.QueueNumber,
+            game.QueueChannelId,
+            game.GameIndexInSeries,
+            game.GameVariantCategory,
+            game.ModeName,
+            game.MapName,
+            game.MapAssetId,
+            game.MapVersionId,
+            game.Team0Score,
+            game.Team1Score,
+            game.StartedAt,
+            game.EndedAt,
+            game.CreatedAt,
+          ]),
+        );
+        statements.push(upsertGamesStmt);
+      }
     }
 
     if (normalizedGamePlayers.length > 0) {
-      const sqliteMaxVariables = 999;
       const variablesPerRow = 26;
-      const maxRowsPerStatement = Math.floor(sqliteMaxVariables / variablesPerRow);
+      const maxRowsPerStatement = Math.floor(SQLITE_MAX_VARIABLES / variablesPerRow);
 
       for (let start = 0; start < normalizedGamePlayers.length; start += maxRowsPerStatement) {
         const chunk = normalizedGamePlayers.slice(start, start + maxRowsPerStatement);
@@ -647,33 +643,37 @@ export class DatabaseService {
     }
 
     if (normalizedSeriesPlayers.length > 0) {
-      const seriesPlayersPlaceholders = normalizedSeriesPlayers
-        .map(() => "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
-        .join(",");
-      const upsertSeriesPlayersStmt = this.DB.prepare(
-        `
+      const variablesPerRow = 13;
+      const maxRowsPerStatement = Math.floor(SQLITE_MAX_VARIABLES / variablesPerRow);
+
+      for (let start = 0; start < normalizedSeriesPlayers.length; start += maxRowsPerStatement) {
+        const chunk = normalizedSeriesPlayers.slice(start, start + maxRowsPerStatement);
+        const seriesPlayersPlaceholders = chunk.map(() => "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").join(",");
+        const upsertSeriesPlayersStmt = this.DB.prepare(
+          `
       INSERT INTO LeaderboardSeriesPlayers (GuildId, QueueNumber, QueueChannelId, XboxXuid, DiscordUserId, GamertagSnapshot, TeamId, PresentAtBeginningCount, SubstituteInCount, SubstituteOutCount, GamesPlayedCount, SeriesWon, CreatedAt)
       VALUES ${seriesPlayersPlaceholders}
       ON CONFLICT(GuildId, QueueNumber, XboxXuid) DO UPDATE SET QueueChannelId=excluded.QueueChannelId, DiscordUserId=excluded.DiscordUserId, GamertagSnapshot=excluded.GamertagSnapshot, TeamId=excluded.TeamId, PresentAtBeginningCount=excluded.PresentAtBeginningCount, SubstituteInCount=excluded.SubstituteInCount, SubstituteOutCount=excluded.SubstituteOutCount, GamesPlayedCount=excluded.GamesPlayedCount, SeriesWon=excluded.SeriesWon
     `,
-      ).bind(
-        ...normalizedSeriesPlayers.flatMap((player) => [
-          player.GuildId,
-          player.QueueNumber,
-          player.QueueChannelId,
-          player.XboxXuid,
-          player.DiscordUserId,
-          player.GamertagSnapshot,
-          player.TeamId,
-          player.PresentAtBeginningCount,
-          player.SubstituteInCount,
-          player.SubstituteOutCount,
-          player.GamesPlayedCount,
-          player.SeriesWon,
-          player.CreatedAt,
-        ]),
-      );
-      statements.push(upsertSeriesPlayersStmt);
+        ).bind(
+          ...chunk.flatMap((player) => [
+            player.GuildId,
+            player.QueueNumber,
+            player.QueueChannelId,
+            player.XboxXuid,
+            player.DiscordUserId,
+            player.GamertagSnapshot,
+            player.TeamId,
+            player.PresentAtBeginningCount,
+            player.SubstituteInCount,
+            player.SubstituteOutCount,
+            player.GamesPlayedCount,
+            player.SeriesWon,
+            player.CreatedAt,
+          ]),
+        );
+        statements.push(upsertSeriesPlayersStmt);
+      }
     }
 
     await this.DB.batch(statements);

--- a/api/services/database/tests/database.test.ts
+++ b/api/services/database/tests/database.test.ts
@@ -740,9 +740,15 @@ describe("Database Service", () => {
         seriesPlayers,
       });
 
-      const batchArgs = batchSpy.mock.calls[0]?.[0] ?? [];
-      expect(batchArgs).toHaveLength(7);
-      expect(prepareSpy).toHaveBeenCalledTimes(10);
+      const preparedQueries = prepareSpy.mock.calls
+        .map(([query]) => query)
+        .filter((query): query is string => typeof query === "string");
+      const seriesPlayerInsertStatements = preparedQueries.filter((query) =>
+        query.includes("INSERT INTO LeaderboardSeriesPlayers"),
+      );
+
+      expect(batchSpy).toHaveBeenCalledTimes(1);
+      expect(seriesPlayerInsertStatements.length).toBeGreaterThan(1);
     });
 
     it("does not overwrite created timestamps in leaderboard upserts", async () => {

--- a/api/services/database/tests/database.test.ts
+++ b/api/services/database/tests/database.test.ts
@@ -698,6 +698,53 @@ describe("Database Service", () => {
       expect(batchSpy).toHaveBeenCalledWith(batchedStatements);
     });
 
+    it("chunks series-player upserts to stay under D1 variable limits", async () => {
+      const series = aFakeLeaderboardSeriesRow();
+      const seriesPlayers = Array.from({ length: 80 }, (_, index) =>
+        aFakeLeaderboardSeriesPlayersRow({
+          XboxXuid: `xuid-${index.toString()}`,
+          DiscordUserId: `discord-${index.toString()}`,
+        }),
+      );
+      const games = [aFakeLeaderboardGamesRow()];
+      const gamePlayers = [aFakeLeaderboardGamePlayersRow()];
+
+      const existingGamesStmt = new FakePreparedStatement<{ MatchId: string; CreatedAt: number }>();
+      const existingGamePlayersStmt = new FakePreparedStatement<{
+        MatchId: string;
+        XboxXuid: string;
+        CreatedAt: number;
+      }>();
+      const existingSeriesPlayersStmt = new FakePreparedStatement<{ XboxXuid: string; CreatedAt: number }>();
+
+      const prepareSpy = vi
+        .spyOn(env.DB, "prepare")
+        .mockReturnValueOnce(existingGamesStmt)
+        .mockReturnValueOnce(existingGamePlayersStmt)
+        .mockReturnValueOnce(existingSeriesPlayersStmt)
+        .mockImplementation(() => new FakePreparedStatement());
+
+      vi.spyOn(existingGamesStmt, "bind").mockReturnThis();
+      vi.spyOn(existingGamePlayersStmt, "bind").mockReturnThis();
+      vi.spyOn(existingSeriesPlayersStmt, "bind").mockReturnThis();
+      vi.spyOn(existingGamesStmt, "all").mockResolvedValue({ ...fakeD1Response, results: [] });
+      vi.spyOn(existingGamePlayersStmt, "all").mockResolvedValue({ ...fakeD1Response, results: [] });
+      vi.spyOn(existingSeriesPlayersStmt, "all").mockResolvedValue({ ...fakeD1Response, results: [] });
+
+      const batchSpy = vi.spyOn(env.DB, "batch").mockResolvedValue([{ ...fakeD1Response, results: [] }]);
+
+      await databaseService.upsertLeaderboardSeriesDataBatch({
+        series,
+        games,
+        gamePlayers,
+        seriesPlayers,
+      });
+
+      const batchArgs = batchSpy.mock.calls[0]?.[0] ?? [];
+      expect(batchArgs).toHaveLength(7);
+      expect(prepareSpy).toHaveBeenCalledTimes(10);
+    });
+
     it("does not overwrite created timestamps in leaderboard upserts", async () => {
       const series = aFakeLeaderboardSeriesRow();
       const seriesPlayers = [aFakeLeaderboardSeriesPlayersRow()];


### PR DESCRIPTION
## Context
After leaderboard persistence/query work merged, Sentry reported `D1_ERROR: too many SQL variables` from `DatabaseService.upsertLeaderboardSeriesDataBatch` during `MATCH_COMPLETED` handling. The failure blocked leaderboard writes for completed series. This PR makes leaderboard persistence D1-safe by ensuring every multi-row statement stays under SQLite/D1 variable limits.

## This PR
- Refactors `upsertLeaderboardSeriesDataBatch` to avoid oversized bind sets:
  - Replaces the large `DELETE ... NOT IN (...)` on `LeaderboardSeriesPlayers` with a simple scoped delete by guild+queue.
  - Chunks `LeaderboardGames` multi-row insert/upsert by max rows per statement based on SQLite variable limits.
  - Keeps `LeaderboardGamePlayers` chunking and standardizes limit usage via shared constant.
  - Chunks `LeaderboardSeriesPlayers` multi-row insert/upsert by max rows per statement.
- Introduces/uses a shared `SQLITE_MAX_VARIABLES = 999` constant in the database service for consistent chunk calculations.
- Adds regression coverage in database tests:
  - verifies large `seriesPlayers` payloads are split into multiple statements under the variable limit.

## Subsequent Work
- Watch Sentry for `too many SQL variables` on `/neatqueue` after deployment to confirm elimination.
- Use the merged observability logs (PR #781) to verify successful progression from `MATCH_COMPLETED` to completed leaderboard persistence.
- If any residual write failures remain, add targeted instrumentation around individual statement execution results.
