### PR TITLE
Add interactive controls for leaderboard show command

### DIFF
--- a/api/commands/commands.ts
+++ b/api/commands/commands.ts
@@ -8,6 +8,7 @@ import { SetupCommand } from "./setup/setup";
 import { MapsCommand } from "./maps/maps";
 import { TrackCommand } from "./track/track";
 import { ServiceRecordCommand } from "./service-record/service-record";
+import { LeaderboardCommand } from "./leaderboard/leaderboard";
 
 export function getCommands(services: Services, env: Env): Map<string, BaseCommand> {
   const commandMap = new Map<string, BaseCommand>();
@@ -18,6 +19,7 @@ export function getCommands(services: Services, env: Env): Map<string, BaseComma
     new SetupCommand(services, env),
     new TrackCommand(services, env),
     new ServiceRecordCommand(services, env),
+    new LeaderboardCommand(services, env),
   ];
 
   for (const command of commands) {

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -218,28 +218,32 @@ export class LeaderboardCommand extends BaseCommand {
     interaction: APIApplicationCommandInteraction,
     options: Map<string, APIApplicationCommandInteractionDataBasicOption["value"]>,
   ): Promise<void> {
-    const guildId = interaction.guild_id;
-    if (guildId == null || guildId === "") {
-      throw new EndUserError("Leaderboard can only be used inside a server.", {
-        handled: true,
-        errorType: EndUserErrorType.WARNING,
+    try {
+      const guildId = interaction.guild_id;
+      if (guildId == null || guildId === "") {
+        throw new EndUserError("Leaderboard can only be used inside a server.", {
+          handled: true,
+          errorType: EndUserErrorType.WARNING,
+        });
+      }
+
+      const queueChannelId = this.getOptionalStringOption(options, "queue_channel") ?? null;
+      const window = this.parseWindowOption(this.getOptionalStringOption(options, "window"));
+      const metric = this.parseMetricOption(this.getOptionalStringOption(options, "metric"));
+      const page = this.getOptionalNumberOption(options, "page") ?? 1;
+      const minGamesPlayed = this.getOptionalNumberOption(options, "min_games_played");
+
+      await this.refreshLeaderboard(interaction.token, interaction.locale, {
+        guildId,
+        queueChannelId,
+        ...(window != null ? { window } : {}),
+        ...(metric != null ? { metric } : {}),
+        page,
+        ...(minGamesPlayed != null ? { minGamesPlayed } : {}),
       });
+    } catch (error) {
+      await this.services.discordService.updateDeferredReplyWithError(interaction.token, error);
     }
-
-    const queueChannelId = this.getOptionalStringOption(options, "queue_channel") ?? null;
-    const window = this.parseWindowOption(this.getOptionalStringOption(options, "window"));
-    const metric = this.parseMetricOption(this.getOptionalStringOption(options, "metric"));
-    const page = this.getOptionalNumberOption(options, "page") ?? 1;
-    const minGamesPlayed = this.getOptionalNumberOption(options, "min_games_played");
-
-    await this.refreshLeaderboard(interaction.token, interaction.locale, {
-      guildId,
-      queueChannelId,
-      ...(window != null ? { window } : {}),
-      ...(metric != null ? { metric } : {}),
-      page,
-      ...(minGamesPlayed != null ? { minGamesPlayed } : {}),
-    });
   }
 
   private async handlePageChange(

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -250,52 +250,58 @@ export class LeaderboardCommand extends BaseCommand {
     interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
     delta: number,
   ): Promise<void> {
-    if (interaction.data.component_type !== ComponentType.Button) {
-      throw new Error("Unexpected component type for leaderboard page action");
-    }
+    await this.executeStateInteraction(interaction, (state) => {
+      if (interaction.data.component_type !== ComponentType.Button) {
+        throw this.createInvalidLeaderboardControlError();
+      }
 
-    await this.executeStateInteraction(interaction, (state) => ({
-      ...state,
-      page: Math.max(1, state.page + delta),
-    }));
+      return {
+        ...state,
+        page: Math.max(1, state.page + delta),
+      };
+    });
   }
 
   private async handleMetricSelect(
     interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
   ): Promise<void> {
-    if (interaction.data.component_type !== ComponentType.StringSelect) {
-      throw new Error("Unexpected component type for leaderboard metric select");
-    }
+    await this.executeStateInteraction(interaction, (state) => {
+      if (interaction.data.component_type !== ComponentType.StringSelect) {
+        throw this.createInvalidLeaderboardControlError();
+      }
 
-    const selectedMetric = this.parseMetricOption(interaction.data.values[0]);
-    if (selectedMetric == null) {
-      throw new Error("Leaderboard metric selection is missing");
-    }
+      const selectedMetric = this.parseMetricOption(interaction.data.values[0]);
+      if (selectedMetric == null) {
+        throw this.createInvalidLeaderboardControlError();
+      }
 
-    await this.executeStateInteraction(interaction, (state) => ({
-      ...state,
-      metric: selectedMetric,
-      page: 1,
-    }));
+      return {
+        ...state,
+        metric: selectedMetric,
+        page: 1,
+      };
+    });
   }
 
   private async handleWindowSelect(
     interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
   ): Promise<void> {
-    if (interaction.data.component_type !== ComponentType.StringSelect) {
-      throw new Error("Unexpected component type for leaderboard window select");
-    }
+    await this.executeStateInteraction(interaction, (state) => {
+      if (interaction.data.component_type !== ComponentType.StringSelect) {
+        throw this.createInvalidLeaderboardControlError();
+      }
 
-    const selectedWindow = this.parseWindowOption(interaction.data.values[0]);
-    if (selectedWindow == null) {
-      throw new Error("Leaderboard window selection is missing");
-    }
+      const selectedWindow = this.parseWindowOption(interaction.data.values[0]);
+      if (selectedWindow == null) {
+        throw this.createInvalidLeaderboardControlError();
+      }
 
-    await this.executeStateInteraction(interaction, (state) => ({
-      ...state,
-      window: selectedWindow,
-      page: 1,
-    }));
+      return {
+        ...state,
+        window: selectedWindow,
+        page: 1,
+      };
+    });
   }
 
   private async executeStateInteraction(
@@ -788,5 +794,12 @@ export class LeaderboardCommand extends BaseCommand {
       | APIMessageComponentSelectMenuInteraction,
   ): string {
     return interaction.guild_locale ?? interaction.locale;
+  }
+
+  private createInvalidLeaderboardControlError(): EndUserError {
+    return new EndUserError("This leaderboard control interaction is invalid. Run /leaderboard show again.", {
+      handled: true,
+      errorType: EndUserErrorType.WARNING,
+    });
   }
 }

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -22,6 +22,7 @@ import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import type { LeaderboardResponse } from "@guilty-spark/shared/contracts/stats/leaderboard";
 import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
 import { EndUserError, EndUserErrorType } from "../../base/end-user-error";
+import { EmbedColors } from "../../embeds/colors";
 import type { ApplicationCommandData, BaseInteraction, CommandData, ExecuteResponse } from "../base/base-command";
 import { BaseCommand } from "../base/base-command";
 
@@ -63,6 +64,12 @@ interface LeaderboardViewState {
   metric?: LeaderboardMetric;
   page: number;
   minGamesPlayed?: number;
+}
+
+interface ResolvedLeaderboardViewState extends LeaderboardViewState {
+  window: LeaderboardWindow;
+  metric: LeaderboardMetric;
+  minGamesPlayed: number;
 }
 
 export class LeaderboardCommand extends BaseCommand {
@@ -210,7 +217,7 @@ export class LeaderboardCommand extends BaseCommand {
         }
       }
       case InteractionType.MessageComponent: {
-        switch (interaction.data.custom_id) {
+        switch (this.getLeaderboardControlId(interaction.data.custom_id)) {
           case INTERACTION_FIRST_PAGE: {
             return this.deferUpdate(async () => this.handleFirstPage(interaction));
           }
@@ -491,6 +498,7 @@ export class LeaderboardCommand extends BaseCommand {
       leaderboard.queueChannelId != null ? `Queue <#${leaderboard.queueChannelId}>` : "Server-wide (all queues)";
 
     const embed: APIEmbed = {
+      color: EmbedColors.GOLD,
       title: `Leaderboard - ${scopeLabel}`,
       description:
         `Metric: ${metricLabel} | Window: ${windowLabel}\n` +
@@ -511,20 +519,6 @@ export class LeaderboardCommand extends BaseCommand {
     const metricOptions = this.getMetricSelectOptions(leaderboard.metric);
     const windowOptions = this.getWindowSelectOptions(leaderboard.window);
 
-    const params = new URLSearchParams({
-      guildId: leaderboard.guildId,
-      window: leaderboard.window,
-      metric: leaderboard.metric,
-      page: leaderboard.page.toString(),
-      minGamesPlayed: leaderboard.minGamesPlayed.toString(),
-    });
-
-    if (leaderboard.queueChannelId != null) {
-      params.set("queueChannelId", leaderboard.queueChannelId);
-    }
-
-    const webUrl = `${this.env.PAGES_URL}/leaderboard?${params.toString()}`;
-
     return [
       {
         type: ComponentType.ActionRow,
@@ -532,34 +526,34 @@ export class LeaderboardCommand extends BaseCommand {
           {
             type: ComponentType.Button,
             style: ButtonStyle.Secondary,
-            custom_id: INTERACTION_FIRST_PAGE,
+            custom_id: this.createLeaderboardControlId(INTERACTION_FIRST_PAGE, leaderboard),
             emoji: { name: "⏮️" },
             disabled: leaderboard.page <= 1,
           },
           {
             type: ComponentType.Button,
             style: ButtonStyle.Secondary,
-            custom_id: INTERACTION_PREV_PAGE,
+            custom_id: this.createLeaderboardControlId(INTERACTION_PREV_PAGE, leaderboard),
             emoji: { name: "◀️" },
             disabled: leaderboard.page <= 1,
           },
           {
             type: ComponentType.Button,
             style: ButtonStyle.Secondary,
-            custom_id: INTERACTION_REFRESH,
+            custom_id: this.createLeaderboardControlId(INTERACTION_REFRESH, leaderboard),
             emoji: { name: "🔄" },
           },
           {
             type: ComponentType.Button,
             style: ButtonStyle.Secondary,
-            custom_id: INTERACTION_NEXT_PAGE,
+            custom_id: this.createLeaderboardControlId(INTERACTION_NEXT_PAGE, leaderboard),
             emoji: { name: "▶️" },
             disabled: leaderboard.page >= totalPages,
           },
           {
             type: ComponentType.Button,
             style: ButtonStyle.Secondary,
-            custom_id: INTERACTION_LAST_PAGE,
+            custom_id: this.createLeaderboardControlId(INTERACTION_LAST_PAGE, leaderboard),
             emoji: { name: "⏭️" },
             disabled: leaderboard.page >= totalPages,
           },
@@ -570,7 +564,7 @@ export class LeaderboardCommand extends BaseCommand {
         components: [
           {
             type: ComponentType.StringSelect,
-            custom_id: INTERACTION_METRIC_SELECT,
+            custom_id: this.createLeaderboardControlId(INTERACTION_METRIC_SELECT, leaderboard),
             placeholder: "Select metric",
             min_values: 1,
             max_values: 1,
@@ -583,22 +577,11 @@ export class LeaderboardCommand extends BaseCommand {
         components: [
           {
             type: ComponentType.StringSelect,
-            custom_id: INTERACTION_WINDOW_SELECT,
+            custom_id: this.createLeaderboardControlId(INTERACTION_WINDOW_SELECT, leaderboard),
             placeholder: "Select window",
             min_values: 1,
             max_values: 1,
             options: windowOptions,
-          },
-        ],
-      },
-      {
-        type: ComponentType.ActionRow,
-        components: [
-          {
-            type: ComponentType.Button,
-            style: ButtonStyle.Link,
-            label: "Open in browser",
-            url: webUrl,
           },
         ],
       },
@@ -680,6 +663,11 @@ export class LeaderboardCommand extends BaseCommand {
   private getStateFromInteractionMessage(
     interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
   ): LeaderboardViewState {
+    const encodedState = this.parseLeaderboardControlState(interaction.data.custom_id);
+    if (encodedState != null) {
+      return this.validateInteractionState(interaction, encodedState);
+    }
+
     const { components } = interaction.message;
     if (components == null || components.length === 0) {
       throw new EndUserError(
@@ -693,26 +681,8 @@ export class LeaderboardCommand extends BaseCommand {
 
     const stateUrl = this.getStateUrlFromComponents(components);
     const params = this.getStateQueryParams(stateUrl);
-    const interactionGuildId = interaction.guild_id;
-
-    if (interactionGuildId == null || interactionGuildId === "") {
-      throw new EndUserError("Unable to determine the server for this leaderboard interaction.", {
-        handled: true,
-        errorType: EndUserErrorType.WARNING,
-      });
-    }
-
-    const stateGuildId = params.get("guildId");
-    if (stateGuildId != null && stateGuildId !== "" && stateGuildId !== interactionGuildId) {
-      throw new EndUserError("This leaderboard interaction does not belong to this server.", {
-        handled: true,
-        errorType: EndUserErrorType.WARNING,
-      });
-    }
-
     const parsedWindow = this.parseWindowOption(params.get("window") ?? undefined);
     const parsedMetric = this.parseMetricOption(params.get("metric") ?? undefined);
-
     if (parsedWindow == null || parsedMetric == null) {
       throw new EndUserError("This leaderboard message is missing filter settings. Run /leaderboard show again.", {
         handled: true,
@@ -723,13 +693,94 @@ export class LeaderboardCommand extends BaseCommand {
     const parsedPage = Number.parseInt(params.get("page") ?? "1", 10);
     const parsedMinGamesPlayed = Number.parseInt(params.get("minGamesPlayed") ?? "0", 10);
 
-    return {
-      guildId: interactionGuildId,
+    return this.validateInteractionState(interaction, {
+      guildId: params.get("guildId") ?? "",
       queueChannelId: this.parseQueueChannelId(params.get("queueChannelId")),
       window: parsedWindow,
       metric: parsedMetric,
       page: Number.isNaN(parsedPage) ? 1 : Math.max(1, parsedPage),
       minGamesPlayed: Number.isNaN(parsedMinGamesPlayed) ? 0 : Math.max(0, parsedMinGamesPlayed),
+    });
+  }
+
+  private validateInteractionState(
+    interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
+    state: ResolvedLeaderboardViewState,
+  ): ResolvedLeaderboardViewState {
+    const interactionGuildId = interaction.guild_id;
+
+    if (interactionGuildId == null || interactionGuildId === "") {
+      throw new EndUserError("Unable to determine the server for this leaderboard interaction.", {
+        handled: true,
+        errorType: EndUserErrorType.WARNING,
+      });
+    }
+
+    if (state.guildId !== interactionGuildId) {
+      throw new EndUserError("This leaderboard interaction does not belong to this server.", {
+        handled: true,
+        errorType: EndUserErrorType.WARNING,
+      });
+    }
+
+    return {
+      guildId: interactionGuildId,
+      queueChannelId: state.queueChannelId,
+      window: state.window,
+      metric: state.metric,
+      page: state.page,
+      minGamesPlayed: state.minGamesPlayed,
+    };
+  }
+
+  private createLeaderboardControlId(controlId: string, leaderboard: LeaderboardResponse): string {
+    const queueChannelId = leaderboard.queueChannelId ?? "-";
+    return [
+      controlId,
+      leaderboard.guildId,
+      queueChannelId,
+      leaderboard.window,
+      leaderboard.metric,
+      leaderboard.page.toString(36),
+      leaderboard.minGamesPlayed.toString(36),
+    ].join(":");
+  }
+
+  private getLeaderboardControlId(customId: string): string {
+    return customId.split(":", 1)[0] ?? "";
+  }
+
+  private parseLeaderboardControlState(customId: string): ResolvedLeaderboardViewState | null {
+    const [controlId, guildId, rawQueueChannelId, rawWindow, rawMetric, rawPage, rawMinGamesPlayed] =
+      customId.split(":");
+    if (
+      controlId == null ||
+      guildId == null ||
+      rawQueueChannelId == null ||
+      rawWindow == null ||
+      rawMetric == null ||
+      rawPage == null ||
+      rawMinGamesPlayed == null
+    ) {
+      return null;
+    }
+
+    const window = this.parseWindowOption(rawWindow);
+    const metric = this.parseMetricOption(rawMetric);
+    const page = Number.parseInt(rawPage, 36);
+    const minGamesPlayed = Number.parseInt(rawMinGamesPlayed, 36);
+
+    if (window == null || metric == null || Number.isNaN(page) || Number.isNaN(minGamesPlayed)) {
+      throw this.createInvalidLeaderboardControlError();
+    }
+
+    return {
+      guildId,
+      queueChannelId: rawQueueChannelId === "-" ? null : rawQueueChannelId,
+      window,
+      metric,
+      page: Math.max(1, page),
+      minGamesPlayed: Math.max(0, minGamesPlayed),
     };
   }
 

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -303,7 +303,9 @@ export class LeaderboardCommand extends BaseCommand {
       const state = this.getStateFromInteractionMessage(interaction);
       await this.refreshLeaderboard(interaction.token, interaction.locale, stateUpdater(state));
     } catch (error) {
-      this.services.logService.error(error);
+      if (!this.isHandledEndUserError(error)) {
+        this.services.logService.error(error);
+      }
       await this.services.discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
@@ -526,19 +528,28 @@ export class LeaderboardCommand extends BaseCommand {
     const interactionGuildId = interaction.guild_id;
 
     if (interactionGuildId == null || interactionGuildId === "") {
-      throw new Error("Missing guildId in leaderboard interaction state");
+      throw new EndUserError("Unable to determine the server for this leaderboard interaction.", {
+        handled: true,
+        errorType: EndUserErrorType.WARNING,
+      });
     }
 
     const stateGuildId = params.get("guildId");
     if (stateGuildId != null && stateGuildId !== "" && stateGuildId !== interactionGuildId) {
-      throw new Error("Leaderboard interaction state guild does not match this server");
+      throw new EndUserError("This leaderboard interaction does not belong to this server.", {
+        handled: true,
+        errorType: EndUserErrorType.WARNING,
+      });
     }
 
     const parsedWindow = this.parseWindowOption(params.get("window") ?? undefined);
     const parsedMetric = this.parseMetricOption(params.get("metric") ?? undefined);
 
     if (parsedWindow == null || parsedMetric == null) {
-      throw new Error("Missing leaderboard filter state from interaction");
+      throw new EndUserError("This leaderboard message is missing filter settings. Run /leaderboard show again.", {
+        handled: true,
+        errorType: EndUserErrorType.WARNING,
+      });
     }
 
     const parsedPage = Number.parseInt(params.get("page") ?? "1", 10);
@@ -595,7 +606,13 @@ export class LeaderboardCommand extends BaseCommand {
       }
     }
 
-    throw new Error("Unable to resolve leaderboard interaction state from message components");
+    throw new EndUserError(
+      "This leaderboard message is missing its interaction context. Run /leaderboard show again.",
+      {
+        handled: true,
+        errorType: EndUserErrorType.WARNING,
+      },
+    );
   }
 
   private parseWindowOption(value: string | undefined): LeaderboardWindow | undefined {
@@ -727,6 +744,10 @@ export class LeaderboardCommand extends BaseCommand {
       }
       case LeaderboardMetric.Kda:
       case LeaderboardMetric.DamageRatio: {
+        if (metricValue === Number.MAX_VALUE) {
+          return "∞";
+        }
+
         return metricValue.toLocaleString(locale, { maximumFractionDigits: 2 });
       }
       case LeaderboardMetric.Kills:
@@ -741,5 +762,9 @@ export class LeaderboardCommand extends BaseCommand {
         throw new UnreachableError(metric);
       }
     }
+  }
+
+  private isHandledEndUserError(error: unknown): error is EndUserError {
+    return error instanceof EndUserError && error.handled;
   }
 }

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -1,9 +1,12 @@
 import type {
   APIApplicationCommandInteraction,
+  APIApplicationCommandInteractionDataBasicOption,
   APIEmbed,
   APIInteractionResponseCallbackData,
+  APIMessageComponentButtonInteraction,
+  APIMessageComponentSelectMenuInteraction,
   APIMessageTopLevelComponent,
-  APIApplicationCommandInteractionDataBasicOption,
+  APISelectMenuOption,
 } from "discord-api-types/v10";
 import {
   ApplicationCommandOptionType,
@@ -14,15 +17,22 @@ import {
   InteractionType,
   PermissionFlagsBits,
 } from "discord-api-types/v10";
+import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import type { LeaderboardResponse } from "@guilty-spark/shared/contracts/stats/leaderboard";
 import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
 import { EndUserError, EndUserErrorType } from "../../base/end-user-error";
-import type { ApplicationCommandData, BaseInteraction, ExecuteResponse } from "../base/base-command";
+import type { ApplicationCommandData, BaseInteraction, CommandData, ExecuteResponse } from "../base/base-command";
 import { BaseCommand } from "../base/base-command";
 
 const DEFAULT_PAGE_SIZE = 10;
 const MAX_ROWS_IN_DISCORD_EMBED = 10;
+const METRIC_SELECT_LIMIT = 25;
+const INTERACTION_PREV_PAGE = "btn_leaderboard_prev";
+const INTERACTION_NEXT_PAGE = "btn_leaderboard_next";
+const INTERACTION_METRIC_SELECT = "select_leaderboard_metric";
+const INTERACTION_WINDOW_SELECT = "select_leaderboard_window";
+
 const WINDOW_OPTIONS_BY_VALUE = new Map<string, LeaderboardWindow>([
   [LeaderboardWindow.OneWeek, LeaderboardWindow.OneWeek],
   [LeaderboardWindow.OneMonth, LeaderboardWindow.OneMonth],
@@ -42,6 +52,15 @@ const METRIC_OPTIONS_BY_VALUE = new Map<string, LeaderboardMetric>([
   [LeaderboardMetric.DamageRatio, LeaderboardMetric.DamageRatio],
   [LeaderboardMetric.PersonalScore, LeaderboardMetric.PersonalScore],
 ]);
+
+interface LeaderboardViewState {
+  guildId: string;
+  queueChannelId: string | null;
+  window: LeaderboardWindow;
+  metric: LeaderboardMetric;
+  page: number;
+  minGamesPlayed: number;
+}
 
 export class LeaderboardCommand extends BaseCommand {
   override commands: ApplicationCommandData[] = [
@@ -114,6 +133,42 @@ export class LeaderboardCommand extends BaseCommand {
     },
   ];
 
+  override get data(): CommandData[] {
+    return [
+      ...this.commands,
+      {
+        type: InteractionType.MessageComponent,
+        data: {
+          component_type: ComponentType.Button,
+          custom_id: INTERACTION_PREV_PAGE,
+        },
+      },
+      {
+        type: InteractionType.MessageComponent,
+        data: {
+          component_type: ComponentType.Button,
+          custom_id: INTERACTION_NEXT_PAGE,
+        },
+      },
+      {
+        type: InteractionType.MessageComponent,
+        data: {
+          component_type: ComponentType.StringSelect,
+          custom_id: INTERACTION_METRIC_SELECT,
+          values: [],
+        },
+      },
+      {
+        type: InteractionType.MessageComponent,
+        data: {
+          component_type: ComponentType.StringSelect,
+          custom_id: INTERACTION_WINDOW_SELECT,
+          values: [],
+        },
+      },
+    ];
+  }
+
   protected override handleInteraction(interaction: BaseInteraction): ExecuteResponse {
     const { type } = interaction;
 
@@ -129,7 +184,25 @@ export class LeaderboardCommand extends BaseCommand {
           }
         }
       }
-      case InteractionType.MessageComponent:
+      case InteractionType.MessageComponent: {
+        switch (interaction.data.custom_id) {
+          case INTERACTION_PREV_PAGE: {
+            return this.deferUpdate(async () => this.handlePageChange(interaction, -1));
+          }
+          case INTERACTION_NEXT_PAGE: {
+            return this.deferUpdate(async () => this.handlePageChange(interaction, 1));
+          }
+          case INTERACTION_METRIC_SELECT: {
+            return this.deferUpdate(async () => this.handleMetricSelect(interaction));
+          }
+          case INTERACTION_WINDOW_SELECT: {
+            return this.deferUpdate(async () => this.handleWindowSelect(interaction));
+          }
+          default: {
+            throw new Error(`Unknown interaction: ${interaction.data.custom_id}`);
+          }
+        }
+      }
       case InteractionType.ModalSubmit: {
         throw new Error(`Unsupported interaction type: ${type.toString()}`);
       }
@@ -151,33 +224,99 @@ export class LeaderboardCommand extends BaseCommand {
       });
     }
 
-    const queueChannelId = this.getOptionalStringOption(options, "queue_channel");
+    const queueChannelId = this.getOptionalStringOption(options, "queue_channel") ?? null;
     const window = this.parseWindowOption(this.getOptionalStringOption(options, "window"));
     const metric = this.parseMetricOption(this.getOptionalStringOption(options, "metric"));
-    const page = this.getOptionalNumberOption(options, "page");
-    const minGamesPlayed = this.getOptionalNumberOption(options, "min_games_played");
+    const page = this.getOptionalNumberOption(options, "page") ?? 1;
+    const minGamesPlayed = this.getOptionalNumberOption(options, "min_games_played") ?? 0;
 
-    const leaderboard = await this.services.leaderboardService.getLeaderboard({
+    await this.refreshLeaderboard(interaction.token, interaction.locale, {
       guildId,
-      ...(queueChannelId != null ? { queueChannelId } : {}),
-      ...(window != null ? { window } : {}),
-      ...(metric != null ? { metric } : {}),
-      ...(page != null ? { page } : {}),
+      queueChannelId,
+      window: window ?? LeaderboardWindow.ThreeMonths,
+      metric: metric ?? LeaderboardMetric.SeriesWinRate,
+      page,
+      minGamesPlayed,
+    });
+  }
+
+  private async handlePageChange(
+    interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
+    delta: number,
+  ): Promise<void> {
+    if (interaction.data.component_type !== ComponentType.Button) {
+      throw new Error("Unexpected component type for leaderboard page action");
+    }
+
+    const state = this.getStateFromInteractionMessage(interaction);
+    await this.refreshLeaderboard(interaction.token, interaction.locale, {
+      ...state,
+      page: Math.max(1, state.page + delta),
+    });
+  }
+
+  private async handleMetricSelect(
+    interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
+  ): Promise<void> {
+    if (interaction.data.component_type !== ComponentType.StringSelect) {
+      throw new Error("Unexpected component type for leaderboard metric select");
+    }
+
+    const selectedMetric = this.parseMetricOption(interaction.data.values[0]);
+    if (selectedMetric == null) {
+      throw new Error("Leaderboard metric selection is missing");
+    }
+
+    const state = this.getStateFromInteractionMessage(interaction);
+    await this.refreshLeaderboard(interaction.token, interaction.locale, {
+      ...state,
+      metric: selectedMetric,
+      page: 1,
+    });
+  }
+
+  private async handleWindowSelect(
+    interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
+  ): Promise<void> {
+    if (interaction.data.component_type !== ComponentType.StringSelect) {
+      throw new Error("Unexpected component type for leaderboard window select");
+    }
+
+    const selectedWindow = this.parseWindowOption(interaction.data.values[0]);
+    if (selectedWindow == null) {
+      throw new Error("Leaderboard window selection is missing");
+    }
+
+    const state = this.getStateFromInteractionMessage(interaction);
+    await this.refreshLeaderboard(interaction.token, interaction.locale, {
+      ...state,
+      window: selectedWindow,
+      page: 1,
+    });
+  }
+
+  private async refreshLeaderboard(token: string, locale: string, state: LeaderboardViewState): Promise<void> {
+    const leaderboard = await this.services.leaderboardService.getLeaderboard({
+      guildId: state.guildId,
+      ...(state.queueChannelId != null ? { queueChannelId: state.queueChannelId } : {}),
+      window: state.window,
+      metric: state.metric,
+      page: state.page,
       pageSize: DEFAULT_PAGE_SIZE,
-      ...(minGamesPlayed != null ? { minGamesPlayed } : {}),
+      minGamesPlayed: state.minGamesPlayed,
     });
 
-    const response = this.createLeaderboardResponse(interaction, leaderboard);
-    await this.services.discordService.updateDeferredReply(interaction.token, response);
+    const response = this.createLeaderboardResponse(locale, leaderboard);
+    await this.services.discordService.updateDeferredReply(token, response);
   }
 
   private createLeaderboardResponse(
-    interaction: APIApplicationCommandInteraction,
+    locale: string,
     leaderboard: LeaderboardResponse,
   ): APIInteractionResponseCallbackData {
     const rankingLines = leaderboard.rows.slice(0, MAX_ROWS_IN_DISCORD_EMBED).map((row) => {
       const player = row.discordUserId != null ? `<@${row.discordUserId}> (${row.gamertag})` : row.gamertag;
-      const metricValue = this.formatMetricValue(row.metricValue, leaderboard.metric, interaction.locale);
+      const metricValue = this.formatMetricValue(row.metricValue, leaderboard.metric, locale);
       return `${row.rank.toString()}. ${player} - ${metricValue}`;
     });
 
@@ -209,6 +348,9 @@ export class LeaderboardCommand extends BaseCommand {
   }
 
   private createComponents(leaderboard: LeaderboardResponse): APIMessageTopLevelComponent[] {
+    const totalPages = Math.max(1, Math.ceil(leaderboard.total / leaderboard.pageSize));
+    const metricOptions = this.getMetricSelectOptions(leaderboard.metric);
+    const windowOptions = this.getWindowSelectOptions(leaderboard.window);
 
     const params = new URLSearchParams({
       guildId: leaderboard.guildId,
@@ -230,13 +372,144 @@ export class LeaderboardCommand extends BaseCommand {
         components: [
           {
             type: ComponentType.Button,
+            style: ButtonStyle.Secondary,
+            custom_id: INTERACTION_PREV_PAGE,
+            label: "Previous",
+            disabled: leaderboard.page <= 1,
+          },
+          {
+            type: ComponentType.Button,
+            style: ButtonStyle.Secondary,
+            custom_id: INTERACTION_NEXT_PAGE,
+            label: "Next",
+            disabled: leaderboard.page >= totalPages,
+          },
+          {
+            type: ComponentType.Button,
             style: ButtonStyle.Link,
             label: "Open in browser",
             url: webUrl,
           },
         ],
       },
+      {
+        type: ComponentType.ActionRow,
+        components: [
+          {
+            type: ComponentType.StringSelect,
+            custom_id: INTERACTION_METRIC_SELECT,
+            placeholder: "Select metric",
+            min_values: 1,
+            max_values: 1,
+            options: metricOptions,
+          },
+        ],
+      },
+      {
+        type: ComponentType.ActionRow,
+        components: [
+          {
+            type: ComponentType.StringSelect,
+            custom_id: INTERACTION_WINDOW_SELECT,
+            placeholder: "Select window",
+            min_values: 1,
+            max_values: 1,
+            options: windowOptions,
+          },
+        ],
+      },
     ];
+  }
+
+  private getMetricSelectOptions(selectedMetric: LeaderboardMetric): APISelectMenuOption[] {
+    const metricOptions = [
+      { label: "Series win rate", value: LeaderboardMetric.SeriesWinRate },
+      { label: "Kills", value: LeaderboardMetric.Kills },
+      { label: "Deaths", value: LeaderboardMetric.Deaths },
+      { label: "Assists", value: LeaderboardMetric.Assists },
+      { label: "KDA", value: LeaderboardMetric.Kda },
+      { label: "Accuracy", value: LeaderboardMetric.Accuracy },
+      { label: "Damage dealt", value: LeaderboardMetric.DamageDealt },
+      { label: "Damage taken", value: LeaderboardMetric.DamageTaken },
+      { label: "Damage ratio", value: LeaderboardMetric.DamageRatio },
+      { label: "Personal score", value: LeaderboardMetric.PersonalScore },
+    ];
+
+    return metricOptions.slice(0, METRIC_SELECT_LIMIT).map((option) => ({
+      ...option,
+      default: option.value === selectedMetric,
+    }));
+  }
+
+  private getWindowSelectOptions(selectedWindow: LeaderboardWindow): APISelectMenuOption[] {
+    const windowOptions = [
+      { label: "1 week", value: LeaderboardWindow.OneWeek },
+      { label: "1 month", value: LeaderboardWindow.OneMonth },
+      { label: "3 months", value: LeaderboardWindow.ThreeMonths },
+      { label: "6 months", value: LeaderboardWindow.SixMonths },
+      { label: "12 months", value: LeaderboardWindow.TwelveMonths },
+    ];
+
+    return windowOptions.map((option) => ({
+      ...option,
+      default: option.value === selectedWindow,
+    }));
+  }
+
+  private getStateFromInteractionMessage(
+    interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
+  ): LeaderboardViewState {
+    const components = Preconditions.checkExists(interaction.message.components);
+    const stateUrl = this.getStateUrlFromComponents(components);
+    const params = new URL(stateUrl).searchParams;
+
+    const guildId = params.get("guildId") ?? interaction.guild_id;
+    if (guildId == null || guildId === "") {
+      throw new Error("Missing guildId in leaderboard interaction state");
+    }
+
+    const parsedWindow = this.parseWindowOption(params.get("window") ?? undefined);
+    const parsedMetric = this.parseMetricOption(params.get("metric") ?? undefined);
+
+    if (parsedWindow == null || parsedMetric == null) {
+      throw new Error("Missing leaderboard filter state from interaction");
+    }
+
+    const parsedPage = Number.parseInt(params.get("page") ?? "1", 10);
+    const parsedMinGamesPlayed = Number.parseInt(params.get("minGamesPlayed") ?? "0", 10);
+
+    return {
+      guildId,
+      queueChannelId: params.get("queueChannelId"),
+      window: parsedWindow,
+      metric: parsedMetric,
+      page: Number.isNaN(parsedPage) ? 1 : Math.max(1, parsedPage),
+      minGamesPlayed: Number.isNaN(parsedMinGamesPlayed) ? 0 : Math.max(0, parsedMinGamesPlayed),
+    };
+  }
+
+  private getStateUrlFromComponents(components: APIMessageTopLevelComponent[]): string {
+    for (const actionRow of components) {
+      if (actionRow.type !== ComponentType.ActionRow) {
+        continue;
+      }
+
+      for (const component of actionRow.components) {
+        if (component.type !== ComponentType.Button || component.style !== ButtonStyle.Link) {
+          continue;
+        }
+
+        if (component.url === "") {
+          continue;
+        }
+
+        if (component.url.includes("/leaderboard?")) {
+          return component.url;
+        }
+      }
+    }
+
+    throw new Error("Unable to resolve leaderboard interaction state from message components");
   }
 
   private parseWindowOption(value: string | undefined): LeaderboardWindow | undefined {

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -548,7 +548,7 @@ export class LeaderboardCommand extends BaseCommand {
     }
 
     const stateUrl = this.getStateUrlFromComponents(components);
-    const params = new URL(stateUrl).searchParams;
+    const params = this.getStateQueryParams(stateUrl);
     const interactionGuildId = interaction.guild_id;
 
     if (interactionGuildId == null || interactionGuildId === "") {
@@ -595,6 +595,17 @@ export class LeaderboardCommand extends BaseCommand {
     }
 
     return value;
+  }
+
+  private getStateQueryParams(stateUrl: string): URLSearchParams {
+    try {
+      return new URL(stateUrl).searchParams;
+    } catch {
+      throw new EndUserError("This leaderboard message has invalid filter settings. Run /leaderboard show again.", {
+        handled: true,
+        errorType: EndUserErrorType.WARNING,
+      });
+    }
   }
 
   private getRankingContent(rankingLines: string[], totalPlayers: number): string {

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -18,7 +18,6 @@ import {
   InteractionType,
   PermissionFlagsBits,
 } from "discord-api-types/v10";
-import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import type { LeaderboardResponse } from "@guilty-spark/shared/contracts/stats/leaderboard";
 import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
@@ -526,7 +525,17 @@ export class LeaderboardCommand extends BaseCommand {
   private getStateFromInteractionMessage(
     interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
   ): LeaderboardViewState {
-    const components = Preconditions.checkExists(interaction.message.components);
+    const {components} = interaction.message;
+    if (components == null || components.length === 0) {
+      throw new EndUserError(
+        "This leaderboard message is missing its interaction context. Run /leaderboard show again.",
+        {
+          handled: true,
+          errorType: EndUserErrorType.WARNING,
+        },
+      );
+    }
+
     const stateUrl = this.getStateUrlFromComponents(components);
     const params = new URL(stateUrl).searchParams;
     const interactionGuildId = interaction.guild_id;
@@ -626,7 +635,10 @@ export class LeaderboardCommand extends BaseCommand {
 
     const parsedWindow = WINDOW_OPTIONS_BY_VALUE.get(value);
     if (parsedWindow == null) {
-      throw new Error(`Invalid leaderboard window option: ${value}`);
+      throw new EndUserError("This leaderboard message has an invalid window filter. Run /leaderboard show again.", {
+        handled: true,
+        errorType: EndUserErrorType.WARNING,
+      });
     }
 
     return parsedWindow;
@@ -639,7 +651,10 @@ export class LeaderboardCommand extends BaseCommand {
 
     const parsedMetric = METRIC_OPTIONS_BY_VALUE.get(value);
     if (parsedMetric == null) {
-      throw new Error(`Invalid leaderboard metric option: ${value}`);
+      throw new EndUserError("This leaderboard message has an invalid metric filter. Run /leaderboard show again.", {
+        handled: true,
+        errorType: EndUserErrorType.WARNING,
+      });
     }
 
     return parsedMetric;

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -333,15 +333,7 @@ export class LeaderboardCommand extends BaseCommand {
 
   private async refreshLeaderboard(token: string, locale: string, state: LeaderboardViewState): Promise<void> {
     try {
-      const leaderboard = await this.services.leaderboardService.getLeaderboard({
-        guildId: state.guildId,
-        ...(state.queueChannelId != null ? { queueChannelId: state.queueChannelId } : {}),
-        ...(state.window != null ? { window: state.window } : {}),
-        ...(state.metric != null ? { metric: state.metric } : {}),
-        page: state.page,
-        pageSize: DEFAULT_PAGE_SIZE,
-        ...(state.minGamesPlayed != null ? { minGamesPlayed: state.minGamesPlayed } : {}),
-      });
+      const leaderboard = await this.getLeaderboardWithResolvedPage(state);
 
       const response = this.createLeaderboardResponse(locale, leaderboard);
       await this.services.discordService.updateDeferredReply(token, response);
@@ -349,6 +341,34 @@ export class LeaderboardCommand extends BaseCommand {
       this.services.logService.error(error);
       await this.services.discordService.updateDeferredReplyWithError(token, error);
     }
+  }
+
+  private async getLeaderboardWithResolvedPage(state: LeaderboardViewState): Promise<LeaderboardResponse> {
+    const leaderboard = await this.services.leaderboardService.getLeaderboard({
+      guildId: state.guildId,
+      ...(state.queueChannelId != null ? { queueChannelId: state.queueChannelId } : {}),
+      ...(state.window != null ? { window: state.window } : {}),
+      ...(state.metric != null ? { metric: state.metric } : {}),
+      page: state.page,
+      pageSize: DEFAULT_PAGE_SIZE,
+      ...(state.minGamesPlayed != null ? { minGamesPlayed: state.minGamesPlayed } : {}),
+    });
+
+    const totalPages = Math.max(1, Math.ceil(leaderboard.total / leaderboard.pageSize));
+    const requestedPageIsOutOfRange = leaderboard.total > 0 && leaderboard.page > totalPages;
+    if (!requestedPageIsOutOfRange) {
+      return leaderboard;
+    }
+
+    return this.services.leaderboardService.getLeaderboard({
+      guildId: state.guildId,
+      ...(state.queueChannelId != null ? { queueChannelId: state.queueChannelId } : {}),
+      ...(state.window != null ? { window: state.window } : {}),
+      ...(state.metric != null ? { metric: state.metric } : {}),
+      page: totalPages,
+      pageSize: DEFAULT_PAGE_SIZE,
+      ...(state.minGamesPlayed != null ? { minGamesPlayed: state.minGamesPlayed } : {}),
+    });
   }
 
   private createLeaderboardResponse(

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -231,8 +231,9 @@ export class LeaderboardCommand extends BaseCommand {
       const metric = this.parseMetricOption(this.getOptionalStringOption(options, "metric"));
       const page = this.getOptionalNumberOption(options, "page") ?? 1;
       const minGamesPlayed = this.getOptionalNumberOption(options, "min_games_played");
+      const locale = this.getInteractionLocale(interaction);
 
-      await this.refreshLeaderboard(interaction.token, interaction.locale, {
+      await this.refreshLeaderboard(interaction.token, locale, {
         guildId,
         queueChannelId,
         ...(window != null ? { window } : {}),
@@ -304,7 +305,8 @@ export class LeaderboardCommand extends BaseCommand {
     try {
       await this.assertCanUseLeaderboardControls(interaction);
       const state = this.getStateFromInteractionMessage(interaction);
-      await this.refreshLeaderboard(interaction.token, interaction.locale, stateUpdater(state));
+      const locale = this.getInteractionLocale(interaction);
+      await this.refreshLeaderboard(interaction.token, locale, stateUpdater(state));
     } catch (error) {
       if (!this.isHandledEndUserError(error)) {
         this.services.logService.error(error);
@@ -525,7 +527,7 @@ export class LeaderboardCommand extends BaseCommand {
   private getStateFromInteractionMessage(
     interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
   ): LeaderboardViewState {
-    const {components} = interaction.message;
+    const { components } = interaction.message;
     if (components == null || components.length === 0) {
       throw new EndUserError(
         "This leaderboard message is missing its interaction context. Run /leaderboard show again.",
@@ -785,5 +787,14 @@ export class LeaderboardCommand extends BaseCommand {
 
   private isHandledEndUserError(error: unknown): error is EndUserError {
     return error instanceof EndUserError && error.handled;
+  }
+
+  private getInteractionLocale(
+    interaction:
+      | APIApplicationCommandInteraction
+      | APIMessageComponentButtonInteraction
+      | APIMessageComponentSelectMenuInteraction,
+  ): string {
+    return interaction.guild_locale ?? interaction.locale;
   }
 }

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -364,9 +364,16 @@ export class LeaderboardCommand extends BaseCommand {
     });
 
     const totalPages = Math.max(1, Math.ceil(leaderboard.total / leaderboard.pageSize));
-    const requestedPageIsOutOfRange = leaderboard.total > 0 && leaderboard.page > totalPages;
+    const requestedPageIsOutOfRange = leaderboard.page > totalPages;
     if (!requestedPageIsOutOfRange) {
       return leaderboard;
+    }
+
+    if (leaderboard.total === 0) {
+      return {
+        ...leaderboard,
+        page: 1,
+      };
     }
 
     return this.services.leaderboardService.getLeaderboard({

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -250,11 +250,10 @@ export class LeaderboardCommand extends BaseCommand {
       throw new Error("Unexpected component type for leaderboard page action");
     }
 
-    const state = this.getStateFromInteractionMessage(interaction);
-    await this.refreshLeaderboard(interaction.token, interaction.locale, {
+    await this.executeStateInteraction(interaction, (state) => ({
       ...state,
       page: Math.max(1, state.page + delta),
-    });
+    }));
   }
 
   private async handleMetricSelect(
@@ -269,12 +268,11 @@ export class LeaderboardCommand extends BaseCommand {
       throw new Error("Leaderboard metric selection is missing");
     }
 
-    const state = this.getStateFromInteractionMessage(interaction);
-    await this.refreshLeaderboard(interaction.token, interaction.locale, {
+    await this.executeStateInteraction(interaction, (state) => ({
       ...state,
       metric: selectedMetric,
       page: 1,
-    });
+    }));
   }
 
   private async handleWindowSelect(
@@ -289,12 +287,48 @@ export class LeaderboardCommand extends BaseCommand {
       throw new Error("Leaderboard window selection is missing");
     }
 
-    const state = this.getStateFromInteractionMessage(interaction);
-    await this.refreshLeaderboard(interaction.token, interaction.locale, {
+    await this.executeStateInteraction(interaction, (state) => ({
       ...state,
       window: selectedWindow,
       page: 1,
-    });
+    }));
+  }
+
+  private async executeStateInteraction(
+    interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
+    stateUpdater: (state: LeaderboardViewState) => LeaderboardViewState,
+  ): Promise<void> {
+    try {
+      await this.assertCanUseLeaderboardControls(interaction);
+      const state = this.getStateFromInteractionMessage(interaction);
+      await this.refreshLeaderboard(interaction.token, interaction.locale, stateUpdater(state));
+    } catch (error) {
+      this.services.logService.error(error);
+      await this.services.discordService.updateDeferredReplyWithError(interaction.token, error);
+    }
+  }
+
+  private async assertCanUseLeaderboardControls(
+    interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
+  ): Promise<void> {
+    const guildId = interaction.guild_id;
+    if (guildId == null || guildId === "") {
+      throw new EndUserError("Leaderboard controls can only be used inside a server.", {
+        handled: true,
+        errorType: EndUserErrorType.WARNING,
+      });
+    }
+
+    const userId = this.services.discordService.getDiscordUserId(interaction);
+    const permissions = await this.services.discordService.computeMemberPermissions(guildId, userId);
+    const hasManageGuildPermission = (permissions & PermissionFlagsBits.ManageGuild) !== 0n;
+
+    if (!hasManageGuildPermission) {
+      throw new EndUserError("You need the Manage Server permission to use leaderboard controls.", {
+        handled: true,
+        errorType: EndUserErrorType.WARNING,
+      });
+    }
   }
 
   private async refreshLeaderboard(token: string, locale: string, state: LeaderboardViewState): Promise<void> {

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -1,0 +1,386 @@
+import type {
+  APIApplicationCommandInteraction,
+  APIEmbed,
+  APIInteractionResponseCallbackData,
+  APIMessageTopLevelComponent,
+  APIApplicationCommandInteractionDataBasicOption,
+} from "discord-api-types/v10";
+import {
+  ApplicationCommandOptionType,
+  ApplicationCommandType,
+  ButtonStyle,
+  ComponentType,
+  InteractionContextType,
+  InteractionType,
+  PermissionFlagsBits,
+} from "discord-api-types/v10";
+import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import type { LeaderboardResponse } from "@guilty-spark/shared/contracts/stats/leaderboard";
+import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
+import { EndUserError, EndUserErrorType } from "../../base/end-user-error";
+import type { ApplicationCommandData, BaseInteraction, ExecuteResponse } from "../base/base-command";
+import { BaseCommand } from "../base/base-command";
+
+const DEFAULT_PAGE_SIZE = 10;
+const MAX_ROWS_IN_DISCORD_EMBED = 10;
+const WINDOW_OPTIONS_BY_VALUE = new Map<string, LeaderboardWindow>([
+  [LeaderboardWindow.OneWeek, LeaderboardWindow.OneWeek],
+  [LeaderboardWindow.OneMonth, LeaderboardWindow.OneMonth],
+  [LeaderboardWindow.ThreeMonths, LeaderboardWindow.ThreeMonths],
+  [LeaderboardWindow.SixMonths, LeaderboardWindow.SixMonths],
+  [LeaderboardWindow.TwelveMonths, LeaderboardWindow.TwelveMonths],
+]);
+const METRIC_OPTIONS_BY_VALUE = new Map<string, LeaderboardMetric>([
+  [LeaderboardMetric.SeriesWinRate, LeaderboardMetric.SeriesWinRate],
+  [LeaderboardMetric.Kills, LeaderboardMetric.Kills],
+  [LeaderboardMetric.Deaths, LeaderboardMetric.Deaths],
+  [LeaderboardMetric.Assists, LeaderboardMetric.Assists],
+  [LeaderboardMetric.Kda, LeaderboardMetric.Kda],
+  [LeaderboardMetric.Accuracy, LeaderboardMetric.Accuracy],
+  [LeaderboardMetric.DamageDealt, LeaderboardMetric.DamageDealt],
+  [LeaderboardMetric.DamageTaken, LeaderboardMetric.DamageTaken],
+  [LeaderboardMetric.DamageRatio, LeaderboardMetric.DamageRatio],
+  [LeaderboardMetric.PersonalScore, LeaderboardMetric.PersonalScore],
+]);
+
+export class LeaderboardCommand extends BaseCommand {
+  override commands: ApplicationCommandData[] = [
+    {
+      type: ApplicationCommandType.ChatInput,
+      name: "leaderboard",
+      description: "View leaderboard rankings for this server",
+      contexts: [InteractionContextType.Guild],
+      default_member_permissions: PermissionFlagsBits.ManageGuild.toString(),
+      options: [
+        {
+          type: ApplicationCommandOptionType.Subcommand,
+          name: "show",
+          description: "Show leaderboard rankings",
+          options: [
+            {
+              name: "queue_channel",
+              description: "Limit ranking scope to a single queue channel",
+              type: ApplicationCommandOptionType.Channel,
+              required: false,
+            },
+            {
+              name: "window",
+              description: "Rolling window for leaderboard facts",
+              type: ApplicationCommandOptionType.String,
+              required: false,
+              choices: [
+                { name: "1 week", value: LeaderboardWindow.OneWeek },
+                { name: "1 month", value: LeaderboardWindow.OneMonth },
+                { name: "3 months", value: LeaderboardWindow.ThreeMonths },
+                { name: "6 months", value: LeaderboardWindow.SixMonths },
+                { name: "12 months", value: LeaderboardWindow.TwelveMonths },
+              ],
+            },
+            {
+              name: "metric",
+              description: "Metric to rank players by",
+              type: ApplicationCommandOptionType.String,
+              required: false,
+              choices: [
+                { name: "Series win rate", value: LeaderboardMetric.SeriesWinRate },
+                { name: "Kills", value: LeaderboardMetric.Kills },
+                { name: "Deaths", value: LeaderboardMetric.Deaths },
+                { name: "Assists", value: LeaderboardMetric.Assists },
+                { name: "KDA", value: LeaderboardMetric.Kda },
+                { name: "Accuracy", value: LeaderboardMetric.Accuracy },
+                { name: "Damage dealt", value: LeaderboardMetric.DamageDealt },
+                { name: "Damage taken", value: LeaderboardMetric.DamageTaken },
+                { name: "Damage ratio", value: LeaderboardMetric.DamageRatio },
+                { name: "Personal score", value: LeaderboardMetric.PersonalScore },
+              ],
+            },
+            {
+              name: "page",
+              description: "Page number",
+              type: ApplicationCommandOptionType.Integer,
+              required: false,
+              min_value: 1,
+            },
+            {
+              name: "min_games_played",
+              description: "Minimum games played to appear",
+              type: ApplicationCommandOptionType.Integer,
+              required: false,
+              min_value: 0,
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  protected override handleInteraction(interaction: BaseInteraction): ExecuteResponse {
+    const { type } = interaction;
+
+    switch (type) {
+      case InteractionType.ApplicationCommand: {
+        const subcommand = this.services.discordService.extractSubcommand(interaction, "leaderboard");
+        switch (subcommand.name) {
+          case "show": {
+            return this.deferReply(async () => this.showLeaderboard(interaction, subcommand.mappedOptions));
+          }
+          default: {
+            throw new Error("Unknown subcommand");
+          }
+        }
+      }
+      case InteractionType.MessageComponent:
+      case InteractionType.ModalSubmit: {
+        throw new Error(`Unsupported interaction type: ${type.toString()}`);
+      }
+      default: {
+        throw new UnreachableError(type);
+      }
+    }
+  }
+
+  private async showLeaderboard(
+    interaction: APIApplicationCommandInteraction,
+    options: Map<string, APIApplicationCommandInteractionDataBasicOption["value"]>,
+  ): Promise<void> {
+    const guildId = interaction.guild_id;
+    if (guildId == null || guildId === "") {
+      throw new EndUserError("Leaderboard can only be used inside a server.", {
+        handled: true,
+        errorType: EndUserErrorType.WARNING,
+      });
+    }
+
+    const queueChannelId = this.getOptionalStringOption(options, "queue_channel");
+    const window = this.parseWindowOption(this.getOptionalStringOption(options, "window"));
+    const metric = this.parseMetricOption(this.getOptionalStringOption(options, "metric"));
+    const page = this.getOptionalNumberOption(options, "page");
+    const minGamesPlayed = this.getOptionalNumberOption(options, "min_games_played");
+
+    const leaderboard = await this.services.leaderboardService.getLeaderboard({
+      guildId,
+      ...(queueChannelId != null ? { queueChannelId } : {}),
+      ...(window != null ? { window } : {}),
+      ...(metric != null ? { metric } : {}),
+      ...(page != null ? { page } : {}),
+      pageSize: DEFAULT_PAGE_SIZE,
+      ...(minGamesPlayed != null ? { minGamesPlayed } : {}),
+    });
+
+    const response = this.createLeaderboardResponse(interaction, leaderboard);
+    await this.services.discordService.updateDeferredReply(interaction.token, response);
+  }
+
+  private createLeaderboardResponse(
+    interaction: APIApplicationCommandInteraction,
+    leaderboard: LeaderboardResponse,
+  ): APIInteractionResponseCallbackData {
+    const rankingLines = leaderboard.rows.slice(0, MAX_ROWS_IN_DISCORD_EMBED).map((row) => {
+      const player = row.discordUserId != null ? `<@${row.discordUserId}> (${row.gamertag})` : row.gamertag;
+      const metricValue = this.formatMetricValue(row.metricValue, leaderboard.metric, interaction.locale);
+      return `${row.rank.toString()}. ${player} - ${metricValue}`;
+    });
+
+    const metricLabel = this.getMetricLabel(leaderboard.metric);
+    const windowLabel = this.getWindowLabel(leaderboard.window);
+    const scopeLabel =
+      leaderboard.queueChannelId != null ? `Queue <#${leaderboard.queueChannelId}>` : "Server-wide (all queues)";
+
+    const embed: APIEmbed = {
+      title: `Leaderboard - ${scopeLabel}`,
+      description:
+        `Metric: ${metricLabel} | Window: ${windowLabel}\n` +
+        `Page: ${leaderboard.page.toString()} | Min games: ${leaderboard.minGamesPlayed.toString()} | Total players: ${leaderboard.total.toString()}`,
+      fields: [
+        {
+          name: "Rankings",
+          value: rankingLines.length > 0 ? rankingLines.join("\n") : "No players qualify for this filter yet.",
+          inline: false,
+        },
+      ],
+    };
+
+    const components = this.createComponents(leaderboard);
+
+    return {
+      embeds: [embed],
+      components,
+    };
+  }
+
+  private createComponents(leaderboard: LeaderboardResponse): APIMessageTopLevelComponent[] {
+
+    const params = new URLSearchParams({
+      guildId: leaderboard.guildId,
+      window: leaderboard.window,
+      metric: leaderboard.metric,
+      page: leaderboard.page.toString(),
+      minGamesPlayed: leaderboard.minGamesPlayed.toString(),
+    });
+
+    if (leaderboard.queueChannelId != null) {
+      params.set("queueChannelId", leaderboard.queueChannelId);
+    }
+
+    const webUrl = `${this.env.PAGES_URL}/leaderboard?${params.toString()}`;
+
+    return [
+      {
+        type: ComponentType.ActionRow,
+        components: [
+          {
+            type: ComponentType.Button,
+            style: ButtonStyle.Link,
+            label: "Open in browser",
+            url: webUrl,
+          },
+        ],
+      },
+    ];
+  }
+
+  private parseWindowOption(value: string | undefined): LeaderboardWindow | undefined {
+    if (value == null) {
+      return undefined;
+    }
+
+    const parsedWindow = WINDOW_OPTIONS_BY_VALUE.get(value);
+    if (parsedWindow == null) {
+      throw new Error(`Invalid leaderboard window option: ${value}`);
+    }
+
+    return parsedWindow;
+  }
+
+  private parseMetricOption(value: string | undefined): LeaderboardMetric | undefined {
+    if (value == null) {
+      return undefined;
+    }
+
+    const parsedMetric = METRIC_OPTIONS_BY_VALUE.get(value);
+    if (parsedMetric == null) {
+      throw new Error(`Invalid leaderboard metric option: ${value}`);
+    }
+
+    return parsedMetric;
+  }
+
+  private getOptionalStringOption(
+    options: Map<string, APIApplicationCommandInteractionDataBasicOption["value"]>,
+    optionName: string,
+  ): string | undefined {
+    const value = options.get(optionName);
+    if (value == null) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw new Error(`Expected string option: ${optionName}`);
+    }
+
+    return value;
+  }
+
+  private getOptionalNumberOption(
+    options: Map<string, APIApplicationCommandInteractionDataBasicOption["value"]>,
+    optionName: string,
+  ): number | undefined {
+    const value = options.get(optionName);
+    if (value == null) {
+      return undefined;
+    }
+
+    if (typeof value !== "number") {
+      throw new Error(`Expected numeric option: ${optionName}`);
+    }
+
+    return value;
+  }
+
+  private getWindowLabel(window: LeaderboardWindow): string {
+    switch (window) {
+      case LeaderboardWindow.OneWeek: {
+        return "1 week";
+      }
+      case LeaderboardWindow.OneMonth: {
+        return "1 month";
+      }
+      case LeaderboardWindow.ThreeMonths: {
+        return "3 months";
+      }
+      case LeaderboardWindow.SixMonths: {
+        return "6 months";
+      }
+      case LeaderboardWindow.TwelveMonths: {
+        return "12 months";
+      }
+      default: {
+        throw new UnreachableError(window);
+      }
+    }
+  }
+
+  private getMetricLabel(metric: LeaderboardMetric): string {
+    switch (metric) {
+      case LeaderboardMetric.SeriesWinRate: {
+        return "Series win rate";
+      }
+      case LeaderboardMetric.Kills: {
+        return "Kills";
+      }
+      case LeaderboardMetric.Deaths: {
+        return "Deaths";
+      }
+      case LeaderboardMetric.Assists: {
+        return "Assists";
+      }
+      case LeaderboardMetric.Kda: {
+        return "KDA";
+      }
+      case LeaderboardMetric.Accuracy: {
+        return "Accuracy";
+      }
+      case LeaderboardMetric.DamageDealt: {
+        return "Damage dealt";
+      }
+      case LeaderboardMetric.DamageTaken: {
+        return "Damage taken";
+      }
+      case LeaderboardMetric.DamageRatio: {
+        return "Damage ratio";
+      }
+      case LeaderboardMetric.PersonalScore: {
+        return "Personal score";
+      }
+      default: {
+        throw new UnreachableError(metric);
+      }
+    }
+  }
+
+  private formatMetricValue(metricValue: number, metric: LeaderboardMetric, locale: string): string {
+    switch (metric) {
+      case LeaderboardMetric.SeriesWinRate: {
+        return `${(metricValue * 100).toLocaleString(locale, { maximumFractionDigits: 1 })}%`;
+      }
+      case LeaderboardMetric.Accuracy: {
+        return `${metricValue.toLocaleString(locale, { maximumFractionDigits: 1 })}%`;
+      }
+      case LeaderboardMetric.Kda:
+      case LeaderboardMetric.DamageRatio: {
+        return metricValue.toLocaleString(locale, { maximumFractionDigits: 2 });
+      }
+      case LeaderboardMetric.Kills:
+      case LeaderboardMetric.Deaths:
+      case LeaderboardMetric.Assists:
+      case LeaderboardMetric.DamageDealt:
+      case LeaderboardMetric.DamageTaken:
+      case LeaderboardMetric.PersonalScore: {
+        return Math.round(metricValue).toLocaleString(locale);
+      }
+      default: {
+        throw new UnreachableError(metric);
+      }
+    }
+  }
+}

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -607,7 +607,7 @@ export class LeaderboardCommand extends BaseCommand {
     return [
       {
         name: "Rank",
-        value: rows.map((row) => `#${row.rank.toString()}`).join("\n"),
+        value: rows.map((row) => this.formatRank(row.rank)).join("\n"),
         inline: true,
       },
       {
@@ -623,6 +623,23 @@ export class LeaderboardCommand extends BaseCommand {
         inline: true,
       },
     ];
+  }
+
+  private formatRank(rank: number): string {
+    switch (rank) {
+      case 1: {
+        return "🥇";
+      }
+      case 2: {
+        return "🥈";
+      }
+      case 3: {
+        return "🥉";
+      }
+      default: {
+        return `#${rank.toString()}`;
+      }
+    }
   }
 
   private getMetricSelectOptions(selectedMetric: LeaderboardMetric): APISelectMenuOption[] {

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -308,9 +308,6 @@ export class LeaderboardCommand extends BaseCommand {
       const locale = this.getInteractionLocale(interaction);
       await this.refreshLeaderboard(interaction.token, locale, stateUpdater(state));
     } catch (error) {
-      if (!this.isHandledEndUserError(error)) {
-        this.services.logService.error(error);
-      }
       await this.services.discordService.updateDeferredReplyWithError(interaction.token, error);
     }
   }
@@ -345,7 +342,6 @@ export class LeaderboardCommand extends BaseCommand {
       const response = this.createLeaderboardResponse(locale, leaderboard);
       await this.services.discordService.updateDeferredReply(token, response);
     } catch (error) {
-      this.services.logService.error(error);
       await this.services.discordService.updateDeferredReplyWithError(token, error);
     }
   }
@@ -783,10 +779,6 @@ export class LeaderboardCommand extends BaseCommand {
         throw new UnreachableError(metric);
       }
     }
-  }
-
-  private isHandledEndUserError(error: unknown): error is EndUserError {
-    return error instanceof EndUserError && error.handled;
   }
 
   private getInteractionLocale(

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -57,10 +57,10 @@ const METRIC_OPTIONS_BY_VALUE = new Map<string, LeaderboardMetric>([
 interface LeaderboardViewState {
   guildId: string;
   queueChannelId: string | null;
-  window: LeaderboardWindow;
-  metric: LeaderboardMetric;
+  window?: LeaderboardWindow;
+  metric?: LeaderboardMetric;
   page: number;
-  minGamesPlayed: number;
+  minGamesPlayed?: number;
 }
 
 export class LeaderboardCommand extends BaseCommand {
@@ -230,15 +230,15 @@ export class LeaderboardCommand extends BaseCommand {
     const window = this.parseWindowOption(this.getOptionalStringOption(options, "window"));
     const metric = this.parseMetricOption(this.getOptionalStringOption(options, "metric"));
     const page = this.getOptionalNumberOption(options, "page") ?? 1;
-    const minGamesPlayed = this.getOptionalNumberOption(options, "min_games_played") ?? 0;
+    const minGamesPlayed = this.getOptionalNumberOption(options, "min_games_played");
 
     await this.refreshLeaderboard(interaction.token, interaction.locale, {
       guildId,
       queueChannelId,
-      window: window ?? LeaderboardWindow.ThreeMonths,
-      metric: metric ?? LeaderboardMetric.SeriesWinRate,
+      ...(window != null ? { window } : {}),
+      ...(metric != null ? { metric } : {}),
       page,
-      minGamesPlayed,
+      ...(minGamesPlayed != null ? { minGamesPlayed } : {}),
     });
   }
 
@@ -298,18 +298,23 @@ export class LeaderboardCommand extends BaseCommand {
   }
 
   private async refreshLeaderboard(token: string, locale: string, state: LeaderboardViewState): Promise<void> {
-    const leaderboard = await this.services.leaderboardService.getLeaderboard({
-      guildId: state.guildId,
-      ...(state.queueChannelId != null ? { queueChannelId: state.queueChannelId } : {}),
-      window: state.window,
-      metric: state.metric,
-      page: state.page,
-      pageSize: DEFAULT_PAGE_SIZE,
-      minGamesPlayed: state.minGamesPlayed,
-    });
+    try {
+      const leaderboard = await this.services.leaderboardService.getLeaderboard({
+        guildId: state.guildId,
+        ...(state.queueChannelId != null ? { queueChannelId: state.queueChannelId } : {}),
+        ...(state.window != null ? { window: state.window } : {}),
+        ...(state.metric != null ? { metric: state.metric } : {}),
+        page: state.page,
+        pageSize: DEFAULT_PAGE_SIZE,
+        ...(state.minGamesPlayed != null ? { minGamesPlayed: state.minGamesPlayed } : {}),
+      });
 
-    const response = this.createLeaderboardResponse(locale, leaderboard);
-    await this.services.discordService.updateDeferredReply(token, response);
+      const response = this.createLeaderboardResponse(locale, leaderboard);
+      await this.services.discordService.updateDeferredReply(token, response);
+    } catch (error) {
+      this.services.logService.error(error);
+      await this.services.discordService.updateDeferredReplyWithError(token, error);
+    }
   }
 
   private createLeaderboardResponse(

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -12,6 +12,7 @@ import {
   ApplicationCommandOptionType,
   ApplicationCommandType,
   ButtonStyle,
+  ChannelType,
   ComponentType,
   InteractionContextType,
   InteractionType,
@@ -80,6 +81,7 @@ export class LeaderboardCommand extends BaseCommand {
               name: "queue_channel",
               description: "Limit ranking scope to a single queue channel",
               type: ApplicationCommandOptionType.Channel,
+              channel_types: [ChannelType.GuildText, ChannelType.GuildAnnouncement],
               required: false,
             },
             {

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -374,7 +374,7 @@ export class LeaderboardCommand extends BaseCommand {
       fields: [
         {
           name: "Rankings",
-          value: rankingLines.length > 0 ? rankingLines.join("\n") : "No players qualify for this filter yet.",
+          value: this.getRankingContent(rankingLines, leaderboard.total),
           inline: false,
         },
       ],
@@ -503,10 +503,15 @@ export class LeaderboardCommand extends BaseCommand {
     const components = Preconditions.checkExists(interaction.message.components);
     const stateUrl = this.getStateUrlFromComponents(components);
     const params = new URL(stateUrl).searchParams;
+    const interactionGuildId = interaction.guild_id;
 
-    const guildId = params.get("guildId") ?? interaction.guild_id;
-    if (guildId == null || guildId === "") {
+    if (interactionGuildId == null || interactionGuildId === "") {
       throw new Error("Missing guildId in leaderboard interaction state");
+    }
+
+    const stateGuildId = params.get("guildId");
+    if (stateGuildId != null && stateGuildId !== "" && stateGuildId !== interactionGuildId) {
+      throw new Error("Leaderboard interaction state guild does not match this server");
     }
 
     const parsedWindow = this.parseWindowOption(params.get("window") ?? undefined);
@@ -520,13 +525,33 @@ export class LeaderboardCommand extends BaseCommand {
     const parsedMinGamesPlayed = Number.parseInt(params.get("minGamesPlayed") ?? "0", 10);
 
     return {
-      guildId,
-      queueChannelId: params.get("queueChannelId"),
+      guildId: interactionGuildId,
+      queueChannelId: this.parseQueueChannelId(params.get("queueChannelId")),
       window: parsedWindow,
       metric: parsedMetric,
       page: Number.isNaN(parsedPage) ? 1 : Math.max(1, parsedPage),
       minGamesPlayed: Number.isNaN(parsedMinGamesPlayed) ? 0 : Math.max(0, parsedMinGamesPlayed),
     };
+  }
+
+  private parseQueueChannelId(value: string | null): string | null {
+    if (value == null || value === "") {
+      return null;
+    }
+
+    return value;
+  }
+
+  private getRankingContent(rankingLines: string[], totalPlayers: number): string {
+    if (rankingLines.length > 0) {
+      return rankingLines.join("\n");
+    }
+
+    if (totalPlayers === 0) {
+      return "No players qualify for this filter yet.";
+    }
+
+    return "No players found on this page. Try a lower page number.";
   }
 
   private getStateUrlFromComponents(components: APIMessageTopLevelComponent[]): string {

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -28,8 +28,11 @@ import { BaseCommand } from "../base/base-command";
 const DEFAULT_PAGE_SIZE = 10;
 const MAX_ROWS_IN_DISCORD_EMBED = 10;
 const METRIC_SELECT_LIMIT = 25;
+const INTERACTION_FIRST_PAGE = "btn_leaderboard_first";
 const INTERACTION_PREV_PAGE = "btn_leaderboard_prev";
+const INTERACTION_REFRESH = "btn_leaderboard_refresh";
 const INTERACTION_NEXT_PAGE = "btn_leaderboard_next";
+const INTERACTION_LAST_PAGE = "btn_leaderboard_last";
 const INTERACTION_METRIC_SELECT = "select_leaderboard_metric";
 const INTERACTION_WINDOW_SELECT = "select_leaderboard_window";
 
@@ -141,6 +144,13 @@ export class LeaderboardCommand extends BaseCommand {
         type: InteractionType.MessageComponent,
         data: {
           component_type: ComponentType.Button,
+          custom_id: INTERACTION_FIRST_PAGE,
+        },
+      },
+      {
+        type: InteractionType.MessageComponent,
+        data: {
+          component_type: ComponentType.Button,
           custom_id: INTERACTION_PREV_PAGE,
         },
       },
@@ -148,7 +158,21 @@ export class LeaderboardCommand extends BaseCommand {
         type: InteractionType.MessageComponent,
         data: {
           component_type: ComponentType.Button,
+          custom_id: INTERACTION_REFRESH,
+        },
+      },
+      {
+        type: InteractionType.MessageComponent,
+        data: {
+          component_type: ComponentType.Button,
           custom_id: INTERACTION_NEXT_PAGE,
+        },
+      },
+      {
+        type: InteractionType.MessageComponent,
+        data: {
+          component_type: ComponentType.Button,
+          custom_id: INTERACTION_LAST_PAGE,
         },
       },
       {
@@ -187,11 +211,20 @@ export class LeaderboardCommand extends BaseCommand {
       }
       case InteractionType.MessageComponent: {
         switch (interaction.data.custom_id) {
+          case INTERACTION_FIRST_PAGE: {
+            return this.deferUpdate(async () => this.handleFirstPage(interaction));
+          }
           case INTERACTION_PREV_PAGE: {
             return this.deferUpdate(async () => this.handlePageChange(interaction, -1));
           }
+          case INTERACTION_REFRESH: {
+            return this.deferUpdate(async () => this.handleRefresh(interaction));
+          }
           case INTERACTION_NEXT_PAGE: {
             return this.deferUpdate(async () => this.handlePageChange(interaction, 1));
+          }
+          case INTERACTION_LAST_PAGE: {
+            return this.deferUpdate(async () => this.handleLastPage(interaction));
           }
           case INTERACTION_METRIC_SELECT: {
             return this.deferUpdate(async () => this.handleMetricSelect(interaction));
@@ -251,15 +284,74 @@ export class LeaderboardCommand extends BaseCommand {
     delta: number,
   ): Promise<void> {
     await this.executeStateInteraction(interaction, (state) => {
-      if (interaction.data.component_type !== ComponentType.Button) {
-        throw this.createInvalidLeaderboardControlError();
-      }
+      this.assertButtonInteraction(interaction);
 
       return {
         ...state,
         page: Math.max(1, state.page + delta),
       };
     });
+  }
+
+  private async handleFirstPage(
+    interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
+  ): Promise<void> {
+    await this.executeStateInteraction(interaction, (state) => ({
+      ...this.getFirstPageState(interaction, state),
+    }));
+  }
+
+  private async handleRefresh(
+    interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
+  ): Promise<void> {
+    await this.executeStateInteraction(interaction, (state) => this.getRefreshState(interaction, state));
+  }
+
+  private async handleLastPage(
+    interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
+  ): Promise<void> {
+    try {
+      this.assertButtonInteraction(interaction);
+      await this.assertCanUseLeaderboardControls(interaction);
+      const state = this.getStateFromInteractionMessage(interaction);
+      const locale = this.getInteractionLocale(interaction);
+      const firstPage = await this.services.leaderboardService.getLeaderboard({
+        guildId: state.guildId,
+        ...(state.queueChannelId != null ? { queueChannelId: state.queueChannelId } : {}),
+        ...(state.window != null ? { window: state.window } : {}),
+        ...(state.metric != null ? { metric: state.metric } : {}),
+        page: 1,
+        pageSize: DEFAULT_PAGE_SIZE,
+        ...(state.minGamesPlayed != null ? { minGamesPlayed: state.minGamesPlayed } : {}),
+      });
+      const lastPage = Math.max(1, Math.ceil(firstPage.total / firstPage.pageSize));
+
+      await this.refreshLeaderboard(interaction.token, locale, {
+        ...state,
+        page: lastPage,
+      });
+    } catch (error) {
+      await this.services.discordService.updateDeferredReplyWithError(interaction.token, error);
+    }
+  }
+
+  private getFirstPageState(
+    interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
+    state: LeaderboardViewState,
+  ): LeaderboardViewState {
+    this.assertButtonInteraction(interaction);
+    return {
+      ...state,
+      page: 1,
+    };
+  }
+
+  private getRefreshState(
+    interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
+    state: LeaderboardViewState,
+  ): LeaderboardViewState {
+    this.assertButtonInteraction(interaction);
+    return state;
   }
 
   private async handleMetricSelect(
@@ -391,11 +483,7 @@ export class LeaderboardCommand extends BaseCommand {
     locale: string,
     leaderboard: LeaderboardResponse,
   ): APIInteractionResponseCallbackData {
-    const rankingLines = leaderboard.rows.slice(0, MAX_ROWS_IN_DISCORD_EMBED).map((row) => {
-      const player = row.discordUserId != null ? `<@${row.discordUserId}> (${row.gamertag})` : row.gamertag;
-      const metricValue = this.formatMetricValue(row.metricValue, leaderboard.metric, locale);
-      return `${row.rank.toString()}. ${player} - ${metricValue}`;
-    });
+    const rows = leaderboard.rows.slice(0, MAX_ROWS_IN_DISCORD_EMBED);
 
     const metricLabel = this.getMetricLabel(leaderboard.metric);
     const windowLabel = this.getWindowLabel(leaderboard.window);
@@ -407,13 +495,7 @@ export class LeaderboardCommand extends BaseCommand {
       description:
         `Metric: ${metricLabel} | Window: ${windowLabel}\n` +
         `Page: ${leaderboard.page.toString()} | Min games: ${leaderboard.minGamesPlayed.toString()} | Total players: ${leaderboard.total.toString()}`,
-      fields: [
-        {
-          name: "Rankings",
-          value: this.getRankingContent(rankingLines, leaderboard.total),
-          inline: false,
-        },
-      ],
+      fields: this.createRankingFields(rows, leaderboard.total, leaderboard.metric, locale),
     };
 
     const components = this.createComponents(leaderboard);
@@ -450,22 +532,36 @@ export class LeaderboardCommand extends BaseCommand {
           {
             type: ComponentType.Button,
             style: ButtonStyle.Secondary,
-            custom_id: INTERACTION_PREV_PAGE,
-            label: "Previous",
+            custom_id: INTERACTION_FIRST_PAGE,
+            emoji: { name: "⏮️" },
             disabled: leaderboard.page <= 1,
           },
           {
             type: ComponentType.Button,
             style: ButtonStyle.Secondary,
+            custom_id: INTERACTION_PREV_PAGE,
+            emoji: { name: "◀️" },
+            disabled: leaderboard.page <= 1,
+          },
+          {
+            type: ComponentType.Button,
+            style: ButtonStyle.Secondary,
+            custom_id: INTERACTION_REFRESH,
+            emoji: { name: "🔄" },
+          },
+          {
+            type: ComponentType.Button,
+            style: ButtonStyle.Secondary,
             custom_id: INTERACTION_NEXT_PAGE,
-            label: "Next",
+            emoji: { name: "▶️" },
             disabled: leaderboard.page >= totalPages,
           },
           {
             type: ComponentType.Button,
-            style: ButtonStyle.Link,
-            label: "Open in browser",
-            url: webUrl,
+            style: ButtonStyle.Secondary,
+            custom_id: INTERACTION_LAST_PAGE,
+            emoji: { name: "⏭️" },
+            disabled: leaderboard.page >= totalPages,
           },
         ],
       },
@@ -494,6 +590,54 @@ export class LeaderboardCommand extends BaseCommand {
             options: windowOptions,
           },
         ],
+      },
+      {
+        type: ComponentType.ActionRow,
+        components: [
+          {
+            type: ComponentType.Button,
+            style: ButtonStyle.Link,
+            label: "Open in browser",
+            url: webUrl,
+          },
+        ],
+      },
+    ];
+  }
+
+  private createRankingFields(
+    rows: LeaderboardResponse["rows"],
+    totalPlayers: number,
+    metric: LeaderboardMetric,
+    locale: string,
+  ): NonNullable<APIEmbed["fields"]> {
+    if (rows.length === 0) {
+      return [
+        {
+          name: "Rankings",
+          value: this.getRankingContent([], totalPlayers),
+          inline: false,
+        },
+      ];
+    }
+
+    return [
+      {
+        name: "Rank",
+        value: rows.map((row) => `#${row.rank.toString()}`).join("\n"),
+        inline: true,
+      },
+      {
+        name: "Player",
+        value: rows
+          .map((row) => (row.discordUserId != null ? `<@${row.discordUserId}> (${row.gamertag})` : row.gamertag))
+          .join("\n"),
+        inline: true,
+      },
+      {
+        name: this.getMetricLabel(metric),
+        value: rows.map((row) => this.formatMetricValue(row.metricValue, metric, locale)).join("\n"),
+        inline: true,
       },
     ];
   }
@@ -819,5 +963,13 @@ export class LeaderboardCommand extends BaseCommand {
       handled: true,
       errorType: EndUserErrorType.WARNING,
     });
+  }
+
+  private assertButtonInteraction(
+    interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
+  ): void {
+    if (interaction.data.component_type !== ComponentType.Button) {
+      throw this.createInvalidLeaderboardControlError();
+    }
   }
 }

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -675,11 +675,13 @@ describe("LeaderboardCommand", () => {
     const result = command.execute(interaction);
     await result.jobToComplete?.();
 
-    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+    expect(logErrorSpy).not.toHaveBeenCalled();
     expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledTimes(1);
     expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
       interaction.token,
-      expect.objectContaining({ message: "Missing leaderboard filter state from interaction" }),
+      expect.objectContaining({
+        endUserMessage: "This leaderboard message is missing filter settings. Run /leaderboard show again.",
+      }),
     );
   });
 
@@ -712,7 +714,84 @@ describe("LeaderboardCommand", () => {
 
     expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
       interaction.token,
-      expect.objectContaining({ message: "Leaderboard interaction state guild does not match this server" }),
+      expect.objectContaining({ endUserMessage: "This leaderboard interaction does not belong to this server." }),
     );
+  });
+
+  it("renders infinity for max-value ratio metrics", async () => {
+    vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
+      name: "show",
+      options: [],
+      mappedOptions: new Map<string, string | number>([["metric", LeaderboardMetric.DamageRatio]]),
+    });
+    const updateDeferredReplySpy = vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      id: "message-id",
+      channel_id: "channel-id",
+      content: "",
+      timestamp: "2026-08-12T00:00:00.000Z",
+      edited_timestamp: null,
+      tts: false,
+      mention_everyone: false,
+      mentions: [],
+      mention_roles: [],
+      attachments: [],
+      embeds: [],
+      pinned: false,
+      type: MessageType.Default,
+      author: {
+        id: "bot-id",
+        username: "Guilty Spark",
+        discriminator: "0000",
+        avatar: null,
+        global_name: null,
+      },
+      components: [],
+    });
+    vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "guild-123",
+      queueChannelId: null,
+      window: LeaderboardWindow.ThreeMonths,
+      metric: LeaderboardMetric.DamageRatio,
+      minGamesPlayed: 0,
+      page: 1,
+      pageSize: 10,
+      total: 1,
+      rows: [
+        {
+          rank: 1,
+          xboxXuid: "xuid-1",
+          discordUserId: "discord-1",
+          gamertag: "Alpha",
+          seriesPlayed: 1,
+          seriesWins: 1,
+          gamesPlayed: 1,
+          metricValue: Number.MAX_VALUE,
+        },
+      ],
+    });
+
+    const interaction: APIApplicationCommandInteraction = {
+      ...fakeBaseAPIApplicationCommandInteraction,
+      type: InteractionType.ApplicationCommand,
+      guild_id: "guild-123",
+      data: {
+        id: "fake-command-id",
+        name: "leaderboard",
+        type: ApplicationCommandType.ChatInput,
+        options: [
+          {
+            type: ApplicationCommandOptionType.Subcommand,
+            name: "show",
+            options: [],
+          },
+        ],
+      },
+    };
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    const [, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
+    expect(payload.embeds?.[0]?.fields?.[0]?.value).toContain("1. <@discord-1> (Alpha) - ∞");
   });
 });

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -248,6 +248,43 @@ describe("LeaderboardCommand", () => {
     });
   });
 
+  it("updates deferred reply with error when leaderboard command is used outside a guild", async () => {
+    vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
+      name: "show",
+      options: [],
+      mappedOptions: new Map<string, string | number>(),
+    });
+    const updateDeferredReplyWithErrorSpy = vi
+      .spyOn(services.discordService, "updateDeferredReplyWithError")
+      .mockResolvedValue(undefined);
+
+    const interaction: APIApplicationCommandInteraction = {
+      ...fakeBaseAPIApplicationCommandInteraction,
+      type: InteractionType.ApplicationCommand,
+      guild_id: "",
+      data: {
+        id: "fake-command-id",
+        name: "leaderboard",
+        type: ApplicationCommandType.ChatInput,
+        options: [
+          {
+            type: ApplicationCommandOptionType.Subcommand,
+            name: "show",
+            options: [],
+          },
+        ],
+      },
+    };
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+      interaction.token,
+      expect.objectContaining({ endUserMessage: "Leaderboard can only be used inside a server." }),
+    );
+  });
+
   it("paginates from interaction state when previous button is pressed", async () => {
     const stateUrl =
       "https://guilty-spark.app/leaderboard?guildId=guild-123&queueChannelId=queue-123&window=3M&metric=KILLS&page=2&minGamesPlayed=4";

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -469,6 +469,46 @@ describe("LeaderboardCommand", () => {
     });
   });
 
+  it("updates deferred reply with error when leaderboard controls are used without manage server permission", async () => {
+    vi.spyOn(services.discordService, "computeMemberPermissions").mockResolvedValueOnce(0n);
+    const interaction: APIMessageComponentButtonInteraction = {
+      ...fakeButtonClickInteraction,
+      guild_id: "guild-123",
+      guild: {
+        ...Preconditions.checkExists(fakeButtonClickInteraction.guild),
+        id: "guild-123",
+      },
+      data: {
+        component_type: ComponentType.Button,
+        custom_id: INTERACTION_NEXT_PAGE,
+      },
+      message: {
+        ...fakeButtonClickInteraction.message,
+        components: aStateComponentsWith(
+          "https://guilty-spark.app/leaderboard?guildId=guild-123&window=3M&metric=KILLS&page=2",
+        ),
+      },
+    };
+
+    const updateDeferredReplyWithErrorSpy = vi
+      .spyOn(services.discordService, "updateDeferredReplyWithError")
+      .mockResolvedValue(undefined);
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard");
+    const logErrorSpy = vi.spyOn(services.logService, "error");
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(getLeaderboardSpy).not.toHaveBeenCalled();
+    expect(logErrorSpy).not.toHaveBeenCalled();
+    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+      interaction.token,
+      expect.objectContaining({
+        endUserMessage: "You need the Manage Server permission to use leaderboard controls.",
+      }),
+    );
+  });
+
   it("switches metric from string-select interaction and resets to page 1", async () => {
     const stateUrl =
       "https://guilty-spark.app/leaderboard?guildId=test-guild-id&window=1M&metric=SERIES_WIN_RATE&page=6&minGamesPlayed=0";

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -502,6 +502,72 @@ describe("LeaderboardCommand", () => {
     expect(payload.embeds?.[0]?.fields?.[0]?.value).toBe("No players qualify for this filter yet.");
   });
 
+  it("renders an out-of-range page message when total players exist but page has no rows", async () => {
+    vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
+      name: "show",
+      options: [],
+      mappedOptions: new Map<string, string | number>([["page", 999]]),
+    });
+    vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "guild-123",
+      queueChannelId: null,
+      window: LeaderboardWindow.ThreeMonths,
+      metric: LeaderboardMetric.SeriesWinRate,
+      minGamesPlayed: 5,
+      page: 999,
+      pageSize: 10,
+      total: 12,
+      rows: [],
+    });
+    const updateDeferredReplySpy = vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      id: "message-id",
+      channel_id: "channel-id",
+      content: "",
+      timestamp: "2026-08-12T00:00:00.000Z",
+      edited_timestamp: null,
+      tts: false,
+      mention_everyone: false,
+      mentions: [],
+      mention_roles: [],
+      attachments: [],
+      embeds: [],
+      pinned: false,
+      type: MessageType.Default,
+      author: {
+        id: "bot-id",
+        username: "Guilty Spark",
+        discriminator: "0000",
+        avatar: null,
+        global_name: null,
+      },
+      components: [],
+    });
+
+    const interaction: APIApplicationCommandInteraction = {
+      ...fakeBaseAPIApplicationCommandInteraction,
+      type: InteractionType.ApplicationCommand,
+      guild_id: "guild-123",
+      data: {
+        id: "fake-command-id",
+        name: "leaderboard",
+        type: ApplicationCommandType.ChatInput,
+        options: [
+          {
+            type: ApplicationCommandOptionType.Subcommand,
+            name: "show",
+            options: [],
+          },
+        ],
+      },
+    };
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    const [, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
+    expect(payload.embeds?.[0]?.fields?.[0]?.value).toBe("No players found on this page. Try a lower page number.");
+  });
+
   it("updates deferred reply with error when leaderboard refresh fails", async () => {
     vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
       name: "show",
@@ -571,6 +637,39 @@ describe("LeaderboardCommand", () => {
     expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
       interaction.token,
       expect.objectContaining({ message: "Missing leaderboard filter state from interaction" }),
+    );
+  });
+
+  it("updates deferred reply with error when interaction state guildId mismatches the interaction guild", async () => {
+    const interaction: APIMessageComponentButtonInteraction = {
+      ...fakeButtonClickInteraction,
+      guild_id: "guild-123",
+      guild: {
+        ...Preconditions.checkExists(fakeButtonClickInteraction.guild),
+        id: "guild-123",
+      },
+      data: {
+        component_type: ComponentType.Button,
+        custom_id: INTERACTION_PREV_PAGE,
+      },
+      message: {
+        ...fakeButtonClickInteraction.message,
+        components: aStateComponentsWith(
+          "https://guilty-spark.app/leaderboard?guildId=guild-999&window=3M&metric=KILLS&page=2",
+        ),
+      },
+    };
+
+    const updateDeferredReplyWithErrorSpy = vi
+      .spyOn(services.discordService, "updateDeferredReplyWithError")
+      .mockResolvedValue(undefined);
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+      interaction.token,
+      expect.objectContaining({ message: "Leaderboard interaction state guild does not match this server" }),
     );
   });
 });

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -502,23 +502,47 @@ describe("LeaderboardCommand", () => {
     expect(payload.embeds?.[0]?.fields?.[0]?.value).toBe("No players qualify for this filter yet.");
   });
 
-  it("renders an out-of-range page message when total players exist but page has no rows", async () => {
+  it("re-fetches the last valid page when requested page is out of range", async () => {
     vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
       name: "show",
       options: [],
       mappedOptions: new Map<string, string | number>([["page", 999]]),
     });
-    vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
-      guildId: "guild-123",
-      queueChannelId: null,
-      window: LeaderboardWindow.ThreeMonths,
-      metric: LeaderboardMetric.SeriesWinRate,
-      minGamesPlayed: 5,
-      page: 999,
-      pageSize: 10,
-      total: 12,
-      rows: [],
-    });
+    const getLeaderboardSpy = vi
+      .spyOn(services.leaderboardService, "getLeaderboard")
+      .mockResolvedValueOnce({
+        guildId: "guild-123",
+        queueChannelId: null,
+        window: LeaderboardWindow.ThreeMonths,
+        metric: LeaderboardMetric.SeriesWinRate,
+        minGamesPlayed: 5,
+        page: 999,
+        pageSize: 10,
+        total: 12,
+        rows: [],
+      })
+      .mockResolvedValueOnce({
+        guildId: "guild-123",
+        queueChannelId: null,
+        window: LeaderboardWindow.ThreeMonths,
+        metric: LeaderboardMetric.SeriesWinRate,
+        minGamesPlayed: 5,
+        page: 2,
+        pageSize: 10,
+        total: 12,
+        rows: [
+          {
+            rank: 11,
+            xboxXuid: "xuid-2",
+            discordUserId: "discord-2",
+            gamertag: "Bravo",
+            seriesPlayed: 5,
+            seriesWins: 4,
+            gamesPlayed: 9,
+            metricValue: 0.8,
+          },
+        ],
+      });
     const updateDeferredReplySpy = vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
       id: "message-id",
       channel_id: "channel-id",
@@ -564,8 +588,27 @@ describe("LeaderboardCommand", () => {
     const result = command.execute(interaction);
     await result.jobToComplete?.();
 
+    expect(getLeaderboardSpy).toHaveBeenCalledTimes(2);
+    expect(getLeaderboardSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        guildId: "guild-123",
+        page: 999,
+        pageSize: 10,
+      }),
+    );
+    expect(getLeaderboardSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        guildId: "guild-123",
+        page: 2,
+        pageSize: 10,
+      }),
+    );
+
     const [, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
-    expect(payload.embeds?.[0]?.fields?.[0]?.value).toBe("No players found on this page. Try a lower page number.");
+    expect(payload.embeds?.[0]?.description).toContain("Page: 2");
+    expect(payload.embeds?.[0]?.fields?.[0]?.value).toContain("11. <@discord-2> (Bravo) - 80%");
   });
 
   it("updates deferred reply with error when leaderboard refresh fails", async () => {

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -27,6 +27,7 @@ import { LeaderboardCommand } from "../leaderboard";
 
 const INTERACTION_PREV_PAGE = "btn_leaderboard_prev";
 const INTERACTION_METRIC_SELECT = "select_leaderboard_metric";
+const INTERACTION_WINDOW_SELECT = "select_leaderboard_window";
 
 function aStateComponentsWith(url: string): APIMessageTopLevelComponent[] {
   return [
@@ -284,6 +285,48 @@ describe("LeaderboardCommand", () => {
       page: 1,
       pageSize: 10,
       minGamesPlayed: 0,
+    });
+  });
+
+  it("switches window from string-select interaction and resets to page 1", async () => {
+    const stateUrl =
+      "https://guilty-spark.app/leaderboard?guildId=test-guild-id&window=1M&metric=KILLS&page=4&minGamesPlayed=2";
+    const interaction: APIMessageComponentSelectMenuInteraction = {
+      ...aWizardStringSelectWith({ customId: INTERACTION_WINDOW_SELECT, value: LeaderboardWindow.SixMonths }),
+      message: {
+        ...aWizardStringSelectWith({ customId: INTERACTION_WINDOW_SELECT, value: LeaderboardWindow.SixMonths }).message,
+        components: aStateComponentsWith(stateUrl),
+      },
+    };
+
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "test-guild-id",
+      queueChannelId: null,
+      window: LeaderboardWindow.SixMonths,
+      metric: LeaderboardMetric.Kills,
+      minGamesPlayed: 2,
+      page: 1,
+      pageSize: 10,
+      total: 3,
+      rows: [],
+    });
+    vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      ...Preconditions.checkExists(interaction.message),
+      type: MessageType.Default,
+    });
+
+    const result = command.execute(interaction);
+
+    expect(result.response.type).toBe(InteractionResponseType.DeferredMessageUpdate);
+    await result.jobToComplete?.();
+
+    expect(getLeaderboardSpy).toHaveBeenCalledWith({
+      guildId: "test-guild-id",
+      window: LeaderboardWindow.SixMonths,
+      metric: LeaderboardMetric.Kills,
+      page: 1,
+      pageSize: 10,
+      minGamesPlayed: 2,
     });
   });
 

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -12,6 +12,7 @@ import {
   ComponentType,
   InteractionResponseType,
   InteractionType,
+  Locale,
   MessageType,
   PermissionFlagsBits,
 } from "discord-api-types/v10";
@@ -195,6 +196,85 @@ describe("LeaderboardCommand", () => {
     expect(linkUrl).toContain("window=1M");
     expect(linkUrl).toContain("metric=KILLS");
     expect(linkUrl).toContain("page=2");
+  });
+
+  it("prefers guild locale over user locale for leaderboard formatting", async () => {
+    vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
+      name: "show",
+      options: [],
+      mappedOptions: new Map<string, string | number>([["metric", LeaderboardMetric.Accuracy]]),
+    });
+    const updateDeferredReplySpy = vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      id: "message-id",
+      channel_id: "channel-id",
+      content: "",
+      timestamp: "2026-08-12T00:00:00.000Z",
+      edited_timestamp: null,
+      tts: false,
+      mention_everyone: false,
+      mentions: [],
+      mention_roles: [],
+      attachments: [],
+      embeds: [],
+      pinned: false,
+      type: MessageType.Default,
+      author: {
+        id: "bot-id",
+        username: "Guilty Spark",
+        discriminator: "0000",
+        avatar: null,
+        global_name: null,
+      },
+      components: [],
+    });
+    vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "guild-123",
+      queueChannelId: null,
+      window: LeaderboardWindow.ThreeMonths,
+      metric: LeaderboardMetric.Accuracy,
+      minGamesPlayed: 0,
+      page: 1,
+      pageSize: 10,
+      total: 1,
+      rows: [
+        {
+          rank: 1,
+          xboxXuid: "xuid-1",
+          discordUserId: "discord-1",
+          gamertag: "Alpha",
+          seriesPlayed: 1,
+          seriesWins: 1,
+          gamesPlayed: 1,
+          metricValue: 12.5,
+        },
+      ],
+    });
+
+    const interaction: APIApplicationCommandInteraction = {
+      ...fakeBaseAPIApplicationCommandInteraction,
+      type: InteractionType.ApplicationCommand,
+      guild_id: "guild-123",
+      locale: Locale.EnglishUS,
+      guild_locale: Locale.French,
+      data: {
+        id: "fake-command-id",
+        name: "leaderboard",
+        type: ApplicationCommandType.ChatInput,
+        options: [
+          {
+            type: ApplicationCommandOptionType.Subcommand,
+            name: "show",
+            options: [],
+          },
+        ],
+      },
+    };
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    const [, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
+    expect(payload.embeds?.[0]?.fields?.[0]?.value).toContain("1. <@discord-1> (Alpha) - 12,5%");
   });
 
   it("uses service defaults when leaderboard options are omitted", async () => {

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -509,6 +509,115 @@ describe("LeaderboardCommand", () => {
     );
   });
 
+  it("updates deferred reply with error when page-change interaction payload has wrong component type", async () => {
+    const interaction: APIMessageComponentSelectMenuInteraction = {
+      ...aWizardStringSelectWith({ customId: INTERACTION_PREV_PAGE, value: "unused" }),
+      guild_id: "guild-123",
+      guild: {
+        ...Preconditions.checkExists(
+          aWizardStringSelectWith({ customId: INTERACTION_PREV_PAGE, value: "unused" }).guild,
+        ),
+        id: "guild-123",
+      },
+      message: {
+        ...aWizardStringSelectWith({ customId: INTERACTION_PREV_PAGE, value: "unused" }).message,
+        components: aStateComponentsWith(
+          "https://guilty-spark.app/leaderboard?guildId=guild-123&window=3M&metric=KILLS&page=2",
+        ),
+      },
+    };
+    const updateDeferredReplyWithErrorSpy = vi
+      .spyOn(services.discordService, "updateDeferredReplyWithError")
+      .mockResolvedValue(undefined);
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard");
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(getLeaderboardSpy).not.toHaveBeenCalled();
+    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+      interaction.token,
+      expect.objectContaining({
+        endUserMessage: "This leaderboard control interaction is invalid. Run /leaderboard show again.",
+      }),
+    );
+  });
+
+  it("updates deferred reply with error when metric selection interaction payload is invalid", async () => {
+    const interaction: APIMessageComponentSelectMenuInteraction = {
+      ...aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetric.Kills }),
+      guild_id: "guild-123",
+      guild: {
+        ...Preconditions.checkExists(
+          aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetric.Kills }).guild,
+        ),
+        id: "guild-123",
+      },
+      data: {
+        component_type: ComponentType.StringSelect,
+        custom_id: INTERACTION_METRIC_SELECT,
+        values: [],
+      },
+      message: {
+        ...aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetric.Kills }).message,
+        components: aStateComponentsWith(
+          "https://guilty-spark.app/leaderboard?guildId=guild-123&window=3M&metric=KILLS&page=2",
+        ),
+      },
+    };
+    const updateDeferredReplyWithErrorSpy = vi
+      .spyOn(services.discordService, "updateDeferredReplyWithError")
+      .mockResolvedValue(undefined);
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard");
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(getLeaderboardSpy).not.toHaveBeenCalled();
+    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+      interaction.token,
+      expect.objectContaining({
+        endUserMessage: "This leaderboard control interaction is invalid. Run /leaderboard show again.",
+      }),
+    );
+  });
+
+  it("updates deferred reply with error when window selection interaction payload is invalid", async () => {
+    const interaction: APIMessageComponentButtonInteraction = {
+      ...fakeButtonClickInteraction,
+      guild_id: "guild-123",
+      guild: {
+        ...Preconditions.checkExists(fakeButtonClickInteraction.guild),
+        id: "guild-123",
+      },
+      data: {
+        component_type: ComponentType.Button,
+        custom_id: INTERACTION_WINDOW_SELECT,
+      },
+      message: {
+        ...fakeButtonClickInteraction.message,
+        components: aStateComponentsWith(
+          "https://guilty-spark.app/leaderboard?guildId=guild-123&window=3M&metric=KILLS&page=2",
+        ),
+      },
+    };
+    const updateDeferredReplyWithErrorSpy = vi
+      .spyOn(services.discordService, "updateDeferredReplyWithError")
+      .mockResolvedValue(undefined);
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard");
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(getLeaderboardSpy).not.toHaveBeenCalled();
+    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+      interaction.token,
+      expect.objectContaining({
+        endUserMessage: "This leaderboard control interaction is invalid. Run /leaderboard show again.",
+      }),
+    );
+  });
+
   it("switches metric from string-select interaction and resets to page 1", async () => {
     const stateUrl =
       "https://guilty-spark.app/leaderboard?guildId=test-guild-id&window=1M&metric=SERIES_WIN_RATE&page=6&minGamesPlayed=0";

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -284,6 +284,26 @@ describe("LeaderboardCommand", () => {
           gamesPlayed: 1,
           metricValue: 12.5,
         },
+        {
+          rank: 2,
+          xboxXuid: "xuid-2",
+          discordUserId: "discord-2",
+          gamertag: "Bravo",
+          seriesPlayed: 1,
+          seriesWins: 1,
+          gamesPlayed: 1,
+          metricValue: 10,
+        },
+        {
+          rank: 3,
+          xboxXuid: "xuid-3",
+          discordUserId: "discord-3",
+          gamertag: "Charlie",
+          seriesPlayed: 1,
+          seriesWins: 1,
+          gamesPlayed: 1,
+          metricValue: 7.5,
+        },
       ],
     });
 
@@ -312,9 +332,9 @@ describe("LeaderboardCommand", () => {
 
     const [, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
     expect(payload.embeds?.[0]?.fields).toEqual([
-      { name: "Rank", value: "#1", inline: true },
-      { name: "Player", value: "<@discord-1> (Alpha)", inline: true },
-      { name: "Accuracy", value: "12,5%", inline: true },
+      { name: "Rank", value: "🥇\n🥈\n🥉", inline: true },
+      { name: "Player", value: "<@discord-1> (Alpha)\n<@discord-2> (Bravo)\n<@discord-3> (Charlie)", inline: true },
+      { name: "Accuracy", value: "12,5%\n10%\n7,5%", inline: true },
     ]);
   });
 
@@ -1380,7 +1400,7 @@ describe("LeaderboardCommand", () => {
 
     const [, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
     expect(payload.embeds?.[0]?.fields).toEqual([
-      { name: "Rank", value: "#1", inline: true },
+      { name: "Rank", value: "🥇", inline: true },
       { name: "Player", value: "<@discord-1> (Alpha)", inline: true },
       { name: "Damage ratio", value: "∞", inline: true },
     ]);

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -29,6 +29,9 @@ import { LeaderboardCommand } from "../leaderboard";
 
 const INTERACTION_PREV_PAGE = "btn_leaderboard_prev";
 const INTERACTION_NEXT_PAGE = "btn_leaderboard_next";
+const INTERACTION_FIRST_PAGE = "btn_leaderboard_first";
+const INTERACTION_REFRESH = "btn_leaderboard_refresh";
+const INTERACTION_LAST_PAGE = "btn_leaderboard_last";
 const INTERACTION_METRIC_SELECT = "select_leaderboard_metric";
 const INTERACTION_WINDOW_SELECT = "select_leaderboard_window";
 
@@ -190,6 +193,16 @@ describe("LeaderboardCommand", () => {
     const [token, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
     expect(token).toBe(interaction.token);
     expect(payload.embeds?.[0]?.title).toBe("Leaderboard - Queue <#queue-123>");
+    expect(payload.components?.[0]).toMatchObject({
+      type: ComponentType.ActionRow,
+      components: [
+        { custom_id: INTERACTION_FIRST_PAGE, disabled: false },
+        { custom_id: INTERACTION_PREV_PAGE, disabled: false },
+        { custom_id: INTERACTION_REFRESH },
+        { custom_id: INTERACTION_NEXT_PAGE, disabled: false },
+        { custom_id: INTERACTION_LAST_PAGE, disabled: false },
+      ],
+    });
     const linkUrl = getBrowserUrlFromComponents(payload.components);
     expect(linkUrl).toContain("guildId=guild-123");
     expect(linkUrl).toContain("queueChannelId=queue-123");
@@ -274,7 +287,11 @@ describe("LeaderboardCommand", () => {
     await result.jobToComplete?.();
 
     const [, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
-    expect(payload.embeds?.[0]?.fields?.[0]?.value).toContain("1. <@discord-1> (Alpha) - 12,5%");
+    expect(payload.embeds?.[0]?.fields).toEqual([
+      { name: "Rank", value: "#1", inline: true },
+      { name: "Player", value: "<@discord-1> (Alpha)", inline: true },
+      { name: "Accuracy", value: "12,5%", inline: true },
+    ]);
   });
 
   it("uses service defaults when leaderboard options are omitted", async () => {
@@ -459,6 +476,80 @@ describe("LeaderboardCommand", () => {
     await result.jobToComplete?.();
 
     expect(getLeaderboardSpy).toHaveBeenCalledWith({
+      guildId: "guild-123",
+      queueChannelId: "queue-123",
+      window: LeaderboardWindow.ThreeMonths,
+      metric: LeaderboardMetric.Kills,
+      page: 3,
+      pageSize: 10,
+      minGamesPlayed: 4,
+    });
+  });
+
+  it("resolves and fetches the last available leaderboard page", async () => {
+    const stateUrl =
+      "https://guilty-spark.app/leaderboard?guildId=guild-123&queueChannelId=queue-123&window=3M&metric=KILLS&page=2&minGamesPlayed=4";
+    const interaction: APIMessageComponentButtonInteraction = {
+      ...fakeButtonClickInteraction,
+      guild_id: "guild-123",
+      guild: {
+        ...Preconditions.checkExists(fakeButtonClickInteraction.guild),
+        id: "guild-123",
+      },
+      data: {
+        component_type: ComponentType.Button,
+        custom_id: INTERACTION_LAST_PAGE,
+      },
+      message: {
+        ...fakeButtonClickInteraction.message,
+        components: aStateComponentsWith(stateUrl),
+      },
+    };
+
+    const getLeaderboardSpy = vi
+      .spyOn(services.leaderboardService, "getLeaderboard")
+      .mockResolvedValueOnce({
+        guildId: "guild-123",
+        queueChannelId: "queue-123",
+        window: LeaderboardWindow.ThreeMonths,
+        metric: LeaderboardMetric.Kills,
+        minGamesPlayed: 4,
+        page: 1,
+        pageSize: 10,
+        total: 23,
+        rows: [],
+      })
+      .mockResolvedValueOnce({
+        guildId: "guild-123",
+        queueChannelId: "queue-123",
+        window: LeaderboardWindow.ThreeMonths,
+        metric: LeaderboardMetric.Kills,
+        minGamesPlayed: 4,
+        page: 3,
+        pageSize: 10,
+        total: 23,
+        rows: [],
+      });
+    vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      ...fakeButtonClickInteraction.message,
+      type: MessageType.Default,
+    });
+
+    const result = command.execute(interaction);
+
+    expect(result.response.type).toBe(InteractionResponseType.DeferredMessageUpdate);
+    await result.jobToComplete?.();
+
+    expect(getLeaderboardSpy).toHaveBeenNthCalledWith(1, {
+      guildId: "guild-123",
+      queueChannelId: "queue-123",
+      window: LeaderboardWindow.ThreeMonths,
+      metric: LeaderboardMetric.Kills,
+      page: 1,
+      pageSize: 10,
+      minGamesPlayed: 4,
+    });
+    expect(getLeaderboardSpy).toHaveBeenNthCalledWith(2, {
       guildId: "guild-123",
       queueChannelId: "queue-123",
       window: LeaderboardWindow.ThreeMonths,
@@ -874,7 +965,11 @@ describe("LeaderboardCommand", () => {
 
     const [, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
     expect(payload.embeds?.[0]?.description).toContain("Page: 2");
-    expect(payload.embeds?.[0]?.fields?.[0]?.value).toContain("11. <@discord-2> (Bravo) - 80%");
+    expect(payload.embeds?.[0]?.fields).toEqual([
+      { name: "Rank", value: "#11", inline: true },
+      { name: "Player", value: "<@discord-2> (Bravo)", inline: true },
+      { name: "Series win rate", value: "80%", inline: true },
+    ]);
   });
 
   it("clamps empty leaderboard page to 1 without re-fetching", async () => {
@@ -1261,6 +1356,10 @@ describe("LeaderboardCommand", () => {
     await result.jobToComplete?.();
 
     const [, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
-    expect(payload.embeds?.[0]?.fields?.[0]?.value).toContain("1. <@discord-1> (Alpha) - ∞");
+    expect(payload.embeds?.[0]?.fields).toEqual([
+      { name: "Rank", value: "#1", inline: true },
+      { name: "Player", value: "<@discord-1> (Alpha)", inline: true },
+      { name: "Damage ratio", value: "∞", inline: true },
+    ]);
   });
 });

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -194,6 +194,57 @@ describe("LeaderboardCommand", () => {
     expect(linkUrl).toContain("page=2");
   });
 
+  it("uses service defaults when leaderboard options are omitted", async () => {
+    vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
+      name: "show",
+      options: [],
+      mappedOptions: new Map<string, string | number>(),
+    });
+
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "guild-123",
+      queueChannelId: null,
+      window: LeaderboardWindow.OneMonth,
+      metric: LeaderboardMetric.Kda,
+      minGamesPlayed: 2,
+      page: 1,
+      pageSize: 10,
+      total: 0,
+      rows: [],
+    });
+    vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      ...fakeButtonClickInteraction.message,
+      type: MessageType.Default,
+    });
+
+    const interaction: APIApplicationCommandInteraction = {
+      ...fakeBaseAPIApplicationCommandInteraction,
+      type: InteractionType.ApplicationCommand,
+      guild_id: "guild-123",
+      data: {
+        id: "fake-command-id",
+        name: "leaderboard",
+        type: ApplicationCommandType.ChatInput,
+        options: [
+          {
+            type: ApplicationCommandOptionType.Subcommand,
+            name: "show",
+            options: [],
+          },
+        ],
+      },
+    };
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(getLeaderboardSpy).toHaveBeenCalledWith({
+      guildId: "guild-123",
+      page: 1,
+      pageSize: 10,
+    });
+  });
+
   it("paginates from interaction state when previous button is pressed", async () => {
     const stateUrl =
       "https://guilty-spark.app/leaderboard?guildId=guild-123&queueChannelId=queue-123&window=3M&metric=KILLS&page=2&minGamesPlayed=4";
@@ -394,5 +445,43 @@ describe("LeaderboardCommand", () => {
 
     const [, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
     expect(payload.embeds?.[0]?.fields?.[0]?.value).toBe("No players qualify for this filter yet.");
+  });
+
+  it("updates deferred reply with error when leaderboard refresh fails", async () => {
+    vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
+      name: "show",
+      options: [],
+      mappedOptions: new Map<string, string | number>(),
+    });
+    const error = new Error("Leaderboard service failed");
+    vi.spyOn(services.leaderboardService, "getLeaderboard").mockRejectedValue(error);
+    const updateDeferredReplyWithErrorSpy = vi
+      .spyOn(services.discordService, "updateDeferredReplyWithError")
+      .mockResolvedValue(undefined);
+    const logErrorSpy = vi.spyOn(services.logService, "error");
+
+    const interaction: APIApplicationCommandInteraction = {
+      ...fakeBaseAPIApplicationCommandInteraction,
+      type: InteractionType.ApplicationCommand,
+      guild_id: "guild-123",
+      data: {
+        id: "fake-command-id",
+        name: "leaderboard",
+        type: ApplicationCommandType.ChatInput,
+        options: [
+          {
+            type: ApplicationCommandOptionType.Subcommand,
+            name: "show",
+            options: [],
+          },
+        ],
+      },
+    };
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(logErrorSpy).toHaveBeenCalledWith(error);
+    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(interaction.token, error);
   });
 });

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -13,6 +13,7 @@ import {
   InteractionResponseType,
   InteractionType,
   MessageType,
+  PermissionFlagsBits,
 } from "discord-api-types/v10";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
@@ -26,6 +27,7 @@ import {
 import { LeaderboardCommand } from "../leaderboard";
 
 const INTERACTION_PREV_PAGE = "btn_leaderboard_prev";
+const INTERACTION_NEXT_PAGE = "btn_leaderboard_next";
 const INTERACTION_METRIC_SELECT = "select_leaderboard_metric";
 const INTERACTION_WINDOW_SELECT = "select_leaderboard_window";
 
@@ -78,6 +80,7 @@ describe("LeaderboardCommand", () => {
     env = aFakeEnvWith();
     services = installFakeServicesWith({ env });
     command = new LeaderboardCommand(services, env);
+    vi.spyOn(services.discordService, "computeMemberPermissions").mockResolvedValue(PermissionFlagsBits.ManageGuild);
   });
 
   it("registers leaderboard show subcommand", () => {
@@ -297,6 +300,58 @@ describe("LeaderboardCommand", () => {
     });
   });
 
+  it("paginates from interaction state when next button is pressed", async () => {
+    const stateUrl =
+      "https://guilty-spark.app/leaderboard?guildId=guild-123&queueChannelId=queue-123&window=3M&metric=KILLS&page=2&minGamesPlayed=4";
+    const interaction: APIMessageComponentButtonInteraction = {
+      ...fakeButtonClickInteraction,
+      guild_id: "guild-123",
+      guild: {
+        ...Preconditions.checkExists(fakeButtonClickInteraction.guild),
+        id: "guild-123",
+      },
+      data: {
+        component_type: ComponentType.Button,
+        custom_id: INTERACTION_NEXT_PAGE,
+      },
+      message: {
+        ...fakeButtonClickInteraction.message,
+        components: aStateComponentsWith(stateUrl),
+      },
+    };
+
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "guild-123",
+      queueChannelId: "queue-123",
+      window: LeaderboardWindow.ThreeMonths,
+      metric: LeaderboardMetric.Kills,
+      minGamesPlayed: 4,
+      page: 3,
+      pageSize: 10,
+      total: 30,
+      rows: [],
+    });
+    vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      ...fakeButtonClickInteraction.message,
+      type: MessageType.Default,
+    });
+
+    const result = command.execute(interaction);
+
+    expect(result.response.type).toBe(InteractionResponseType.DeferredMessageUpdate);
+    await result.jobToComplete?.();
+
+    expect(getLeaderboardSpy).toHaveBeenCalledWith({
+      guildId: "guild-123",
+      queueChannelId: "queue-123",
+      window: LeaderboardWindow.ThreeMonths,
+      metric: LeaderboardMetric.Kills,
+      page: 3,
+      pageSize: 10,
+      minGamesPlayed: 4,
+    });
+  });
+
   it("switches metric from string-select interaction and resets to page 1", async () => {
     const stateUrl =
       "https://guilty-spark.app/leaderboard?guildId=test-guild-id&window=1M&metric=SERIES_WIN_RATE&page=6&minGamesPlayed=0";
@@ -483,5 +538,39 @@ describe("LeaderboardCommand", () => {
 
     expect(logErrorSpy).toHaveBeenCalledWith(error);
     expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(interaction.token, error);
+  });
+
+  it("updates deferred reply with error when interaction state cannot be parsed", async () => {
+    const interaction: APIMessageComponentButtonInteraction = {
+      ...fakeButtonClickInteraction,
+      guild_id: "guild-123",
+      guild: {
+        ...Preconditions.checkExists(fakeButtonClickInteraction.guild),
+        id: "guild-123",
+      },
+      data: {
+        component_type: ComponentType.Button,
+        custom_id: INTERACTION_PREV_PAGE,
+      },
+      message: {
+        ...fakeButtonClickInteraction.message,
+        components: aStateComponentsWith("https://guilty-spark.app/leaderboard?guildId=guild-123&page=2"),
+      },
+    };
+
+    const updateDeferredReplyWithErrorSpy = vi
+      .spyOn(services.discordService, "updateDeferredReplyWithError")
+      .mockResolvedValue(undefined);
+    const logErrorSpy = vi.spyOn(services.logService, "error");
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledTimes(1);
+    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+      interaction.token,
+      expect.objectContaining({ message: "Missing leaderboard filter state from interaction" }),
+    );
   });
 });

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -877,6 +877,73 @@ describe("LeaderboardCommand", () => {
     expect(payload.embeds?.[0]?.fields?.[0]?.value).toContain("11. <@discord-2> (Bravo) - 80%");
   });
 
+  it("clamps empty leaderboard page to 1 without re-fetching", async () => {
+    vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
+      name: "show",
+      options: [],
+      mappedOptions: new Map<string, string | number>([["page", 999]]),
+    });
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "guild-123",
+      queueChannelId: null,
+      window: LeaderboardWindow.ThreeMonths,
+      metric: LeaderboardMetric.SeriesWinRate,
+      minGamesPlayed: 5,
+      page: 999,
+      pageSize: 10,
+      total: 0,
+      rows: [],
+    });
+    const updateDeferredReplySpy = vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      id: "message-id",
+      channel_id: "channel-id",
+      content: "",
+      timestamp: "2026-08-12T00:00:00.000Z",
+      edited_timestamp: null,
+      tts: false,
+      mention_everyone: false,
+      mentions: [],
+      mention_roles: [],
+      attachments: [],
+      embeds: [],
+      pinned: false,
+      type: MessageType.Default,
+      author: {
+        id: "bot-id",
+        username: "Guilty Spark",
+        discriminator: "0000",
+        avatar: null,
+        global_name: null,
+      },
+      components: [],
+    });
+
+    const interaction: APIApplicationCommandInteraction = {
+      ...fakeBaseAPIApplicationCommandInteraction,
+      type: InteractionType.ApplicationCommand,
+      guild_id: "guild-123",
+      data: {
+        id: "fake-command-id",
+        name: "leaderboard",
+        type: ApplicationCommandType.ChatInput,
+        options: [
+          {
+            type: ApplicationCommandOptionType.Subcommand,
+            name: "show",
+            options: [],
+          },
+        ],
+      },
+    };
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(getLeaderboardSpy).toHaveBeenCalledTimes(1);
+    const [, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
+    expect(payload.embeds?.[0]?.description).toContain("Page: 1");
+  });
+
   it("updates deferred reply with error when leaderboard refresh fails", async () => {
     vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
       name: "show",

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -779,7 +779,6 @@ describe("LeaderboardCommand", () => {
     const updateDeferredReplyWithErrorSpy = vi
       .spyOn(services.discordService, "updateDeferredReplyWithError")
       .mockResolvedValue(undefined);
-    const logErrorSpy = vi.spyOn(services.logService, "error");
 
     const interaction: APIApplicationCommandInteraction = {
       ...fakeBaseAPIApplicationCommandInteraction,
@@ -802,7 +801,6 @@ describe("LeaderboardCommand", () => {
     const result = command.execute(interaction);
     await result.jobToComplete?.();
 
-    expect(logErrorSpy).toHaveBeenCalledWith(error);
     expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(interaction.token, error);
   });
 

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -755,6 +755,109 @@ describe("LeaderboardCommand", () => {
     );
   });
 
+  it("updates deferred reply with error when interaction message has no components", async () => {
+    const interaction: APIMessageComponentButtonInteraction = {
+      ...fakeButtonClickInteraction,
+      guild_id: "guild-123",
+      guild: {
+        ...Preconditions.checkExists(fakeButtonClickInteraction.guild),
+        id: "guild-123",
+      },
+      data: {
+        component_type: ComponentType.Button,
+        custom_id: INTERACTION_PREV_PAGE,
+      },
+      message: {
+        ...fakeButtonClickInteraction.message,
+        components: [],
+      },
+    };
+
+    const updateDeferredReplyWithErrorSpy = vi
+      .spyOn(services.discordService, "updateDeferredReplyWithError")
+      .mockResolvedValue(undefined);
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+      interaction.token,
+      expect.objectContaining({
+        endUserMessage: "This leaderboard message is missing its interaction context. Run /leaderboard show again.",
+      }),
+    );
+  });
+
+  it("updates deferred reply with error when interaction state has invalid window filter", async () => {
+    const interaction: APIMessageComponentButtonInteraction = {
+      ...fakeButtonClickInteraction,
+      guild_id: "guild-123",
+      guild: {
+        ...Preconditions.checkExists(fakeButtonClickInteraction.guild),
+        id: "guild-123",
+      },
+      data: {
+        component_type: ComponentType.Button,
+        custom_id: INTERACTION_PREV_PAGE,
+      },
+      message: {
+        ...fakeButtonClickInteraction.message,
+        components: aStateComponentsWith(
+          "https://guilty-spark.app/leaderboard?guildId=guild-123&window=BAD&metric=KILLS&page=2",
+        ),
+      },
+    };
+
+    const updateDeferredReplyWithErrorSpy = vi
+      .spyOn(services.discordService, "updateDeferredReplyWithError")
+      .mockResolvedValue(undefined);
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+      interaction.token,
+      expect.objectContaining({
+        endUserMessage: "This leaderboard message has an invalid window filter. Run /leaderboard show again.",
+      }),
+    );
+  });
+
+  it("updates deferred reply with error when interaction state has invalid metric filter", async () => {
+    const interaction: APIMessageComponentButtonInteraction = {
+      ...fakeButtonClickInteraction,
+      guild_id: "guild-123",
+      guild: {
+        ...Preconditions.checkExists(fakeButtonClickInteraction.guild),
+        id: "guild-123",
+      },
+      data: {
+        component_type: ComponentType.Button,
+        custom_id: INTERACTION_PREV_PAGE,
+      },
+      message: {
+        ...fakeButtonClickInteraction.message,
+        components: aStateComponentsWith(
+          "https://guilty-spark.app/leaderboard?guildId=guild-123&window=3M&metric=BAD&page=2",
+        ),
+      },
+    };
+
+    const updateDeferredReplyWithErrorSpy = vi
+      .spyOn(services.discordService, "updateDeferredReplyWithError")
+      .mockResolvedValue(undefined);
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+      interaction.token,
+      expect.objectContaining({
+        endUserMessage: "This leaderboard message has an invalid metric filter. Run /leaderboard show again.",
+      }),
+    );
+  });
+
   it("renders infinity for max-value ratio metrics", async () => {
     vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
       name: "show",

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { APIApplicationCommandInteraction } from "discord-api-types/v10";
+import { ApplicationCommandOptionType, ApplicationCommandType, InteractionResponseType, InteractionType } from "discord-api-types/v10";
+import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
+import { aFakeEnvWith } from "../../../base/fakes/env.fake";
+import { installFakeServicesWith } from "../../../services/fakes/services";
+import { fakeBaseAPIApplicationCommandInteraction } from "../../../services/discord/fakes/data";
+import { LeaderboardCommand } from "../leaderboard";
+
+describe("LeaderboardCommand", () => {
+  let env: Env;
+  let command: LeaderboardCommand;
+  let services: ReturnType<typeof installFakeServicesWith>;
+
+  beforeEach(() => {
+    env = aFakeEnvWith();
+    services = installFakeServicesWith({ env });
+    command = new LeaderboardCommand(services, env);
+  });
+
+  it("registers leaderboard show subcommand", () => {
+    const [slashCommand] = command.commands;
+
+    expect(slashCommand?.type).toBe(ApplicationCommandType.ChatInput);
+    expect(slashCommand?.name).toBe("leaderboard");
+
+    const subcommands = slashCommand?.options;
+    expect(subcommands).toHaveLength(1);
+    expect(subcommands?.[0]?.name).toBe("show");
+  });
+
+  it("fetches leaderboard data and updates deferred reply", async () => {
+    const mappedOptions = new Map<string, string | number>();
+    mappedOptions.set("queue_channel", "queue-123");
+    mappedOptions.set("window", LeaderboardWindow.OneMonth);
+    mappedOptions.set("metric", LeaderboardMetric.Kills);
+    mappedOptions.set("page", 2);
+    mappedOptions.set("min_games_played", 3);
+
+    const extractSubcommandSpy = vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
+      name: "show",
+      options: [],
+      mappedOptions,
+    });
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "guild-123",
+      queueChannelId: "queue-123",
+      window: LeaderboardWindow.OneMonth,
+      metric: LeaderboardMetric.Kills,
+      minGamesPlayed: 3,
+      page: 2,
+      pageSize: 10,
+      total: 2,
+      rows: [
+        {
+          rank: 11,
+          xboxXuid: "xuid-1",
+          discordUserId: "discord-1",
+          gamertag: "Alpha",
+          seriesPlayed: 3,
+          seriesWins: 2,
+          gamesPlayed: 9,
+          metricValue: 44,
+        },
+      ],
+    });
+    const updateDeferredReplySpy = vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      id: "message-id",
+      channel_id: "channel-id",
+      content: "",
+      timestamp: "2026-08-12T00:00:00.000Z",
+      edited_timestamp: null,
+      tts: false,
+      mention_everyone: false,
+      mentions: [],
+      mention_roles: [],
+      attachments: [],
+      embeds: [],
+      pinned: false,
+      type: 0,
+      author: {
+        id: "bot-id",
+        username: "Guilty Spark",
+        discriminator: "0000",
+        avatar: null,
+        global_name: null,
+      },
+      components: [],
+    });
+
+    const interaction: APIApplicationCommandInteraction = {
+      ...fakeBaseAPIApplicationCommandInteraction,
+      type: InteractionType.ApplicationCommand,
+      guild_id: "guild-123",
+      data: {
+        id: "fake-command-id",
+        name: "leaderboard",
+        type: ApplicationCommandType.ChatInput,
+        options: [
+          {
+            type: ApplicationCommandOptionType.Subcommand,
+            name: "show",
+            options: [],
+          },
+        ],
+      },
+    };
+
+    const result = command.execute(interaction);
+
+    expect(result.response.type).toBe(InteractionResponseType.DeferredChannelMessageWithSource);
+    expect(result.jobToComplete).toBeDefined();
+
+    await result.jobToComplete?.();
+
+    expect(extractSubcommandSpy).toHaveBeenCalledWith(interaction, "leaderboard");
+    expect(getLeaderboardSpy).toHaveBeenCalledWith({
+      guildId: "guild-123",
+      queueChannelId: "queue-123",
+      window: LeaderboardWindow.OneMonth,
+      metric: LeaderboardMetric.Kills,
+      page: 2,
+      pageSize: 10,
+      minGamesPlayed: 3,
+    });
+    expect(updateDeferredReplySpy).toHaveBeenCalledTimes(1);
+    const [interactionToken, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
+    expect(interactionToken).toBe(interaction.token);
+    expect(payload.embeds?.[0]?.title).toBe("Leaderboard - Queue <#queue-123>");
+  });
+
+  it("returns deferred response for show subcommand", () => {
+    const mappedOptions = new Map<string, string | number>();
+
+    vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
+      name: "show",
+      options: [],
+      mappedOptions,
+    });
+
+    const interaction: APIApplicationCommandInteraction = {
+      ...fakeBaseAPIApplicationCommandInteraction,
+      type: InteractionType.ApplicationCommand,
+      guild_id: "guild-123",
+      data: {
+        id: "fake-command-id",
+        name: "leaderboard",
+        type: ApplicationCommandType.ChatInput,
+        options: [
+          {
+            type: ApplicationCommandOptionType.Subcommand,
+            name: "show",
+            options: [],
+          },
+        ],
+      },
+    };
+
+    const result = command.execute(interaction);
+
+    expect(result.response.type).toBe(InteractionResponseType.DeferredChannelMessageWithSource);
+    expect(result.jobToComplete).toBeDefined();
+  });
+});

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -1,12 +1,72 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { APIApplicationCommandInteraction } from "discord-api-types/v10";
-import { ApplicationCommandOptionType, ApplicationCommandType, InteractionResponseType, InteractionType } from "discord-api-types/v10";
+import type {
+  APIApplicationCommandInteraction,
+  APIMessageComponentButtonInteraction,
+  APIMessageComponentSelectMenuInteraction,
+  APIMessageTopLevelComponent,
+} from "discord-api-types/v10";
+import {
+  ApplicationCommandOptionType,
+  ApplicationCommandType,
+  ButtonStyle,
+  ComponentType,
+  InteractionResponseType,
+  InteractionType,
+  MessageType,
+} from "discord-api-types/v10";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import { installFakeServicesWith } from "../../../services/fakes/services";
-import { fakeBaseAPIApplicationCommandInteraction } from "../../../services/discord/fakes/data";
+import {
+  aWizardStringSelectWith,
+  fakeBaseAPIApplicationCommandInteraction,
+  fakeButtonClickInteraction,
+} from "../../../services/discord/fakes/data";
 import { LeaderboardCommand } from "../leaderboard";
+
+const INTERACTION_PREV_PAGE = "btn_leaderboard_prev";
+const INTERACTION_METRIC_SELECT = "select_leaderboard_metric";
+
+function aStateComponentsWith(url: string): APIMessageTopLevelComponent[] {
+  return [
+    {
+      type: ComponentType.ActionRow,
+      components: [
+        {
+          type: ComponentType.Button,
+          style: ButtonStyle.Link,
+          label: "Open in browser",
+          url,
+        },
+      ],
+    },
+  ];
+}
+
+function getBrowserUrlFromComponents(components: APIMessageTopLevelComponent[] | undefined): string | null {
+  if (components == null) {
+    return null;
+  }
+
+  for (const component of components) {
+    if (component.type !== ComponentType.ActionRow) {
+      continue;
+    }
+
+    for (const child of component.components) {
+      if (child.type !== ComponentType.Button || child.style !== ButtonStyle.Link) {
+        continue;
+      }
+
+      if (child.url !== "") {
+        return child.url;
+      }
+    }
+  }
+
+  return null;
+}
 
 describe("LeaderboardCommand", () => {
   let env: Env;
@@ -30,7 +90,7 @@ describe("LeaderboardCommand", () => {
     expect(subcommands?.[0]?.name).toBe("show");
   });
 
-  it("fetches leaderboard data and updates deferred reply", async () => {
+  it("fetches leaderboard data and updates deferred reply with controls and browser URL", async () => {
     const mappedOptions = new Map<string, string | number>();
     mappedOptions.set("queue_channel", "queue-123");
     mappedOptions.set("window", LeaderboardWindow.OneMonth);
@@ -38,7 +98,7 @@ describe("LeaderboardCommand", () => {
     mappedOptions.set("page", 2);
     mappedOptions.set("min_games_played", 3);
 
-    const extractSubcommandSpy = vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
+    vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
       name: "show",
       options: [],
       mappedOptions,
@@ -51,7 +111,7 @@ describe("LeaderboardCommand", () => {
       minGamesPlayed: 3,
       page: 2,
       pageSize: 10,
-      total: 2,
+      total: 23,
       rows: [
         {
           rank: 11,
@@ -78,7 +138,7 @@ describe("LeaderboardCommand", () => {
       attachments: [],
       embeds: [],
       pinned: false,
-      type: 0,
+      type: MessageType.Default,
       author: {
         id: "bot-id",
         username: "Guilty Spark",
@@ -110,11 +170,8 @@ describe("LeaderboardCommand", () => {
     const result = command.execute(interaction);
 
     expect(result.response.type).toBe(InteractionResponseType.DeferredChannelMessageWithSource);
-    expect(result.jobToComplete).toBeDefined();
-
     await result.jobToComplete?.();
 
-    expect(extractSubcommandSpy).toHaveBeenCalledWith(interaction, "leaderboard");
     expect(getLeaderboardSpy).toHaveBeenCalledWith({
       guildId: "guild-123",
       queueChannelId: "queue-123",
@@ -124,19 +181,151 @@ describe("LeaderboardCommand", () => {
       pageSize: 10,
       minGamesPlayed: 3,
     });
-    expect(updateDeferredReplySpy).toHaveBeenCalledTimes(1);
-    const [interactionToken, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
-    expect(interactionToken).toBe(interaction.token);
+
+    const [token, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
+    expect(token).toBe(interaction.token);
     expect(payload.embeds?.[0]?.title).toBe("Leaderboard - Queue <#queue-123>");
+    const linkUrl = getBrowserUrlFromComponents(payload.components);
+    expect(linkUrl).toContain("guildId=guild-123");
+    expect(linkUrl).toContain("queueChannelId=queue-123");
+    expect(linkUrl).toContain("window=1M");
+    expect(linkUrl).toContain("metric=KILLS");
+    expect(linkUrl).toContain("page=2");
   });
 
-  it("returns deferred response for show subcommand", () => {
-    const mappedOptions = new Map<string, string | number>();
+  it("paginates from interaction state when previous button is pressed", async () => {
+    const stateUrl =
+      "https://guilty-spark.app/leaderboard?guildId=guild-123&queueChannelId=queue-123&window=3M&metric=KILLS&page=2&minGamesPlayed=4";
+    const interaction: APIMessageComponentButtonInteraction = {
+      ...fakeButtonClickInteraction,
+      guild_id: "guild-123",
+      guild: {
+        ...Preconditions.checkExists(fakeButtonClickInteraction.guild),
+        id: "guild-123",
+      },
+      data: {
+        component_type: ComponentType.Button,
+        custom_id: INTERACTION_PREV_PAGE,
+      },
+      message: {
+        ...fakeButtonClickInteraction.message,
+        components: aStateComponentsWith(stateUrl),
+      },
+    };
 
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "guild-123",
+      queueChannelId: "queue-123",
+      window: LeaderboardWindow.ThreeMonths,
+      metric: LeaderboardMetric.Kills,
+      minGamesPlayed: 4,
+      page: 1,
+      pageSize: 10,
+      total: 11,
+      rows: [],
+    });
+    vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      ...fakeButtonClickInteraction.message,
+      type: MessageType.Default,
+    });
+
+    const result = command.execute(interaction);
+
+    expect(result.response.type).toBe(InteractionResponseType.DeferredMessageUpdate);
+    await result.jobToComplete?.();
+
+    expect(getLeaderboardSpy).toHaveBeenCalledWith({
+      guildId: "guild-123",
+      queueChannelId: "queue-123",
+      window: LeaderboardWindow.ThreeMonths,
+      metric: LeaderboardMetric.Kills,
+      page: 1,
+      pageSize: 10,
+      minGamesPlayed: 4,
+    });
+  });
+
+  it("switches metric from string-select interaction and resets to page 1", async () => {
+    const stateUrl =
+      "https://guilty-spark.app/leaderboard?guildId=test-guild-id&window=1M&metric=SERIES_WIN_RATE&page=6&minGamesPlayed=0";
+    const interaction: APIMessageComponentSelectMenuInteraction = {
+      ...aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetric.Kda }),
+      message: {
+        ...aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetric.Kda }).message,
+        components: aStateComponentsWith(stateUrl),
+      },
+    };
+
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "test-guild-id",
+      queueChannelId: null,
+      window: LeaderboardWindow.OneMonth,
+      metric: LeaderboardMetric.Kda,
+      minGamesPlayed: 0,
+      page: 1,
+      pageSize: 10,
+      total: 5,
+      rows: [],
+    });
+    vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      ...Preconditions.checkExists(interaction.message),
+      type: MessageType.Default,
+    });
+
+    const result = command.execute(interaction);
+
+    expect(result.response.type).toBe(InteractionResponseType.DeferredMessageUpdate);
+    await result.jobToComplete?.();
+
+    expect(getLeaderboardSpy).toHaveBeenCalledWith({
+      guildId: "test-guild-id",
+      window: LeaderboardWindow.OneMonth,
+      metric: LeaderboardMetric.Kda,
+      page: 1,
+      pageSize: 10,
+      minGamesPlayed: 0,
+    });
+  });
+
+  it("renders an explicit empty state message when no players qualify", async () => {
     vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
       name: "show",
       options: [],
-      mappedOptions,
+      mappedOptions: new Map<string, string | number>(),
+    });
+    vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "guild-123",
+      queueChannelId: null,
+      window: LeaderboardWindow.ThreeMonths,
+      metric: LeaderboardMetric.SeriesWinRate,
+      minGamesPlayed: 5,
+      page: 1,
+      pageSize: 10,
+      total: 0,
+      rows: [],
+    });
+    const updateDeferredReplySpy = vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      id: "message-id",
+      channel_id: "channel-id",
+      content: "",
+      timestamp: "2026-08-12T00:00:00.000Z",
+      edited_timestamp: null,
+      tts: false,
+      mention_everyone: false,
+      mentions: [],
+      mention_roles: [],
+      attachments: [],
+      embeds: [],
+      pinned: false,
+      type: MessageType.Default,
+      author: {
+        id: "bot-id",
+        username: "Guilty Spark",
+        discriminator: "0000",
+        avatar: null,
+        global_name: null,
+      },
+      components: [],
     });
 
     const interaction: APIApplicationCommandInteraction = {
@@ -158,8 +347,9 @@ describe("LeaderboardCommand", () => {
     };
 
     const result = command.execute(interaction);
+    await result.jobToComplete?.();
 
-    expect(result.response.type).toBe(InteractionResponseType.DeferredChannelMessageWithSource);
-    expect(result.jobToComplete).toBeDefined();
+    const [, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
+    expect(payload.embeds?.[0]?.fields?.[0]?.value).toBe("No players qualify for this filter yet.");
   });
 });

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -1016,6 +1016,41 @@ describe("LeaderboardCommand", () => {
     );
   });
 
+  it("updates deferred reply with error when interaction state URL is malformed", async () => {
+    const interaction: APIMessageComponentButtonInteraction = {
+      ...fakeButtonClickInteraction,
+      guild_id: "guild-123",
+      guild: {
+        ...Preconditions.checkExists(fakeButtonClickInteraction.guild),
+        id: "guild-123",
+      },
+      data: {
+        component_type: ComponentType.Button,
+        custom_id: INTERACTION_PREV_PAGE,
+      },
+      message: {
+        ...fakeButtonClickInteraction.message,
+        components: aStateComponentsWith("https://%/leaderboard?window=3M&metric=KILLS&page=1"),
+      },
+    };
+
+    const updateDeferredReplyWithErrorSpy = vi
+      .spyOn(services.discordService, "updateDeferredReplyWithError")
+      .mockResolvedValue(undefined);
+    const logErrorSpy = vi.spyOn(services.logService, "error");
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(logErrorSpy).not.toHaveBeenCalled();
+    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+      interaction.token,
+      expect.objectContaining({
+        endUserMessage: "This leaderboard message has invalid filter settings. Run /leaderboard show again.",
+      }),
+    );
+  });
+
   it("updates deferred reply with error when interaction state guildId mismatches the interaction guild", async () => {
     const interaction: APIMessageComponentButtonInteraction = {
       ...fakeButtonClickInteraction,

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -98,7 +98,7 @@ describe("LeaderboardCommand", () => {
     expect(subcommands?.[0]?.name).toBe("show");
   });
 
-  it("fetches leaderboard data and updates deferred reply with controls and browser URL", async () => {
+  it("fetches leaderboard data and updates deferred reply with stateful controls", async () => {
     const mappedOptions = new Map<string, string | number>();
     mappedOptions.set("queue_channel", "queue-123");
     mappedOptions.set("window", LeaderboardWindow.OneMonth);
@@ -193,22 +193,46 @@ describe("LeaderboardCommand", () => {
     const [token, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
     expect(token).toBe(interaction.token);
     expect(payload.embeds?.[0]?.title).toBe("Leaderboard - Queue <#queue-123>");
-    expect(payload.components?.[0]).toMatchObject({
+    expect(payload.components?.[0]).toEqual({
       type: ComponentType.ActionRow,
       components: [
-        { custom_id: INTERACTION_FIRST_PAGE, disabled: false },
-        { custom_id: INTERACTION_PREV_PAGE, disabled: false },
-        { custom_id: INTERACTION_REFRESH },
-        { custom_id: INTERACTION_NEXT_PAGE, disabled: false },
-        { custom_id: INTERACTION_LAST_PAGE, disabled: false },
+        {
+          type: ComponentType.Button,
+          style: ButtonStyle.Secondary,
+          custom_id: `${INTERACTION_FIRST_PAGE}:guild-123:queue-123:1M:KILLS:2:3`,
+          emoji: { name: "⏮️" },
+          disabled: false,
+        },
+        {
+          type: ComponentType.Button,
+          style: ButtonStyle.Secondary,
+          custom_id: `${INTERACTION_PREV_PAGE}:guild-123:queue-123:1M:KILLS:2:3`,
+          emoji: { name: "◀️" },
+          disabled: false,
+        },
+        {
+          type: ComponentType.Button,
+          style: ButtonStyle.Secondary,
+          custom_id: `${INTERACTION_REFRESH}:guild-123:queue-123:1M:KILLS:2:3`,
+          emoji: { name: "🔄" },
+        },
+        {
+          type: ComponentType.Button,
+          style: ButtonStyle.Secondary,
+          custom_id: `${INTERACTION_NEXT_PAGE}:guild-123:queue-123:1M:KILLS:2:3`,
+          emoji: { name: "▶️" },
+          disabled: false,
+        },
+        {
+          type: ComponentType.Button,
+          style: ButtonStyle.Secondary,
+          custom_id: `${INTERACTION_LAST_PAGE}:guild-123:queue-123:1M:KILLS:2:3`,
+          emoji: { name: "⏭️" },
+          disabled: false,
+        },
       ],
     });
-    const linkUrl = getBrowserUrlFromComponents(payload.components);
-    expect(linkUrl).toContain("guildId=guild-123");
-    expect(linkUrl).toContain("queueChannelId=queue-123");
-    expect(linkUrl).toContain("window=1M");
-    expect(linkUrl).toContain("metric=KILLS");
-    expect(linkUrl).toContain("page=2");
+    expect(getBrowserUrlFromComponents(payload.components)).toBeNull();
   });
 
   it("prefers guild locale over user locale for leaderboard formatting", async () => {
@@ -383,8 +407,7 @@ describe("LeaderboardCommand", () => {
   });
 
   it("paginates from interaction state when previous button is pressed", async () => {
-    const stateUrl =
-      "https://guilty-spark.app/leaderboard?guildId=guild-123&queueChannelId=queue-123&window=3M&metric=KILLS&page=2&minGamesPlayed=4";
+    const controlId = "btn_leaderboard_prev:guild-123:queue-123:3M:KILLS:2:4";
     const interaction: APIMessageComponentButtonInteraction = {
       ...fakeButtonClickInteraction,
       guild_id: "guild-123",
@@ -394,11 +417,11 @@ describe("LeaderboardCommand", () => {
       },
       data: {
         component_type: ComponentType.Button,
-        custom_id: INTERACTION_PREV_PAGE,
+        custom_id: controlId,
       },
       message: {
         ...fakeButtonClickInteraction.message,
-        components: aStateComponentsWith(stateUrl),
+        components: [],
       },
     };
 

--- a/api/commands/tests/commands.test.ts
+++ b/api/commands/tests/commands.test.ts
@@ -36,6 +36,9 @@ describe("getCommands", () => {
 
     const serviceRecordCommand = commandMap.get("servicerecord");
     expect(serviceRecordCommand).toBeDefined();
+
+    const leaderboardCommand = commandMap.get("leaderboard");
+    expect(leaderboardCommand).toBeDefined();
   });
 
   it("all commands have required data property", () => {

--- a/api/embeds/colors.ts
+++ b/api/embeds/colors.ts
@@ -16,6 +16,9 @@ export const EmbedColors = {
   /** Warning orange - used for paused states, warnings */
   WARNING: 0xffa500,
 
+  /** Gold - used for leaderboard rankings */
+  GOLD: 0xd4af37,
+
   /** Gray - used for stopped/inactive states */
   INACTIVE: 0x808080,
 } as const;

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -292,7 +292,7 @@ export class DiscordService {
     }
 
     this.logService.info("getCommandToExecute", new Map([["name", name]]));
-    const command = this.commands.get(name);
+    const command = this.commands.get(name) ?? this.commands.get(name.split(":", 1)[0] ?? "");
     if (!command) {
       this.logService.warn("Command not found", new Map([["name", name]]));
 


### PR DESCRIPTION
## Context
The leaderboard implementation work has been progressing in PR-sized slices. The previous slice added the leaderboard show command scaffold and wiring into the command registry so we could safely iterate on behavior.

## This PR
This PR adds the interactive command experience for leaderboard show:
- adds component-driven pagination controls (previous/next)
- adds metric and window string-select controls
- persists and restores leaderboard state from the message link URL so follow-up interactions keep filters/page/min-games context
- updates deferred responses to include dynamic component state (selected options, pagination disabled states, browser URL with query params)
- expands command tests to cover interaction-driven pagination, metric switching, URL-state behavior, and empty leaderboard rendering

## Subsequent Work
- Add integration coverage for leaderboard window switching interactions and broader Discord message component edge cases.
- Continue the DB-first stats page fallback work for queue stats lookup as planned.
