### PR TITLE
Rework leaderboard metric selector for Discord option limits

### DIFF
--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -43,6 +43,7 @@ import type { ApplicationCommandData, BaseInteraction, CommandData, ExecuteRespo
 import { BaseCommand } from "../base/base-command";
 
 const DEFAULT_PAGE_SIZE = 10;
+const LEGACY_LEADERBOARD_METRIC_SELECT_CONTROL_ID = "select_leaderboard_metric";
 
 const METRIC_FAMILIES_IN_OPTION_ORDER: readonly LeaderboardMetricFamily[] = [
   LeaderboardMetricFamily.PersonalScore,
@@ -240,6 +241,14 @@ export class LeaderboardCommand extends BaseCommand {
         type: InteractionType.MessageComponent,
         data: {
           component_type: ComponentType.StringSelect,
+          custom_id: LEGACY_LEADERBOARD_METRIC_SELECT_CONTROL_ID,
+          values: [],
+        },
+      },
+      {
+        type: InteractionType.MessageComponent,
+        data: {
+          component_type: ComponentType.StringSelect,
           custom_id: LEADERBOARD_METRIC_AGGREGATION_SELECT_CONTROL_ID,
           values: [],
         },
@@ -288,6 +297,9 @@ export class LeaderboardCommand extends BaseCommand {
             return this.deferUpdate(async () => this.handleLastPage(interaction));
           }
           case LEADERBOARD_METRIC_FAMILY_SELECT_CONTROL_ID: {
+            return this.deferUpdate(async () => this.handleMetricFamilySelect(interaction));
+          }
+          case LEGACY_LEADERBOARD_METRIC_SELECT_CONTROL_ID: {
             return this.deferUpdate(async () => this.handleMetricFamilySelect(interaction));
           }
           case LEADERBOARD_METRIC_AGGREGATION_SELECT_CONTROL_ID: {
@@ -774,7 +786,7 @@ export class LeaderboardCommand extends BaseCommand {
     const parsedFamily = METRIC_FAMILY_OPTIONS_BY_VALUE.get(value);
     if (parsedFamily == null) {
       throw new EndUserError(
-        "This leaderboard message has an invalid stat family filter. Run /leaderboard show again.",
+        "This leaderboard request has an invalid stat family filter. Run /leaderboard show again.",
         {
           handled: true,
           errorType: EndUserErrorType.WARNING,
@@ -793,7 +805,7 @@ export class LeaderboardCommand extends BaseCommand {
     const parsedAggregation = METRIC_AGGREGATION_OPTIONS_BY_VALUE.get(value);
     if (parsedAggregation == null) {
       throw new EndUserError(
-        "This leaderboard message has an invalid aggregation filter. Run /leaderboard show again.",
+        "This leaderboard request has an invalid aggregation filter. Run /leaderboard show again.",
         {
           handled: true,
           errorType: EndUserErrorType.WARNING,

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -16,13 +16,24 @@ import {
   PermissionFlagsBits,
 } from "discord-api-types/v10";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
-import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
+import {
+  LeaderboardMetric,
+  LeaderboardMetricAggregation,
+  LeaderboardMetricFamily,
+  LeaderboardWindow,
+  getLeaderboardFamilyAggregations,
+  getLeaderboardMetricAggregationLabel,
+  getLeaderboardMetricFamily,
+  getLeaderboardMetricFamilyLabel,
+  resolveLeaderboardMetric,
+} from "@guilty-spark/shared/halo/leaderboard";
 import { EndUserError, EndUserErrorType } from "../../base/end-user-error";
 import {
   createLeaderboardResponse,
   LEADERBOARD_FIRST_PAGE_CONTROL_ID,
   LEADERBOARD_LAST_PAGE_CONTROL_ID,
-  LEADERBOARD_METRIC_SELECT_CONTROL_ID,
+  LEADERBOARD_METRIC_AGGREGATION_SELECT_CONTROL_ID,
+  LEADERBOARD_METRIC_FAMILY_SELECT_CONTROL_ID,
   LEADERBOARD_NEXT_PAGE_CONTROL_ID,
   LEADERBOARD_PREV_PAGE_CONTROL_ID,
   LEADERBOARD_REFRESH_CONTROL_ID,
@@ -32,6 +43,28 @@ import type { ApplicationCommandData, BaseInteraction, CommandData, ExecuteRespo
 import { BaseCommand } from "../base/base-command";
 
 const DEFAULT_PAGE_SIZE = 10;
+
+const METRIC_FAMILIES_IN_OPTION_ORDER: readonly LeaderboardMetricFamily[] = [
+  LeaderboardMetricFamily.PersonalScore,
+  LeaderboardMetricFamily.Kills,
+  LeaderboardMetricFamily.Deaths,
+  LeaderboardMetricFamily.Assists,
+  LeaderboardMetricFamily.HeadshotKills,
+  LeaderboardMetricFamily.ShotsHit,
+  LeaderboardMetricFamily.ShotsFired,
+  LeaderboardMetricFamily.DamageDealt,
+  LeaderboardMetricFamily.DamageTaken,
+  LeaderboardMetricFamily.SeriesWinRate,
+  LeaderboardMetricFamily.Kda,
+  LeaderboardMetricFamily.Accuracy,
+  LeaderboardMetricFamily.DamageRatio,
+  LeaderboardMetricFamily.AvgLifeSeconds,
+  LeaderboardMetricFamily.AvgDamagePerLife,
+];
+
+const METRIC_AGGREGATIONS_IN_OPTION_ORDER: readonly LeaderboardMetricAggregation[] = [
+  LeaderboardMetricAggregation.Total,
+];
 
 const WINDOW_OPTIONS_BY_VALUE = new Map<string, LeaderboardWindow>([
   [LeaderboardWindow.OneWeek, LeaderboardWindow.OneWeek],
@@ -57,6 +90,12 @@ const METRIC_OPTIONS_BY_VALUE = new Map<string, LeaderboardMetric>([
   [LeaderboardMetric.AvgDamagePerLife, LeaderboardMetric.AvgDamagePerLife],
   [LeaderboardMetric.PersonalScore, LeaderboardMetric.PersonalScore],
 ]);
+const METRIC_FAMILY_OPTIONS_BY_VALUE = new Map<string, LeaderboardMetricFamily>(
+  METRIC_FAMILIES_IN_OPTION_ORDER.map((family) => [family, family]),
+);
+const METRIC_AGGREGATION_OPTIONS_BY_VALUE = new Map<string, LeaderboardMetricAggregation>(
+  METRIC_AGGREGATIONS_IN_OPTION_ORDER.map((aggregation) => [aggregation, aggregation]),
+);
 
 interface LeaderboardViewState {
   guildId: string;
@@ -108,26 +147,27 @@ export class LeaderboardCommand extends BaseCommand {
               ],
             },
             {
-              name: "metric",
-              description: "Metric to rank players by",
+              name: "metric_family",
+              description: "Stat family to rank players by",
               type: ApplicationCommandOptionType.String,
               required: false,
               choices: [
-                { name: "Series win rate", value: LeaderboardMetric.SeriesWinRate },
-                { name: "Kills", value: LeaderboardMetric.Kills },
-                { name: "Deaths", value: LeaderboardMetric.Deaths },
-                { name: "Assists", value: LeaderboardMetric.Assists },
-                { name: "Headshot kills", value: LeaderboardMetric.HeadshotKills },
-                { name: "Shots hit", value: LeaderboardMetric.ShotsHit },
-                { name: "Shots fired", value: LeaderboardMetric.ShotsFired },
-                { name: "KDA", value: LeaderboardMetric.Kda },
-                { name: "Accuracy", value: LeaderboardMetric.Accuracy },
-                { name: "Damage dealt", value: LeaderboardMetric.DamageDealt },
-                { name: "Damage taken", value: LeaderboardMetric.DamageTaken },
-                { name: "Damage ratio", value: LeaderboardMetric.DamageRatio },
-                { name: "Avg life time", value: LeaderboardMetric.AvgLifeSeconds },
-                { name: "Avg damage per life", value: LeaderboardMetric.AvgDamagePerLife },
-                { name: "Personal score", value: LeaderboardMetric.PersonalScore },
+                ...METRIC_FAMILIES_IN_OPTION_ORDER.map((family) => ({
+                  name: getLeaderboardMetricFamilyLabel(family),
+                  value: family,
+                })),
+              ],
+            },
+            {
+              name: "aggregation",
+              description: "How the stat is aggregated (only applies to some stat families)",
+              type: ApplicationCommandOptionType.String,
+              required: false,
+              choices: [
+                ...METRIC_AGGREGATIONS_IN_OPTION_ORDER.map((aggregation) => ({
+                  name: getLeaderboardMetricAggregationLabel(aggregation),
+                  value: aggregation,
+                })),
               ],
             },
             {
@@ -192,7 +232,15 @@ export class LeaderboardCommand extends BaseCommand {
         type: InteractionType.MessageComponent,
         data: {
           component_type: ComponentType.StringSelect,
-          custom_id: LEADERBOARD_METRIC_SELECT_CONTROL_ID,
+          custom_id: LEADERBOARD_METRIC_FAMILY_SELECT_CONTROL_ID,
+          values: [],
+        },
+      },
+      {
+        type: InteractionType.MessageComponent,
+        data: {
+          component_type: ComponentType.StringSelect,
+          custom_id: LEADERBOARD_METRIC_AGGREGATION_SELECT_CONTROL_ID,
           values: [],
         },
       },
@@ -239,8 +287,11 @@ export class LeaderboardCommand extends BaseCommand {
           case LEADERBOARD_LAST_PAGE_CONTROL_ID: {
             return this.deferUpdate(async () => this.handleLastPage(interaction));
           }
-          case LEADERBOARD_METRIC_SELECT_CONTROL_ID: {
-            return this.deferUpdate(async () => this.handleMetricSelect(interaction));
+          case LEADERBOARD_METRIC_FAMILY_SELECT_CONTROL_ID: {
+            return this.deferUpdate(async () => this.handleMetricFamilySelect(interaction));
+          }
+          case LEADERBOARD_METRIC_AGGREGATION_SELECT_CONTROL_ID: {
+            return this.deferUpdate(async () => this.handleMetricAggregationSelect(interaction));
           }
           case LEADERBOARD_WINDOW_SELECT_CONTROL_ID: {
             return this.deferUpdate(async () => this.handleWindowSelect(interaction));
@@ -274,7 +325,10 @@ export class LeaderboardCommand extends BaseCommand {
 
       const queueChannelId = this.getOptionalStringOption(options, "queue_channel") ?? null;
       const window = this.parseWindowOption(this.getOptionalStringOption(options, "window"));
-      const metric = this.parseMetricOption(this.getOptionalStringOption(options, "metric"));
+      const metric = this.resolveMetricFromFamilyAndAggregationOptions(
+        this.getOptionalStringOption(options, "metric_family"),
+        this.getOptionalStringOption(options, "aggregation"),
+      );
       const page = this.getOptionalNumberOption(options, "page") ?? 1;
       const minGamesPlayed = this.getOptionalNumberOption(options, "min_games_played");
       const locale = this.getInteractionLocale(interaction);
@@ -367,7 +421,7 @@ export class LeaderboardCommand extends BaseCommand {
     return state;
   }
 
-  private async handleMetricSelect(
+  private async handleMetricFamilySelect(
     interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
   ): Promise<void> {
     await this.executeStateInteraction(interaction, (state) => {
@@ -375,14 +429,37 @@ export class LeaderboardCommand extends BaseCommand {
         throw this.createInvalidLeaderboardControlError();
       }
 
-      const selectedMetric = this.parseMetricOption(interaction.data.values[0]);
-      if (selectedMetric == null) {
+      const selectedFamily = this.parseMetricFamilyOption(interaction.data.values[0]);
+      if (selectedFamily == null) {
         throw this.createInvalidLeaderboardControlError();
       }
 
       return {
         ...state,
-        metric: selectedMetric,
+        metric: resolveLeaderboardMetric(selectedFamily, null),
+        page: 1,
+      };
+    });
+  }
+
+  private async handleMetricAggregationSelect(
+    interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
+  ): Promise<void> {
+    await this.executeStateInteraction(interaction, (state) => {
+      if (interaction.data.component_type !== ComponentType.StringSelect) {
+        throw this.createInvalidLeaderboardControlError();
+      }
+
+      const selectedAggregation = this.parseMetricAggregationOption(interaction.data.values[0]);
+      if (selectedAggregation == null || state.metric == null) {
+        throw this.createInvalidLeaderboardControlError();
+      }
+
+      const currentFamily = getLeaderboardMetricFamily(state.metric);
+
+      return {
+        ...state,
+        metric: resolveLeaderboardMetric(currentFamily, selectedAggregation),
         page: 1,
       };
     });
@@ -687,6 +764,65 @@ export class LeaderboardCommand extends BaseCommand {
     }
 
     return parsedMetric;
+  }
+
+  private parseMetricFamilyOption(value: string | undefined): LeaderboardMetricFamily | undefined {
+    if (value == null) {
+      return undefined;
+    }
+
+    const parsedFamily = METRIC_FAMILY_OPTIONS_BY_VALUE.get(value);
+    if (parsedFamily == null) {
+      throw new EndUserError(
+        "This leaderboard message has an invalid stat family filter. Run /leaderboard show again.",
+        {
+          handled: true,
+          errorType: EndUserErrorType.WARNING,
+        },
+      );
+    }
+
+    return parsedFamily;
+  }
+
+  private parseMetricAggregationOption(value: string | undefined): LeaderboardMetricAggregation | undefined {
+    if (value == null) {
+      return undefined;
+    }
+
+    const parsedAggregation = METRIC_AGGREGATION_OPTIONS_BY_VALUE.get(value);
+    if (parsedAggregation == null) {
+      throw new EndUserError(
+        "This leaderboard message has an invalid aggregation filter. Run /leaderboard show again.",
+        {
+          handled: true,
+          errorType: EndUserErrorType.WARNING,
+        },
+      );
+    }
+
+    return parsedAggregation;
+  }
+
+  private resolveMetricFromFamilyAndAggregationOptions(
+    familyValue: string | undefined,
+    aggregationValue: string | undefined,
+  ): LeaderboardMetric | undefined {
+    const family = this.parseMetricFamilyOption(familyValue);
+    if (family == null) {
+      return undefined;
+    }
+
+    const aggregation = this.parseMetricAggregationOption(aggregationValue) ?? null;
+    const supportedAggregations = getLeaderboardFamilyAggregations(family);
+    if (aggregation != null && supportedAggregations.length > 0 && !supportedAggregations.includes(aggregation)) {
+      throw new EndUserError("This aggregation is not valid for the selected stat family.", {
+        handled: true,
+        errorType: EndUserErrorType.WARNING,
+      });
+    }
+
+    return resolveLeaderboardMetric(family, aggregation);
   }
 
   private getOptionalStringOption(

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -815,7 +815,7 @@ export class LeaderboardCommand extends BaseCommand {
 
     const aggregation = this.parseMetricAggregationOption(aggregationValue) ?? null;
     const supportedAggregations = getLeaderboardFamilyAggregations(family);
-    if (aggregation != null && supportedAggregations.length > 0 && !supportedAggregations.includes(aggregation)) {
+    if (aggregation != null && (supportedAggregations.length === 0 || !supportedAggregations.includes(aggregation))) {
       throw new EndUserError("This aggregation is not valid for the selected stat family.", {
         handled: true,
         errorType: EndUserErrorType.WARNING,

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -16,10 +16,12 @@ import {
   PermissionFlagsBits,
 } from "discord-api-types/v10";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import type {
+  LeaderboardMetricFamily} from "@guilty-spark/shared/halo/leaderboard";
 import {
+  LEADERBOARD_METRIC_FAMILIES_IN_DISPLAY_ORDER,
   LeaderboardMetric,
   LeaderboardMetricAggregation,
-  LeaderboardMetricFamily,
   LeaderboardWindow,
   getLeaderboardFamilyAggregations,
   getLeaderboardMetricAggregationLabel,
@@ -44,24 +46,6 @@ import { BaseCommand } from "../base/base-command";
 
 const DEFAULT_PAGE_SIZE = 10;
 const LEGACY_LEADERBOARD_METRIC_SELECT_CONTROL_ID = "select_leaderboard_metric";
-
-const METRIC_FAMILIES_IN_OPTION_ORDER: readonly LeaderboardMetricFamily[] = [
-  LeaderboardMetricFamily.SeriesWinRate,
-  LeaderboardMetricFamily.Kda,
-  LeaderboardMetricFamily.Accuracy,
-  LeaderboardMetricFamily.DamageRatio,
-  LeaderboardMetricFamily.AvgLifeSeconds,
-  LeaderboardMetricFamily.AvgDamagePerLife,
-  LeaderboardMetricFamily.PersonalScore,
-  LeaderboardMetricFamily.Kills,
-  LeaderboardMetricFamily.Deaths,
-  LeaderboardMetricFamily.Assists,
-  LeaderboardMetricFamily.HeadshotKills,
-  LeaderboardMetricFamily.ShotsHit,
-  LeaderboardMetricFamily.ShotsFired,
-  LeaderboardMetricFamily.DamageDealt,
-  LeaderboardMetricFamily.DamageTaken,
-];
 
 const METRIC_AGGREGATIONS_IN_OPTION_ORDER: readonly LeaderboardMetricAggregation[] = [
   LeaderboardMetricAggregation.Total,
@@ -92,7 +76,7 @@ const METRIC_OPTIONS_BY_VALUE = new Map<string, LeaderboardMetric>([
   [LeaderboardMetric.PersonalScore, LeaderboardMetric.PersonalScore],
 ]);
 const METRIC_FAMILY_OPTIONS_BY_VALUE = new Map<string, LeaderboardMetricFamily>(
-  METRIC_FAMILIES_IN_OPTION_ORDER.map((family) => [family, family]),
+  LEADERBOARD_METRIC_FAMILIES_IN_DISPLAY_ORDER.map((family) => [family, family]),
 );
 const METRIC_AGGREGATION_OPTIONS_BY_VALUE = new Map<string, LeaderboardMetricAggregation>(
   METRIC_AGGREGATIONS_IN_OPTION_ORDER.map((aggregation) => [aggregation, aggregation]),
@@ -153,7 +137,7 @@ export class LeaderboardCommand extends BaseCommand {
               type: ApplicationCommandOptionType.String,
               required: false,
               choices: [
-                ...METRIC_FAMILIES_IN_OPTION_ORDER.map((family) => ({
+                ...LEADERBOARD_METRIC_FAMILIES_IN_DISPLAY_ORDER.map((family) => ({
                   name: getLeaderboardMetricFamilyLabel(family),
                   value: family,
                 })),

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -16,9 +16,8 @@ import {
   PermissionFlagsBits,
 } from "discord-api-types/v10";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
-import type {
-  LeaderboardMetricFamily} from "@guilty-spark/shared/halo/leaderboard";
 import {
+  type LeaderboardMetricFamily,
   LEADERBOARD_METRIC_FAMILIES_IN_DISPLAY_ORDER,
   LeaderboardMetric,
   LeaderboardMetricAggregation,

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -46,6 +46,12 @@ const DEFAULT_PAGE_SIZE = 10;
 const LEGACY_LEADERBOARD_METRIC_SELECT_CONTROL_ID = "select_leaderboard_metric";
 
 const METRIC_FAMILIES_IN_OPTION_ORDER: readonly LeaderboardMetricFamily[] = [
+  LeaderboardMetricFamily.SeriesWinRate,
+  LeaderboardMetricFamily.Kda,
+  LeaderboardMetricFamily.Accuracy,
+  LeaderboardMetricFamily.DamageRatio,
+  LeaderboardMetricFamily.AvgLifeSeconds,
+  LeaderboardMetricFamily.AvgDamagePerLife,
   LeaderboardMetricFamily.PersonalScore,
   LeaderboardMetricFamily.Kills,
   LeaderboardMetricFamily.Deaths,
@@ -55,12 +61,6 @@ const METRIC_FAMILIES_IN_OPTION_ORDER: readonly LeaderboardMetricFamily[] = [
   LeaderboardMetricFamily.ShotsFired,
   LeaderboardMetricFamily.DamageDealt,
   LeaderboardMetricFamily.DamageTaken,
-  LeaderboardMetricFamily.SeriesWinRate,
-  LeaderboardMetricFamily.Kda,
-  LeaderboardMetricFamily.Accuracy,
-  LeaderboardMetricFamily.DamageRatio,
-  LeaderboardMetricFamily.AvgLifeSeconds,
-  LeaderboardMetricFamily.AvgDamagePerLife,
 ];
 
 const METRIC_AGGREGATIONS_IN_OPTION_ORDER: readonly LeaderboardMetricAggregation[] = [

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -524,6 +524,50 @@ describe("LeaderboardCommand", () => {
     );
   });
 
+  it("updates deferred reply with error when aggregation is provided for an implicit-aggregation family", async () => {
+    vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
+      name: "show",
+      options: [],
+      mappedOptions: new Map<string, string | number>([
+        ["metric_family", LeaderboardMetricFamily.Kda],
+        ["aggregation", "TOTAL"],
+      ]),
+    });
+    const updateDeferredReplyWithErrorSpy = vi
+      .spyOn(services.discordService, "updateDeferredReplyWithError")
+      .mockResolvedValue(undefined);
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard");
+
+    const interaction: APIApplicationCommandInteraction = {
+      ...fakeBaseAPIApplicationCommandInteraction,
+      type: InteractionType.ApplicationCommand,
+      guild_id: "guild-123",
+      data: {
+        id: "fake-command-id",
+        name: "leaderboard",
+        type: ApplicationCommandType.ChatInput,
+        options: [
+          {
+            type: ApplicationCommandOptionType.Subcommand,
+            name: "show",
+            options: [],
+          },
+        ],
+      },
+    };
+
+    const result = command.execute(interaction);
+    await result.jobToComplete?.();
+
+    expect(getLeaderboardSpy).not.toHaveBeenCalled();
+    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+      interaction.token,
+      expect.objectContaining({
+        endUserMessage: "This aggregation is not valid for the selected stat family.",
+      }),
+    );
+  });
+
   it("paginates from interaction state when previous button is pressed", async () => {
     const controlId = "btn_leaderboard_prev:guild-123:queue-123:3M:KILLS:2:4";
     const interaction: APIMessageComponentButtonInteraction = {

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -33,6 +33,7 @@ const INTERACTION_FIRST_PAGE = "btn_leaderboard_first";
 const INTERACTION_REFRESH = "btn_leaderboard_refresh";
 const INTERACTION_LAST_PAGE = "btn_leaderboard_last";
 const INTERACTION_METRIC_SELECT = "select_leaderboard_metric_family";
+const INTERACTION_LEGACY_METRIC_SELECT = "select_leaderboard_metric";
 const INTERACTION_WINDOW_SELECT = "select_leaderboard_window";
 
 function aStateComponentsWith(url: string): APIMessageTopLevelComponent[] {
@@ -931,6 +932,54 @@ describe("LeaderboardCommand", () => {
       guildId: "test-guild-id",
       window: LeaderboardWindow.OneMonth,
       metric: LeaderboardMetric.Kda,
+      page: 1,
+      pageSize: 10,
+      minGamesPlayed: 0,
+    });
+  });
+
+  it("switches metric from legacy metric string-select interaction and resets to page 1", async () => {
+    const stateUrl =
+      "https://guilty-spark.app/leaderboard?guildId=test-guild-id&window=1M&metric=SERIES_WIN_RATE&page=6&minGamesPlayed=0";
+    const interaction: APIMessageComponentSelectMenuInteraction = {
+      ...aWizardStringSelectWith({ customId: INTERACTION_LEGACY_METRIC_SELECT, value: LeaderboardMetric.ShotsHit }),
+      data: {
+        component_type: ComponentType.StringSelect,
+        custom_id: INTERACTION_LEGACY_METRIC_SELECT,
+        values: [LeaderboardMetric.ShotsHit],
+      },
+      message: {
+        ...aWizardStringSelectWith({ customId: INTERACTION_LEGACY_METRIC_SELECT, value: LeaderboardMetric.ShotsHit })
+          .message,
+        components: aStateComponentsWith(stateUrl),
+      },
+    };
+
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "test-guild-id",
+      queueChannelId: null,
+      window: LeaderboardWindow.OneMonth,
+      metric: LeaderboardMetric.ShotsHit,
+      minGamesPlayed: 0,
+      page: 1,
+      pageSize: 10,
+      total: 5,
+      rows: [],
+    });
+    vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      ...Preconditions.checkExists(interaction.message),
+      type: MessageType.Default,
+    });
+
+    const result = command.execute(interaction);
+
+    expect(result.response.type).toBe(InteractionResponseType.DeferredMessageUpdate);
+    await result.jobToComplete?.();
+
+    expect(getLeaderboardSpy).toHaveBeenCalledWith({
+      guildId: "test-guild-id",
+      window: LeaderboardWindow.OneMonth,
+      metric: LeaderboardMetric.ShotsHit,
       page: 1,
       pageSize: 10,
       minGamesPlayed: 0,

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -17,7 +17,7 @@ import {
   PermissionFlagsBits,
 } from "discord-api-types/v10";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
-import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
+import { LeaderboardMetric, LeaderboardMetricFamily, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
 import { installFakeServicesWith } from "../../../services/fakes/services";
 import {
@@ -32,7 +32,7 @@ const INTERACTION_NEXT_PAGE = "btn_leaderboard_next";
 const INTERACTION_FIRST_PAGE = "btn_leaderboard_first";
 const INTERACTION_REFRESH = "btn_leaderboard_refresh";
 const INTERACTION_LAST_PAGE = "btn_leaderboard_last";
-const INTERACTION_METRIC_SELECT = "select_leaderboard_metric";
+const INTERACTION_METRIC_SELECT = "select_leaderboard_metric_family";
 const INTERACTION_WINDOW_SELECT = "select_leaderboard_window";
 
 function aStateComponentsWith(url: string): APIMessageTopLevelComponent[] {
@@ -102,7 +102,7 @@ describe("LeaderboardCommand", () => {
     const mappedOptions = new Map<string, string | number>();
     mappedOptions.set("queue_channel", "queue-123");
     mappedOptions.set("window", LeaderboardWindow.OneMonth);
-    mappedOptions.set("metric", LeaderboardMetric.Kills);
+    mappedOptions.set("metric_family", LeaderboardMetricFamily.Kills);
     mappedOptions.set("page", 2);
     mappedOptions.set("min_games_played", 3);
 
@@ -249,7 +249,7 @@ describe("LeaderboardCommand", () => {
     vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
       name: "show",
       options: [],
-      mappedOptions: new Map<string, string | number>([["metric", LeaderboardMetric.Accuracy]]),
+      mappedOptions: new Map<string, string | number>([["metric_family", LeaderboardMetricFamily.Accuracy]]),
     });
     const updateDeferredReplySpy = vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
       id: "message-id",
@@ -403,7 +403,7 @@ describe("LeaderboardCommand", () => {
     const mappedOptions = new Map<string, string | number>();
     mappedOptions.set("queue_channel", "queue-123");
     mappedOptions.set("window", LeaderboardWindow.OneMonth);
-    mappedOptions.set("metric", LeaderboardMetric.Kills);
+    mappedOptions.set("metric_family", LeaderboardMetricFamily.Kills);
     mappedOptions.set("page", 2);
     mappedOptions.set("min_games_played", 3);
 
@@ -777,11 +777,11 @@ describe("LeaderboardCommand", () => {
 
   it("updates deferred reply with error when metric selection interaction payload is invalid", async () => {
     const interaction: APIMessageComponentSelectMenuInteraction = {
-      ...aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetric.Kills }),
+      ...aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetricFamily.Kills }),
       guild_id: "guild-123",
       guild: {
         ...Preconditions.checkExists(
-          aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetric.Kills }).guild,
+          aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetricFamily.Kills }).guild,
         ),
         id: "guild-123",
       },
@@ -791,7 +791,8 @@ describe("LeaderboardCommand", () => {
         values: [],
       },
       message: {
-        ...aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetric.Kills }).message,
+        ...aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetricFamily.Kills })
+          .message,
         components: aStateComponentsWith(
           "https://guilty-spark.app/leaderboard?guildId=guild-123&window=3M&metric=KILLS&page=2",
         ),
@@ -854,9 +855,9 @@ describe("LeaderboardCommand", () => {
     const stateUrl =
       "https://guilty-spark.app/leaderboard?guildId=test-guild-id&window=1M&metric=SERIES_WIN_RATE&page=6&minGamesPlayed=0";
     const interaction: APIMessageComponentSelectMenuInteraction = {
-      ...aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetric.Kda }),
+      ...aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetricFamily.Kda }),
       message: {
-        ...aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetric.Kda }).message,
+        ...aWizardStringSelectWith({ customId: INTERACTION_METRIC_SELECT, value: LeaderboardMetricFamily.Kda }).message,
         components: aStateComponentsWith(stateUrl),
       },
     };
@@ -1427,7 +1428,7 @@ describe("LeaderboardCommand", () => {
     vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
       name: "show",
       options: [],
-      mappedOptions: new Map<string, string | number>([["metric", LeaderboardMetric.DamageRatio]]),
+      mappedOptions: new Map<string, string | number>([["metric_family", LeaderboardMetricFamily.DamageRatio]]),
     });
     const updateDeferredReplySpy = vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
       id: "message-id",

--- a/api/services/leaderboard/leaderboard-message.ts
+++ b/api/services/leaderboard/leaderboard-message.ts
@@ -1,15 +1,26 @@
 import type { APIEmbed, APIMessage, APIMessageTopLevelComponent } from "discord-api-types/v10";
 import { ComponentType } from "discord-api-types/v10";
-import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
+import {
+  LeaderboardMetricAggregation,
+  LeaderboardMetricFamily,
+  LeaderboardWindow,
+  resolveLeaderboardMetric,
+} from "@guilty-spark/shared/halo/leaderboard";
+import type { LeaderboardMetric } from "@guilty-spark/shared/halo/leaderboard";
 import type { LeaderboardPostRow } from "../database/types/leaderboard_post";
-import { LEADERBOARD_METRIC_SELECT_CONTROL_ID, LEADERBOARD_WINDOW_SELECT_CONTROL_ID } from "./leaderboard-response";
+import {
+  LEADERBOARD_METRIC_AGGREGATION_SELECT_CONTROL_ID,
+  LEADERBOARD_METRIC_FAMILY_SELECT_CONTROL_ID,
+  LEADERBOARD_WINDOW_SELECT_CONTROL_ID,
+} from "./leaderboard-response";
 
 const LEADERBOARD_FOOTER_PATTERN = /^Page (\d+) of (\d+) \| Min games: (\d+) \| Total players: (\d+)$/;
 const LEGACY_LEADERBOARD_DESCRIPTION_PATTERN = /Page (\d+) of (\d+) \| Min games: (\d+) \| Total players: (\d+)/;
 const LEGACY_LEADERBOARD_SUMMARY_PATTERN = /Page: (\d+) \| Min games: (\d+) \| Total players: (\d+)/;
 
 const WINDOW_VALUES = new Set<string>(Object.values(LeaderboardWindow));
-const METRIC_VALUES = new Set<string>(Object.values(LeaderboardMetric));
+const METRIC_FAMILY_VALUES = new Set<string>(Object.values(LeaderboardMetricFamily));
+const METRIC_AGGREGATION_VALUES = new Set<string>(Object.values(LeaderboardMetricAggregation));
 
 export interface LeaderboardMessageState {
   guildId: string;
@@ -24,8 +35,12 @@ function isLeaderboardWindow(value: string): value is LeaderboardWindow {
   return WINDOW_VALUES.has(value);
 }
 
-function isLeaderboardMetric(value: string): value is LeaderboardMetric {
-  return METRIC_VALUES.has(value);
+function isLeaderboardMetricFamily(value: string): value is LeaderboardMetricFamily {
+  return METRIC_FAMILY_VALUES.has(value);
+}
+
+function isLeaderboardMetricAggregation(value: string): value is LeaderboardMetricAggregation {
+  return METRIC_AGGREGATION_VALUES.has(value);
 }
 
 function getSelectedValue(components: APIMessageTopLevelComponent[], prefix: string): string | null {
@@ -57,12 +72,21 @@ function getSelectedWindow(components: APIMessageTopLevelComponent[]): Leaderboa
 }
 
 function getSelectedMetric(components: APIMessageTopLevelComponent[]): LeaderboardMetric | null {
-  const value = getSelectedValue(components, LEADERBOARD_METRIC_SELECT_CONTROL_ID);
-  if (value == null || !isLeaderboardMetric(value)) {
+  const familyValue = getSelectedValue(components, LEADERBOARD_METRIC_FAMILY_SELECT_CONTROL_ID);
+  if (familyValue == null || !isLeaderboardMetricFamily(familyValue)) {
     return null;
   }
 
-  return value;
+  const aggregationValue = getSelectedValue(components, LEADERBOARD_METRIC_AGGREGATION_SELECT_CONTROL_ID);
+  if (aggregationValue != null && !isLeaderboardMetricAggregation(aggregationValue)) {
+    return null;
+  }
+
+  try {
+    return resolveLeaderboardMetric(familyValue, aggregationValue ?? null);
+  } catch {
+    return null;
+  }
 }
 
 function parsePageAndMinGames(text: string): { page: number; minGamesPlayed: number } | null {

--- a/api/services/leaderboard/leaderboard-message.ts
+++ b/api/services/leaderboard/leaderboard-message.ts
@@ -1,12 +1,12 @@
 import type { APIEmbed, APIMessage, APIMessageTopLevelComponent } from "discord-api-types/v10";
 import { ComponentType } from "discord-api-types/v10";
 import {
+  LeaderboardMetric,
   LeaderboardMetricAggregation,
   LeaderboardMetricFamily,
   LeaderboardWindow,
   resolveLeaderboardMetric,
 } from "@guilty-spark/shared/halo/leaderboard";
-import type { LeaderboardMetric } from "@guilty-spark/shared/halo/leaderboard";
 import type { LeaderboardPostRow } from "../database/types/leaderboard_post";
 import {
   LEADERBOARD_METRIC_AGGREGATION_SELECT_CONTROL_ID,
@@ -17,8 +17,10 @@ import {
 const LEADERBOARD_FOOTER_PATTERN = /^Page (\d+) of (\d+) \| Min games: (\d+) \| Total players: (\d+)$/;
 const LEGACY_LEADERBOARD_DESCRIPTION_PATTERN = /Page (\d+) of (\d+) \| Min games: (\d+) \| Total players: (\d+)/;
 const LEGACY_LEADERBOARD_SUMMARY_PATTERN = /Page: (\d+) \| Min games: (\d+) \| Total players: (\d+)/;
+const LEGACY_LEADERBOARD_METRIC_SELECT_CONTROL_ID = "select_leaderboard_metric";
 
 const WINDOW_VALUES = new Set<string>(Object.values(LeaderboardWindow));
+const METRIC_VALUES = new Set<string>(Object.values(LeaderboardMetric));
 const METRIC_FAMILY_VALUES = new Set<string>(Object.values(LeaderboardMetricFamily));
 const METRIC_AGGREGATION_VALUES = new Set<string>(Object.values(LeaderboardMetricAggregation));
 
@@ -37,6 +39,10 @@ function isLeaderboardWindow(value: string): value is LeaderboardWindow {
 
 function isLeaderboardMetricFamily(value: string): value is LeaderboardMetricFamily {
   return METRIC_FAMILY_VALUES.has(value);
+}
+
+function isLeaderboardMetric(value: string): value is LeaderboardMetric {
+  return METRIC_VALUES.has(value);
 }
 
 function isLeaderboardMetricAggregation(value: string): value is LeaderboardMetricAggregation {
@@ -73,20 +79,29 @@ function getSelectedWindow(components: APIMessageTopLevelComponent[]): Leaderboa
 
 function getSelectedMetric(components: APIMessageTopLevelComponent[]): LeaderboardMetric | null {
   const familyValue = getSelectedValue(components, LEADERBOARD_METRIC_FAMILY_SELECT_CONTROL_ID);
-  if (familyValue == null || !isLeaderboardMetricFamily(familyValue)) {
+  if (familyValue != null) {
+    if (!isLeaderboardMetricFamily(familyValue)) {
+      return null;
+    }
+
+    const aggregationValue = getSelectedValue(components, LEADERBOARD_METRIC_AGGREGATION_SELECT_CONTROL_ID);
+    if (aggregationValue != null && !isLeaderboardMetricAggregation(aggregationValue)) {
+      return null;
+    }
+
+    try {
+      return resolveLeaderboardMetric(familyValue, aggregationValue ?? null);
+    } catch {
+      return null;
+    }
+  }
+
+  const legacyMetricValue = getSelectedValue(components, LEGACY_LEADERBOARD_METRIC_SELECT_CONTROL_ID);
+  if (legacyMetricValue == null || !isLeaderboardMetric(legacyMetricValue)) {
     return null;
   }
 
-  const aggregationValue = getSelectedValue(components, LEADERBOARD_METRIC_AGGREGATION_SELECT_CONTROL_ID);
-  if (aggregationValue != null && !isLeaderboardMetricAggregation(aggregationValue)) {
-    return null;
-  }
-
-  try {
-    return resolveLeaderboardMetric(familyValue, aggregationValue ?? null);
-  } catch {
-    return null;
-  }
+  return legacyMetricValue;
 }
 
 function parsePageAndMinGames(text: string): { page: number; minGamesPlayed: number } | null {

--- a/api/services/leaderboard/leaderboard-response.ts
+++ b/api/services/leaderboard/leaderboard-response.ts
@@ -9,6 +9,8 @@ import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import type { LeaderboardResponse } from "@guilty-spark/shared/contracts/stats/leaderboard";
 import {
   LEADERBOARD_METRIC_FAMILIES_IN_DISPLAY_ORDER,
+  type LeaderboardMetricAggregation,
+  type LeaderboardMetricFamily,
   LeaderboardMetric,
   LeaderboardWindow,
   getDefaultLeaderboardAggregation,
@@ -17,8 +19,6 @@ import {
   getLeaderboardMetricFamily,
   getLeaderboardMetricFamilyLabel,
 } from "@guilty-spark/shared/halo/leaderboard";
-import type { LeaderboardMetricAggregation ,
-  LeaderboardMetricFamily} from "@guilty-spark/shared/halo/leaderboard";
 import { EmbedColors } from "../../embeds/colors";
 
 const MAX_ROWS_IN_DISCORD_EMBED = 10;

--- a/api/services/leaderboard/leaderboard-response.ts
+++ b/api/services/leaderboard/leaderboard-response.ts
@@ -8,8 +8,8 @@ import { ButtonStyle, ComponentType } from "discord-api-types/v10";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import type { LeaderboardResponse } from "@guilty-spark/shared/contracts/stats/leaderboard";
 import {
+  LEADERBOARD_METRIC_FAMILIES_IN_DISPLAY_ORDER,
   LeaderboardMetric,
-  LeaderboardMetricFamily,
   LeaderboardWindow,
   getDefaultLeaderboardAggregation,
   getLeaderboardFamilyAggregations,
@@ -17,7 +17,8 @@ import {
   getLeaderboardMetricFamily,
   getLeaderboardMetricFamilyLabel,
 } from "@guilty-spark/shared/halo/leaderboard";
-import type { LeaderboardMetricAggregation } from "@guilty-spark/shared/halo/leaderboard";
+import type { LeaderboardMetricAggregation ,
+  LeaderboardMetricFamily} from "@guilty-spark/shared/halo/leaderboard";
 import { EmbedColors } from "../../embeds/colors";
 
 const MAX_ROWS_IN_DISCORD_EMBED = 10;
@@ -61,26 +62,8 @@ function formatRank(rank: number): string {
   }
 }
 
-const METRIC_FAMILIES_IN_DISPLAY_ORDER: readonly LeaderboardMetricFamily[] = [
-  LeaderboardMetricFamily.SeriesWinRate,
-  LeaderboardMetricFamily.Kda,
-  LeaderboardMetricFamily.Accuracy,
-  LeaderboardMetricFamily.DamageRatio,
-  LeaderboardMetricFamily.AvgLifeSeconds,
-  LeaderboardMetricFamily.AvgDamagePerLife,
-  LeaderboardMetricFamily.PersonalScore,
-  LeaderboardMetricFamily.Kills,
-  LeaderboardMetricFamily.Deaths,
-  LeaderboardMetricFamily.Assists,
-  LeaderboardMetricFamily.HeadshotKills,
-  LeaderboardMetricFamily.ShotsHit,
-  LeaderboardMetricFamily.ShotsFired,
-  LeaderboardMetricFamily.DamageDealt,
-  LeaderboardMetricFamily.DamageTaken,
-];
-
 function getMetricFamilySelectOptions(selectedFamily: LeaderboardMetricFamily): APISelectMenuOption[] {
-  return METRIC_FAMILIES_IN_DISPLAY_ORDER.map((family) => ({
+  return LEADERBOARD_METRIC_FAMILIES_IN_DISPLAY_ORDER.map((family) => ({
     label: getLeaderboardMetricFamilyLabel(family),
     value: family,
     default: family === selectedFamily,

--- a/api/services/leaderboard/leaderboard-response.ts
+++ b/api/services/leaderboard/leaderboard-response.ts
@@ -7,18 +7,28 @@ import type {
 import { ButtonStyle, ComponentType } from "discord-api-types/v10";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
 import type { LeaderboardResponse } from "@guilty-spark/shared/contracts/stats/leaderboard";
-import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
+import {
+  LeaderboardMetric,
+  LeaderboardMetricFamily,
+  LeaderboardWindow,
+  getDefaultLeaderboardAggregation,
+  getLeaderboardFamilyAggregations,
+  getLeaderboardMetricAggregationLabel,
+  getLeaderboardMetricFamily,
+  getLeaderboardMetricFamilyLabel,
+} from "@guilty-spark/shared/halo/leaderboard";
+import type { LeaderboardMetricAggregation } from "@guilty-spark/shared/halo/leaderboard";
 import { EmbedColors } from "../../embeds/colors";
 
 const MAX_ROWS_IN_DISCORD_EMBED = 10;
-const METRIC_SELECT_LIMIT = 25;
 
 export const LEADERBOARD_FIRST_PAGE_CONTROL_ID = "btn_leaderboard_first";
 export const LEADERBOARD_PREV_PAGE_CONTROL_ID = "btn_leaderboard_prev";
 export const LEADERBOARD_REFRESH_CONTROL_ID = "btn_leaderboard_refresh";
 export const LEADERBOARD_NEXT_PAGE_CONTROL_ID = "btn_leaderboard_next";
 export const LEADERBOARD_LAST_PAGE_CONTROL_ID = "btn_leaderboard_last";
-export const LEADERBOARD_METRIC_SELECT_CONTROL_ID = "select_leaderboard_metric";
+export const LEADERBOARD_METRIC_FAMILY_SELECT_CONTROL_ID = "select_leaderboard_metric_family";
+export const LEADERBOARD_METRIC_AGGREGATION_SELECT_CONTROL_ID = "select_leaderboard_metric_aggregation";
 export const LEADERBOARD_WINDOW_SELECT_CONTROL_ID = "select_leaderboard_window";
 
 function createLeaderboardControlId(controlId: string, leaderboard: LeaderboardResponse): string {
@@ -51,28 +61,42 @@ function formatRank(rank: number): string {
   }
 }
 
-function getMetricSelectOptions(selectedMetric: LeaderboardMetric): APISelectMenuOption[] {
-  const metricOptions = [
-    { label: "Series win rate", value: LeaderboardMetric.SeriesWinRate },
-    { label: "Kills", value: LeaderboardMetric.Kills },
-    { label: "Deaths", value: LeaderboardMetric.Deaths },
-    { label: "Assists", value: LeaderboardMetric.Assists },
-    { label: "Headshot kills", value: LeaderboardMetric.HeadshotKills },
-    { label: "Shots hit", value: LeaderboardMetric.ShotsHit },
-    { label: "Shots fired", value: LeaderboardMetric.ShotsFired },
-    { label: "KDA", value: LeaderboardMetric.Kda },
-    { label: "Accuracy", value: LeaderboardMetric.Accuracy },
-    { label: "Damage dealt", value: LeaderboardMetric.DamageDealt },
-    { label: "Damage taken", value: LeaderboardMetric.DamageTaken },
-    { label: "Damage ratio", value: LeaderboardMetric.DamageRatio },
-    { label: "Avg life time", value: LeaderboardMetric.AvgLifeSeconds },
-    { label: "Avg damage per life", value: LeaderboardMetric.AvgDamagePerLife },
-    { label: "Personal score", value: LeaderboardMetric.PersonalScore },
-  ];
+const METRIC_FAMILIES_IN_DISPLAY_ORDER: readonly LeaderboardMetricFamily[] = [
+  LeaderboardMetricFamily.PersonalScore,
+  LeaderboardMetricFamily.Kills,
+  LeaderboardMetricFamily.Deaths,
+  LeaderboardMetricFamily.Assists,
+  LeaderboardMetricFamily.HeadshotKills,
+  LeaderboardMetricFamily.ShotsHit,
+  LeaderboardMetricFamily.ShotsFired,
+  LeaderboardMetricFamily.DamageDealt,
+  LeaderboardMetricFamily.DamageTaken,
+  LeaderboardMetricFamily.SeriesWinRate,
+  LeaderboardMetricFamily.Kda,
+  LeaderboardMetricFamily.Accuracy,
+  LeaderboardMetricFamily.DamageRatio,
+  LeaderboardMetricFamily.AvgLifeSeconds,
+  LeaderboardMetricFamily.AvgDamagePerLife,
+];
 
-  return metricOptions.slice(0, METRIC_SELECT_LIMIT).map((option) => ({
-    ...option,
-    default: option.value === selectedMetric,
+function getMetricFamilySelectOptions(selectedFamily: LeaderboardMetricFamily): APISelectMenuOption[] {
+  return METRIC_FAMILIES_IN_DISPLAY_ORDER.map((family) => ({
+    label: getLeaderboardMetricFamilyLabel(family),
+    value: family,
+    default: family === selectedFamily,
+  }));
+}
+
+function getMetricAggregationSelectOptions(
+  family: LeaderboardMetricFamily,
+  selectedAggregation: LeaderboardMetricAggregation | null,
+): APISelectMenuOption[] {
+  const resolvedSelectedAggregation = selectedAggregation ?? getDefaultLeaderboardAggregation(family);
+
+  return getLeaderboardFamilyAggregations(family).map((aggregation) => ({
+    label: getLeaderboardMetricAggregationLabel(aggregation),
+    value: aggregation,
+    default: aggregation === resolvedSelectedAggregation,
   }));
 }
 
@@ -251,7 +275,9 @@ function createRankingFields(
 
 function createComponents(leaderboard: LeaderboardResponse): APIMessageTopLevelComponent[] {
   const totalPages = Math.max(1, Math.ceil(leaderboard.total / leaderboard.pageSize));
-  const metricOptions = getMetricSelectOptions(leaderboard.metric);
+  const selectedFamily = getLeaderboardMetricFamily(leaderboard.metric);
+  const familyOptions = getMetricFamilySelectOptions(selectedFamily);
+  const aggregationOptions = getMetricAggregationSelectOptions(selectedFamily, null);
   const windowOptions = getWindowSelectOptions(leaderboard.window);
   const controls = [
     [LEADERBOARD_FIRST_PAGE_CONTROL_ID, "⏮️", leaderboard.page <= 1],
@@ -261,7 +287,7 @@ function createComponents(leaderboard: LeaderboardResponse): APIMessageTopLevelC
     [LEADERBOARD_LAST_PAGE_CONTROL_ID, "⏭️", leaderboard.page >= totalPages],
   ] as const;
 
-  return [
+  const rows: APIMessageTopLevelComponent[] = [
     {
       type: ComponentType.ActionRow,
       components: controls.map(([controlId, emoji, disabled]) => ({
@@ -277,28 +303,47 @@ function createComponents(leaderboard: LeaderboardResponse): APIMessageTopLevelC
       components: [
         {
           type: ComponentType.StringSelect,
-          custom_id: createLeaderboardControlId(LEADERBOARD_METRIC_SELECT_CONTROL_ID, leaderboard),
-          placeholder: "Select metric",
+          custom_id: createLeaderboardControlId(LEADERBOARD_METRIC_FAMILY_SELECT_CONTROL_ID, leaderboard),
+          placeholder: "Select stat",
           min_values: 1,
           max_values: 1,
-          options: metricOptions,
-        },
-      ],
-    },
-    {
-      type: ComponentType.ActionRow,
-      components: [
-        {
-          type: ComponentType.StringSelect,
-          custom_id: createLeaderboardControlId(LEADERBOARD_WINDOW_SELECT_CONTROL_ID, leaderboard),
-          placeholder: "Select window",
-          min_values: 1,
-          max_values: 1,
-          options: windowOptions,
+          options: familyOptions,
         },
       ],
     },
   ];
+
+  if (aggregationOptions.length > 0) {
+    rows.push({
+      type: ComponentType.ActionRow,
+      components: [
+        {
+          type: ComponentType.StringSelect,
+          custom_id: createLeaderboardControlId(LEADERBOARD_METRIC_AGGREGATION_SELECT_CONTROL_ID, leaderboard),
+          placeholder: "Select aggregation",
+          min_values: 1,
+          max_values: 1,
+          options: aggregationOptions,
+        },
+      ],
+    });
+  }
+
+  rows.push({
+    type: ComponentType.ActionRow,
+    components: [
+      {
+        type: ComponentType.StringSelect,
+        custom_id: createLeaderboardControlId(LEADERBOARD_WINDOW_SELECT_CONTROL_ID, leaderboard),
+        placeholder: "Select window",
+        min_values: 1,
+        max_values: 1,
+        options: windowOptions,
+      },
+    ],
+  });
+
+  return rows;
 }
 
 export function createLeaderboardResponse(

--- a/api/services/leaderboard/leaderboard-response.ts
+++ b/api/services/leaderboard/leaderboard-response.ts
@@ -62,6 +62,12 @@ function formatRank(rank: number): string {
 }
 
 const METRIC_FAMILIES_IN_DISPLAY_ORDER: readonly LeaderboardMetricFamily[] = [
+  LeaderboardMetricFamily.SeriesWinRate,
+  LeaderboardMetricFamily.Kda,
+  LeaderboardMetricFamily.Accuracy,
+  LeaderboardMetricFamily.DamageRatio,
+  LeaderboardMetricFamily.AvgLifeSeconds,
+  LeaderboardMetricFamily.AvgDamagePerLife,
   LeaderboardMetricFamily.PersonalScore,
   LeaderboardMetricFamily.Kills,
   LeaderboardMetricFamily.Deaths,
@@ -71,12 +77,6 @@ const METRIC_FAMILIES_IN_DISPLAY_ORDER: readonly LeaderboardMetricFamily[] = [
   LeaderboardMetricFamily.ShotsFired,
   LeaderboardMetricFamily.DamageDealt,
   LeaderboardMetricFamily.DamageTaken,
-  LeaderboardMetricFamily.SeriesWinRate,
-  LeaderboardMetricFamily.Kda,
-  LeaderboardMetricFamily.Accuracy,
-  LeaderboardMetricFamily.DamageRatio,
-  LeaderboardMetricFamily.AvgLifeSeconds,
-  LeaderboardMetricFamily.AvgDamagePerLife,
 ];
 
 function getMetricFamilySelectOptions(selectedFamily: LeaderboardMetricFamily): APISelectMenuOption[] {

--- a/api/services/leaderboard/tests/leaderboard-message.test.ts
+++ b/api/services/leaderboard/tests/leaderboard-message.test.ts
@@ -17,10 +17,12 @@ function aLeaderboardMessageWith({
   metric = LeaderboardMetric.Kills,
   window = LeaderboardWindow.ThreeMonths,
   footer = "Page 2 of 4 | Min games: 5 | Total players: 32",
+  useLegacyMetricSelect = false,
 }: {
   metric?: LeaderboardMetric;
   window?: LeaderboardWindow;
   footer?: string;
+  useLegacyMetricSelect?: boolean;
 } = {}): APIMessage {
   const family = getLeaderboardMetricFamily(metric);
   const defaultAggregation = getDefaultLeaderboardAggregation(family);
@@ -30,14 +32,22 @@ function aLeaderboardMessageWith({
       components: [
         {
           type: ComponentType.StringSelect,
-          custom_id: "select_leaderboard_metric_family:state",
+          custom_id: useLegacyMetricSelect
+            ? "select_leaderboard_metric:state"
+            : "select_leaderboard_metric_family:state",
           min_values: 1,
           max_values: 1,
-          options: [{ label: getLeaderboardMetricFamilyLabel(family), value: family, default: true }],
+          options: [
+            {
+              label: useLegacyMetricSelect ? "Kills" : getLeaderboardMetricFamilyLabel(family),
+              value: useLegacyMetricSelect ? metric : family,
+              default: true,
+            },
+          ],
         },
       ],
     },
-    ...(defaultAggregation != null
+    ...(!useLegacyMetricSelect && defaultAggregation != null
       ? [
           {
             type: ComponentType.ActionRow as const,
@@ -100,6 +110,26 @@ describe("getLeaderboardMessageState", () => {
       queueChannelId: "queue-123",
       window: LeaderboardWindow.SixMonths,
       metric: LeaderboardMetric.DamageRatio,
+      page: 2,
+      minGamesPlayed: 5,
+    });
+  });
+
+  it("derives metric from legacy metric selector controls", () => {
+    const post = aFakeLeaderboardPostRow({ GuildId: "guild-123", QueueChannelId: "queue-123" });
+    const message = aLeaderboardMessageWith({
+      metric: LeaderboardMetric.HeadshotKills,
+      window: LeaderboardWindow.OneMonth,
+      useLegacyMetricSelect: true,
+    });
+
+    const state = getLeaderboardMessageState(message, post);
+
+    expect(state).toEqual({
+      guildId: "guild-123",
+      queueChannelId: "queue-123",
+      window: LeaderboardWindow.OneMonth,
+      metric: LeaderboardMetric.HeadshotKills,
       page: 2,
       minGamesPlayed: 5,
     });

--- a/api/services/leaderboard/tests/leaderboard-message.test.ts
+++ b/api/services/leaderboard/tests/leaderboard-message.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { APIMessage, APIMessageTopLevelComponent } from "discord-api-types/v10";
 import { ComponentType } from "discord-api-types/v10";
-import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
+import {
+  LeaderboardMetric,
+  LeaderboardWindow,
+  getDefaultLeaderboardAggregation,
+  getLeaderboardMetricAggregationLabel,
+  getLeaderboardMetricFamily,
+  getLeaderboardMetricFamilyLabel,
+} from "@guilty-spark/shared/halo/leaderboard";
 import { aFakeLeaderboardPostRow } from "../../database/fakes/database.fake";
 import { fakeButtonClickInteraction } from "../../discord/fakes/data";
 import { getLeaderboardMessageState } from "../leaderboard-message";
@@ -15,19 +22,43 @@ function aLeaderboardMessageWith({
   window?: LeaderboardWindow;
   footer?: string;
 } = {}): APIMessage {
+  const family = getLeaderboardMetricFamily(metric);
+  const defaultAggregation = getDefaultLeaderboardAggregation(family);
   const components: APIMessageTopLevelComponent[] = [
     {
       type: ComponentType.ActionRow,
       components: [
         {
           type: ComponentType.StringSelect,
-          custom_id: "select_leaderboard_metric:state",
+          custom_id: "select_leaderboard_metric_family:state",
           min_values: 1,
           max_values: 1,
-          options: [{ label: "Kills", value: metric, default: true }],
+          options: [{ label: getLeaderboardMetricFamilyLabel(family), value: family, default: true }],
         },
       ],
     },
+    ...(defaultAggregation != null
+      ? [
+          {
+            type: ComponentType.ActionRow as const,
+            components: [
+              {
+                type: ComponentType.StringSelect as const,
+                custom_id: "select_leaderboard_metric_aggregation:state",
+                min_values: 1,
+                max_values: 1,
+                options: [
+                  {
+                    label: getLeaderboardMetricAggregationLabel(defaultAggregation),
+                    value: defaultAggregation,
+                    default: true,
+                  },
+                ],
+              },
+            ],
+          },
+        ]
+      : []),
     {
       type: ComponentType.ActionRow,
       components: [

--- a/api/services/leaderboard/tests/leaderboard-response.test.ts
+++ b/api/services/leaderboard/tests/leaderboard-response.test.ts
@@ -45,7 +45,7 @@ describe("createLeaderboardResponse", () => {
         footer: { text: "Page 2 of 3 | Min games: 3 | Total players: 23" },
       },
     ]);
-    expect(response.components).toHaveLength(3);
+    expect(response.components).toHaveLength(4);
   });
 
   it("formats newly added metrics and includes them in metric select options", () => {

--- a/api/services/leaderboard/tests/leaderboard-response.test.ts
+++ b/api/services/leaderboard/tests/leaderboard-response.test.ts
@@ -186,4 +186,44 @@ describe("createLeaderboardResponse", () => {
       inline: true,
     });
   });
+
+  it("omits aggregation selector for metrics with implicit aggregation", () => {
+    const leaderboard: LeaderboardResponse = {
+      guildId: "guild-123",
+      queueChannelId: "queue-123",
+      window: LeaderboardWindow.OneMonth,
+      metric: LeaderboardMetric.Kda,
+      minGamesPlayed: 3,
+      page: 1,
+      pageSize: 10,
+      total: 1,
+      rows: [
+        {
+          rank: 1,
+          xboxXuid: "xuid-1",
+          discordUserId: "discord-1",
+          gamertag: "Alpha",
+          seriesPlayed: 3,
+          seriesWins: 2,
+          gamesPlayed: 9,
+          metricValue: 1.44,
+        },
+      ],
+    };
+
+    const response = createLeaderboardResponse("en-US", leaderboard, "<t:1733483139:R>");
+    expect(response.components).toHaveLength(3);
+    const windowSelectRow = response.components?.[2];
+    expect(windowSelectRow?.type).toBe(ComponentType.ActionRow);
+    if (windowSelectRow?.type !== ComponentType.ActionRow) {
+      throw new Error("Expected window select row to be an action row");
+    }
+
+    const [windowSelect] = windowSelectRow.components;
+    expect(windowSelect?.type).toBe(ComponentType.StringSelect);
+    if (windowSelect?.type !== ComponentType.StringSelect) {
+      throw new Error("Expected window select control to be a string select");
+    }
+    expect(windowSelect.placeholder).toBe("Select window");
+  });
 });

--- a/api/services/leaderboard/tests/leaderboard-response.test.ts
+++ b/api/services/leaderboard/tests/leaderboard-response.test.ts
@@ -147,6 +147,14 @@ describe("createLeaderboardResponse", () => {
     }
 
     const optionLabels = metricSelect.options.map((option) => option.label);
+    expect(optionLabels.slice(0, 6)).toEqual([
+      "Series win rate",
+      "KDA",
+      "Accuracy",
+      "Damage ratio",
+      "Avg life time",
+      "Avg damage per life",
+    ]);
     expect(optionLabels).toContain("Headshot kills");
     expect(optionLabels).toContain("Shots hit");
     expect(optionLabels).toContain("Shots fired");

--- a/api/services/leaderboard/tests/leaderboard.test.ts
+++ b/api/services/leaderboard/tests/leaderboard.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { APIMessage, APIMessageTopLevelComponent } from "discord-api-types/v10";
 import { ComponentType, Locale } from "discord-api-types/v10";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
-import { LeaderboardMetric, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
+import { LeaderboardMetric, LeaderboardMetricFamily, LeaderboardWindow } from "@guilty-spark/shared/halo/leaderboard";
 import type { LeaderboardRankingRow } from "../../database/types/leaderboard_ranking_row";
 import {
   aFakeDatabaseServiceWith,
@@ -30,10 +30,10 @@ function aLeaderboardMessageWith({
       components: [
         {
           type: ComponentType.StringSelect,
-          custom_id: "select_leaderboard_metric:guild-1:queue-1:3M:KILLS:2:3",
+          custom_id: "select_leaderboard_metric_family:guild-1:queue-1:3M:KILLS:2:3",
           min_values: 1,
           max_values: 1,
-          options: [{ label: "Kills", value: LeaderboardMetric.Kills, default: true }],
+          options: [{ label: "Kills", value: LeaderboardMetricFamily.Kills, default: true }],
         },
       ],
     },

--- a/shared/src/halo/leaderboard.ts
+++ b/shared/src/halo/leaderboard.ts
@@ -50,6 +50,24 @@ export enum LeaderboardMetricFamily {
   AvgDamagePerLife = "AVG_DAMAGE_PER_LIFE",
 }
 
+export const LEADERBOARD_METRIC_FAMILIES_IN_DISPLAY_ORDER: readonly LeaderboardMetricFamily[] = [
+  LeaderboardMetricFamily.SeriesWinRate,
+  LeaderboardMetricFamily.Kda,
+  LeaderboardMetricFamily.Accuracy,
+  LeaderboardMetricFamily.DamageRatio,
+  LeaderboardMetricFamily.AvgLifeSeconds,
+  LeaderboardMetricFamily.AvgDamagePerLife,
+  LeaderboardMetricFamily.PersonalScore,
+  LeaderboardMetricFamily.Kills,
+  LeaderboardMetricFamily.Deaths,
+  LeaderboardMetricFamily.Assists,
+  LeaderboardMetricFamily.HeadshotKills,
+  LeaderboardMetricFamily.ShotsHit,
+  LeaderboardMetricFamily.ShotsFired,
+  LeaderboardMetricFamily.DamageDealt,
+  LeaderboardMetricFamily.DamageTaken,
+];
+
 export enum LeaderboardMetricAggregation {
   Total = "TOTAL",
 }

--- a/shared/src/halo/leaderboard.ts
+++ b/shared/src/halo/leaderboard.ts
@@ -28,9 +28,9 @@ export enum LeaderboardMetric {
 
 /**
  * Stat family groups leaderboard metrics for the two-step Discord picker (family -> aggregation).
- * Every `LeaderboardMetric` belongs to exactly one family; families with more than one valid
- * aggregation (e.g. total vs. average per series) will expose an aggregation selector once those
- * variants exist.
+ * Every `LeaderboardMetric` belongs to exactly one family; families with one or more valid
+ * aggregations expose the aggregation selector, while families with no valid aggregations are
+ * treated as having an implicit aggregation and skip that selector.
  */
 export enum LeaderboardMetricFamily {
   PersonalScore = "PERSONAL_SCORE",

--- a/shared/src/halo/leaderboard.ts
+++ b/shared/src/halo/leaderboard.ts
@@ -1,3 +1,5 @@
+import { UnreachableError } from "../base/unreachable-error";
+
 export enum LeaderboardWindow {
   OneWeek = "1W",
   OneMonth = "1M",
@@ -22,4 +24,256 @@ export enum LeaderboardMetric {
   AvgLifeSeconds = "AVG_LIFE_SECONDS",
   AvgDamagePerLife = "AVG_DAMAGE_PER_LIFE",
   PersonalScore = "PERSONAL_SCORE",
+}
+
+/**
+ * Stat family groups leaderboard metrics for the two-step Discord picker (family -> aggregation).
+ * Every `LeaderboardMetric` belongs to exactly one family; families with more than one valid
+ * aggregation (e.g. total vs. average per series) will expose an aggregation selector once those
+ * variants exist.
+ */
+export enum LeaderboardMetricFamily {
+  PersonalScore = "PERSONAL_SCORE",
+  Kills = "KILLS",
+  Deaths = "DEATHS",
+  Assists = "ASSISTS",
+  HeadshotKills = "HEADSHOT_KILLS",
+  ShotsHit = "SHOTS_HIT",
+  ShotsFired = "SHOTS_FIRED",
+  DamageDealt = "DAMAGE_DEALT",
+  DamageTaken = "DAMAGE_TAKEN",
+  SeriesWinRate = "SERIES_WIN_RATE",
+  Kda = "KDA",
+  Accuracy = "ACCURACY",
+  DamageRatio = "DAMAGE_RATIO",
+  AvgLifeSeconds = "AVG_LIFE_SECONDS",
+  AvgDamagePerLife = "AVG_DAMAGE_PER_LIFE",
+}
+
+export enum LeaderboardMetricAggregation {
+  Total = "TOTAL",
+}
+
+export function getLeaderboardMetricFamily(metric: LeaderboardMetric): LeaderboardMetricFamily {
+  switch (metric) {
+    case LeaderboardMetric.PersonalScore: {
+      return LeaderboardMetricFamily.PersonalScore;
+    }
+    case LeaderboardMetric.Kills: {
+      return LeaderboardMetricFamily.Kills;
+    }
+    case LeaderboardMetric.Deaths: {
+      return LeaderboardMetricFamily.Deaths;
+    }
+    case LeaderboardMetric.Assists: {
+      return LeaderboardMetricFamily.Assists;
+    }
+    case LeaderboardMetric.HeadshotKills: {
+      return LeaderboardMetricFamily.HeadshotKills;
+    }
+    case LeaderboardMetric.ShotsHit: {
+      return LeaderboardMetricFamily.ShotsHit;
+    }
+    case LeaderboardMetric.ShotsFired: {
+      return LeaderboardMetricFamily.ShotsFired;
+    }
+    case LeaderboardMetric.DamageDealt: {
+      return LeaderboardMetricFamily.DamageDealt;
+    }
+    case LeaderboardMetric.DamageTaken: {
+      return LeaderboardMetricFamily.DamageTaken;
+    }
+    case LeaderboardMetric.SeriesWinRate: {
+      return LeaderboardMetricFamily.SeriesWinRate;
+    }
+    case LeaderboardMetric.Kda: {
+      return LeaderboardMetricFamily.Kda;
+    }
+    case LeaderboardMetric.Accuracy: {
+      return LeaderboardMetricFamily.Accuracy;
+    }
+    case LeaderboardMetric.DamageRatio: {
+      return LeaderboardMetricFamily.DamageRatio;
+    }
+    case LeaderboardMetric.AvgLifeSeconds: {
+      return LeaderboardMetricFamily.AvgLifeSeconds;
+    }
+    case LeaderboardMetric.AvgDamagePerLife: {
+      return LeaderboardMetricFamily.AvgDamagePerLife;
+    }
+    default: {
+      throw new UnreachableError(metric);
+    }
+  }
+}
+
+/**
+ * Valid aggregations for a family, in preferred/default order. An empty array means the family
+ * has a single implicit form (rate/ratio/lifetime metrics) and should not show an aggregation selector.
+ */
+export function getLeaderboardFamilyAggregations(
+  family: LeaderboardMetricFamily,
+): readonly LeaderboardMetricAggregation[] {
+  switch (family) {
+    case LeaderboardMetricFamily.PersonalScore:
+    case LeaderboardMetricFamily.Kills:
+    case LeaderboardMetricFamily.Deaths:
+    case LeaderboardMetricFamily.Assists:
+    case LeaderboardMetricFamily.HeadshotKills:
+    case LeaderboardMetricFamily.ShotsHit:
+    case LeaderboardMetricFamily.ShotsFired:
+    case LeaderboardMetricFamily.DamageDealt:
+    case LeaderboardMetricFamily.DamageTaken: {
+      return [LeaderboardMetricAggregation.Total];
+    }
+    case LeaderboardMetricFamily.SeriesWinRate:
+    case LeaderboardMetricFamily.Kda:
+    case LeaderboardMetricFamily.Accuracy:
+    case LeaderboardMetricFamily.DamageRatio:
+    case LeaderboardMetricFamily.AvgLifeSeconds:
+    case LeaderboardMetricFamily.AvgDamagePerLife: {
+      return [];
+    }
+    default: {
+      throw new UnreachableError(family);
+    }
+  }
+}
+
+export function getDefaultLeaderboardAggregation(family: LeaderboardMetricFamily): LeaderboardMetricAggregation | null {
+  return getLeaderboardFamilyAggregations(family)[0] ?? null;
+}
+
+/**
+ * Resolves a (family, aggregation) selection to one concrete `LeaderboardMetric`. Callers must
+ * validate the aggregation against `getLeaderboardFamilyAggregations` before calling this — an
+ * unsupported combination is treated as a programming error, not user input.
+ */
+export function resolveLeaderboardMetric(
+  family: LeaderboardMetricFamily,
+  aggregation: LeaderboardMetricAggregation | null,
+): LeaderboardMetric {
+  const supportedAggregations = getLeaderboardFamilyAggregations(family);
+  const resolvedAggregation = aggregation ?? getDefaultLeaderboardAggregation(family);
+
+  const isUnsupportedAggregation =
+    supportedAggregations.length > 0
+      ? resolvedAggregation == null || !supportedAggregations.includes(resolvedAggregation)
+      : aggregation != null;
+  if (isUnsupportedAggregation) {
+    throw new Error(`Unsupported leaderboard aggregation for family "${family}"`);
+  }
+
+  switch (family) {
+    case LeaderboardMetricFamily.PersonalScore: {
+      return LeaderboardMetric.PersonalScore;
+    }
+    case LeaderboardMetricFamily.Kills: {
+      return LeaderboardMetric.Kills;
+    }
+    case LeaderboardMetricFamily.Deaths: {
+      return LeaderboardMetric.Deaths;
+    }
+    case LeaderboardMetricFamily.Assists: {
+      return LeaderboardMetric.Assists;
+    }
+    case LeaderboardMetricFamily.HeadshotKills: {
+      return LeaderboardMetric.HeadshotKills;
+    }
+    case LeaderboardMetricFamily.ShotsHit: {
+      return LeaderboardMetric.ShotsHit;
+    }
+    case LeaderboardMetricFamily.ShotsFired: {
+      return LeaderboardMetric.ShotsFired;
+    }
+    case LeaderboardMetricFamily.DamageDealt: {
+      return LeaderboardMetric.DamageDealt;
+    }
+    case LeaderboardMetricFamily.DamageTaken: {
+      return LeaderboardMetric.DamageTaken;
+    }
+    case LeaderboardMetricFamily.SeriesWinRate: {
+      return LeaderboardMetric.SeriesWinRate;
+    }
+    case LeaderboardMetricFamily.Kda: {
+      return LeaderboardMetric.Kda;
+    }
+    case LeaderboardMetricFamily.Accuracy: {
+      return LeaderboardMetric.Accuracy;
+    }
+    case LeaderboardMetricFamily.DamageRatio: {
+      return LeaderboardMetric.DamageRatio;
+    }
+    case LeaderboardMetricFamily.AvgLifeSeconds: {
+      return LeaderboardMetric.AvgLifeSeconds;
+    }
+    case LeaderboardMetricFamily.AvgDamagePerLife: {
+      return LeaderboardMetric.AvgDamagePerLife;
+    }
+    default: {
+      throw new UnreachableError(family);
+    }
+  }
+}
+
+export function getLeaderboardMetricFamilyLabel(family: LeaderboardMetricFamily): string {
+  switch (family) {
+    case LeaderboardMetricFamily.PersonalScore: {
+      return "Personal score";
+    }
+    case LeaderboardMetricFamily.Kills: {
+      return "Kills";
+    }
+    case LeaderboardMetricFamily.Deaths: {
+      return "Deaths";
+    }
+    case LeaderboardMetricFamily.Assists: {
+      return "Assists";
+    }
+    case LeaderboardMetricFamily.HeadshotKills: {
+      return "Headshot kills";
+    }
+    case LeaderboardMetricFamily.ShotsHit: {
+      return "Shots hit";
+    }
+    case LeaderboardMetricFamily.ShotsFired: {
+      return "Shots fired";
+    }
+    case LeaderboardMetricFamily.DamageDealt: {
+      return "Damage dealt";
+    }
+    case LeaderboardMetricFamily.DamageTaken: {
+      return "Damage taken";
+    }
+    case LeaderboardMetricFamily.SeriesWinRate: {
+      return "Series win rate";
+    }
+    case LeaderboardMetricFamily.Kda: {
+      return "KDA";
+    }
+    case LeaderboardMetricFamily.Accuracy: {
+      return "Accuracy";
+    }
+    case LeaderboardMetricFamily.DamageRatio: {
+      return "Damage ratio";
+    }
+    case LeaderboardMetricFamily.AvgLifeSeconds: {
+      return "Avg life time";
+    }
+    case LeaderboardMetricFamily.AvgDamagePerLife: {
+      return "Avg damage per life";
+    }
+    default: {
+      throw new UnreachableError(family);
+    }
+  }
+}
+
+export function getLeaderboardMetricAggregationLabel(aggregation: LeaderboardMetricAggregation): string {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- becomes non-trivial once PR6b adds aggregations
+  if (aggregation === LeaderboardMetricAggregation.Total) {
+    return "Total";
+  }
+
+  throw new UnreachableError(aggregation);
 }

--- a/shared/src/halo/leaderboard.ts
+++ b/shared/src/halo/leaderboard.ts
@@ -270,10 +270,9 @@ export function getLeaderboardMetricFamilyLabel(family: LeaderboardMetricFamily)
 }
 
 export function getLeaderboardMetricAggregationLabel(aggregation: LeaderboardMetricAggregation): string {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- becomes non-trivial once PR6b adds aggregations
-  if (aggregation === LeaderboardMetricAggregation.Total) {
-    return "Total";
-  }
+  const labelsByAggregation: Record<LeaderboardMetricAggregation, string> = {
+    [LeaderboardMetricAggregation.Total]: "Total",
+  };
 
-  throw new UnreachableError(aggregation);
+  return labelsByAggregation[aggregation];
 }

--- a/shared/src/halo/tests/leaderboard.test.ts
+++ b/shared/src/halo/tests/leaderboard.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  LeaderboardMetric,
+  LeaderboardMetricAggregation,
+  LeaderboardMetricFamily,
+  getDefaultLeaderboardAggregation,
+  getLeaderboardFamilyAggregations,
+  getLeaderboardMetricAggregationLabel,
+  getLeaderboardMetricFamily,
+  getLeaderboardMetricFamilyLabel,
+  resolveLeaderboardMetric,
+} from "../leaderboard";
+
+describe("getLeaderboardMetricFamily", () => {
+  it.each(Object.values(LeaderboardMetric))("resolves a family for every LeaderboardMetric member (%s)", (metric) => {
+    expect(() => getLeaderboardMetricFamily(metric)).not.toThrow();
+  });
+});
+
+describe("getLeaderboardFamilyAggregations / getDefaultLeaderboardAggregation", () => {
+  it("exposes a single Total aggregation for count/score families", () => {
+    expect(getLeaderboardFamilyAggregations(LeaderboardMetricFamily.Kills)).toEqual([
+      LeaderboardMetricAggregation.Total,
+    ]);
+    expect(getDefaultLeaderboardAggregation(LeaderboardMetricFamily.Kills)).toBe(LeaderboardMetricAggregation.Total);
+  });
+
+  it("exposes no aggregations for rate/ratio/lifetime families", () => {
+    expect(getLeaderboardFamilyAggregations(LeaderboardMetricFamily.SeriesWinRate)).toEqual([]);
+    expect(getDefaultLeaderboardAggregation(LeaderboardMetricFamily.SeriesWinRate)).toBeNull();
+  });
+});
+
+describe("resolveLeaderboardMetric", () => {
+  it("resolves a count/score family with an explicit Total aggregation", () => {
+    expect(resolveLeaderboardMetric(LeaderboardMetricFamily.Kills, LeaderboardMetricAggregation.Total)).toBe(
+      LeaderboardMetric.Kills,
+    );
+  });
+
+  it("defaults to Total when no aggregation is provided for a count/score family", () => {
+    expect(resolveLeaderboardMetric(LeaderboardMetricFamily.DamageDealt, null)).toBe(LeaderboardMetric.DamageDealt);
+  });
+
+  it("resolves a rate/ratio/lifetime family without requiring an aggregation", () => {
+    expect(resolveLeaderboardMetric(LeaderboardMetricFamily.Kda, null)).toBe(LeaderboardMetric.Kda);
+    expect(resolveLeaderboardMetric(LeaderboardMetricFamily.SeriesWinRate, null)).toBe(LeaderboardMetric.SeriesWinRate);
+  });
+
+  it("throws when an unsupported aggregation is passed for a rate/ratio/lifetime family", () => {
+    expect(() => resolveLeaderboardMetric(LeaderboardMetricFamily.Kda, LeaderboardMetricAggregation.Total)).toThrow();
+  });
+
+  it("round-trips every LeaderboardMetric through its family and default aggregation", () => {
+    for (const metric of Object.values(LeaderboardMetric)) {
+      const family = getLeaderboardMetricFamily(metric);
+      const defaultAggregation = getDefaultLeaderboardAggregation(family);
+      expect(resolveLeaderboardMetric(family, defaultAggregation)).toBe(metric);
+    }
+  });
+});
+
+describe("getLeaderboardMetricFamilyLabel / getLeaderboardMetricAggregationLabel", () => {
+  it.each(Object.values(LeaderboardMetricFamily))("returns a non-empty label for family %s", (family) => {
+    expect(getLeaderboardMetricFamilyLabel(family).length).toBeGreaterThan(0);
+  });
+
+  it("returns a label for the Total aggregation", () => {
+    expect(getLeaderboardMetricAggregationLabel(LeaderboardMetricAggregation.Total)).toBe("Total");
+  });
+});


### PR DESCRIPTION
## Context
The leaderboard metric inventory is expanding beyond Discord's 25-option limit for both slash-command choices and StringSelect components. The selector needs to support the future metric inventory without changing the leaderboard query model or creating an awkward paging flow.

## This PR
- Adds shared `LeaderboardMetricFamily` and `LeaderboardMetricAggregation` types plus family-to-metric resolution.
- Replaces the flat Discord metric selector with a two-step Stat family -> Aggregation picker.
- Replaces `/leaderboard show metric` with optional `metric_family` and `aggregation` options.
- Updates persisted message-state parsing and regression coverage.
- Keeps all 15 existing metrics and query behavior unchanged; current count/score families default to Total aggregation.

Validation: full format, typecheck, lint, and test suite passed (248 files, 3491 tests; 1 skipped).

## Subsequent Work
PR6b will add the remaining win-count, win-rate, per-series-average, and per-game-average metrics, then populate the aggregation selector with the new valid variants and implement the corresponding persistence/query changes.