### PR TITLE
Reap stale leaderboard posts weekly

### DIFF
--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -337,6 +337,12 @@ export class DatabaseService {
     return response.results;
   }
 
+  async getAllLeaderboardPosts(): Promise<LeaderboardPostRow[]> {
+    const stmt = this.DB.prepare("SELECT * FROM LeaderboardPosts");
+    const response = await stmt.all<LeaderboardPostRow>();
+    return response.results;
+  }
+
   async deleteLeaderboardPost(channelId: string, messageId: string): Promise<void> {
     const query = "DELETE FROM LeaderboardPosts WHERE ChannelId = ? AND MessageId = ?";
     const stmt = this.DB.prepare(query).bind(channelId, messageId);

--- a/api/services/database/tests/database.test.ts
+++ b/api/services/database/tests/database.test.ts
@@ -926,6 +926,18 @@ describe("Database Service", () => {
       expect(posts).toEqual([guildWidePost, queuePost]);
     });
 
+    it("gets every leaderboard post for reaping", async () => {
+      const post = aFakeLeaderboardPostRow();
+      const fakePreparedStatement = new FakePreparedStatement<typeof post>();
+      const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      vi.spyOn(fakePreparedStatement, "all").mockResolvedValue({ ...fakeD1Response, results: [post] });
+
+      const posts = await databaseService.getAllLeaderboardPosts();
+
+      expect(prepareSpy).toHaveBeenCalledWith("SELECT * FROM LeaderboardPosts");
+      expect(posts).toEqual([post]);
+    });
+
     it("deletes a leaderboard post registration by Discord message identity", async () => {
       const fakePreparedStatement = new FakePreparedStatement();
       const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);

--- a/api/services/leaderboard/leaderboard-post-reaper.ts
+++ b/api/services/leaderboard/leaderboard-post-reaper.ts
@@ -69,6 +69,14 @@ export class LeaderboardPostReaper {
   private async deletePost(post: LeaderboardPostRow): Promise<boolean> {
     try {
       await this.databaseService.deleteLeaderboardPost(post.ChannelId, post.MessageId);
+      this.logService.info(
+        "LeaderboardPostReaper: deleted missing leaderboard post registration",
+        new Map([
+          ["guildId", post.GuildId],
+          ["channelId", post.ChannelId],
+          ["messageId", post.MessageId],
+        ]),
+      );
       return true;
     } catch (error) {
       this.logService.warn(

--- a/api/services/leaderboard/leaderboard-post-reaper.ts
+++ b/api/services/leaderboard/leaderboard-post-reaper.ts
@@ -1,0 +1,86 @@
+import { DiscordError } from "../discord/discord-error";
+import type { DatabaseService } from "../database/database";
+import type { LeaderboardPostRow } from "../database/types/leaderboard_post";
+import type { DiscordService } from "../discord/discord";
+import type { LogService } from "../log/types";
+
+export interface LeaderboardPostReaperOpts {
+  databaseService: DatabaseService;
+  discordService: DiscordService;
+  logService: LogService;
+}
+
+export class LeaderboardPostReaper {
+  private readonly databaseService: DatabaseService;
+  private readonly discordService: DiscordService;
+  private readonly logService: LogService;
+
+  constructor({ databaseService, discordService, logService }: LeaderboardPostReaperOpts) {
+    this.databaseService = databaseService;
+    this.discordService = discordService;
+    this.logService = logService;
+  }
+
+  async execute(): Promise<void> {
+    const posts = await this.databaseService.getAllLeaderboardPosts();
+    let deletedCount = 0;
+
+    for (const post of posts) {
+      if (await this.reapPost(post)) {
+        deletedCount += 1;
+      }
+    }
+
+    this.logService.info(
+      "LeaderboardPostReaper: completed",
+      new Map([
+        ["totalPosts", posts.length.toString()],
+        ["deletedPosts", deletedCount.toString()],
+      ]),
+    );
+  }
+
+  private async reapPost(post: LeaderboardPostRow): Promise<boolean> {
+    try {
+      await this.discordService.getMessage(post.ChannelId, post.MessageId);
+      return false;
+    } catch (error) {
+      const isConfirmedMissingResource =
+        error instanceof DiscordError &&
+        error.httpStatus === 404 &&
+        (error.restError.code === 10003 || error.restError.code === 10008);
+      if (!isConfirmedMissingResource) {
+        this.logService.warn(
+          error,
+          new Map([
+            ["guildId", post.GuildId],
+            ["channelId", post.ChannelId],
+            ["messageId", post.MessageId],
+            ["reason", "Failed to validate leaderboard post during reap"],
+          ]),
+        );
+        return false;
+      }
+
+      return await this.deletePost(post);
+    }
+  }
+
+  private async deletePost(post: LeaderboardPostRow): Promise<boolean> {
+    try {
+      await this.databaseService.deleteLeaderboardPost(post.ChannelId, post.MessageId);
+      return true;
+    } catch (error) {
+      this.logService.warn(
+        error,
+        new Map([
+          ["guildId", post.GuildId],
+          ["channelId", post.ChannelId],
+          ["messageId", post.MessageId],
+          ["reason", "Failed to delete missing leaderboard post registration during reap"],
+        ]),
+      );
+      return false;
+    }
+  }
+}

--- a/api/services/leaderboard/tests/leaderboard-post-reaper.test.ts
+++ b/api/services/leaderboard/tests/leaderboard-post-reaper.test.ts
@@ -50,10 +50,19 @@ describe("LeaderboardPostReaper", () => {
       new DiscordError(404, { code: 10008, message: "Unknown Message" }),
     );
     const deletePostSpy = vi.spyOn(databaseService, "deleteLeaderboardPost").mockResolvedValue(undefined);
+    const infoSpy = vi.spyOn(logService, "info");
 
     await reaper.execute();
 
     expect(deletePostSpy).toHaveBeenCalledWith(post.ChannelId, post.MessageId);
+    expect(infoSpy).toHaveBeenCalledWith(
+      "LeaderboardPostReaper: deleted missing leaderboard post registration",
+      new Map([
+        ["guildId", post.GuildId],
+        ["channelId", post.ChannelId],
+        ["messageId", post.MessageId],
+      ]),
+    );
   });
 
   it("keeps posts when Discord reports a transient error", async () => {

--- a/api/services/leaderboard/tests/leaderboard-post-reaper.test.ts
+++ b/api/services/leaderboard/tests/leaderboard-post-reaper.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DatabaseService } from "../../database/database";
+import { aFakeDatabaseServiceWith, aFakeLeaderboardPostRow } from "../../database/fakes/database.fake";
+import type { DiscordService } from "../../discord/discord";
+import { aFakeDiscordServiceWith } from "../../discord/fakes/discord.fake";
+import { apiMessage } from "../../discord/fakes/data";
+import { DiscordError } from "../../discord/discord-error";
+import type { LogService } from "../../log/types";
+import { aFakeLogServiceWith } from "../../log/fakes/log.fake";
+import { LeaderboardPostReaper } from "../leaderboard-post-reaper";
+
+describe("LeaderboardPostReaper", () => {
+  let databaseService: DatabaseService;
+  let discordService: DiscordService;
+  let logService: LogService;
+  let reaper: LeaderboardPostReaper;
+
+  beforeEach(() => {
+    databaseService = aFakeDatabaseServiceWith();
+    discordService = aFakeDiscordServiceWith();
+    logService = aFakeLogServiceWith();
+    reaper = new LeaderboardPostReaper({ databaseService, discordService, logService });
+  });
+
+  it("does not fetch messages when no leaderboard posts exist", async () => {
+    vi.spyOn(databaseService, "getAllLeaderboardPosts").mockResolvedValue([]);
+    const getMessageSpy = vi.spyOn(discordService, "getMessage");
+
+    await reaper.execute();
+
+    expect(getMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps leaderboard posts whose Discord messages exist", async () => {
+    const post = aFakeLeaderboardPostRow();
+    vi.spyOn(databaseService, "getAllLeaderboardPosts").mockResolvedValue([post]);
+    const getMessageSpy = vi.spyOn(discordService, "getMessage").mockResolvedValue(apiMessage);
+    const deletePostSpy = vi.spyOn(databaseService, "deleteLeaderboardPost");
+
+    await reaper.execute();
+
+    expect(getMessageSpy).toHaveBeenCalledWith(post.ChannelId, post.MessageId);
+    expect(deletePostSpy).not.toHaveBeenCalled();
+  });
+
+  it("deletes posts whose Discord message is confirmed missing", async () => {
+    const post = aFakeLeaderboardPostRow();
+    vi.spyOn(databaseService, "getAllLeaderboardPosts").mockResolvedValue([post]);
+    vi.spyOn(discordService, "getMessage").mockRejectedValue(
+      new DiscordError(404, { code: 10008, message: "Unknown Message" }),
+    );
+    const deletePostSpy = vi.spyOn(databaseService, "deleteLeaderboardPost").mockResolvedValue(undefined);
+
+    await reaper.execute();
+
+    expect(deletePostSpy).toHaveBeenCalledWith(post.ChannelId, post.MessageId);
+  });
+
+  it("keeps posts when Discord reports a transient error", async () => {
+    const post = aFakeLeaderboardPostRow();
+    vi.spyOn(databaseService, "getAllLeaderboardPosts").mockResolvedValue([post]);
+    vi.spyOn(discordService, "getMessage").mockRejectedValue(new Error("Discord temporarily unavailable"));
+    const deletePostSpy = vi.spyOn(databaseService, "deleteLeaderboardPost");
+
+    await reaper.execute();
+
+    expect(deletePostSpy).not.toHaveBeenCalled();
+  });
+
+  it("continues reaping posts when deletion of one missing registration fails", async () => {
+    const firstPost = aFakeLeaderboardPostRow();
+    const secondPost = aFakeLeaderboardPostRow({ ChannelId: "leaderboard-channel-2", MessageId: "leaderboard-message-2" });
+    vi.spyOn(databaseService, "getAllLeaderboardPosts").mockResolvedValue([firstPost, secondPost]);
+    vi.spyOn(discordService, "getMessage")
+      .mockRejectedValueOnce(new DiscordError(404, { code: 10008, message: "Unknown Message" }))
+      .mockRejectedValueOnce(new DiscordError(404, { code: 10003, message: "Unknown Channel" }));
+    const deletePostSpy = vi
+      .spyOn(databaseService, "deleteLeaderboardPost")
+      .mockRejectedValueOnce(new Error("D1 temporarily unavailable"))
+      .mockResolvedValueOnce(undefined);
+
+    await reaper.execute();
+
+    expect(deletePostSpy).toHaveBeenCalledTimes(2);
+    expect(deletePostSpy).toHaveBeenNthCalledWith(1, firstPost.ChannelId, firstPost.MessageId);
+    expect(deletePostSpy).toHaveBeenNthCalledWith(2, secondPost.ChannelId, secondPost.MessageId);
+  });
+});

--- a/api/services/leaderboard/tests/leaderboard-post-reaper.test.ts
+++ b/api/services/leaderboard/tests/leaderboard-post-reaper.test.ts
@@ -69,7 +69,10 @@ describe("LeaderboardPostReaper", () => {
 
   it("continues reaping posts when deletion of one missing registration fails", async () => {
     const firstPost = aFakeLeaderboardPostRow();
-    const secondPost = aFakeLeaderboardPostRow({ ChannelId: "leaderboard-channel-2", MessageId: "leaderboard-message-2" });
+    const secondPost = aFakeLeaderboardPostRow({
+      ChannelId: "leaderboard-channel-2",
+      MessageId: "leaderboard-message-2",
+    });
     vi.spyOn(databaseService, "getAllLeaderboardPosts").mockResolvedValue([firstPost, secondPost]);
     vi.spyOn(discordService, "getMessage")
       .mockRejectedValueOnce(new DiscordError(404, { code: 10008, message: "Unknown Message" }))

--- a/api/services/leaderboard/tests/leaderboard.test.ts
+++ b/api/services/leaderboard/tests/leaderboard.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { APIMessage, APIMessageTopLevelComponent } from "discord-api-types/v10";
-import { ComponentType } from "discord-api-types/v10";
+import { ComponentType, Locale } from "discord-api-types/v10";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
 import type { LeaderboardRankingRow } from "../../database/types/leaderboard_ranking_row";
@@ -294,7 +294,9 @@ describe("LeaderboardService", () => {
       rows: killsRankingRows,
     });
     vi.spyOn(discordService, "getMessage").mockResolvedValue(aLeaderboardMessageWith());
-    const getGuildPreferredLocaleSpy = vi.spyOn(discordService, "getGuildPreferredLocale").mockResolvedValue("en-US");
+    const getGuildPreferredLocaleSpy = vi
+      .spyOn(discordService, "getGuildPreferredLocale")
+      .mockResolvedValue(Locale.EnglishUS);
     const editMessageSpy = vi.spyOn(discordService, "editMessage").mockResolvedValue(apiMessage);
 
     await service.refreshPostsForCompletedQueue("guild-1", "queue-1");
@@ -333,7 +335,7 @@ describe("LeaderboardService", () => {
     const service = new LeaderboardService({ databaseService, discordService, haloService, logService });
     const post = aFakeLeaderboardPostRow();
     vi.spyOn(databaseService, "findLeaderboardPostsForRefresh").mockResolvedValue([post]);
-    vi.spyOn(discordService, "getGuildPreferredLocale").mockResolvedValue("en-US");
+    vi.spyOn(discordService, "getGuildPreferredLocale").mockResolvedValue(Locale.EnglishUS);
     vi.spyOn(discordService, "getMessage").mockResolvedValue(aLeaderboardMessageWith());
     vi.spyOn(databaseService, "getLeaderboardConfig").mockResolvedValue(
       aFakeLeaderboardConfigRow({ GuildId: "guild-1", MinGamesPlayed: 3 }),
@@ -357,7 +359,7 @@ describe("LeaderboardService", () => {
     const service = new LeaderboardService({ databaseService, discordService, haloService, logService });
     const post = aFakeLeaderboardPostRow();
     vi.spyOn(databaseService, "findLeaderboardPostsForRefresh").mockResolvedValue([post]);
-    vi.spyOn(discordService, "getGuildPreferredLocale").mockResolvedValue("en-US");
+    vi.spyOn(discordService, "getGuildPreferredLocale").mockResolvedValue(Locale.EnglishUS);
     vi.spyOn(discordService, "getMessage").mockRejectedValue(
       new DiscordError(404, { code: 10008, message: "Unknown Message" }),
     );
@@ -387,7 +389,7 @@ describe("LeaderboardService", () => {
       total: 23,
       rows: killsRankingRows,
     });
-    vi.spyOn(discordService, "getGuildPreferredLocale").mockResolvedValue("en-US");
+    vi.spyOn(discordService, "getGuildPreferredLocale").mockResolvedValue(Locale.EnglishUS);
     const editMessageSpy = vi.spyOn(discordService, "editMessage").mockResolvedValue(apiMessage);
     const warnSpy = vi.spyOn(logService, "warn");
 
@@ -424,7 +426,7 @@ describe("LeaderboardService", () => {
       total: 23,
       rows: killsRankingRows,
     });
-    vi.spyOn(discordService, "getGuildPreferredLocale").mockResolvedValue("en-US");
+    vi.spyOn(discordService, "getGuildPreferredLocale").mockResolvedValue(Locale.EnglishUS);
     const editMessageSpy = vi.spyOn(discordService, "editMessage").mockResolvedValue(apiMessage);
     const warnSpy = vi.spyOn(logService, "warn");
 
@@ -454,7 +456,7 @@ describe("LeaderboardService", () => {
       MessageId: "leaderboard-message-1",
     });
     vi.spyOn(databaseService, "findLeaderboardPostsForRefresh").mockResolvedValue([post]);
-    vi.spyOn(discordService, "getGuildPreferredLocale").mockResolvedValue("en-US");
+    vi.spyOn(discordService, "getGuildPreferredLocale").mockResolvedValue(Locale.EnglishUS);
     vi.spyOn(discordService, "getMessage").mockResolvedValue(
       aLeaderboardMessageWith({ footer: "Leaderboard pagination unavailable" }),
     );

--- a/api/worker.ts
+++ b/api/worker.ts
@@ -48,7 +48,7 @@ export default Sentry.withSentry(
     scheduled: async (controller: ScheduledController, env: Env): Promise<void> => {
       const { databaseService, discordService, logService } = installServices({ env });
       switch (controller.cron) {
-        case "43 15 * * *": {
+        case "0 15 * * *": {
           const cleanup = new StaleNeatQueueConfigCleanup({ databaseService, discordService, logService });
           await cleanup.execute();
           break;

--- a/api/worker.ts
+++ b/api/worker.ts
@@ -3,6 +3,7 @@ import { installServices } from "./services/install";
 import { createApiRouter } from "./base/router";
 import { Server } from "./server";
 import { StaleNeatQueueConfigCleanup } from "./services/neatqueue/stale-config-cleanup";
+import { LeaderboardPostReaper } from "./services/leaderboard/leaderboard-post-reaper";
 
 // Export Durable Object classes
 export { LiveTrackerDO } from "./durable-objects/live-tracker/live-tracker-do";
@@ -44,10 +45,15 @@ export default Sentry.withSentry(
   }),
   {
     fetch: server.router.fetch,
-    scheduled: async (_controller: ScheduledController, env: Env): Promise<void> => {
+    scheduled: async (controller: ScheduledController, env: Env): Promise<void> => {
       const { databaseService, discordService, logService } = installServices({ env });
       const cleanup = new StaleNeatQueueConfigCleanup({ databaseService, discordService, logService });
       await cleanup.execute();
+
+      if (controller.cron === "0 0 * * 0") {
+        const reaper = new LeaderboardPostReaper({ databaseService, discordService, logService });
+        await reaper.execute();
+      }
     },
   },
 );

--- a/api/worker.ts
+++ b/api/worker.ts
@@ -47,12 +47,20 @@ export default Sentry.withSentry(
     fetch: server.router.fetch,
     scheduled: async (controller: ScheduledController, env: Env): Promise<void> => {
       const { databaseService, discordService, logService } = installServices({ env });
-      const cleanup = new StaleNeatQueueConfigCleanup({ databaseService, discordService, logService });
-      await cleanup.execute();
-
-      if (controller.cron === "0 0 * * 0") {
-        const reaper = new LeaderboardPostReaper({ databaseService, discordService, logService });
-        await reaper.execute();
+      switch (controller.cron) {
+        case "43 15 * * *": {
+          const cleanup = new StaleNeatQueueConfigCleanup({ databaseService, discordService, logService });
+          await cleanup.execute();
+          break;
+        }
+        case "0 0 * * 0": {
+          const reaper = new LeaderboardPostReaper({ databaseService, discordService, logService });
+          await reaper.execute();
+          break;
+        }
+        default: {
+          logService.warn("Received unexpected cron expression", new Map([["cron", controller.cron]]));
+        }
       }
     },
   },

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -6,7 +6,7 @@
   "compatibility_date": "2026-02-28",
   "upload_source_maps": true,
 
-  // Daily cleanup of NeatQueue configs whose queue channel no longer exists
+  // Scheduled jobs: daily stale NeatQueue cleanup and weekly leaderboard post reaping
   "triggers": {
     "crons": ["43 15 * * *", "0 0 * * 0"],
   },

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -8,7 +8,7 @@
 
   // Scheduled jobs: daily stale NeatQueue cleanup and weekly leaderboard post reaping
   "triggers": {
-    "crons": ["43 15 * * *", "0 0 * * 0"],
+    "crons": ["0 15 * * *", "0 0 * * 0"],
   },
 
   // KV namespaces for development

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -8,7 +8,7 @@
 
   // Daily cleanup of NeatQueue configs whose queue channel no longer exists
   "triggers": {
-    "crons": ["43 15 * * *"],
+    "crons": ["43 15 * * *", "0 0 * * 0"],
   },
 
   // KV namespaces for development


### PR DESCRIPTION
## Context
Leaderboard posts now refresh when a completed series persists, but posts deleted outside that event path can remain registered indefinitely. This final PR5 lifecycle slice adds a periodic validation pass with the same conservative cleanup rule.

## This PR
- adds a weekly Worker cron for leaderboard post validation
- adds `LeaderboardPostReaper`, which checks every registered Discord message with the channel-message API
- deletes a registry entry only for confirmed Discord `404` errors `10003` (Unknown Channel) or `10008` (Unknown Message)
- retains and logs transient or unexpected failures, and continues reaping remaining posts if one database deletion fails
- adds all-post database lookup and focused reaper/database coverage
- corrects leaderboard refresh test mocks to use Discord's typed `Locale` result

## Subsequent Work
- Implement the planned public interaction policy: static locked boards or publicly navigable/filterable boards, followed by optional guild/role policy configuration.
- Continue metric expansion and objective-stat discovery after lifecycle behavior is reviewed.
