### PR TITLE
Fix D1 variable-limit overflow in leaderboard batch persistence

### DIFF
--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -22,6 +22,7 @@ import type { LeaderboardConfigRow } from "./types/leaderboard_config";
 
 const DEFAULT_LEADERBOARD_ENABLED_WINDOWS_JSON = '["1W","1M","3M","6M","12M"]';
 const SQLITE_MAX_VARIABLES = 999;
+const D1_SAFE_MAX_VARIABLES_PER_STATEMENT = 100;
 
 interface LeaderboardRankingsQuery {
   guildId: string;
@@ -523,6 +524,7 @@ export class DatabaseService {
       ...player,
       CreatedAt: existingSeriesPlayerCreatedAt.get(player.XboxXuid) ?? player.CreatedAt,
     }));
+    const statementVariableLimit = Math.min(SQLITE_MAX_VARIABLES, D1_SAFE_MAX_VARIABLES_PER_STATEMENT);
 
     const statements: D1PreparedStatement[] = [];
     const upsertSeriesStmt = this.DB.prepare(
@@ -559,7 +561,7 @@ export class DatabaseService {
 
     if (normalizedGames.length > 0) {
       const variablesPerRow = 15;
-      const maxRowsPerStatement = Math.floor(SQLITE_MAX_VARIABLES / variablesPerRow);
+      const maxRowsPerStatement = Math.max(1, Math.floor(statementVariableLimit / variablesPerRow));
 
       for (let start = 0; start < normalizedGames.length; start += maxRowsPerStatement) {
         const chunk = normalizedGames.slice(start, start + maxRowsPerStatement);
@@ -595,7 +597,7 @@ export class DatabaseService {
 
     if (normalizedGamePlayers.length > 0) {
       const variablesPerRow = 26;
-      const maxRowsPerStatement = Math.floor(SQLITE_MAX_VARIABLES / variablesPerRow);
+      const maxRowsPerStatement = Math.max(1, Math.floor(statementVariableLimit / variablesPerRow));
 
       for (let start = 0; start < normalizedGamePlayers.length; start += maxRowsPerStatement) {
         const chunk = normalizedGamePlayers.slice(start, start + maxRowsPerStatement);
@@ -644,7 +646,7 @@ export class DatabaseService {
 
     if (normalizedSeriesPlayers.length > 0) {
       const variablesPerRow = 13;
-      const maxRowsPerStatement = Math.floor(SQLITE_MAX_VARIABLES / variablesPerRow);
+      const maxRowsPerStatement = Math.max(1, Math.floor(statementVariableLimit / variablesPerRow));
 
       for (let start = 0; start < normalizedSeriesPlayers.length; start += maxRowsPerStatement) {
         const chunk = normalizedSeriesPlayers.slice(start, start + maxRowsPerStatement);

--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -22,7 +22,7 @@ import type { LeaderboardConfigRow } from "./types/leaderboard_config";
 
 const DEFAULT_LEADERBOARD_ENABLED_WINDOWS_JSON = '["1W","1M","3M","6M","12M"]';
 const SQLITE_MAX_VARIABLES = 999;
-// Keep statement bind counts well below the D1/SQLite 999-variable ceiling in batch upserts.
+// D1 accepts at most 100 bound parameters per statement, so batch upserts must chunk below this cap.
 const D1_SAFE_MAX_VARIABLES_PER_STATEMENT = 100;
 
 interface LeaderboardRankingsQuery {

--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -22,6 +22,7 @@ import type { LeaderboardConfigRow } from "./types/leaderboard_config";
 
 const DEFAULT_LEADERBOARD_ENABLED_WINDOWS_JSON = '["1W","1M","3M","6M","12M"]';
 const SQLITE_MAX_VARIABLES = 999;
+// Keep statement bind counts well below the D1/SQLite 999-variable ceiling in batch upserts.
 const D1_SAFE_MAX_VARIABLES_PER_STATEMENT = 100;
 
 interface LeaderboardRankingsQuery {

--- a/api/services/database/tests/database.test.ts
+++ b/api/services/database/tests/database.test.ts
@@ -751,6 +751,71 @@ describe("Database Service", () => {
       expect(seriesPlayerInsertStatements.length).toBeGreaterThan(1);
     });
 
+    it("chunks batch inserts for match-complete payload sizes", async () => {
+      const series = aFakeLeaderboardSeriesRow();
+      const seriesPlayers = Array.from({ length: 8 }, (_, index) =>
+        aFakeLeaderboardSeriesPlayersRow({
+          XboxXuid: `series-xuid-${index.toString()}`,
+          DiscordUserId: `series-discord-${index.toString()}`,
+        }),
+      );
+      const games = Array.from({ length: 2 }, (_, index) =>
+        aFakeLeaderboardGamesRow({
+          MatchId: `match-${index.toString()}`,
+        }),
+      );
+      const gamePlayers = Array.from({ length: 16 }, (_, index) =>
+        aFakeLeaderboardGamePlayersRow({
+          MatchId: `match-${Math.floor(index / 8).toString()}`,
+          XboxXuid: `game-xuid-${index.toString()}`,
+          DiscordUserId: `game-discord-${index.toString()}`,
+        }),
+      );
+
+      const existingGamesStmt = new FakePreparedStatement<{ MatchId: string; CreatedAt: number }>();
+      const existingGamePlayersStmt = new FakePreparedStatement<{
+        MatchId: string;
+        XboxXuid: string;
+        CreatedAt: number;
+      }>();
+      const existingSeriesPlayersStmt = new FakePreparedStatement<{ XboxXuid: string; CreatedAt: number }>();
+
+      const prepareSpy = vi
+        .spyOn(env.DB, "prepare")
+        .mockReturnValueOnce(existingGamesStmt)
+        .mockReturnValueOnce(existingGamePlayersStmt)
+        .mockReturnValueOnce(existingSeriesPlayersStmt)
+        .mockImplementation(() => new FakePreparedStatement());
+
+      vi.spyOn(existingGamesStmt, "bind").mockReturnThis();
+      vi.spyOn(existingGamePlayersStmt, "bind").mockReturnThis();
+      vi.spyOn(existingSeriesPlayersStmt, "bind").mockReturnThis();
+      vi.spyOn(existingGamesStmt, "all").mockResolvedValue({ ...fakeD1Response, results: [] });
+      vi.spyOn(existingGamePlayersStmt, "all").mockResolvedValue({ ...fakeD1Response, results: [] });
+      vi.spyOn(existingSeriesPlayersStmt, "all").mockResolvedValue({ ...fakeD1Response, results: [] });
+
+      await databaseService.upsertLeaderboardSeriesDataBatch({
+        series,
+        games,
+        gamePlayers,
+        seriesPlayers,
+      });
+
+      const preparedQueries = prepareSpy.mock.calls
+        .map(([query]) => query)
+        .filter((query): query is string => typeof query === "string");
+
+      const gamePlayerInsertStatements = preparedQueries.filter((query) =>
+        query.includes("INSERT INTO LeaderboardGamePlayers"),
+      );
+      const seriesPlayerInsertStatements = preparedQueries.filter((query) =>
+        query.includes("INSERT INTO LeaderboardSeriesPlayers"),
+      );
+
+      expect(gamePlayerInsertStatements.length).toBeGreaterThan(1);
+      expect(seriesPlayerInsertStatements.length).toBeGreaterThan(1);
+    });
+
     it("does not overwrite created timestamps in leaderboard upserts", async () => {
       const series = aFakeLeaderboardSeriesRow();
       const seriesPlayers = [aFakeLeaderboardSeriesPlayersRow()];

--- a/api/services/database/tests/database.test.ts
+++ b/api/services/database/tests/database.test.ts
@@ -811,9 +811,17 @@ describe("Database Service", () => {
       const seriesPlayerInsertStatements = preparedQueries.filter((query) =>
         query.includes("INSERT INTO LeaderboardSeriesPlayers"),
       );
+      const d1MaxBoundParametersPerStatement = 100;
+      const countBoundParameters = (sql: string): number => sql.split("?").length - 1;
 
       expect(gamePlayerInsertStatements.length).toBeGreaterThan(1);
       expect(seriesPlayerInsertStatements.length).toBeGreaterThan(1);
+      for (const query of gamePlayerInsertStatements) {
+        expect(countBoundParameters(query)).toBeLessThanOrEqual(d1MaxBoundParametersPerStatement);
+      }
+      for (const query of seriesPlayerInsertStatements) {
+        expect(countBoundParameters(query)).toBeLessThanOrEqual(d1MaxBoundParametersPerStatement);
+      }
     });
 
     it("does not overwrite created timestamps in leaderboard upserts", async () => {


### PR DESCRIPTION
## Context
Leaderboard persistence during match completion is still failing in production with D1 variable-limit errors. The request logs show the failure is raised from leaderboard series batch persistence while handling MATCH_COMPLETED, which prevents leaderboard data from being written consistently.

## This PR
- introduces a D1-safe per-statement bind-variable cap for leaderboard series batch persistence
- applies that cap to chunking logic for games, game players, and series players in the batch upsert path
- adds regression coverage for the real-world match completion payload shape from logs (2 games, 16 game-player rows, 8 series-player rows)
- verifies that batch inserts are split across multiple statements where required, avoiding variable-limit overflows

## Subsequent Work
- monitor production logs for MATCH_COMPLETED persistence to confirm no further variable-limit failures on this path
- if needed, apply the same D1-safe cap pattern to other high-volume bulk insert paths outside leaderboard persistence
