### PR TITLE
Fix average damage per life calculation

### DIFF
--- a/api/commands/stats/tests/__snapshots__/stats.test.ts.snap
+++ b/api/commands/stats/tests/__snapshots__/stats.test.ts.snap
@@ -23,7 +23,7 @@ KDA: 0.66
 Headshot kills: 6
 Shots H:F (acc): 83:178 (46.62%)
 Damage D:T (D/T): 4,736:4,879 (0.97)
-Avg life time (damage/life): 32s (338.29)
+Avg life time (damage/life): 32s (315.73)
 Captures: __**2**__
 Captures assists: 0
 Carrier time: 9s
@@ -42,7 +42,7 @@ KDA: __**10.33**__
 Headshot kills: __**17**__
 Shots H:F (acc): 108:182 (59.34%)
 Damage D:T (D/T): **5,890**:4,614 __**(1.28)**__
-Avg life time (damage/life): 29s (392.67)
+Avg life time (damage/life): 29s (368.13)
 Captures: 1
 Captures assists: 2
 Carrier time: 20s
@@ -68,7 +68,7 @@ KDA: 3
 Headshot kills: 11
 Shots H:F (acc): **122**:**189** **(64.55%)**
 Damage D:T (D/T): 5,717:5,479 (1.04)
-Avg life time (damage/life): 27s (336.29)
+Avg life time (damage/life): 27s (317.61)
 Captures: 0
 Captures assists: 1
 Carrier time: 11s
@@ -87,7 +87,7 @@ KDA: 10
 Headshot kills: 10
 Shots H:F (acc): 84:162 (51.85%)
 Damage D:T (D/T): 3,859:__**3,049**__ (1.27)
-Avg life time (damage/life): __**53s**__ __**(428.78)**__
+Avg life time (damage/life): __**53s**__ __**(385.9)**__
 Captures: 0
 Captures assists: __**3**__
 Carrier time: **22s**
@@ -118,7 +118,7 @@ KDA: **5**
 Headshot kills: **16**
 Shots H:F (acc): __**134**__:__**200**__ __**(67%)**__
 Damage D:T (D/T): __**6,202**__:5,431 **(1.14)**
-Avg life time (damage/life): 27s **(387.63)**
+Avg life time (damage/life): 27s **(364.82)**
 Captures: **0**
 Captures assists: **0**
 Carrier time: 26s
@@ -137,7 +137,7 @@ KDA: 1.66
 Headshot kills: 9
 Shots H:F (acc): 81:160 (50.62%)
 Damage D:T (D/T): 3,657:**4,401** (0.83)
-Avg life time (damage/life): 27s (228.56)
+Avg life time (damage/life): 27s (215.12)
 Captures: **0**
 Captures assists: **0**
 Carrier time: __**1m 3s**__
@@ -163,7 +163,7 @@ KDA: -7.66
 Headshot kills: 9
 Shots H:F (acc): 99:191 (51.83%)
 Damage D:T (D/T): 4,094:5,882 (0.7)
-Avg life time (damage/life): 19s (194.95)
+Avg life time (damage/life): 19s (186.09)
 Captures: **0**
 Captures assists: **0**
 Carrier time: 0s
@@ -182,7 +182,7 @@ KDA: -5.33
 Headshot kills: 5
 Shots H:F (acc): 77:163 (47.23%)
 Damage D:T (D/T): 3,859:5,057 (0.76)
-Avg life time (damage/life): **29s** (257.27)
+Avg life time (damage/life): **29s** (241.19)
 Captures: **0**
 Captures assists: **0**
 Carrier time: 17s
@@ -283,7 +283,7 @@ KDA: __75.66__
 Headshot kills: __133__
 Shots H:F (acc): __1,405__:__2,576__ __(54.41%)__
 Damage D:T (D/T): __64,494__:__59,743__ __(1.08)__
-Avg life time (damage/life): __35s__ __(383.89)__
+Avg life time (damage/life): __35s__ __(381.62)__
 2x<:TripleKill:1322814228477906944> 16x<:DoubleKill:1322814147980689430> 11x<:Perfect:1322879561515532308> <:OfftheRack:1322884747881353279> 7x<:ShotCaller:1322884687693086771> 8x<:KillingSpree:1322803050347499541> <:NoScope:1322882248516702220> 4x<:Snipe:1322872969571340370> 2x<:Killjoy:1322802841039147129> 3x<:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 10x<:Rifleman:1322860656399220828> 6x<:Reversal:1322872797701083166> 5x<:GuardianAngel:1322873057928286248> 4x<:Wingman:1322854221095108609> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:BackSmack:1322872596135546891> <:Spotter:1322814780796309505> <:Boxer:1322864064082477077>",
             },
             {
@@ -296,7 +296,7 @@ KDA: -14.33
 Headshot kills: 108
 Shots H:F (acc): 1,293:2,466 (52.64%)
 Damage D:T (D/T): 58,909:65,491 (0.9)
-Avg life time (damage/life): 28s (280.52)
+Avg life time (damage/life): 28s (279.19)
 <:SneakKing:1322883516039696415> 17x<:DoubleKill:1322814147980689430> 6x<:ShotCaller:1322884687693086771> 11x<:Perfect:1322879561515532308> 2x<:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:NadeShot:1322877140605206528> <:Whiplash:1322882310122504202> <:ClusterLuck:1322871366961205269> 12x<:Rifleman:1322860656399220828> 8x<:Killjoy:1322802841039147129> <:Stick:1322871787695898676> <:StoppedShort:1322806739778670652> <:Reversal:1322872797701083166> <:GuardianAngel:1322873057928286248> 2x<:Spotter:1322814780796309505> <:LastShot:1322884170606972959> 4x<:Wingman:1322854221095108609> <:BackSmack:1322872596135546891> <:Bodyguard:1322867380136841279>",
             },
             {
@@ -329,7 +329,7 @@ KDA: **25.66**
 Headshot kills: **39**
 Shots H:F (acc): __**439**__:__**760**__ **(58.49%)**
 Damage D:T (D/T): **17,916**:16,468 (1.09)
-Avg life time (damage/life): 28s (373.25)
+Avg life time (damage/life): 28s (365.63)
 <:TripleKill:1322814228477906944> 5x<:ShotCaller:1322884687693086771> <:NoScope:1322882248516702220> 8x<:DoubleKill:1322814147980689430> 4x<:KillingSpree:1322803050347499541> 4x<:Perfect:1322879561515532308> 2x<:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 2x<:Reversal:1322872797701083166> 3x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609> <:Killjoy:1322802841039147129> <:Boxer:1322864064082477077>",
             },
             {
@@ -342,7 +342,7 @@ KDA: 17
 Headshot kills: 33
 Shots H:F (acc): 307:578 (52.11%)
 Damage D:T (D/T): 16,174:16,029 (1.01)
-Avg life time (damage/life): 33s (367.59)
+Avg life time (damage/life): 33s (359.42)
 2x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> 2x<:ShotCaller:1322884687693086771> 3x<:Snipe:1322872969571340370> 2x<:Rifleman:1322860656399220828> 4x<:Reversal:1322872797701083166> 3x<:GuardianAngel:1322873057928286248> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:Wingman:1322854221095108609> <:Stick:1322871787695898676> 2x<:BackSmack:1322872596135546891>",
             },
             {
@@ -362,7 +362,7 @@ KDA: 12.99
 Headshot kills: 29
 Shots H:F (acc): 355:654 (54.19%)
 Damage D:T (D/T): 17,245:14,994 __**(1.15)**__
-Avg life time (damage/life): 28s (374.89)
+Avg life time (damage/life): 28s (366.91)
 <:TripleKill:1322814228477906944> <:OfftheRack:1322884747881353279> 4x<:DoubleKill:1322814147980689430> 2x<:Perfect:1322879561515532308> 3x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
             },
             {
@@ -375,7 +375,7 @@ KDA: 23
 Headshot kills: 32
 Shots H:F (acc): 304:584 (51.33%)
 Damage D:T (D/T): 13,159:__**12,252**__ (1.07)
-Avg life time (damage/life): __**53s**__ __**(438.63)**__
+Avg life time (damage/life): __**53s**__ __**(424.48)**__
 <:DoubleKill:1322814147980689430> 3x<:Perfect:1322879561515532308> 4x<:KillingSpree:1322803050347499541> <:Killjoy:1322802841039147129> 2x<:Rifleman:1322860656399220828> <:Snipe:1322872969571340370> 2x<:GuardianAngel:1322873057928286248> <:Spotter:1322814780796309505>",
             },
             {
@@ -408,7 +408,7 @@ KDA: __**26.66**__
 Headshot kills: __**49**__
 Shots H:F (acc): **420**:**692** __**(61.24%)**__
 Damage D:T (D/T): __**19,567**__:17,444 **(1.12)**
-Avg life time (damage/life): 28s **(399.33)**
+Avg life time (damage/life): 28s **(391.34)**
 <:SneakKing:1322883516039696415> 11x<:DoubleKill:1322814147980689430> 8x<:Perfect:1322879561515532308> 2x<:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:Whiplash:1322882310122504202> 3x<:Rifleman:1322860656399220828> 3x<:Killjoy:1322802841039147129> <:Wingman:1322854221095108609>",
             },
             {
@@ -421,7 +421,7 @@ KDA: -4.34
 Headshot kills: 23
 Shots H:F (acc): 283:592 (47.77%)
 Damage D:T (D/T): 12,421:**15,088** (0.82)
-Avg life time (damage/life): 25s (234.36)
+Avg life time (damage/life): 25s (230.02)
 <:Perfect:1322879561515532308> <:ShotCaller:1322884687693086771> <:ClusterLuck:1322871366961205269> <:DoubleKill:1322814147980689430> 3x<:Rifleman:1322860656399220828> <:Stick:1322871787695898676> <:Killjoy:1322802841039147129> <:GuardianAngel:1322873057928286248> <:Wingman:1322854221095108609> <:Spotter:1322814780796309505> <:Bodyguard:1322867380136841279>",
             },
             {
@@ -441,7 +441,7 @@ KDA: -18.99
 Headshot kills: 20
 Shots H:F (acc): 301:587 (52.51%)
 Damage D:T (D/T): 13,363:17,195 (0.78)
-Avg life time (damage/life): 22s (226.49)
+Avg life time (damage/life): 22s (222.72)
 3x<:DoubleKill:1322814147980689430> 3x<:Rifleman:1322860656399220828> <:Reversal:1322872797701083166> <:LastShot:1322884170606972959> <:Wingman:1322854221095108609> 2x<:Killjoy:1322802841039147129> <:BackSmack:1322872596135546891>",
             },
             {
@@ -454,7 +454,7 @@ KDA: -15.33
 Headshot kills: 16
 Shots H:F (acc): 289:595 (48.53%)
 Damage D:T (D/T): 13,558:15,764 (0.86)
-Avg life time (damage/life): **29s** (276.69)
+Avg life time (damage/life): **29s** (271.16)
 5x<:ShotCaller:1322884687693086771> 2x<:Perfect:1322879561515532308> 2x<:DoubleKill:1322814147980689430> <:NadeShot:1322877140605206528> 3x<:Rifleman:1322860656399220828> <:StoppedShort:1322806739778670652> 2x<:Killjoy:1322802841039147129> <:Spotter:1322814780796309505> <:Wingman:1322854221095108609>",
             },
             {
@@ -492,7 +492,7 @@ KDA: 0.66
 Headshot kills: 6
 Shots H:F (acc): 83:178 (46.62%)
 Damage D:T (D/T): 4,736:4,879 (0.97)
-Avg life time (damage/life): 32s (338.29)
+Avg life time (damage/life): 32s (315.73)
 Captures: __**2**__
 Captures assists: 0
 Carrier time: 9s
@@ -511,7 +511,7 @@ KDA: __**10.33**__
 Headshot kills: __**17**__
 Shots H:F (acc): 108:182 (59.34%)
 Damage D:T (D/T): **5,890**:4,614 __**(1.28)**__
-Avg life time (damage/life): 29s (392.67)
+Avg life time (damage/life): 29s (368.13)
 Captures: 1
 Captures assists: 2
 Carrier time: 20s
@@ -537,7 +537,7 @@ KDA: 3
 Headshot kills: 11
 Shots H:F (acc): **122**:**189** **(64.55%)**
 Damage D:T (D/T): 5,717:5,479 (1.04)
-Avg life time (damage/life): 27s (336.29)
+Avg life time (damage/life): 27s (317.61)
 Captures: 0
 Captures assists: 1
 Carrier time: 11s
@@ -556,7 +556,7 @@ KDA: 10
 Headshot kills: 10
 Shots H:F (acc): 84:162 (51.85%)
 Damage D:T (D/T): 3,859:__**3,049**__ (1.27)
-Avg life time (damage/life): __**53s**__ __**(428.78)**__
+Avg life time (damage/life): __**53s**__ __**(385.9)**__
 Captures: 0
 Captures assists: __**3**__
 Carrier time: **22s**
@@ -587,7 +587,7 @@ KDA: **5**
 Headshot kills: **16**
 Shots H:F (acc): __**134**__:__**200**__ __**(67%)**__
 Damage D:T (D/T): __**6,202**__:5,431 **(1.14)**
-Avg life time (damage/life): 27s **(387.63)**
+Avg life time (damage/life): 27s **(364.82)**
 Captures: **0**
 Captures assists: **0**
 Carrier time: 26s
@@ -606,7 +606,7 @@ KDA: 1.66
 Headshot kills: 9
 Shots H:F (acc): 81:160 (50.62%)
 Damage D:T (D/T): 3,657:**4,401** (0.83)
-Avg life time (damage/life): 27s (228.56)
+Avg life time (damage/life): 27s (215.12)
 Captures: **0**
 Captures assists: **0**
 Carrier time: __**1m 3s**__
@@ -632,7 +632,7 @@ KDA: -7.66
 Headshot kills: 9
 Shots H:F (acc): 99:191 (51.83%)
 Damage D:T (D/T): 4,094:5,882 (0.7)
-Avg life time (damage/life): 19s (194.95)
+Avg life time (damage/life): 19s (186.09)
 Captures: **0**
 Captures assists: **0**
 Carrier time: 0s
@@ -651,7 +651,7 @@ KDA: -5.33
 Headshot kills: 5
 Shots H:F (acc): 77:163 (47.23%)
 Damage D:T (D/T): 3,859:5,057 (0.76)
-Avg life time (damage/life): **29s** (257.27)
+Avg life time (damage/life): **29s** (241.19)
 Captures: **0**
 Captures assists: **0**
 Carrier time: 17s
@@ -696,7 +696,7 @@ KDA: 18
 Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
-Avg life time (damage/life): 25s (405.32)
+Avg life time (damage/life): 25s (385.05)
 Captures: __**0**__
 Occupation time: **1m 11s**
 Secures: __**0**__
@@ -714,7 +714,7 @@ KDA: 7
 Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
-Avg life time (damage/life): 27s (355.63)
+Avg life time (damage/life): 27s (337.85)
 Captures: __**0**__
 Occupation time: 44s
 Secures: __**0**__
@@ -739,7 +739,7 @@ KDA: 7
 Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
-Avg life time (damage/life): 27s (369.94)
+Avg life time (damage/life): 27s (350.47)
 Captures: __**0**__
 Occupation time: 49s
 Secures: __**0**__
@@ -757,7 +757,7 @@ KDA: __**20.33**__
 Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
-Avg life time (damage/life): __**1m 19s**__ __**(858.57)**__
+Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
 Captures: __**0**__
 Occupation time: 53s
 Secures: __**0**__
@@ -787,7 +787,7 @@ KDA: -7.66
 Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
-Avg life time (damage/life): 17s (205.4)
+Avg life time (damage/life): 17s (197.5)
 Captures: __**0**__
 Occupation time: __**1m 29s**__
 Secures: __**0**__
@@ -805,7 +805,7 @@ KDA: -11.66
 Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
-Avg life time (damage/life): 17s (207.73)
+Avg life time (damage/life): 17s (200.04)
 Captures: __**0**__
 Occupation time: 35s
 Secures: __**0**__
@@ -830,7 +830,7 @@ KDA: -11.66
 Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
-Avg life time (damage/life): 19s (230.21)
+Avg life time (damage/life): 19s (221)
 Captures: __**0**__
 Occupation time: 48s
 Secures: __**0**__
@@ -848,7 +848,7 @@ KDA: **9.33**
 Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
-Avg life time (damage/life): **20s** **(312.48)**
+Avg life time (damage/life): **20s** **(299.46)**
 Captures: __**0**__
 Occupation time: 47s
 Secures: __**0**__
@@ -892,7 +892,7 @@ KDA: **5.33**
 Headshot kills: **13**
 Shots H:F (acc): 138:211 __**(65.4%)**__
 Damage D:T (D/T): **5,850**:4,647 __**(1.26)**__
-Avg life time (damage/life): 25s **(417.86)**
+Avg life time (damage/life): 25s **(390)**
 2x<:DoubleKill:1322814147980689430> <:Rifleman:1322860656399220828>",
             },
             {
@@ -905,7 +905,7 @@ KDA: 4.66
 Headshot kills: 3
 Shots H:F (acc): __**141**__:__**283**__ (49.82%)
 Damage D:T (D/T): 4,498:**4,249** (1.06)
-Avg life time (damage/life): 31s (374.83)
+Avg life time (damage/life): 31s (346)
 <:ShotCaller:1322884687693086771> <:KillingSpree:1322803050347499541> <:Stick:1322871787695898676> <:Rifleman:1322860656399220828> <:Killjoy:1322802841039147129> <:Boxer:1322864064082477077>",
             },
             {
@@ -925,7 +925,7 @@ KDA: -0.33
 Headshot kills: 2
 Shots H:F (acc): 63:159 (39.62%)
 Damage D:T (D/T): 3,527:4,516 (0.78)
-Avg life time (damage/life): __**42s**__ (352.7)
+Avg life time (damage/life): __**42s**__ (320.64)
 <:Reversal:1322872797701083166>",
             },
             {
@@ -938,7 +938,7 @@ KDA: -7.33
 Headshot kills: 4
 Shots H:F (acc): 79:180 (43.88%)
 Damage D:T (D/T): 3,290:4,656 (0.71)
-Avg life time (damage/life): 25s (235)
+Avg life time (damage/life): 25s (219.33)
 <:Spotter:1322814780796309505>",
             },
             {
@@ -963,7 +963,7 @@ KDA: __**12.33**__
 Headshot kills: __**14**__
 Shots H:F (acc): **116**:**195** **(59.48%)**
 Damage D:T (D/T): __**6,178**__:5,163 **(1.2)**
-Avg life time (damage/life): **38s** __**(617.8)**__
+Avg life time (damage/life): **38s** __**(561.64)**__
 3x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> <:KillingSpree:1322803050347499541> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
             },
             {
@@ -976,7 +976,7 @@ KDA: 1.66
 Headshot kills: 4
 Shots H:F (acc): 82:193 (42.48%)
 Damage D:T (D/T): 3,629:__**3,885**__ (0.93)
-Avg life time (damage/life): 31s (302.42)
+Avg life time (damage/life): 31s (279.15)
 <:ShotCaller:1322884687693086771> <:ClusterLuck:1322871366961205269> <:DoubleKill:1322814147980689430> <:Spotter:1322814780796309505> <:Rifleman:1322860656399220828> <:Bodyguard:1322867380136841279>",
             },
             {
@@ -996,7 +996,7 @@ KDA: 0.33
 Headshot kills: 6
 Shots H:F (acc): 75:129 (58.13%)
 Damage D:T (D/T): 3,868:4,158 (0.93)
-Avg life time (damage/life): 31s (322.33)
+Avg life time (damage/life): 31s (297.54)
 <:DoubleKill:1322814147980689430> <:BackSmack:1322872596135546891> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828>",
             },
             {
@@ -1009,7 +1009,7 @@ KDA: 1.66
 Headshot kills: 6
 Shots H:F (acc): 98:**195** (50.25%)
 Damage D:T (D/T): 4,174:4,150 (1.01)
-Avg life time (damage/life): **38s** (417.4)
+Avg life time (damage/life): **38s** (379.45)
 <:DoubleKill:1322814147980689430> <:Perfect:1322879561515532308> <:Rifleman:1322860656399220828>",
             },
             {

--- a/api/embeds/stats/tests/__snapshots__/attrition-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/attrition-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: **5.33**
 Headshot kills: **13**
 Shots H:F (acc): 138:211 __**(65.4%)**__
 Damage D:T (D/T): **5,850**:4,647 __**(1.26)**__
-Avg life time (damage/life): 25s **(417.86)**
+Avg life time (damage/life): 25s **(390)**
 2x<:DoubleKill:1322814147980689430> <:Rifleman:1322860656399220828>",
     },
     {
@@ -32,7 +32,7 @@ KDA: 4.66
 Headshot kills: 3
 Shots H:F (acc): __**141**__:__**283**__ (49.82%)
 Damage D:T (D/T): 4,498:**4,249** (1.06)
-Avg life time (damage/life): 31s (374.83)
+Avg life time (damage/life): 31s (346)
 <:ShotCaller:1322884687693086771> <:KillingSpree:1322803050347499541> <:Stick:1322871787695898676> <:Rifleman:1322860656399220828> <:Killjoy:1322802841039147129> <:Boxer:1322864064082477077>",
     },
     {
@@ -52,7 +52,7 @@ KDA: -0.33
 Headshot kills: 2
 Shots H:F (acc): 63:159 (39.62%)
 Damage D:T (D/T): 3,527:4,516 (0.78)
-Avg life time (damage/life): __**42s**__ (352.7)
+Avg life time (damage/life): __**42s**__ (320.64)
 <:Reversal:1322872797701083166>",
     },
     {
@@ -65,7 +65,7 @@ KDA: -7.33
 Headshot kills: 4
 Shots H:F (acc): 79:180 (43.88%)
 Damage D:T (D/T): 3,290:4,656 (0.71)
-Avg life time (damage/life): 25s (235)
+Avg life time (damage/life): 25s (219.33)
 <:Spotter:1322814780796309505>",
     },
     {
@@ -90,7 +90,7 @@ KDA: __**12.33**__
 Headshot kills: __**14**__
 Shots H:F (acc): **116**:**195** **(59.48%)**
 Damage D:T (D/T): __**6,178**__:5,163 **(1.2)**
-Avg life time (damage/life): **38s** __**(617.8)**__
+Avg life time (damage/life): **38s** __**(561.64)**__
 3x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> <:KillingSpree:1322803050347499541> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
     },
     {
@@ -103,7 +103,7 @@ KDA: 1.66
 Headshot kills: 4
 Shots H:F (acc): 82:193 (42.48%)
 Damage D:T (D/T): 3,629:__**3,885**__ (0.93)
-Avg life time (damage/life): 31s (302.42)
+Avg life time (damage/life): 31s (279.15)
 <:ShotCaller:1322884687693086771> <:ClusterLuck:1322871366961205269> <:DoubleKill:1322814147980689430> <:Spotter:1322814780796309505> <:Rifleman:1322860656399220828> <:Bodyguard:1322867380136841279>",
     },
     {
@@ -123,7 +123,7 @@ KDA: 0.33
 Headshot kills: 6
 Shots H:F (acc): 75:129 (58.13%)
 Damage D:T (D/T): 3,868:4,158 (0.93)
-Avg life time (damage/life): 31s (322.33)
+Avg life time (damage/life): 31s (297.54)
 <:DoubleKill:1322814147980689430> <:BackSmack:1322872596135546891> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828>",
     },
     {
@@ -136,7 +136,7 @@ KDA: 1.66
 Headshot kills: 6
 Shots H:F (acc): 98:**195** (50.25%)
 Damage D:T (D/T): 4,174:4,150 (1.01)
-Avg life time (damage/life): **38s** (417.4)
+Avg life time (damage/life): **38s** (379.45)
 <:DoubleKill:1322814147980689430> <:Perfect:1322879561515532308> <:Rifleman:1322860656399220828>",
     },
     {

--- a/api/embeds/stats/tests/__snapshots__/ctf-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/ctf-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: 0.66
 Headshot kills: 6
 Shots H:F (acc): 83:178 (46.62%)
 Damage D:T (D/T): 4,736:4,879 (0.97)
-Avg life time (damage/life): 32s (338.29)
+Avg life time (damage/life): 32s (315.73)
 Captures: __**2**__
 Captures assists: 0
 Carrier time: 9s
@@ -38,7 +38,7 @@ KDA: __**10.33**__
 Headshot kills: __**17**__
 Shots H:F (acc): 108:182 (59.34%)
 Damage D:T (D/T): **5,890**:4,614 __**(1.28)**__
-Avg life time (damage/life): 29s (392.67)
+Avg life time (damage/life): 29s (368.13)
 Captures: 1
 Captures assists: 2
 Carrier time: 20s
@@ -64,7 +64,7 @@ KDA: 3
 Headshot kills: 11
 Shots H:F (acc): **122**:**189** **(64.55%)**
 Damage D:T (D/T): 5,717:5,479 (1.04)
-Avg life time (damage/life): 27s (336.29)
+Avg life time (damage/life): 27s (317.61)
 Captures: 0
 Captures assists: 1
 Carrier time: 11s
@@ -83,7 +83,7 @@ KDA: 10
 Headshot kills: 10
 Shots H:F (acc): 84:162 (51.85%)
 Damage D:T (D/T): 3,859:__**3,049**__ (1.27)
-Avg life time (damage/life): __**53s**__ __**(428.78)**__
+Avg life time (damage/life): __**53s**__ __**(385.9)**__
 Captures: 0
 Captures assists: __**3**__
 Carrier time: **22s**
@@ -114,7 +114,7 @@ KDA: **5**
 Headshot kills: **16**
 Shots H:F (acc): __**134**__:__**200**__ __**(67%)**__
 Damage D:T (D/T): __**6,202**__:5,431 **(1.14)**
-Avg life time (damage/life): 27s **(387.63)**
+Avg life time (damage/life): 27s **(364.82)**
 Captures: **0**
 Captures assists: **0**
 Carrier time: 26s
@@ -133,7 +133,7 @@ KDA: 1.66
 Headshot kills: 9
 Shots H:F (acc): 81:160 (50.62%)
 Damage D:T (D/T): 3,657:**4,401** (0.83)
-Avg life time (damage/life): 27s (228.56)
+Avg life time (damage/life): 27s (215.12)
 Captures: **0**
 Captures assists: **0**
 Carrier time: __**1m 3s**__
@@ -159,7 +159,7 @@ KDA: -7.66
 Headshot kills: 9
 Shots H:F (acc): 99:191 (51.83%)
 Damage D:T (D/T): 4,094:5,882 (0.7)
-Avg life time (damage/life): 19s (194.95)
+Avg life time (damage/life): 19s (186.09)
 Captures: **0**
 Captures assists: **0**
 Carrier time: 0s
@@ -178,7 +178,7 @@ KDA: -5.33
 Headshot kills: 5
 Shots H:F (acc): 77:163 (47.23%)
 Damage D:T (D/T): 3,859:5,057 (0.76)
-Avg life time (damage/life): **29s** (257.27)
+Avg life time (damage/life): **29s** (241.19)
 Captures: **0**
 Captures assists: **0**
 Carrier time: 17s

--- a/api/embeds/stats/tests/__snapshots__/elimination-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/elimination-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: __**10**__
 Headshot kills: __**5**__
 Shots H:F (acc): __**50**__:__**100**__ __**(0.5%)**__
 Damage D:T (D/T): __**2,500**__:__**1,500**__ __**(1.67)**__
-Avg life time (damage/life): __**45s**__ __**(416.67)**__
+Avg life time (damage/life): __**45s**__ __**(357.14)**__
 Eliminations: __**3**__
 Elimination assists: __**2**__
 Allies revived: __**1**__

--- a/api/embeds/stats/tests/__snapshots__/escalation-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/escalation-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: **5.33**
 Headshot kills: **13**
 Shots H:F (acc): 138:211 __**(65.4%)**__
 Damage D:T (D/T): **5,850**:4,647 __**(1.26)**__
-Avg life time (damage/life): 25s **(417.86)**
+Avg life time (damage/life): 25s **(390)**
 2x<:DoubleKill:1322814147980689430> <:Rifleman:1322860656399220828>",
     },
     {
@@ -32,7 +32,7 @@ KDA: 4.66
 Headshot kills: 3
 Shots H:F (acc): __**141**__:__**283**__ (49.82%)
 Damage D:T (D/T): 4,498:**4,249** (1.06)
-Avg life time (damage/life): 31s (374.83)
+Avg life time (damage/life): 31s (346)
 <:ShotCaller:1322884687693086771> <:KillingSpree:1322803050347499541> <:Stick:1322871787695898676> <:Rifleman:1322860656399220828> <:Killjoy:1322802841039147129> <:Boxer:1322864064082477077>",
     },
     {
@@ -52,7 +52,7 @@ KDA: -0.33
 Headshot kills: 2
 Shots H:F (acc): 63:159 (39.62%)
 Damage D:T (D/T): 3,527:4,516 (0.78)
-Avg life time (damage/life): __**42s**__ (352.7)
+Avg life time (damage/life): __**42s**__ (320.64)
 <:Reversal:1322872797701083166>",
     },
     {
@@ -65,7 +65,7 @@ KDA: -7.33
 Headshot kills: 4
 Shots H:F (acc): 79:180 (43.88%)
 Damage D:T (D/T): 3,290:4,656 (0.71)
-Avg life time (damage/life): 25s (235)
+Avg life time (damage/life): 25s (219.33)
 <:Spotter:1322814780796309505>",
     },
     {
@@ -90,7 +90,7 @@ KDA: __**12.33**__
 Headshot kills: __**14**__
 Shots H:F (acc): **116**:**195** **(59.48%)**
 Damage D:T (D/T): __**6,178**__:5,163 **(1.2)**
-Avg life time (damage/life): **38s** __**(617.8)**__
+Avg life time (damage/life): **38s** __**(561.64)**__
 3x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> <:KillingSpree:1322803050347499541> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
     },
     {
@@ -103,7 +103,7 @@ KDA: 1.66
 Headshot kills: 4
 Shots H:F (acc): 82:193 (42.48%)
 Damage D:T (D/T): 3,629:__**3,885**__ (0.93)
-Avg life time (damage/life): 31s (302.42)
+Avg life time (damage/life): 31s (279.15)
 <:ShotCaller:1322884687693086771> <:ClusterLuck:1322871366961205269> <:DoubleKill:1322814147980689430> <:Spotter:1322814780796309505> <:Rifleman:1322860656399220828> <:Bodyguard:1322867380136841279>",
     },
     {
@@ -123,7 +123,7 @@ KDA: 0.33
 Headshot kills: 6
 Shots H:F (acc): 75:129 (58.13%)
 Damage D:T (D/T): 3,868:4,158 (0.93)
-Avg life time (damage/life): 31s (322.33)
+Avg life time (damage/life): 31s (297.54)
 <:DoubleKill:1322814147980689430> <:BackSmack:1322872596135546891> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828>",
     },
     {
@@ -136,7 +136,7 @@ KDA: 1.66
 Headshot kills: 6
 Shots H:F (acc): 98:**195** (50.25%)
 Damage D:T (D/T): 4,174:4,150 (1.01)
-Avg life time (damage/life): **38s** (417.4)
+Avg life time (damage/life): **38s** (379.45)
 <:DoubleKill:1322814147980689430> <:Perfect:1322879561515532308> <:Rifleman:1322860656399220828>",
     },
     {

--- a/api/embeds/stats/tests/__snapshots__/extraction-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/extraction-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: __**10**__
 Headshot kills: __**5**__
 Shots H:F (acc): __**50**__:__**100**__ __**(0.5%)**__
 Damage D:T (D/T): __**2,500**__:__**1,500**__ __**(1.67)**__
-Avg life time (damage/life): __**45s**__ __**(416.67)**__
+Avg life time (damage/life): __**45s**__ __**(357.14)**__
 Successful extractions: __**2**__
 Extraction initiations completed: __**2**__
 Extraction initiations denied: __**0**__

--- a/api/embeds/stats/tests/__snapshots__/fiesta-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/fiesta-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: **5.33**
 Headshot kills: **13**
 Shots H:F (acc): 138:211 __**(65.4%)**__
 Damage D:T (D/T): **5,850**:4,647 __**(1.26)**__
-Avg life time (damage/life): 25s **(417.86)**
+Avg life time (damage/life): 25s **(390)**
 2x<:DoubleKill:1322814147980689430> <:Rifleman:1322860656399220828>",
     },
     {
@@ -32,7 +32,7 @@ KDA: 4.66
 Headshot kills: 3
 Shots H:F (acc): __**141**__:__**283**__ (49.82%)
 Damage D:T (D/T): 4,498:**4,249** (1.06)
-Avg life time (damage/life): 31s (374.83)
+Avg life time (damage/life): 31s (346)
 <:ShotCaller:1322884687693086771> <:KillingSpree:1322803050347499541> <:Stick:1322871787695898676> <:Rifleman:1322860656399220828> <:Killjoy:1322802841039147129> <:Boxer:1322864064082477077>",
     },
     {
@@ -52,7 +52,7 @@ KDA: -0.33
 Headshot kills: 2
 Shots H:F (acc): 63:159 (39.62%)
 Damage D:T (D/T): 3,527:4,516 (0.78)
-Avg life time (damage/life): __**42s**__ (352.7)
+Avg life time (damage/life): __**42s**__ (320.64)
 <:Reversal:1322872797701083166>",
     },
     {
@@ -65,7 +65,7 @@ KDA: -7.33
 Headshot kills: 4
 Shots H:F (acc): 79:180 (43.88%)
 Damage D:T (D/T): 3,290:4,656 (0.71)
-Avg life time (damage/life): 25s (235)
+Avg life time (damage/life): 25s (219.33)
 <:Spotter:1322814780796309505>",
     },
     {
@@ -90,7 +90,7 @@ KDA: __**12.33**__
 Headshot kills: __**14**__
 Shots H:F (acc): **116**:**195** **(59.48%)**
 Damage D:T (D/T): __**6,178**__:5,163 **(1.2)**
-Avg life time (damage/life): **38s** __**(617.8)**__
+Avg life time (damage/life): **38s** __**(561.64)**__
 3x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> <:KillingSpree:1322803050347499541> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
     },
     {
@@ -103,7 +103,7 @@ KDA: 1.66
 Headshot kills: 4
 Shots H:F (acc): 82:193 (42.48%)
 Damage D:T (D/T): 3,629:__**3,885**__ (0.93)
-Avg life time (damage/life): 31s (302.42)
+Avg life time (damage/life): 31s (279.15)
 <:ShotCaller:1322884687693086771> <:ClusterLuck:1322871366961205269> <:DoubleKill:1322814147980689430> <:Spotter:1322814780796309505> <:Rifleman:1322860656399220828> <:Bodyguard:1322867380136841279>",
     },
     {
@@ -123,7 +123,7 @@ KDA: 0.33
 Headshot kills: 6
 Shots H:F (acc): 75:129 (58.13%)
 Damage D:T (D/T): 3,868:4,158 (0.93)
-Avg life time (damage/life): 31s (322.33)
+Avg life time (damage/life): 31s (297.54)
 <:DoubleKill:1322814147980689430> <:BackSmack:1322872596135546891> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828>",
     },
     {
@@ -136,7 +136,7 @@ KDA: 1.66
 Headshot kills: 6
 Shots H:F (acc): 98:**195** (50.25%)
 Damage D:T (D/T): 4,174:4,150 (1.01)
-Avg life time (damage/life): **38s** (417.4)
+Avg life time (damage/life): **38s** (379.45)
 <:DoubleKill:1322814147980689430> <:Perfect:1322879561515532308> <:Rifleman:1322860656399220828>",
     },
     {

--- a/api/embeds/stats/tests/__snapshots__/firefight-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/firefight-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: __**10**__
 Headshot kills: __**5**__
 Shots H:F (acc): __**50**__:__**100**__ __**(0.5%)**__
 Damage D:T (D/T): __**2,500**__:__**1,500**__ __**(1.67)**__
-Avg life time (damage/life): __**45s**__ __**(416.67)**__
+Avg life time (damage/life): __**45s**__ __**(357.14)**__
 Eliminations: __**3**__
 Elimination assists: __**2**__
 Allies revived: __**1**__

--- a/api/embeds/stats/tests/__snapshots__/grifball-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/grifball-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: **5.33**
 Headshot kills: **13**
 Shots H:F (acc): 138:211 __**(65.4%)**__
 Damage D:T (D/T): **5,850**:4,647 __**(1.26)**__
-Avg life time (damage/life): 25s **(417.86)**
+Avg life time (damage/life): 25s **(390)**
 2x<:DoubleKill:1322814147980689430> <:Rifleman:1322860656399220828>",
     },
     {
@@ -32,7 +32,7 @@ KDA: 4.66
 Headshot kills: 3
 Shots H:F (acc): __**141**__:__**283**__ (49.82%)
 Damage D:T (D/T): 4,498:**4,249** (1.06)
-Avg life time (damage/life): 31s (374.83)
+Avg life time (damage/life): 31s (346)
 <:ShotCaller:1322884687693086771> <:KillingSpree:1322803050347499541> <:Stick:1322871787695898676> <:Rifleman:1322860656399220828> <:Killjoy:1322802841039147129> <:Boxer:1322864064082477077>",
     },
     {
@@ -52,7 +52,7 @@ KDA: -0.33
 Headshot kills: 2
 Shots H:F (acc): 63:159 (39.62%)
 Damage D:T (D/T): 3,527:4,516 (0.78)
-Avg life time (damage/life): __**42s**__ (352.7)
+Avg life time (damage/life): __**42s**__ (320.64)
 <:Reversal:1322872797701083166>",
     },
     {
@@ -65,7 +65,7 @@ KDA: -7.33
 Headshot kills: 4
 Shots H:F (acc): 79:180 (43.88%)
 Damage D:T (D/T): 3,290:4,656 (0.71)
-Avg life time (damage/life): 25s (235)
+Avg life time (damage/life): 25s (219.33)
 <:Spotter:1322814780796309505>",
     },
     {
@@ -90,7 +90,7 @@ KDA: __**12.33**__
 Headshot kills: __**14**__
 Shots H:F (acc): **116**:**195** **(59.48%)**
 Damage D:T (D/T): __**6,178**__:5,163 **(1.2)**
-Avg life time (damage/life): **38s** __**(617.8)**__
+Avg life time (damage/life): **38s** __**(561.64)**__
 3x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> <:KillingSpree:1322803050347499541> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
     },
     {
@@ -103,7 +103,7 @@ KDA: 1.66
 Headshot kills: 4
 Shots H:F (acc): 82:193 (42.48%)
 Damage D:T (D/T): 3,629:__**3,885**__ (0.93)
-Avg life time (damage/life): 31s (302.42)
+Avg life time (damage/life): 31s (279.15)
 <:ShotCaller:1322884687693086771> <:ClusterLuck:1322871366961205269> <:DoubleKill:1322814147980689430> <:Spotter:1322814780796309505> <:Rifleman:1322860656399220828> <:Bodyguard:1322867380136841279>",
     },
     {
@@ -123,7 +123,7 @@ KDA: 0.33
 Headshot kills: 6
 Shots H:F (acc): 75:129 (58.13%)
 Damage D:T (D/T): 3,868:4,158 (0.93)
-Avg life time (damage/life): 31s (322.33)
+Avg life time (damage/life): 31s (297.54)
 <:DoubleKill:1322814147980689430> <:BackSmack:1322872596135546891> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828>",
     },
     {
@@ -136,7 +136,7 @@ KDA: 1.66
 Headshot kills: 6
 Shots H:F (acc): 98:**195** (50.25%)
 Damage D:T (D/T): 4,174:4,150 (1.01)
-Avg life time (damage/life): **38s** (417.4)
+Avg life time (damage/life): **38s** (379.45)
 <:DoubleKill:1322814147980689430> <:Perfect:1322879561515532308> <:Rifleman:1322860656399220828>",
     },
     {

--- a/api/embeds/stats/tests/__snapshots__/infection-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/infection-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: __**10**__
 Headshot kills: __**5**__
 Shots H:F (acc): __**50**__:__**100**__ __**(0.5%)**__
 Damage D:T (D/T): __**2,500**__:__**1,500**__ __**(1.67)**__
-Avg life time (damage/life): __**45s**__ __**(416.67)**__
+Avg life time (damage/life): __**45s**__ __**(357.14)**__
 Alphas killed: __**1**__
 Infected killed: __**5**__
 Kills as last spartan standing: __**2**__

--- a/api/embeds/stats/tests/__snapshots__/koth-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/koth-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: 18
 Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
-Avg life time (damage/life): 25s (405.32)
+Avg life time (damage/life): 25s (385.05)
 Captures: __**0**__
 Occupation time: **1m 11s**
 Secures: __**0**__
@@ -37,7 +37,7 @@ KDA: 7
 Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
-Avg life time (damage/life): 27s (355.63)
+Avg life time (damage/life): 27s (337.85)
 Captures: __**0**__
 Occupation time: 44s
 Secures: __**0**__
@@ -62,7 +62,7 @@ KDA: 7
 Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
-Avg life time (damage/life): 27s (369.94)
+Avg life time (damage/life): 27s (350.47)
 Captures: __**0**__
 Occupation time: 49s
 Secures: __**0**__
@@ -80,7 +80,7 @@ KDA: __**20.33**__
 Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
-Avg life time (damage/life): __**1m 19s**__ __**(858.57)**__
+Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
 Captures: __**0**__
 Occupation time: 53s
 Secures: __**0**__
@@ -110,7 +110,7 @@ KDA: -7.66
 Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
-Avg life time (damage/life): 17s (205.4)
+Avg life time (damage/life): 17s (197.5)
 Captures: __**0**__
 Occupation time: __**1m 29s**__
 Secures: __**0**__
@@ -128,7 +128,7 @@ KDA: -11.66
 Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
-Avg life time (damage/life): 17s (207.73)
+Avg life time (damage/life): 17s (200.04)
 Captures: __**0**__
 Occupation time: 35s
 Secures: __**0**__
@@ -153,7 +153,7 @@ KDA: -11.66
 Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
-Avg life time (damage/life): 19s (230.21)
+Avg life time (damage/life): 19s (221)
 Captures: __**0**__
 Occupation time: 48s
 Secures: __**0**__
@@ -171,7 +171,7 @@ KDA: **9.33**
 Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
-Avg life time (damage/life): **20s** **(312.48)**
+Avg life time (damage/life): **20s** **(299.46)**
 Captures: __**0**__
 Occupation time: 47s
 Secures: __**0**__

--- a/api/embeds/stats/tests/__snapshots__/land-grab-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/land-grab-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: -5
 Headshot kills: 1
 Shots H:F (acc): 66:404 (16.33%)
 Damage D:T (D/T): 1,715:2,612 (0.66)
-Avg life time (damage/life): 27s (190.56)",
+Avg life time (damage/life): 27s (171.5)",
     },
     {
       "inline": true,
@@ -31,7 +31,7 @@ KDA: **4**
 Headshot kills: 1
 Shots H:F (acc): 123:285 (43.15%)
 Damage D:T (D/T): 2,418:**2,024** (1.19)
-Avg life time (damage/life): **36s** (345.43)
+Avg life time (damage/life): **36s** (302.25)
 <:DoubleKill:1322814147980689430> <:Killjoy:1322802841039147129> <:BackSmack:1322872596135546891>",
     },
     {
@@ -51,7 +51,7 @@ KDA: 0.33
 Headshot kills: **4**
 Shots H:F (acc): 114:237 **(48.1%)**
 Damage D:T (D/T): 2,253:2,526 (0.89)
-Avg life time (damage/life): 23s (225.3)
+Avg life time (damage/life): 23s (204.82)
 <:TripleKill:1322814228477906944> <:DoubleKill:1322814147980689430> <:Killjoy:1322802841039147129>",
     },
     {
@@ -64,7 +64,7 @@ KDA: 1
 Headshot kills: 3
 Shots H:F (acc): **158**:__**723**__ (21.85%)
 Damage D:T (D/T): **3,774**:2,186 **(1.73)**
-Avg life time (damage/life): 36s **(471.75)**
+Avg life time (damage/life): 36s **(419.33)**
 <:Grapplejack:1322884573906075729>",
     },
     {
@@ -84,7 +84,7 @@ KDA: -4.33
 Headshot kills: 1
 Shots H:F (acc): 61:161 (37.88%)
 Damage D:T (D/T): 1,322:2,416 (0.55)
-Avg life time (damage/life): 23s (132.2)
+Avg life time (damage/life): 23s (120.18)
 <:Killjoy:1322802841039147129> <:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351>",
     },
     {
@@ -97,7 +97,7 @@ KDA: -5
 Headshot kills: 2
 Shots H:F (acc): 75:207 (36.23%)
 Damage D:T (D/T): 1,846:3,332 (0.55)
-Avg life time (damage/life): 14s (131.86)
+Avg life time (damage/life): 14s (123.07)
 <:DoubleKill:1322814147980689430>",
     },
     {
@@ -117,7 +117,7 @@ KDA: 0
 Headshot kills: 1
 Shots H:F (acc): 123:316 (38.92%)
 Damage D:T (D/T): 2,825:2,306 (1.23)
-Avg life time (damage/life): 31s (353.13)",
+Avg life time (damage/life): 31s (313.89)",
     },
     {
       "inline": true,
@@ -129,7 +129,7 @@ KDA: -7
 Headshot kills: 0
 Shots H:F (acc): 76:305 (24.91%)
 Damage D:T (D/T): 1,243:3,058 (0.41)
-Avg life time (damage/life): 16s (95.62)
+Avg life time (damage/life): 16s (88.79)
 2x<:DoubleKill:1322814147980689430> <:BackSmack:1322872596135546891> <:Killjoy:1322802841039147129>",
     },
     {
@@ -154,7 +154,7 @@ KDA: 6
 Headshot kills: 4
 Shots H:F (acc): 107:299 (35.78%)
 Damage D:T (D/T): 2,255:1,904 (1.18)
-Avg life time (damage/life): 43s (375.83)
+Avg life time (damage/life): 43s (322.14)
 <:KillingSpree:1322803050347499541> <:Stick:1322871787695898676> <:BackSmack:1322872596135546891> <:GuardianAngel:1322873057928286248>",
     },
     {
@@ -167,7 +167,7 @@ KDA: -4.33
 Headshot kills: 1
 Shots H:F (acc): 94:233 (40.34%)
 Damage D:T (D/T): 1,847:2,873 (0.64)
-Avg life time (damage/life): 27s (184.7)",
+Avg life time (damage/life): 27s (167.91)",
     },
     {
       "inline": false,
@@ -186,7 +186,7 @@ KDA: -4.33
 Headshot kills: 1
 Shots H:F (acc): 65:170 (38.23%)
 Damage D:T (D/T): 1,131:2,237 (0.51)
-Avg life time (damage/life): 31s (141.38)",
+Avg life time (damage/life): 31s (125.67)",
     },
     {
       "inline": true,
@@ -198,7 +198,7 @@ KDA: __**24.33**__
 Headshot kills: __**20**__
 Shots H:F (acc): 197:314 __**(62.73%)**__
 Damage D:T (D/T): __**7,623**__:1,989 __**(3.83)**__
-Avg life time (damage/life): 43s __**(1,270.5)**__
+Avg life time (damage/life): 43s __**(1,089)**__
 <:AutopilotEngaged:1322883411660243016> 2x<:TripleKill:1322814228477906944> <:KillingFrenzy:1322803174238584853> 4x<:DoubleKill:1322814147980689430> <:OfftheRack:1322884747881353279> 3x<:Perfect:1322879561515532308> 2x<:KillingSpree:1322803050347499541> 5x<:Snipe:1322872969571340370> <:Sharpshooter:1322866954457055242> <:Rifleman:1322860656399220828> <:GuardianAngel:1322873057928286248> <:Reversal:1322872797701083166> <:Stick:1322871787695898676>",
     },
     {
@@ -218,7 +218,7 @@ KDA: 0.66
 Headshot kills: 3
 Shots H:F (acc): 160:386 (41.45%)
 Damage D:T (D/T): 1,552:2,026 (0.77)
-Avg life time (damage/life): 43s (258.67)",
+Avg life time (damage/life): 43s (221.71)",
     },
     {
       "inline": true,
@@ -230,7 +230,7 @@ KDA: -1
 Headshot kills: 0
 Shots H:F (acc): 118:**596** (19.79%)
 Damage D:T (D/T): 1,975:1,869 (1.06)
-Avg life time (damage/life): 36s (282.14)
+Avg life time (damage/life): 36s (246.88)
 <:Splatter:1322872682592735242>",
     },
     {
@@ -250,7 +250,7 @@ KDA: 3
 Headshot kills: 2
 Shots H:F (acc): 147:450 (32.66%)
 Damage D:T (D/T): 1,051:__**1,202**__ (0.87)
-Avg life time (damage/life): __**1m 23s**__ (350.33)",
+Avg life time (damage/life): __**1m 23s**__ (262.75)",
     },
     {
       "inline": true,
@@ -262,7 +262,7 @@ KDA: 12
 Headshot kills: 7
 Shots H:F (acc): __**202**__:418 (48.32%)
 Damage D:T (D/T): 3,961:2,231 (1.78)
-Avg life time (damage/life): 43s (660.17)
+Avg life time (damage/life): 43s (565.86)
 <:TripleKill:1322814228477906944> 3x<:DoubleKill:1322814147980689430> <:KillingSpree:1322803050347499541> <:HailMary:1322882032103325768> <:Reversal:1322872797701083166> <:Gunslinger:1322866262736637992> <:QuickDraw:1322884127212699660>",
     },
     {

--- a/api/embeds/stats/tests/__snapshots__/minigame-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/minigame-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: **5.33**
 Headshot kills: **13**
 Shots H:F (acc): 138:211 __**(65.4%)**__
 Damage D:T (D/T): **5,850**:4,647 __**(1.26)**__
-Avg life time (damage/life): 25s **(417.86)**
+Avg life time (damage/life): 25s **(390)**
 2x<:DoubleKill:1322814147980689430> <:Rifleman:1322860656399220828>",
     },
     {
@@ -32,7 +32,7 @@ KDA: 4.66
 Headshot kills: 3
 Shots H:F (acc): __**141**__:__**283**__ (49.82%)
 Damage D:T (D/T): 4,498:**4,249** (1.06)
-Avg life time (damage/life): 31s (374.83)
+Avg life time (damage/life): 31s (346)
 <:ShotCaller:1322884687693086771> <:KillingSpree:1322803050347499541> <:Stick:1322871787695898676> <:Rifleman:1322860656399220828> <:Killjoy:1322802841039147129> <:Boxer:1322864064082477077>",
     },
     {
@@ -52,7 +52,7 @@ KDA: -0.33
 Headshot kills: 2
 Shots H:F (acc): 63:159 (39.62%)
 Damage D:T (D/T): 3,527:4,516 (0.78)
-Avg life time (damage/life): __**42s**__ (352.7)
+Avg life time (damage/life): __**42s**__ (320.64)
 <:Reversal:1322872797701083166>",
     },
     {
@@ -65,7 +65,7 @@ KDA: -7.33
 Headshot kills: 4
 Shots H:F (acc): 79:180 (43.88%)
 Damage D:T (D/T): 3,290:4,656 (0.71)
-Avg life time (damage/life): 25s (235)
+Avg life time (damage/life): 25s (219.33)
 <:Spotter:1322814780796309505>",
     },
     {
@@ -90,7 +90,7 @@ KDA: __**12.33**__
 Headshot kills: __**14**__
 Shots H:F (acc): **116**:**195** **(59.48%)**
 Damage D:T (D/T): __**6,178**__:5,163 **(1.2)**
-Avg life time (damage/life): **38s** __**(617.8)**__
+Avg life time (damage/life): **38s** __**(561.64)**__
 3x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> <:KillingSpree:1322803050347499541> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
     },
     {
@@ -103,7 +103,7 @@ KDA: 1.66
 Headshot kills: 4
 Shots H:F (acc): 82:193 (42.48%)
 Damage D:T (D/T): 3,629:__**3,885**__ (0.93)
-Avg life time (damage/life): 31s (302.42)
+Avg life time (damage/life): 31s (279.15)
 <:ShotCaller:1322884687693086771> <:ClusterLuck:1322871366961205269> <:DoubleKill:1322814147980689430> <:Spotter:1322814780796309505> <:Rifleman:1322860656399220828> <:Bodyguard:1322867380136841279>",
     },
     {
@@ -123,7 +123,7 @@ KDA: 0.33
 Headshot kills: 6
 Shots H:F (acc): 75:129 (58.13%)
 Damage D:T (D/T): 3,868:4,158 (0.93)
-Avg life time (damage/life): 31s (322.33)
+Avg life time (damage/life): 31s (297.54)
 <:DoubleKill:1322814147980689430> <:BackSmack:1322872596135546891> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828>",
     },
     {
@@ -136,7 +136,7 @@ KDA: 1.66
 Headshot kills: 6
 Shots H:F (acc): 98:**195** (50.25%)
 Damage D:T (D/T): 4,174:4,150 (1.01)
-Avg life time (damage/life): **38s** (417.4)
+Avg life time (damage/life): **38s** (379.45)
 <:DoubleKill:1322814147980689430> <:Perfect:1322879561515532308> <:Rifleman:1322860656399220828>",
     },
     {

--- a/api/embeds/stats/tests/__snapshots__/oddball-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/oddball-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: -4
 Headshot kills: 4
 Shots H:F (acc): 161:326 (49.38%)
 Damage D:T (D/T): 7,718:**9,491** (0.81)
-Avg life time (damage/life): **27s** (266.14)
+Avg life time (damage/life): **27s** (257.27)
 Total time as carrier: **1m 33s**
 Longest time as carrier: **22s**
 2x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:FromtheGrave:1322884008773816351> <:Rifleman:1322860656399220828> <:Spotter:1322814780796309505> <:Bodyguard:1322867380136841279> <:Boxer:1322864064082477077>",
@@ -34,7 +34,7 @@ KDA: -13
 Headshot kills: 10
 Shots H:F (acc): 181:362 (50%)
 Damage D:T (D/T): 8,476:10,836 (0.78)
-Avg life time (damage/life): 20s (235.44)
+Avg life time (damage/life): 20s (229.08)
 Total time as carrier: 53s
 Longest time as carrier: 15s
 2x<:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:ShotCaller:1322884687693086771> <:Reversal:1322872797701083166> <:BackSmack:1322872596135546891> <:Boxer:1322864064082477077> <:Rifleman:1322860656399220828> 2x<:FromtheGrave:1322884008773816351> <:Killjoy:1322802841039147129>",
@@ -56,7 +56,7 @@ KDA: **10.33**
 Headshot kills: __**31**__
 Shots H:F (acc): **268**:**458** __**(58.51%)**__
 Damage D:T (D/T): **11,620**:11,411 **(1.02)**
-Avg life time (damage/life): 24s **(352.12)**
+Avg life time (damage/life): 24s **(341.76)**
 Total time as carrier: 48s
 Longest time as carrier: 11s
 4x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> <:Stick:1322871787695898676> <:Rifleman:1322860656399220828> <:Bodyguard:1322867380136841279> 2x<:Reversal:1322872797701083166> <:Wingman:1322854221095108609> 2x<:Killjoy:1322802841039147129>",
@@ -71,7 +71,7 @@ KDA: 1.66
 Headshot kills: 17
 Shots H:F (acc): 251:443 (56.65%)
 Damage D:T (D/T): 10,303:10,590 (0.97)
-Avg life time (damage/life): 23s (321.97)
+Avg life time (damage/life): 23s (312.21)
 Total time as carrier: 21s
 Longest time as carrier: 10s
 3x<:Perfect:1322879561515532308> 3x<:ShotCaller:1322884687693086771> 2x<:DoubleKill:1322814147980689430> <:Rifleman:1322860656399220828> <:Reversal:1322872797701083166> <:Spotter:1322814780796309505> 2x<:Stick:1322871787695898676> <:BackSmack:1322872596135546891> <:Boxer:1322864064082477077> <:Wingman:1322854221095108609>",
@@ -98,7 +98,7 @@ KDA: 14.33
 Headshot kills: 20
 Shots H:F (acc): 224:409 (54.76%)
 Damage D:T (D/T): 9,430:__**8,596**__ (1.1)
-Avg life time (damage/life): __**41s**__ (449.05)
+Avg life time (damage/life): __**41s**__ (428.64)
 Total time as carrier: __**1m 45s**__
 Longest time as carrier: __**25s**__
 <:360:1322885279266373703> 2x<:Perfect:1322879561515532308> 4x<:ShotCaller:1322884687693086771> <:KillingSpree:1322803050347499541> <:Stick:1322871787695898676> 2x<:FromtheGrave:1322884008773816351> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609> <:Spotter:1322814780796309505> <:BackSmack:1322872596135546891> <:Boxer:1322864064082477077>",
@@ -113,7 +113,7 @@ KDA: 4.33
 Headshot kills: 18
 Shots H:F (acc): 237:447 (53.02%)
 Damage D:T (D/T): 10,815:10,019 (1.08)
-Avg life time (damage/life): 25s (348.87)
+Avg life time (damage/life): 25s (337.97)
 Total time as carrier: 1m 26s
 Longest time as carrier: 24s
 <:Perfect:1322879561515532308> <:ShotCaller:1322884687693086771> 3x<:DoubleKill:1322814147980689430> <:KillingSpree:1322803050347499541> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609> <:GuardianAngel:1322873057928286248> <:FromtheGrave:1322884008773816351>",
@@ -135,7 +135,7 @@ KDA: __**30**__
 Headshot kills: **30**
 Shots H:F (acc): __**335**__:__**582**__ **(57.56%)**
 Damage D:T (D/T): __**13,919**__:10,011 __**(1.39)**__
-Avg life time (damage/life): 33s __**(579.96)**__
+Avg life time (damage/life): 33s __**(556.76)**__
 Total time as carrier: 45s
 Longest time as carrier: 13s
 8x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> <:ShotCaller:1322884687693086771> 2x<:KillingSpree:1322803050347499541> <:Rifleman:1322860656399220828> 2x<:BackSmack:1322872596135546891> <:Reversal:1322872797701083166> <:Wingman:1322854221095108609> 2x<:Stick:1322871787695898676> 2x<:FromtheGrave:1322884008773816351> <:Boxer:1322864064082477077> <:Bodyguard:1322867380136841279> <:GuardianAngel:1322873057928286248>",
@@ -150,7 +150,7 @@ KDA: -6.66
 Headshot kills: 12
 Shots H:F (acc): 158:322 (49.06%)
 Damage D:T (D/T): 7,200:9,781 (0.74)
-Avg life time (damage/life): 22s (218.18)
+Avg life time (damage/life): 22s (211.76)
 Total time as carrier: 33s
 Longest time as carrier: 11s
 <:Perfect:1322879561515532308> 2x<:Reversal:1322872797701083166> <:Stick:1322871787695898676> <:Rifleman:1322860656399220828> <:FromtheGrave:1322884008773816351> <:Bodyguard:1322867380136841279> <:Wingman:1322854221095108609>",

--- a/api/embeds/stats/tests/__snapshots__/series-players-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/series-players-embed.test.ts.snap
@@ -15,7 +15,7 @@ KDA: **25.66**
 Headshot kills: **39**
 Shots H:F (acc): __**439**__:__**760**__ **(58.49%)**
 Damage D:T (D/T): **17,916**:16,468 (1.09)
-Avg life time (damage/life): 28s (373.25)
+Avg life time (damage/life): 28s (365.63)
 <:TripleKill:1322814228477906944> 5x<:ShotCaller:1322884687693086771> <:NoScope:1322882248516702220> 8x<:DoubleKill:1322814147980689430> 4x<:KillingSpree:1322803050347499541> 4x<:Perfect:1322879561515532308> 2x<:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 2x<:Reversal:1322872797701083166> 3x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609> <:Killjoy:1322802841039147129> <:Boxer:1322864064082477077>",
       },
       {
@@ -28,7 +28,7 @@ KDA: 17
 Headshot kills: 33
 Shots H:F (acc): 307:578 (52.11%)
 Damage D:T (D/T): 16,174:16,029 (1.01)
-Avg life time (damage/life): 33s (367.59)
+Avg life time (damage/life): 33s (359.42)
 2x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> 2x<:ShotCaller:1322884687693086771> 3x<:Snipe:1322872969571340370> 2x<:Rifleman:1322860656399220828> 4x<:Reversal:1322872797701083166> 3x<:GuardianAngel:1322873057928286248> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:Wingman:1322854221095108609> <:Stick:1322871787695898676> 2x<:BackSmack:1322872596135546891>",
       },
       {
@@ -48,7 +48,7 @@ KDA: 12.99
 Headshot kills: 29
 Shots H:F (acc): 355:654 (54.19%)
 Damage D:T (D/T): 17,245:14,994 __**(1.15)**__
-Avg life time (damage/life): 28s (374.89)
+Avg life time (damage/life): 28s (366.91)
 <:TripleKill:1322814228477906944> <:OfftheRack:1322884747881353279> 4x<:DoubleKill:1322814147980689430> 2x<:Perfect:1322879561515532308> 3x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
       },
       {
@@ -61,7 +61,7 @@ KDA: 23
 Headshot kills: 32
 Shots H:F (acc): 304:584 (51.33%)
 Damage D:T (D/T): 13,159:__**12,252**__ (1.07)
-Avg life time (damage/life): __**53s**__ __**(438.63)**__
+Avg life time (damage/life): __**53s**__ __**(424.48)**__
 <:DoubleKill:1322814147980689430> 3x<:Perfect:1322879561515532308> 4x<:KillingSpree:1322803050347499541> <:Killjoy:1322802841039147129> 2x<:Rifleman:1322860656399220828> <:Snipe:1322872969571340370> 2x<:GuardianAngel:1322873057928286248> <:Spotter:1322814780796309505>",
       },
       {
@@ -87,7 +87,7 @@ KDA: __**26.66**__
 Headshot kills: __**49**__
 Shots H:F (acc): **420**:**692** __**(61.24%)**__
 Damage D:T (D/T): __**19,567**__:17,444 **(1.12)**
-Avg life time (damage/life): 28s **(399.33)**
+Avg life time (damage/life): 28s **(391.34)**
 <:SneakKing:1322883516039696415> 11x<:DoubleKill:1322814147980689430> 8x<:Perfect:1322879561515532308> 2x<:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:Whiplash:1322882310122504202> 3x<:Rifleman:1322860656399220828> 3x<:Killjoy:1322802841039147129> <:Wingman:1322854221095108609>",
       },
       {
@@ -100,7 +100,7 @@ KDA: -4.34
 Headshot kills: 23
 Shots H:F (acc): 283:592 (47.77%)
 Damage D:T (D/T): 12,421:**15,088** (0.82)
-Avg life time (damage/life): 25s (234.36)
+Avg life time (damage/life): 25s (230.02)
 <:Perfect:1322879561515532308> <:ShotCaller:1322884687693086771> <:ClusterLuck:1322871366961205269> <:DoubleKill:1322814147980689430> 3x<:Rifleman:1322860656399220828> <:Stick:1322871787695898676> <:Killjoy:1322802841039147129> <:GuardianAngel:1322873057928286248> <:Wingman:1322854221095108609> <:Spotter:1322814780796309505> <:Bodyguard:1322867380136841279>",
       },
       {
@@ -120,7 +120,7 @@ KDA: -18.99
 Headshot kills: 20
 Shots H:F (acc): 301:587 (52.51%)
 Damage D:T (D/T): 13,363:17,195 (0.78)
-Avg life time (damage/life): 22s (226.49)
+Avg life time (damage/life): 22s (222.72)
 3x<:DoubleKill:1322814147980689430> 3x<:Rifleman:1322860656399220828> <:Reversal:1322872797701083166> <:LastShot:1322884170606972959> <:Wingman:1322854221095108609> 2x<:Killjoy:1322802841039147129> <:BackSmack:1322872596135546891>",
       },
       {
@@ -133,7 +133,7 @@ KDA: -15.33
 Headshot kills: 16
 Shots H:F (acc): 289:595 (48.53%)
 Damage D:T (D/T): 13,558:15,764 (0.86)
-Avg life time (damage/life): **29s** (276.69)
+Avg life time (damage/life): **29s** (271.16)
 5x<:ShotCaller:1322884687693086771> 2x<:Perfect:1322879561515532308> 2x<:DoubleKill:1322814147980689430> <:NadeShot:1322877140605206528> 3x<:Rifleman:1322860656399220828> <:StoppedShort:1322806739778670652> 2x<:Killjoy:1322802841039147129> <:Spotter:1322814780796309505> <:Wingman:1322854221095108609>",
       },
       {

--- a/api/embeds/stats/tests/__snapshots__/slayer-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/slayer-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: **5.33**
 Headshot kills: **13**
 Shots H:F (acc): 138:211 __**(65.4%)**__
 Damage D:T (D/T): **5,850**:4,647 __**(1.26)**__
-Avg life time (damage/life): 25s **(417.86)**
+Avg life time (damage/life): 25s **(390)**
 2x<:DoubleKill:1322814147980689430> <:Rifleman:1322860656399220828>",
     },
     {
@@ -32,7 +32,7 @@ KDA: 4.66
 Headshot kills: 3
 Shots H:F (acc): __**141**__:__**283**__ (49.82%)
 Damage D:T (D/T): 4,498:**4,249** (1.06)
-Avg life time (damage/life): 31s (374.83)
+Avg life time (damage/life): 31s (346)
 <:ShotCaller:1322884687693086771> <:KillingSpree:1322803050347499541> <:Stick:1322871787695898676> <:Rifleman:1322860656399220828> <:Killjoy:1322802841039147129> <:Boxer:1322864064082477077>",
     },
     {
@@ -52,7 +52,7 @@ KDA: -0.33
 Headshot kills: 2
 Shots H:F (acc): 63:159 (39.62%)
 Damage D:T (D/T): 3,527:4,516 (0.78)
-Avg life time (damage/life): __**42s**__ (352.7)
+Avg life time (damage/life): __**42s**__ (320.64)
 <:Reversal:1322872797701083166>",
     },
     {
@@ -65,7 +65,7 @@ KDA: -7.33
 Headshot kills: 4
 Shots H:F (acc): 79:180 (43.88%)
 Damage D:T (D/T): 3,290:4,656 (0.71)
-Avg life time (damage/life): 25s (235)
+Avg life time (damage/life): 25s (219.33)
 <:Spotter:1322814780796309505>",
     },
     {
@@ -90,7 +90,7 @@ KDA: __**12.33**__
 Headshot kills: __**14**__
 Shots H:F (acc): **116**:**195** **(59.48%)**
 Damage D:T (D/T): __**6,178**__:5,163 **(1.2)**
-Avg life time (damage/life): **38s** __**(617.8)**__
+Avg life time (damage/life): **38s** __**(561.64)**__
 3x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> <:KillingSpree:1322803050347499541> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
     },
     {
@@ -103,7 +103,7 @@ KDA: 1.66
 Headshot kills: 4
 Shots H:F (acc): 82:193 (42.48%)
 Damage D:T (D/T): 3,629:__**3,885**__ (0.93)
-Avg life time (damage/life): 31s (302.42)
+Avg life time (damage/life): 31s (279.15)
 <:ShotCaller:1322884687693086771> <:ClusterLuck:1322871366961205269> <:DoubleKill:1322814147980689430> <:Spotter:1322814780796309505> <:Rifleman:1322860656399220828> <:Bodyguard:1322867380136841279>",
     },
     {
@@ -123,7 +123,7 @@ KDA: 0.33
 Headshot kills: 6
 Shots H:F (acc): 75:129 (58.13%)
 Damage D:T (D/T): 3,868:4,158 (0.93)
-Avg life time (damage/life): 31s (322.33)
+Avg life time (damage/life): 31s (297.54)
 <:DoubleKill:1322814147980689430> <:BackSmack:1322872596135546891> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828>",
     },
     {
@@ -136,7 +136,7 @@ KDA: 1.66
 Headshot kills: 6
 Shots H:F (acc): 98:**195** (50.25%)
 Damage D:T (D/T): 4,174:4,150 (1.01)
-Avg life time (damage/life): **38s** (417.4)
+Avg life time (damage/life): **38s** (379.45)
 <:DoubleKill:1322814147980689430> <:Perfect:1322879561515532308> <:Rifleman:1322860656399220828>",
     },
     {

--- a/api/embeds/stats/tests/__snapshots__/stockpile-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/stockpile-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: __**10**__
 Headshot kills: __**5**__
 Shots H:F (acc): __**50**__:__**100**__ __**(0.5%)**__
 Damage D:T (D/T): __**2,500**__:__**1,500**__ __**(1.67)**__
-Avg life time (damage/life): __**45s**__ __**(416.67)**__
+Avg life time (damage/life): __**45s**__ __**(357.14)**__
 Power seeds deposited: __**3**__
 Power seeds stolen: __**1**__
 Kills as power seed carrier: __**2**__

--- a/api/embeds/stats/tests/__snapshots__/strongholds-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/strongholds-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: **0.33**
 Headshot kills: 11
 Shots H:F (acc): 125:201 __**(62.18%)**__
 Damage D:T (D/T): 5,771:**5,949** **(0.97)**
-Avg life time (damage/life): 22s (274.81)
+Avg life time (damage/life): 22s (262.32)
 Captures: 10
 Occupation time: 1m 34s
 Secures: 2
@@ -37,7 +37,7 @@ KDA: -1.66
 Headshot kills: **12**
 Shots H:F (acc): __**155**__:__**253**__ (61.26%)
 Damage D:T (D/T): **6,633**:6,892 (0.96)
-Avg life time (damage/life): 21s **(301.5)**
+Avg life time (damage/life): 21s **(288.39)**
 Captures: 9
 Occupation time: 1m 28s
 Secures: 2
@@ -62,7 +62,7 @@ KDA: -6.33
 Headshot kills: 9
 Shots H:F (acc): 88:170 (51.76%)
 Damage D:T (D/T): 4,528:6,405 (0.71)
-Avg life time (damage/life): 21s (215.62)
+Avg life time (damage/life): 21s (205.82)
 Captures: __**12**__
 Occupation time: __**2m 10s**__
 Secures: 2
@@ -80,7 +80,7 @@ KDA: -4.66
 Headshot kills: 6
 Shots H:F (acc): 128:220 (58.18%)
 Damage D:T (D/T): 5,716:6,138 (0.93)
-Avg life time (damage/life): **24s** (300.84)
+Avg life time (damage/life): **24s** (285.8)
 Captures: 6
 Occupation time: 1m 10s
 Secures: __**3**__
@@ -110,7 +110,7 @@ KDA: __**11**__
 Headshot kills: __**20**__
 Shots H:F (acc): **141**:237 **(59.49%)**
 Damage D:T (D/T): __**7,066**__:6,496 (1.09)
-Avg life time (damage/life): 24s (353.3)
+Avg life time (damage/life): 24s (336.48)
 Captures: 7
 Occupation time: 1m 32s
 Secures: 2
@@ -128,7 +128,7 @@ KDA: 6.33
 Headshot kills: 9
 Shots H:F (acc): 128:**248** (51.61%)
 Damage D:T (D/T): 6,660:6,197 (1.07)
-Avg life time (damage/life): 28s (391.76)
+Avg life time (damage/life): 28s (370)
 Captures: **8**
 Occupation time: **1m 49s**
 Secures: 1
@@ -153,7 +153,7 @@ KDA: 10
 Headshot kills: 12
 Shots H:F (acc): 112:229 (48.9%)
 Damage D:T (D/T): 5,374:5,154 (1.04)
-Avg life time (damage/life): __**43s**__ __**(447.83)**__
+Avg life time (damage/life): __**43s**__ (413.38)
 Captures: **8**
 Occupation time: 1m 41s
 Secures: __**3**__
@@ -171,7 +171,7 @@ KDA: 5.33
 Headshot kills: 11
 Shots H:F (acc): 125:228 (54.82%)
 Damage D:T (D/T): 5,803:__**4,939**__ __**(1.17)**__
-Avg life time (damage/life): 39s (446.38)
+Avg life time (damage/life): 39s __**(414.5)**__
 Captures: 6
 Occupation time: 1m 5s
 Secures: 2

--- a/api/embeds/stats/tests/__snapshots__/total-control-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/total-control-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: **14**
 Headshot kills: 5
 Shots H:F (acc): __**329**__:__**875**__ (37.59%)
 Damage D:T (D/T): **6,630**:3,707 **(1.79)**
-Avg life time (damage/life): 40s **(602.73)**
+Avg life time (damage/life): 40s **(552.5)**
 2x<:OfftheRack:1322884747881353279> <:KillingSpree:1322803050347499541> <:Perfect:1322879561515532308> 2x<:Snipe:1322872969571340370> <:GuardianAngel:1322873057928286248> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
     },
     {
@@ -32,7 +32,7 @@ KDA: 11.66
 Headshot kills: **13**
 Shots H:F (acc): 223:621 (35.9%)
 Damage D:T (D/T): 6,544:3,809 (1.72)
-Avg life time (damage/life): 33s (503.38)
+Avg life time (damage/life): 33s (467.43)
 <:Overkill:1322814293691076649> <:TripleKill:1322814228477906944> 4x<:DoubleKill:1322814147980689430> <:YardSale:1322884799886786571> <:KillingSpree:1322803050347499541> <:Gunslinger:1322866262736637992> <:LastShot:1322884170606972959> <:Killjoy:1322802841039147129> 4x<:Snipe:1322872969571340370>",
     },
     {
@@ -52,7 +52,7 @@ KDA: 1
 Headshot kills: 3
 Shots H:F (acc): 112:268 **(41.79%)**
 Damage D:T (D/T): 3,113:4,286 (0.73)
-Avg life time (damage/life): 30s (222.36)
+Avg life time (damage/life): 30s (207.53)
 <:OfftheRack:1322884747881353279> <:KillingSpree:1322803050347499541> <:DoubleKill:1322814147980689430> <:Killjoy:1322802841039147129> 2x<:Reversal:1322872797701083166> <:Wheelman:1322854352334884938>",
     },
     {
@@ -65,7 +65,7 @@ KDA: -5.33
 Headshot kills: 0
 Shots H:F (acc): 241:680 (35.44%)
 Damage D:T (D/T): 4,331:4,578 (0.95)
-Avg life time (damage/life): 25s (254.76)
+Avg life time (damage/life): 25s (240.61)
 2x<:DoubleKill:1322814147980689430> <:OdinsRaven:1322873365278756884> <:BackSmack:1322872596135546891> <:Rifleman:1322860656399220828>",
     },
     {
@@ -85,7 +85,7 @@ KDA: -8.33
 Headshot kills: 1
 Shots H:F (acc): 73:329 (22.18%)
 Damage D:T (D/T): 2,065:4,031 (0.51)
-Avg life time (damage/life): 28s (137.67)
+Avg life time (damage/life): 28s (129.06)
 <:360:1322885279266373703> <:Kong:1322873292180160604>",
     },
     {
@@ -98,7 +98,7 @@ KDA: -2
 Headshot kills: 1
 Shots H:F (acc): 106:522 (20.3%)
 Damage D:T (D/T): 2,582:2,390 (1.08)
-Avg life time (damage/life): **57s** (322.75)
+Avg life time (damage/life): **57s** (286.89)
 <:ShotCaller:1322884687693086771>",
     },
     {
@@ -118,7 +118,7 @@ KDA: 3.33
 Headshot kills: 0
 Shots H:F (acc): 74:241 (30.7%)
 Damage D:T (D/T): 3,844:2,892 (1.33)
-Avg life time (damage/life): 40s (349.45)
+Avg life time (damage/life): 40s (320.33)
 2x<:DoubleKill:1322814147980689430> <:KillingSpree:1322803050347499541> <:Killjoy:1322802841039147129> <:Driver:1322854828468342784>",
     },
     {
@@ -131,7 +131,7 @@ KDA: -1
 Headshot kills: 0
 Shots H:F (acc): 127:414 (30.67%)
 Damage D:T (D/T): 1,877:__**2,367**__ (0.79)
-Avg life time (damage/life): 35s (208.56)
+Avg life time (damage/life): 35s (187.7)
 <:DoubleKill:1322814147980689430> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828>",
     },
     {
@@ -156,7 +156,7 @@ KDA: __**38.33**__
 Headshot kills: __**29**__
 Shots H:F (acc): 197:326 __**(60.42%)**__
 Damage D:T (D/T): __**10,707**__:**3,031** __**(3.53)**__
-Avg life time (damage/life): __**1m 6s**__ __**(1,529.57)**__
+Avg life time (damage/life): __**1m 6s**__ __**(1,338.38)**__
 <:Killtacular:1322814341950603275> 2x<:Overkill:1322814293691076649> <:RunningRiot:1322804226656571394> 3x<:TripleKill:1322814228477906944> 2x<:KillingFrenzy:1322803174238584853> 9x<:DoubleKill:1322814147980689430> 3x<:KillingSpree:1322803050347499541> 4x<:Perfect:1322879561515532308> <:NoScope:1322882248516702220> <:YardSale:1322884799886786571> <:Pull:1322883571912015912> 9x<:Snipe:1322872969571340370> <:Sharpshooter:1322866954457055242> <:GuardianAngel:1322873057928286248> 3x<:Killjoy:1322802841039147129> <:Gunslinger:1322866262736637992> <:Rifleman:1322860656399220828> <:Bomber:1322863948101586956> <:LastShot:1322884170606972959> <:Reversal:1322872797701083166>",
     },
     {
@@ -169,7 +169,7 @@ KDA: 3
 Headshot kills: 6
 Shots H:F (acc): 180:440 (40.9%)
 Damage D:T (D/T): 3,260:3,530 (0.92)
-Avg life time (damage/life): 45s (326)
+Avg life time (damage/life): 45s (296.36)
 <:DoubleKill:1322814147980689430> <:KillingSpree:1322803050347499541> <:Gunslinger:1322866262736637992>",
     },
     {
@@ -189,7 +189,7 @@ KDA: 2.33
 Headshot kills: 3
 Shots H:F (acc): 163:405 (40.24%)
 Damage D:T (D/T): 3,248:4,207 (0.77)
-Avg life time (damage/life): 45s (324.8)
+Avg life time (damage/life): 45s (295.27)
 <:QuickDraw:1322884127212699660> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
     },
     {
@@ -202,7 +202,7 @@ KDA: 1
 Headshot kills: 3
 Shots H:F (acc): 91:209 (43.54%)
 Damage D:T (D/T): 3,662:3,411 (1.07)
-Avg life time (damage/life): 33s (281.69)
+Avg life time (damage/life): 33s (261.57)
 3x<:DoubleKill:1322814147980689430> <:NoScope:1322882248516702220> <:KillingSpree:1322803050347499541> <:Snipe:1322872969571340370>",
     },
     {
@@ -222,7 +222,7 @@ KDA: -2.66
 Headshot kills: 2
 Shots H:F (acc): 182:408 (44.6%)
 Damage D:T (D/T): 2,617:3,314 (0.79)
-Avg life time (damage/life): 40s (237.91)
+Avg life time (damage/life): 40s (218.08)
 <:BackSmack:1322872596135546891> <:Reversal:1322872797701083166>",
     },
     {
@@ -235,7 +235,7 @@ KDA: -6.66
 Headshot kills: 0
 Shots H:F (acc): 141:437 (32.26%)
 Damage D:T (D/T): 2,526:4,373 (0.58)
-Avg life time (damage/life): 30s (180.43)
+Avg life time (damage/life): 30s (168.4)
 <:WindshieldWiper:1322882369019052052> <:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351>",
     },
     {
@@ -255,7 +255,7 @@ KDA: -3.66
 Headshot kills: 2
 Shots H:F (acc): **230**:**704** (32.67%)
 Damage D:T (D/T): 3,868:3,629 (1.07)
-Avg life time (damage/life): 40s (351.64)
+Avg life time (damage/life): 40s (322.33)
 <:YardSale:1322884799886786571>",
     },
     {
@@ -268,7 +268,7 @@ KDA: -10.66
 Headshot kills: 0
 Shots H:F (acc): 54:210 (25.71%)
 Damage D:T (D/T): 1,222:3,887 (0.31)
-Avg life time (damage/life): 25s (76.38)
+Avg life time (damage/life): 25s (71.88)
 <:Reversal:1322872797701083166>",
     },
     {

--- a/api/embeds/stats/tests/__snapshots__/unknown-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/unknown-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: **5.33**
 Headshot kills: **13**
 Shots H:F (acc): 138:211 __**(65.4%)**__
 Damage D:T (D/T): **5,850**:4,647 __**(1.26)**__
-Avg life time (damage/life): 25s **(417.86)**
+Avg life time (damage/life): 25s **(390)**
 2x<:DoubleKill:1322814147980689430> <:Rifleman:1322860656399220828>",
     },
     {
@@ -32,7 +32,7 @@ KDA: 4.66
 Headshot kills: 3
 Shots H:F (acc): __**141**__:__**283**__ (49.82%)
 Damage D:T (D/T): 4,498:**4,249** (1.06)
-Avg life time (damage/life): 31s (374.83)
+Avg life time (damage/life): 31s (346)
 <:ShotCaller:1322884687693086771> <:KillingSpree:1322803050347499541> <:Stick:1322871787695898676> <:Rifleman:1322860656399220828> <:Killjoy:1322802841039147129> <:Boxer:1322864064082477077>",
     },
     {
@@ -52,7 +52,7 @@ KDA: -0.33
 Headshot kills: 2
 Shots H:F (acc): 63:159 (39.62%)
 Damage D:T (D/T): 3,527:4,516 (0.78)
-Avg life time (damage/life): __**42s**__ (352.7)
+Avg life time (damage/life): __**42s**__ (320.64)
 <:Reversal:1322872797701083166>",
     },
     {
@@ -65,7 +65,7 @@ KDA: -7.33
 Headshot kills: 4
 Shots H:F (acc): 79:180 (43.88%)
 Damage D:T (D/T): 3,290:4,656 (0.71)
-Avg life time (damage/life): 25s (235)
+Avg life time (damage/life): 25s (219.33)
 <:Spotter:1322814780796309505>",
     },
     {
@@ -90,7 +90,7 @@ KDA: __**12.33**__
 Headshot kills: __**14**__
 Shots H:F (acc): **116**:**195** **(59.48%)**
 Damage D:T (D/T): __**6,178**__:5,163 **(1.2)**
-Avg life time (damage/life): **38s** __**(617.8)**__
+Avg life time (damage/life): **38s** __**(561.64)**__
 3x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> <:KillingSpree:1322803050347499541> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
     },
     {
@@ -103,7 +103,7 @@ KDA: 1.66
 Headshot kills: 4
 Shots H:F (acc): 82:193 (42.48%)
 Damage D:T (D/T): 3,629:__**3,885**__ (0.93)
-Avg life time (damage/life): 31s (302.42)
+Avg life time (damage/life): 31s (279.15)
 <:ShotCaller:1322884687693086771> <:ClusterLuck:1322871366961205269> <:DoubleKill:1322814147980689430> <:Spotter:1322814780796309505> <:Rifleman:1322860656399220828> <:Bodyguard:1322867380136841279>",
     },
     {
@@ -123,7 +123,7 @@ KDA: 0.33
 Headshot kills: 6
 Shots H:F (acc): 75:129 (58.13%)
 Damage D:T (D/T): 3,868:4,158 (0.93)
-Avg life time (damage/life): 31s (322.33)
+Avg life time (damage/life): 31s (297.54)
 <:DoubleKill:1322814147980689430> <:BackSmack:1322872596135546891> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828>",
     },
     {
@@ -136,7 +136,7 @@ KDA: 1.66
 Headshot kills: 6
 Shots H:F (acc): 98:**195** (50.25%)
 Damage D:T (D/T): 4,174:4,150 (1.01)
-Avg life time (damage/life): **38s** (417.4)
+Avg life time (damage/life): **38s** (379.45)
 <:DoubleKill:1322814147980689430> <:Perfect:1322879561515532308> <:Rifleman:1322860656399220828>",
     },
     {

--- a/api/embeds/stats/tests/__snapshots__/vip-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/vip-match-embed.test.ts.snap
@@ -19,7 +19,7 @@ KDA: __**15.66**__
 Headshot kills: __**18**__
 Shots H:F (acc): **270**:470 __**(57.44%)**__
 Damage D:T (D/T): 6,613:4,087 __**(1.62)**__
-Avg life time (damage/life): 37s (601.18)
+Avg life time (damage/life): 37s (551.08)
 VIP kills: __**6**__
 VIP Assists: 1
 Kills as VIP: __**4**__
@@ -39,7 +39,7 @@ KDA: 5
 Headshot kills: 3
 Shots H:F (acc): 251:**485** (51.75%)
 Damage D:T (D/T): __**6,807**__:4,933 (1.38)
-Avg life time (damage/life): 33s **(618.82)**
+Avg life time (damage/life): 33s **(567.25)**
 VIP kills: 4
 VIP Assists: __**3**__
 Kills as VIP: 2
@@ -66,7 +66,7 @@ KDA: 2.33
 Headshot kills: 3
 Shots H:F (acc): 83:207 (40.09%)
 Damage D:T (D/T): 2,375:**2,002** (1.19)
-Avg life time (damage/life): __**55s**__ (339.29)
+Avg life time (damage/life): __**55s**__ (296.88)
 VIP kills: 1
 VIP Assists: 0
 Kills as VIP: 0
@@ -86,7 +86,7 @@ KDA: -5.33
 Headshot kills: 0
 Shots H:F (acc): 102:362 (28.17%)
 Damage D:T (D/T): 2,721:4,748 (0.57)
-Avg life time (damage/life): 33s (247.36)
+Avg life time (damage/life): 33s (226.75)
 VIP kills: 1
 VIP Assists: 1
 Kills as VIP: 2
@@ -118,7 +118,7 @@ KDA: **9**
 Headshot kills: 2
 Shots H:F (acc): __**378**__:__**775**__ **(48.77%)**
 Damage D:T (D/T): **6,247**:4,444 **(1.41)**
-Avg life time (damage/life): **37s** __**(624.7)**__
+Avg life time (damage/life): **37s** __**(567.91)**__
 VIP kills: **5**
 VIP Assists: 1
 Kills as VIP: 1
@@ -138,7 +138,7 @@ KDA: -5.66
 Headshot kills: **3**
 Shots H:F (acc): 133:352 (37.78%)
 Damage D:T (D/T): 4,597:5,035 (0.91)
-Avg life time (damage/life): 20s (287.31)
+Avg life time (damage/life): 20s (270.41)
 VIP kills: 2
 VIP Assists: __**3**__
 Kills as VIP: **3**
@@ -164,7 +164,7 @@ KDA: -8
 Headshot kills: 0
 Shots H:F (acc): 50:214 (23.36%)
 Damage D:T (D/T): 1,454:5,611 (0.26)
-Avg life time (damage/life): 25s (103.86)
+Avg life time (damage/life): 25s (96.93)
 VIP kills: 1
 VIP Assists: 2
 Kills as VIP: **3**
@@ -184,7 +184,7 @@ KDA: -4
 Headshot kills: 0
 Shots H:F (acc): 9:55 (16.36%)
 Damage D:T (D/T): 194:__**1,020**__ (0.19)
-Avg life time (damage/life): 21s (48.5)
+Avg life time (damage/life): 21s (38.8)
 VIP kills: 0
 VIP Assists: 0
 Kills as VIP: 0

--- a/api/services/leaderboard/leaderboard.ts
+++ b/api/services/leaderboard/leaderboard.ts
@@ -578,7 +578,7 @@ export class LeaderboardService {
           DamageTaken: coreStats.DamageTaken,
           DamageRatio: getSafeRatioValue(coreStats.DamageDealt, coreStats.DamageTaken),
           AvgLifeSeconds: this.getAverageLifeSeconds(coreStats.AverageLifeDuration),
-          AvgDamagePerLife: getSafeRatioValue(coreStats.DamageDealt, deaths),
+          AvgDamagePerLife: getSafeRatioValue(coreStats.DamageDealt, deaths + 1),
           ObjectiveStatsJson: JSON.stringify(teamStats.Stats),
           MedalsJson: JSON.stringify(coreStats.Medals),
           CreatedAt: nowEpoch,

--- a/api/services/leaderboard/tests/leaderboard.test.ts
+++ b/api/services/leaderboard/tests/leaderboard.test.ts
@@ -561,6 +561,41 @@ describe("LeaderboardService", () => {
     );
   });
 
+  it("persists average damage per life using total lives", async () => {
+    const databaseService = aFakeDatabaseServiceWith();
+    const haloService = aFakeHaloServiceWith({ databaseService });
+    const logService = aFakeLogServiceWith();
+    const service = new LeaderboardService({ databaseService, haloService, logService });
+    const match = Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf"));
+    const player = Preconditions.checkExists(match.Players[0]);
+    const teamStats = Preconditions.checkExists(player.PlayerTeamStats[0]);
+    teamStats.Stats.CoreStats = {
+      ...teamStats.Stats.CoreStats,
+      DamageDealt: 15000,
+      Deaths: 10,
+    };
+    const upsertSpy = vi.spyOn(databaseService, "upsertLeaderboardSeriesDataBatch");
+
+    await service.persistSeriesData({
+      request: {
+        action: "MATCH_COMPLETED",
+        guild: "guild-1",
+        channel: "channel-1",
+        queue: "ranked",
+        match_number: 42,
+        winning_team_index: teamStats.TeamId,
+        teams: [],
+      },
+      neatQueueConfig: aFakeNeatQueueConfigRow(),
+      series: [match],
+      locale: "en-US",
+    });
+
+    const [payload] = Preconditions.checkExists(upsertSpy.mock.calls[0]);
+    const gamePlayer = Preconditions.checkExists(payload.gamePlayers[0]);
+    expect(gamePlayer.AvgDamagePerLife).toBe(15000 / 11);
+  });
+
   it("logs refresh failures separately from persistence failures", async () => {
     const databaseService = aFakeDatabaseServiceWith();
     const haloService = aFakeHaloServiceWith({ databaseService });

--- a/api/services/neatqueue/tests/__snapshots__/neatqueue.test.ts.snap
+++ b/api/services/neatqueue/tests/__snapshots__/neatqueue.test.ts.snap
@@ -67,7 +67,7 @@ KDA: __74__
 Headshot kills: __111__
 Shots H:F (acc): __984__:1,743 __(56.35%)__
 Damage D:T (D/T): __47,329__:__41,675__ __(1.14)__
-Avg life time (damage/life): __40s__ __(401.09)__
+Avg life time (damage/life): __40s__ __(397.72)__
 2x<:TripleKill:1322814228477906944> 14x<:DoubleKill:1322814147980689430> 11x<:Perfect:1322879561515532308> <:OfftheRack:1322884747881353279> 6x<:ShotCaller:1322884687693086771> 7x<:KillingSpree:1322803050347499541> <:NoScope:1322882248516702220> 4x<:Snipe:1322872969571340370> <:Killjoy:1322802841039147129> 2x<:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 8x<:Rifleman:1322860656399220828> 5x<:Reversal:1322872797701083166> 5x<:GuardianAngel:1322873057928286248> 4x<:Wingman:1322854221095108609> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:BackSmack:1322872596135546891>",
             },
             {
@@ -80,7 +80,7 @@ KDA: -29.33
 Headshot kills: 78
 Shots H:F (acc): 922:__1,754__ (52.91%)
 Damage D:T (D/T): 41,060:48,135 (0.85)
-Avg life time (damage/life): 23s (247.35)
+Avg life time (damage/life): 23s (245.87)
 <:SneakKing:1322883516039696415> 11x<:DoubleKill:1322814147980689430> 5x<:ShotCaller:1322884687693086771> 7x<:Perfect:1322879561515532308> <:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:NadeShot:1322877140605206528> <:Whiplash:1322882310122504202> 8x<:Rifleman:1322860656399220828> 7x<:Killjoy:1322802841039147129> <:Stick:1322871787695898676> <:StoppedShort:1322806739778670652> <:Reversal:1322872797701083166> <:GuardianAngel:1322873057928286248> <:Spotter:1322814780796309505> <:LastShot:1322884170606972959> 3x<:Wingman:1322854221095108609>",
             },
             {
@@ -113,7 +113,7 @@ KDA: 21
 Headshot kills: __**36**__
 Shots H:F (acc): **298**:**477** __**(62.83%)**__
 Damage D:T (D/T): __**13,418**__:12,219 (1.1)
-Avg life time (damage/life): 26s (372.72)
+Avg life time (damage/life): 26s (362.65)
 <:TripleKill:1322814228477906944> 4x<:ShotCaller:1322884687693086771> <:NoScope:1322882248516702220> 8x<:DoubleKill:1322814147980689430> 3x<:KillingSpree:1322803050347499541> 4x<:Perfect:1322879561515532308> <:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 2x<:Reversal:1322872797701083166> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
             },
             {
@@ -126,7 +126,7 @@ KDA: 17.33
 Headshot kills: 31
 Shots H:F (acc): 244:419 (58.36%)
 Damage D:T (D/T): 12,647:11,513 (1.1)
-Avg life time (damage/life): 28s (371.97)
+Avg life time (damage/life): 28s (361.34)
 2x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> 2x<:ShotCaller:1322884687693086771> 3x<:Snipe:1322872969571340370> 2x<:Rifleman:1322860656399220828> 3x<:Reversal:1322872797701083166> 3x<:GuardianAngel:1322873057928286248> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:Wingman:1322854221095108609> <:Stick:1322871787695898676> 2x<:BackSmack:1322872596135546891>",
             },
             {
@@ -146,7 +146,7 @@ KDA: __**30.33**__
 Headshot kills: 28
 Shots H:F (acc): 225:404 (55.05%)
 Damage D:T (D/T): 9,869:__**7,596**__ __**(1.3)**__
-Avg life time (damage/life): __**1m 6s**__ __**(616.81)**__
+Avg life time (damage/life): __**1m 6s**__ __**(580.53)**__
 <:DoubleKill:1322814147980689430> 3x<:Perfect:1322879561515532308> 4x<:KillingSpree:1322803050347499541> <:Killjoy:1322802841039147129> 2x<:Rifleman:1322860656399220828> <:Snipe:1322872969571340370> 2x<:GuardianAngel:1322873057928286248>",
             },
             {
@@ -159,7 +159,7 @@ KDA: 7.66
 Headshot kills: 16
 Shots H:F (acc): 217:443 (48.59%)
 Damage D:T (D/T): 11,395:10,347 (1.1)
-Avg life time (damage/life): 30s (356.09)
+Avg life time (damage/life): 30s (345.3)
 <:TripleKill:1322814228477906944> <:OfftheRack:1322884747881353279> 2x<:DoubleKill:1322814147980689430> 2x<:Perfect:1322879561515532308> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
             },
             {
@@ -192,7 +192,7 @@ KDA: **14.33**
 Headshot kills: **35**
 Shots H:F (acc): __**304**__:__**497**__ **(62.11%)**
 Damage D:T (D/T): **13,389**:12,281 **(1.09)**
-Avg life time (damage/life): 24s **(343.31)**
+Avg life time (damage/life): 24s **(334.73)**
 <:SneakKing:1322883516039696415> 8x<:DoubleKill:1322814147980689430> 5x<:Perfect:1322879561515532308> <:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:Whiplash:1322882310122504202> 2x<:Rifleman:1322860656399220828> 3x<:Killjoy:1322802841039147129>",
             },
             {
@@ -205,7 +205,7 @@ KDA: -6
 Headshot kills: 19
 Shots H:F (acc): 201:399 (50.41%)
 Damage D:T (D/T): 8,792:**11,203** (0.78)
-Avg life time (damage/life): 22s (214.44)
+Avg life time (damage/life): 22s (209.33)
 <:Perfect:1322879561515532308> 2x<:Rifleman:1322860656399220828> <:Stick:1322871787695898676> <:Killjoy:1322802841039147129> <:GuardianAngel:1322873057928286248> <:Wingman:1322854221095108609>",
             },
             {
@@ -225,7 +225,7 @@ KDA: -19.32
 Headshot kills: 14
 Shots H:F (acc): 226:458 (49.7%)
 Damage D:T (D/T): 9,495:13,037 (0.73)
-Avg life time (damage/life): 18s (202.02)
+Avg life time (damage/life): 18s (197.81)
 2x<:DoubleKill:1322814147980689430> 2x<:Rifleman:1322860656399220828> <:Reversal:1322872797701083166> <:LastShot:1322884170606972959> <:Wingman:1322854221095108609> <:Killjoy:1322802841039147129>",
             },
             {
@@ -238,7 +238,7 @@ KDA: -16.99
 Headshot kills: 10
 Shots H:F (acc): 191:400 (47.66%)
 Damage D:T (D/T): 9,384:11,614 (0.81)
-Avg life time (damage/life): **24s** (240.62)
+Avg life time (damage/life): **24s** (234.6)
 5x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:NadeShot:1322877140605206528> 2x<:Rifleman:1322860656399220828> <:StoppedShort:1322806739778670652> 2x<:Killjoy:1322802841039147129> <:Spotter:1322814780796309505> <:Wingman:1322854221095108609>",
             },
             {
@@ -276,7 +276,7 @@ KDA: 0.66
 Headshot kills: 6
 Shots H:F (acc): 83:178 (46.62%)
 Damage D:T (D/T): 4,736:4,879 (0.97)
-Avg life time (damage/life): 32s (338.29)
+Avg life time (damage/life): 32s (315.73)
 Captures: __**2**__
 Captures assists: 0
 Carrier time: 9s
@@ -295,7 +295,7 @@ KDA: __**10.33**__
 Headshot kills: __**17**__
 Shots H:F (acc): 108:182 (59.34%)
 Damage D:T (D/T): **5,890**:4,614 __**(1.28)**__
-Avg life time (damage/life): 29s (392.67)
+Avg life time (damage/life): 29s (368.13)
 Captures: 1
 Captures assists: 2
 Carrier time: 20s
@@ -321,7 +321,7 @@ KDA: 3
 Headshot kills: 11
 Shots H:F (acc): **122**:**189** **(64.55%)**
 Damage D:T (D/T): 5,717:5,479 (1.04)
-Avg life time (damage/life): 27s (336.29)
+Avg life time (damage/life): 27s (317.61)
 Captures: 0
 Captures assists: 1
 Carrier time: 11s
@@ -340,7 +340,7 @@ KDA: 10
 Headshot kills: 10
 Shots H:F (acc): 84:162 (51.85%)
 Damage D:T (D/T): 3,859:__**3,049**__ (1.27)
-Avg life time (damage/life): __**53s**__ __**(428.78)**__
+Avg life time (damage/life): __**53s**__ __**(385.9)**__
 Captures: 0
 Captures assists: __**3**__
 Carrier time: **22s**
@@ -371,7 +371,7 @@ KDA: **5**
 Headshot kills: **16**
 Shots H:F (acc): __**134**__:__**200**__ __**(67%)**__
 Damage D:T (D/T): __**6,202**__:5,431 **(1.14)**
-Avg life time (damage/life): 27s **(387.63)**
+Avg life time (damage/life): 27s **(364.82)**
 Captures: **0**
 Captures assists: **0**
 Carrier time: 26s
@@ -390,7 +390,7 @@ KDA: 1.66
 Headshot kills: 9
 Shots H:F (acc): 81:160 (50.62%)
 Damage D:T (D/T): 3,657:**4,401** (0.83)
-Avg life time (damage/life): 27s (228.56)
+Avg life time (damage/life): 27s (215.12)
 Captures: **0**
 Captures assists: **0**
 Carrier time: __**1m 3s**__
@@ -416,7 +416,7 @@ KDA: -7.66
 Headshot kills: 9
 Shots H:F (acc): 99:191 (51.83%)
 Damage D:T (D/T): 4,094:5,882 (0.7)
-Avg life time (damage/life): 19s (194.95)
+Avg life time (damage/life): 19s (186.09)
 Captures: **0**
 Captures assists: **0**
 Carrier time: 0s
@@ -435,7 +435,7 @@ KDA: -5.33
 Headshot kills: 5
 Shots H:F (acc): 77:163 (47.23%)
 Damage D:T (D/T): 3,859:5,057 (0.76)
-Avg life time (damage/life): **29s** (257.27)
+Avg life time (damage/life): **29s** (241.19)
 Captures: **0**
 Captures assists: **0**
 Carrier time: 17s
@@ -480,7 +480,7 @@ KDA: 18
 Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
-Avg life time (damage/life): 25s (405.32)
+Avg life time (damage/life): 25s (385.05)
 Captures: __**0**__
 Occupation time: **1m 11s**
 Secures: __**0**__
@@ -498,7 +498,7 @@ KDA: 7
 Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
-Avg life time (damage/life): 27s (355.63)
+Avg life time (damage/life): 27s (337.85)
 Captures: __**0**__
 Occupation time: 44s
 Secures: __**0**__
@@ -523,7 +523,7 @@ KDA: 7
 Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
-Avg life time (damage/life): 27s (369.94)
+Avg life time (damage/life): 27s (350.47)
 Captures: __**0**__
 Occupation time: 49s
 Secures: __**0**__
@@ -541,7 +541,7 @@ KDA: __**20.33**__
 Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
-Avg life time (damage/life): __**1m 19s**__ __**(858.57)**__
+Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
 Captures: __**0**__
 Occupation time: 53s
 Secures: __**0**__
@@ -571,7 +571,7 @@ KDA: -7.66
 Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
-Avg life time (damage/life): 17s (205.4)
+Avg life time (damage/life): 17s (197.5)
 Captures: __**0**__
 Occupation time: __**1m 29s**__
 Secures: __**0**__
@@ -589,7 +589,7 @@ KDA: -11.66
 Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
-Avg life time (damage/life): 17s (207.73)
+Avg life time (damage/life): 17s (200.04)
 Captures: __**0**__
 Occupation time: 35s
 Secures: __**0**__
@@ -614,7 +614,7 @@ KDA: -11.66
 Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
-Avg life time (damage/life): 19s (230.21)
+Avg life time (damage/life): 19s (221)
 Captures: __**0**__
 Occupation time: 48s
 Secures: __**0**__
@@ -632,7 +632,7 @@ KDA: **9.33**
 Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
-Avg life time (damage/life): **20s** **(312.48)**
+Avg life time (damage/life): **20s** **(299.46)**
 Captures: __**0**__
 Occupation time: 47s
 Secures: __**0**__
@@ -724,7 +724,7 @@ KDA: __74__
 Headshot kills: __111__
 Shots H:F (acc): __984__:1,743 __(56.35%)__
 Damage D:T (D/T): __47,329__:__41,675__ __(1.14)__
-Avg life time (damage/life): __40s__ __(401.09)__
+Avg life time (damage/life): __40s__ __(397.72)__
 2x<:TripleKill:1322814228477906944> 14x<:DoubleKill:1322814147980689430> 11x<:Perfect:1322879561515532308> <:OfftheRack:1322884747881353279> 6x<:ShotCaller:1322884687693086771> 7x<:KillingSpree:1322803050347499541> <:NoScope:1322882248516702220> 4x<:Snipe:1322872969571340370> <:Killjoy:1322802841039147129> 2x<:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 8x<:Rifleman:1322860656399220828> 5x<:Reversal:1322872797701083166> 5x<:GuardianAngel:1322873057928286248> 4x<:Wingman:1322854221095108609> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:BackSmack:1322872596135546891>",
             },
             {
@@ -737,7 +737,7 @@ KDA: -29.33
 Headshot kills: 78
 Shots H:F (acc): 922:__1,754__ (52.91%)
 Damage D:T (D/T): 41,060:48,135 (0.85)
-Avg life time (damage/life): 23s (247.35)
+Avg life time (damage/life): 23s (245.87)
 <:SneakKing:1322883516039696415> 11x<:DoubleKill:1322814147980689430> 5x<:ShotCaller:1322884687693086771> 7x<:Perfect:1322879561515532308> <:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:NadeShot:1322877140605206528> <:Whiplash:1322882310122504202> 8x<:Rifleman:1322860656399220828> 7x<:Killjoy:1322802841039147129> <:Stick:1322871787695898676> <:StoppedShort:1322806739778670652> <:Reversal:1322872797701083166> <:GuardianAngel:1322873057928286248> <:Spotter:1322814780796309505> <:LastShot:1322884170606972959> 3x<:Wingman:1322854221095108609>",
             },
             {
@@ -770,7 +770,7 @@ KDA: 21
 Headshot kills: __**36**__
 Shots H:F (acc): **298**:**477** __**(62.83%)**__
 Damage D:T (D/T): __**13,418**__:12,219 (1.1)
-Avg life time (damage/life): 26s (372.72)
+Avg life time (damage/life): 26s (362.65)
 <:TripleKill:1322814228477906944> 4x<:ShotCaller:1322884687693086771> <:NoScope:1322882248516702220> 8x<:DoubleKill:1322814147980689430> 3x<:KillingSpree:1322803050347499541> 4x<:Perfect:1322879561515532308> <:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 2x<:Reversal:1322872797701083166> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
             },
             {
@@ -783,7 +783,7 @@ KDA: 17.33
 Headshot kills: 31
 Shots H:F (acc): 244:419 (58.36%)
 Damage D:T (D/T): 12,647:11,513 (1.1)
-Avg life time (damage/life): 28s (371.97)
+Avg life time (damage/life): 28s (361.34)
 2x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> 2x<:ShotCaller:1322884687693086771> 3x<:Snipe:1322872969571340370> 2x<:Rifleman:1322860656399220828> 3x<:Reversal:1322872797701083166> 3x<:GuardianAngel:1322873057928286248> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:Wingman:1322854221095108609> <:Stick:1322871787695898676> 2x<:BackSmack:1322872596135546891>",
             },
             {
@@ -803,7 +803,7 @@ KDA: __**30.33**__
 Headshot kills: 28
 Shots H:F (acc): 225:404 (55.05%)
 Damage D:T (D/T): 9,869:__**7,596**__ __**(1.3)**__
-Avg life time (damage/life): __**1m 6s**__ __**(616.81)**__
+Avg life time (damage/life): __**1m 6s**__ __**(580.53)**__
 <:DoubleKill:1322814147980689430> 3x<:Perfect:1322879561515532308> 4x<:KillingSpree:1322803050347499541> <:Killjoy:1322802841039147129> 2x<:Rifleman:1322860656399220828> <:Snipe:1322872969571340370> 2x<:GuardianAngel:1322873057928286248>",
             },
             {
@@ -816,7 +816,7 @@ KDA: 7.66
 Headshot kills: 16
 Shots H:F (acc): 217:443 (48.59%)
 Damage D:T (D/T): 11,395:10,347 (1.1)
-Avg life time (damage/life): 30s (356.09)
+Avg life time (damage/life): 30s (345.3)
 <:TripleKill:1322814228477906944> <:OfftheRack:1322884747881353279> 2x<:DoubleKill:1322814147980689430> 2x<:Perfect:1322879561515532308> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
             },
             {
@@ -849,7 +849,7 @@ KDA: **14.33**
 Headshot kills: **35**
 Shots H:F (acc): __**304**__:__**497**__ **(62.11%)**
 Damage D:T (D/T): **13,389**:12,281 **(1.09)**
-Avg life time (damage/life): 24s **(343.31)**
+Avg life time (damage/life): 24s **(334.73)**
 <:SneakKing:1322883516039696415> 8x<:DoubleKill:1322814147980689430> 5x<:Perfect:1322879561515532308> <:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:Whiplash:1322882310122504202> 2x<:Rifleman:1322860656399220828> 3x<:Killjoy:1322802841039147129>",
             },
             {
@@ -862,7 +862,7 @@ KDA: -6
 Headshot kills: 19
 Shots H:F (acc): 201:399 (50.41%)
 Damage D:T (D/T): 8,792:**11,203** (0.78)
-Avg life time (damage/life): 22s (214.44)
+Avg life time (damage/life): 22s (209.33)
 <:Perfect:1322879561515532308> 2x<:Rifleman:1322860656399220828> <:Stick:1322871787695898676> <:Killjoy:1322802841039147129> <:GuardianAngel:1322873057928286248> <:Wingman:1322854221095108609>",
             },
             {
@@ -882,7 +882,7 @@ KDA: -19.32
 Headshot kills: 14
 Shots H:F (acc): 226:458 (49.7%)
 Damage D:T (D/T): 9,495:13,037 (0.73)
-Avg life time (damage/life): 18s (202.02)
+Avg life time (damage/life): 18s (197.81)
 2x<:DoubleKill:1322814147980689430> 2x<:Rifleman:1322860656399220828> <:Reversal:1322872797701083166> <:LastShot:1322884170606972959> <:Wingman:1322854221095108609> <:Killjoy:1322802841039147129>",
             },
             {
@@ -895,7 +895,7 @@ KDA: -16.99
 Headshot kills: 10
 Shots H:F (acc): 191:400 (47.66%)
 Damage D:T (D/T): 9,384:11,614 (0.81)
-Avg life time (damage/life): **24s** (240.62)
+Avg life time (damage/life): **24s** (234.6)
 5x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:NadeShot:1322877140605206528> 2x<:Rifleman:1322860656399220828> <:StoppedShort:1322806739778670652> 2x<:Killjoy:1322802841039147129> <:Spotter:1322814780796309505> <:Wingman:1322854221095108609>",
             },
             {
@@ -1068,7 +1068,7 @@ KDA: 17.34
 Headshot kills: 106
 Shots H:F (acc): 1,258:2,300 __(55%)__
 Damage D:T (D/T): 58,319:60,349 (0.97)
-Avg life time (damage/life): __39s__ (315.24)
+Avg life time (damage/life): __39s__ (313.54)
 <:TripleKill:1322814228477906944> 13x<:Perfect:1322879561515532308> 9x<:ShotCaller:1322884687693086771> 11x<:DoubleKill:1322814147980689430> <:OfftheRack:1322884747881353279> 2x<:KillingSpree:1322803050347499541> <:NoScope:1322882248516702220> 4x<:Stick:1322871787695898676> 7x<:Reversal:1322872797701083166> 8x<:Rifleman:1322860656399220828> 2x<:BackSmack:1322872596135546891> 3x<:Boxer:1322864064082477077> 4x<:FromtheGrave:1322884008773816351> 3x<:Bodyguard:1322867380136841279> 2x<:Spotter:1322814780796309505> 4x<:Wingman:1322854221095108609> 4x<:Killjoy:1322802841039147129> 4x<:Snipe:1322872969571340370> 2x<:GuardianAngel:1322873057928286248> <:LastShot:1322884170606972959>",
             },
             {
@@ -1081,7 +1081,7 @@ KDA: __34.33__
 Headshot kills: __119__
 Shots H:F (acc): __1,345__:__2,474__ (54.48%)
 Damage D:T (D/T): __59,176__:__59,178__ __(1)__
-Avg life time (damage/life): 29s __(334.33)__
+Avg life time (damage/life): 29s __(332.45)__
 <:360:1322885279266373703> 16x<:Perfect:1322879561515532308> 8x<:ShotCaller:1322884687693086771> 10x<:DoubleKill:1322814147980689430> 5x<:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> 4x<:Reversal:1322872797701083166> 5x<:Stick:1322871787695898676> 6x<:FromtheGrave:1322884008773816351> 8x<:Rifleman:1322860656399220828> 3x<:BackSmack:1322872596135546891> 4x<:Wingman:1322854221095108609> 2x<:GuardianAngel:1322873057928286248> 2x<:Boxer:1322864064082477077> 2x<:Bodyguard:1322867380136841279> <:Spotter:1322814780796309505> 2x<:Killjoy:1322802841039147129> <:StoppedShort:1322806739778670652>",
             },
             {
@@ -1114,7 +1114,7 @@ KDA: **20.66**
 Headshot kills: __**48**__
 Shots H:F (acc): __**376**__:**640** (58.92%)
 Damage D:T (D/T): __**17,510**__:16,025 (1.09)
-Avg life time (damage/life): 27s (364.79)
+Avg life time (damage/life): 27s (357.35)
 6x<:Perfect:1322879561515532308> 4x<:DoubleKill:1322814147980689430> <:ShotCaller:1322884687693086771> <:Stick:1322871787695898676> 2x<:Rifleman:1322860656399220828> 2x<:Bodyguard:1322867380136841279> 4x<:Reversal:1322872797701083166> 2x<:Wingman:1322854221095108609> 2x<:Killjoy:1322802841039147129> 3x<:Snipe:1322872969571340370> 2x<:GuardianAngel:1322873057928286248> <:LastShot:1322884170606972959>",
             },
             {
@@ -1127,7 +1127,7 @@ KDA: 4.66
 Headshot kills: 28
 Shots H:F (acc): 373:632 __**(60.6%)**__
 Damage D:T (D/T): 16,020:16,069 (1)
-Avg life time (damage/life): 25s (326.94)
+Avg life time (damage/life): 25s (320.4)
 3x<:Perfect:1322879561515532308> 5x<:ShotCaller:1322884687693086771> 2x<:DoubleKill:1322814147980689430> <:NoScope:1322882248516702220> 2x<:Rifleman:1322860656399220828> 2x<:Reversal:1322872797701083166> <:Spotter:1322814780796309505> 3x<:Stick:1322871787695898676> <:BackSmack:1322872596135546891> <:Boxer:1322864064082477077> 2x<:Wingman:1322854221095108609> <:FromtheGrave:1322884008773816351>",
             },
             {
@@ -1147,7 +1147,7 @@ KDA: -20.66
 Headshot kills: 19
 Shots H:F (acc): 280:553 (50.91%)
 Damage D:T (D/T): 12,570:16,718 (0.75)
-Avg life time (damage/life): 20s (220.53)
+Avg life time (damage/life): 20s (216.72)
 2x<:Perfect:1322879561515532308> 2x<:DoubleKill:1322814147980689430> <:ShotCaller:1322884687693086771> 2x<:Reversal:1322872797701083166> <:BackSmack:1322872596135546891> <:Boxer:1322864064082477077> 2x<:Rifleman:1322860656399220828> 2x<:FromtheGrave:1322884008773816351> <:Killjoy:1322802841039147129>",
             },
             {
@@ -1160,7 +1160,7 @@ KDA: -4
 Headshot kills: 4
 Shots H:F (acc): 161:326 (24.69%)
 Damage D:T (D/T): 7,718:9,491 (0.81)
-Avg life time (damage/life): 27s (266.14)
+Avg life time (damage/life): 27s (257.27)
 2x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:FromtheGrave:1322884008773816351> <:Rifleman:1322860656399220828> <:Spotter:1322814780796309505> <:Bodyguard:1322867380136841279> <:Boxer:1322864064082477077>",
             },
             {
@@ -1180,7 +1180,7 @@ KDA: 10
 Headshot kills: 10
 Shots H:F (acc): 84:162 (25.93%)
 Damage D:T (D/T): 3,859:__**3,049**__ **(1.27)**
-Avg life time (damage/life): __**53s**__ **(428.78)**
+Avg life time (damage/life): __**53s**__ **(385.9)**
 <:DoubleKill:1322814147980689430> <:Perfect:1322879561515532308> 2x<:KillingSpree:1322803050347499541> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828> <:Snipe:1322872969571340370>",
             },
             {
@@ -1213,7 +1213,7 @@ KDA: 9.33
 Headshot kills: **34**
 Shots H:F (acc): **371**:__**647**__ **(60.01%)**
 Damage D:T (D/T): **17,017**:15,450 (1.1)
-Avg life time (damage/life): 26s (362.06)
+Avg life time (damage/life): 26s (354.52)
 4x<:Perfect:1322879561515532308> <:ShotCaller:1322884687693086771> 6x<:DoubleKill:1322814147980689430> 2x<:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609> <:GuardianAngel:1322873057928286248> <:FromtheGrave:1322884008773816351> <:Killjoy:1322802841039147129>",
             },
             {
@@ -1226,7 +1226,7 @@ KDA: __**30**__
 Headshot kills: 30
 Shots H:F (acc): 335:582 (28.78%)
 Damage D:T (D/T): 13,919:10,011 __**(1.39)**__
-Avg life time (damage/life): 33s __**(579.96)**__
+Avg life time (damage/life): 33s __**(556.76)**__
 8x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> <:ShotCaller:1322884687693086771> 2x<:KillingSpree:1322803050347499541> <:Rifleman:1322860656399220828> 2x<:BackSmack:1322872596135546891> <:Reversal:1322872797701083166> <:Wingman:1322854221095108609> 2x<:Stick:1322871787695898676> 2x<:FromtheGrave:1322884008773816351> <:Boxer:1322864064082477077> <:Bodyguard:1322867380136841279> <:GuardianAngel:1322873057928286248>",
             },
             {
@@ -1246,7 +1246,7 @@ KDA: -6
 Headshot kills: 18
 Shots H:F (acc): 241:500 (47.84%)
 Damage D:T (D/T): 11,936:14,660 (0.81)
-Avg life time (damage/life): 27s (253.96)
+Avg life time (damage/life): 27s (248.67)
 <:TripleKill:1322814228477906944> <:Perfect:1322879561515532308> <:OfftheRack:1322884747881353279> 2x<:DoubleKill:1322814147980689430> 2x<:Reversal:1322872797701083166> <:Stick:1322871787695898676> 2x<:Rifleman:1322860656399220828> <:FromtheGrave:1322884008773816351> <:Bodyguard:1322867380136841279> <:Wingman:1322854221095108609>",
             },
             {
@@ -1259,7 +1259,7 @@ KDA: 14.33
 Headshot kills: 20
 Shots H:F (acc): 224:409 (27.38%)
 Damage D:T (D/T): 9,430:8,596 (1.1)
-Avg life time (damage/life): **41s** (449.05)
+Avg life time (damage/life): **41s** (428.64)
 <:360:1322885279266373703> 2x<:Perfect:1322879561515532308> 4x<:ShotCaller:1322884687693086771> <:KillingSpree:1322803050347499541> <:Stick:1322871787695898676> 2x<:FromtheGrave:1322884008773816351> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609> <:Spotter:1322814780796309505> <:BackSmack:1322872596135546891> <:Boxer:1322864064082477077>",
             },
             {
@@ -1279,7 +1279,7 @@ KDA: 1.66
 Headshot kills: 9
 Shots H:F (acc): 81:160 (25.31%)
 Damage D:T (D/T): 3,657:**4,401** (0.83)
-Avg life time (damage/life): 27s (228.56)
+Avg life time (damage/life): 27s (215.12)
 <:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> <:Stick:1322871787695898676> <:Killjoy:1322802841039147129>",
             },
             {
@@ -1292,7 +1292,7 @@ KDA: -5.33
 Headshot kills: 5
 Shots H:F (acc): 77:163 (23.61%)
 Damage D:T (D/T): 3,859:5,057 (0.76)
-Avg life time (damage/life): 29s (257.27)
+Avg life time (damage/life): 29s (241.19)
 2x<:ShotCaller:1322884687693086771> <:Rifleman:1322860656399220828> <:StoppedShort:1322806739778670652>",
             },
             {
@@ -1399,7 +1399,7 @@ KDA: __74__
 Headshot kills: __111__
 Shots H:F (acc): __984__:1,743 __(56.35%)__
 Damage D:T (D/T): __47,329__:__41,675__ __(1.14)__
-Avg life time (damage/life): __40s__ __(401.09)__
+Avg life time (damage/life): __40s__ __(397.72)__
 2x<:TripleKill:1322814228477906944> 14x<:DoubleKill:1322814147980689430> 11x<:Perfect:1322879561515532308> <:OfftheRack:1322884747881353279> 6x<:ShotCaller:1322884687693086771> 7x<:KillingSpree:1322803050347499541> <:NoScope:1322882248516702220> 4x<:Snipe:1322872969571340370> <:Killjoy:1322802841039147129> 2x<:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 8x<:Rifleman:1322860656399220828> 5x<:Reversal:1322872797701083166> 5x<:GuardianAngel:1322873057928286248> 4x<:Wingman:1322854221095108609> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:BackSmack:1322872596135546891>",
             },
             {
@@ -1412,7 +1412,7 @@ KDA: -29.33
 Headshot kills: 78
 Shots H:F (acc): 922:__1,754__ (52.91%)
 Damage D:T (D/T): 41,060:48,135 (0.85)
-Avg life time (damage/life): 23s (247.35)
+Avg life time (damage/life): 23s (245.87)
 <:SneakKing:1322883516039696415> 11x<:DoubleKill:1322814147980689430> 5x<:ShotCaller:1322884687693086771> 7x<:Perfect:1322879561515532308> <:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:NadeShot:1322877140605206528> <:Whiplash:1322882310122504202> 8x<:Rifleman:1322860656399220828> 7x<:Killjoy:1322802841039147129> <:Stick:1322871787695898676> <:StoppedShort:1322806739778670652> <:Reversal:1322872797701083166> <:GuardianAngel:1322873057928286248> <:Spotter:1322814780796309505> <:LastShot:1322884170606972959> 3x<:Wingman:1322854221095108609>",
             },
             {
@@ -1445,7 +1445,7 @@ KDA: 21
 Headshot kills: __**36**__
 Shots H:F (acc): **298**:**477** __**(62.83%)**__
 Damage D:T (D/T): __**13,418**__:12,219 (1.1)
-Avg life time (damage/life): 26s (372.72)
+Avg life time (damage/life): 26s (362.65)
 <:TripleKill:1322814228477906944> 4x<:ShotCaller:1322884687693086771> <:NoScope:1322882248516702220> 8x<:DoubleKill:1322814147980689430> 3x<:KillingSpree:1322803050347499541> 4x<:Perfect:1322879561515532308> <:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 2x<:Reversal:1322872797701083166> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
             },
             {
@@ -1458,7 +1458,7 @@ KDA: 17.33
 Headshot kills: 31
 Shots H:F (acc): 244:419 (58.36%)
 Damage D:T (D/T): 12,647:11,513 (1.1)
-Avg life time (damage/life): 28s (371.97)
+Avg life time (damage/life): 28s (361.34)
 2x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> 2x<:ShotCaller:1322884687693086771> 3x<:Snipe:1322872969571340370> 2x<:Rifleman:1322860656399220828> 3x<:Reversal:1322872797701083166> 3x<:GuardianAngel:1322873057928286248> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:Wingman:1322854221095108609> <:Stick:1322871787695898676> 2x<:BackSmack:1322872596135546891>",
             },
             {
@@ -1478,7 +1478,7 @@ KDA: __**30.33**__
 Headshot kills: 28
 Shots H:F (acc): 225:404 (55.05%)
 Damage D:T (D/T): 9,869:__**7,596**__ __**(1.3)**__
-Avg life time (damage/life): __**1m 6s**__ __**(616.81)**__
+Avg life time (damage/life): __**1m 6s**__ __**(580.53)**__
 <:DoubleKill:1322814147980689430> 3x<:Perfect:1322879561515532308> 4x<:KillingSpree:1322803050347499541> <:Killjoy:1322802841039147129> 2x<:Rifleman:1322860656399220828> <:Snipe:1322872969571340370> 2x<:GuardianAngel:1322873057928286248>",
             },
             {
@@ -1491,7 +1491,7 @@ KDA: 7.66
 Headshot kills: 16
 Shots H:F (acc): 217:443 (48.59%)
 Damage D:T (D/T): 11,395:10,347 (1.1)
-Avg life time (damage/life): 30s (356.09)
+Avg life time (damage/life): 30s (345.3)
 <:TripleKill:1322814228477906944> <:OfftheRack:1322884747881353279> 2x<:DoubleKill:1322814147980689430> 2x<:Perfect:1322879561515532308> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
             },
             {
@@ -1524,7 +1524,7 @@ KDA: **14.33**
 Headshot kills: **35**
 Shots H:F (acc): __**304**__:__**497**__ **(62.11%)**
 Damage D:T (D/T): **13,389**:12,281 **(1.09)**
-Avg life time (damage/life): 24s **(343.31)**
+Avg life time (damage/life): 24s **(334.73)**
 <:SneakKing:1322883516039696415> 8x<:DoubleKill:1322814147980689430> 5x<:Perfect:1322879561515532308> <:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:Whiplash:1322882310122504202> 2x<:Rifleman:1322860656399220828> 3x<:Killjoy:1322802841039147129>",
             },
             {
@@ -1537,7 +1537,7 @@ KDA: -6
 Headshot kills: 19
 Shots H:F (acc): 201:399 (50.41%)
 Damage D:T (D/T): 8,792:**11,203** (0.78)
-Avg life time (damage/life): 22s (214.44)
+Avg life time (damage/life): 22s (209.33)
 <:Perfect:1322879561515532308> 2x<:Rifleman:1322860656399220828> <:Stick:1322871787695898676> <:Killjoy:1322802841039147129> <:GuardianAngel:1322873057928286248> <:Wingman:1322854221095108609>",
             },
             {
@@ -1557,7 +1557,7 @@ KDA: -19.32
 Headshot kills: 14
 Shots H:F (acc): 226:458 (49.7%)
 Damage D:T (D/T): 9,495:13,037 (0.73)
-Avg life time (damage/life): 18s (202.02)
+Avg life time (damage/life): 18s (197.81)
 2x<:DoubleKill:1322814147980689430> 2x<:Rifleman:1322860656399220828> <:Reversal:1322872797701083166> <:LastShot:1322884170606972959> <:Wingman:1322854221095108609> <:Killjoy:1322802841039147129>",
             },
             {
@@ -1570,7 +1570,7 @@ KDA: -16.99
 Headshot kills: 10
 Shots H:F (acc): 191:400 (47.66%)
 Damage D:T (D/T): 9,384:11,614 (0.81)
-Avg life time (damage/life): **24s** (240.62)
+Avg life time (damage/life): **24s** (234.6)
 5x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:NadeShot:1322877140605206528> 2x<:Rifleman:1322860656399220828> <:StoppedShort:1322806739778670652> 2x<:Killjoy:1322802841039147129> <:Spotter:1322814780796309505> <:Wingman:1322854221095108609>",
             },
             {
@@ -1608,7 +1608,7 @@ KDA: 0.66
 Headshot kills: 6
 Shots H:F (acc): 83:178 (46.62%)
 Damage D:T (D/T): 4,736:4,879 (0.97)
-Avg life time (damage/life): 32s (338.29)
+Avg life time (damage/life): 32s (315.73)
 Captures: __**2**__
 Captures assists: 0
 Carrier time: 9s
@@ -1627,7 +1627,7 @@ KDA: __**10.33**__
 Headshot kills: __**17**__
 Shots H:F (acc): 108:182 (59.34%)
 Damage D:T (D/T): **5,890**:4,614 __**(1.28)**__
-Avg life time (damage/life): 29s (392.67)
+Avg life time (damage/life): 29s (368.13)
 Captures: 1
 Captures assists: 2
 Carrier time: 20s
@@ -1653,7 +1653,7 @@ KDA: 3
 Headshot kills: 11
 Shots H:F (acc): **122**:**189** **(64.55%)**
 Damage D:T (D/T): 5,717:5,479 (1.04)
-Avg life time (damage/life): 27s (336.29)
+Avg life time (damage/life): 27s (317.61)
 Captures: 0
 Captures assists: 1
 Carrier time: 11s
@@ -1672,7 +1672,7 @@ KDA: 10
 Headshot kills: 10
 Shots H:F (acc): 84:162 (51.85%)
 Damage D:T (D/T): 3,859:__**3,049**__ (1.27)
-Avg life time (damage/life): __**53s**__ __**(428.78)**__
+Avg life time (damage/life): __**53s**__ __**(385.9)**__
 Captures: 0
 Captures assists: __**3**__
 Carrier time: **22s**
@@ -1703,7 +1703,7 @@ KDA: **5**
 Headshot kills: **16**
 Shots H:F (acc): __**134**__:__**200**__ __**(67%)**__
 Damage D:T (D/T): __**6,202**__:5,431 **(1.14)**
-Avg life time (damage/life): 27s **(387.63)**
+Avg life time (damage/life): 27s **(364.82)**
 Captures: **0**
 Captures assists: **0**
 Carrier time: 26s
@@ -1722,7 +1722,7 @@ KDA: 1.66
 Headshot kills: 9
 Shots H:F (acc): 81:160 (50.62%)
 Damage D:T (D/T): 3,657:**4,401** (0.83)
-Avg life time (damage/life): 27s (228.56)
+Avg life time (damage/life): 27s (215.12)
 Captures: **0**
 Captures assists: **0**
 Carrier time: __**1m 3s**__
@@ -1748,7 +1748,7 @@ KDA: -7.66
 Headshot kills: 9
 Shots H:F (acc): 99:191 (51.83%)
 Damage D:T (D/T): 4,094:5,882 (0.7)
-Avg life time (damage/life): 19s (194.95)
+Avg life time (damage/life): 19s (186.09)
 Captures: **0**
 Captures assists: **0**
 Carrier time: 0s
@@ -1767,7 +1767,7 @@ KDA: -5.33
 Headshot kills: 5
 Shots H:F (acc): 77:163 (47.23%)
 Damage D:T (D/T): 3,859:5,057 (0.76)
-Avg life time (damage/life): **29s** (257.27)
+Avg life time (damage/life): **29s** (241.19)
 Captures: **0**
 Captures assists: **0**
 Carrier time: 17s
@@ -1812,7 +1812,7 @@ KDA: 18
 Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
-Avg life time (damage/life): 25s (405.32)
+Avg life time (damage/life): 25s (385.05)
 Captures: __**0**__
 Occupation time: **1m 11s**
 Secures: __**0**__
@@ -1830,7 +1830,7 @@ KDA: 7
 Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
-Avg life time (damage/life): 27s (355.63)
+Avg life time (damage/life): 27s (337.85)
 Captures: __**0**__
 Occupation time: 44s
 Secures: __**0**__
@@ -1855,7 +1855,7 @@ KDA: 7
 Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
-Avg life time (damage/life): 27s (369.94)
+Avg life time (damage/life): 27s (350.47)
 Captures: __**0**__
 Occupation time: 49s
 Secures: __**0**__
@@ -1873,7 +1873,7 @@ KDA: __**20.33**__
 Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
-Avg life time (damage/life): __**1m 19s**__ __**(858.57)**__
+Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
 Captures: __**0**__
 Occupation time: 53s
 Secures: __**0**__
@@ -1903,7 +1903,7 @@ KDA: -7.66
 Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
-Avg life time (damage/life): 17s (205.4)
+Avg life time (damage/life): 17s (197.5)
 Captures: __**0**__
 Occupation time: __**1m 29s**__
 Secures: __**0**__
@@ -1921,7 +1921,7 @@ KDA: -11.66
 Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
-Avg life time (damage/life): 17s (207.73)
+Avg life time (damage/life): 17s (200.04)
 Captures: __**0**__
 Occupation time: 35s
 Secures: __**0**__
@@ -1946,7 +1946,7 @@ KDA: -11.66
 Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
-Avg life time (damage/life): 19s (230.21)
+Avg life time (damage/life): 19s (221)
 Captures: __**0**__
 Occupation time: 48s
 Secures: __**0**__
@@ -1964,7 +1964,7 @@ KDA: **9.33**
 Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
-Avg life time (damage/life): **20s** **(312.48)**
+Avg life time (damage/life): **20s** **(299.46)**
 Captures: __**0**__
 Occupation time: 47s
 Secures: __**0**__
@@ -2056,7 +2056,7 @@ KDA: __74__
 Headshot kills: __111__
 Shots H:F (acc): __984__:1,743 __(56.35%)__
 Damage D:T (D/T): __47,329__:__41,675__ __(1.14)__
-Avg life time (damage/life): __40s__ __(401.09)__
+Avg life time (damage/life): __40s__ __(397.72)__
 2x<:TripleKill:1322814228477906944> 14x<:DoubleKill:1322814147980689430> 11x<:Perfect:1322879561515532308> <:OfftheRack:1322884747881353279> 6x<:ShotCaller:1322884687693086771> 7x<:KillingSpree:1322803050347499541> <:NoScope:1322882248516702220> 4x<:Snipe:1322872969571340370> <:Killjoy:1322802841039147129> 2x<:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 8x<:Rifleman:1322860656399220828> 5x<:Reversal:1322872797701083166> 5x<:GuardianAngel:1322873057928286248> 4x<:Wingman:1322854221095108609> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:BackSmack:1322872596135546891>",
             },
             {
@@ -2069,7 +2069,7 @@ KDA: -29.33
 Headshot kills: 78
 Shots H:F (acc): 922:__1,754__ (52.91%)
 Damage D:T (D/T): 41,060:48,135 (0.85)
-Avg life time (damage/life): 23s (247.35)
+Avg life time (damage/life): 23s (245.87)
 <:SneakKing:1322883516039696415> 11x<:DoubleKill:1322814147980689430> 5x<:ShotCaller:1322884687693086771> 7x<:Perfect:1322879561515532308> <:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:NadeShot:1322877140605206528> <:Whiplash:1322882310122504202> 8x<:Rifleman:1322860656399220828> 7x<:Killjoy:1322802841039147129> <:Stick:1322871787695898676> <:StoppedShort:1322806739778670652> <:Reversal:1322872797701083166> <:GuardianAngel:1322873057928286248> <:Spotter:1322814780796309505> <:LastShot:1322884170606972959> 3x<:Wingman:1322854221095108609>",
             },
             {
@@ -2102,7 +2102,7 @@ KDA: 21
 Headshot kills: __**36**__
 Shots H:F (acc): **298**:**477** __**(62.83%)**__
 Damage D:T (D/T): __**13,418**__:12,219 (1.1)
-Avg life time (damage/life): 26s (372.72)
+Avg life time (damage/life): 26s (362.65)
 <:TripleKill:1322814228477906944> 4x<:ShotCaller:1322884687693086771> <:NoScope:1322882248516702220> 8x<:DoubleKill:1322814147980689430> 3x<:KillingSpree:1322803050347499541> 4x<:Perfect:1322879561515532308> <:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 2x<:Reversal:1322872797701083166> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
             },
             {
@@ -2115,7 +2115,7 @@ KDA: 17.33
 Headshot kills: 31
 Shots H:F (acc): 244:419 (58.36%)
 Damage D:T (D/T): 12,647:11,513 (1.1)
-Avg life time (damage/life): 28s (371.97)
+Avg life time (damage/life): 28s (361.34)
 2x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> 2x<:ShotCaller:1322884687693086771> 3x<:Snipe:1322872969571340370> 2x<:Rifleman:1322860656399220828> 3x<:Reversal:1322872797701083166> 3x<:GuardianAngel:1322873057928286248> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:Wingman:1322854221095108609> <:Stick:1322871787695898676> 2x<:BackSmack:1322872596135546891>",
             },
             {
@@ -2135,7 +2135,7 @@ KDA: __**30.33**__
 Headshot kills: 28
 Shots H:F (acc): 225:404 (55.05%)
 Damage D:T (D/T): 9,869:__**7,596**__ __**(1.3)**__
-Avg life time (damage/life): __**1m 6s**__ __**(616.81)**__
+Avg life time (damage/life): __**1m 6s**__ __**(580.53)**__
 <:DoubleKill:1322814147980689430> 3x<:Perfect:1322879561515532308> 4x<:KillingSpree:1322803050347499541> <:Killjoy:1322802841039147129> 2x<:Rifleman:1322860656399220828> <:Snipe:1322872969571340370> 2x<:GuardianAngel:1322873057928286248>",
             },
             {
@@ -2148,7 +2148,7 @@ KDA: 7.66
 Headshot kills: 16
 Shots H:F (acc): 217:443 (48.59%)
 Damage D:T (D/T): 11,395:10,347 (1.1)
-Avg life time (damage/life): 30s (356.09)
+Avg life time (damage/life): 30s (345.3)
 <:TripleKill:1322814228477906944> <:OfftheRack:1322884747881353279> 2x<:DoubleKill:1322814147980689430> 2x<:Perfect:1322879561515532308> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
             },
             {
@@ -2181,7 +2181,7 @@ KDA: **14.33**
 Headshot kills: **35**
 Shots H:F (acc): __**304**__:__**497**__ **(62.11%)**
 Damage D:T (D/T): **13,389**:12,281 **(1.09)**
-Avg life time (damage/life): 24s **(343.31)**
+Avg life time (damage/life): 24s **(334.73)**
 <:SneakKing:1322883516039696415> 8x<:DoubleKill:1322814147980689430> 5x<:Perfect:1322879561515532308> <:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:Whiplash:1322882310122504202> 2x<:Rifleman:1322860656399220828> 3x<:Killjoy:1322802841039147129>",
             },
             {
@@ -2194,7 +2194,7 @@ KDA: -6
 Headshot kills: 19
 Shots H:F (acc): 201:399 (50.41%)
 Damage D:T (D/T): 8,792:**11,203** (0.78)
-Avg life time (damage/life): 22s (214.44)
+Avg life time (damage/life): 22s (209.33)
 <:Perfect:1322879561515532308> 2x<:Rifleman:1322860656399220828> <:Stick:1322871787695898676> <:Killjoy:1322802841039147129> <:GuardianAngel:1322873057928286248> <:Wingman:1322854221095108609>",
             },
             {
@@ -2214,7 +2214,7 @@ KDA: -19.32
 Headshot kills: 14
 Shots H:F (acc): 226:458 (49.7%)
 Damage D:T (D/T): 9,495:13,037 (0.73)
-Avg life time (damage/life): 18s (202.02)
+Avg life time (damage/life): 18s (197.81)
 2x<:DoubleKill:1322814147980689430> 2x<:Rifleman:1322860656399220828> <:Reversal:1322872797701083166> <:LastShot:1322884170606972959> <:Wingman:1322854221095108609> <:Killjoy:1322802841039147129>",
             },
             {
@@ -2227,7 +2227,7 @@ KDA: -16.99
 Headshot kills: 10
 Shots H:F (acc): 191:400 (47.66%)
 Damage D:T (D/T): 9,384:11,614 (0.81)
-Avg life time (damage/life): **24s** (240.62)
+Avg life time (damage/life): **24s** (234.6)
 5x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:NadeShot:1322877140605206528> 2x<:Rifleman:1322860656399220828> <:StoppedShort:1322806739778670652> 2x<:Killjoy:1322802841039147129> <:Spotter:1322814780796309505> <:Wingman:1322854221095108609>",
             },
             {
@@ -2400,7 +2400,7 @@ KDA: 17.34
 Headshot kills: 106
 Shots H:F (acc): 1,258:2,300 __(55%)__
 Damage D:T (D/T): 58,319:60,349 (0.97)
-Avg life time (damage/life): __39s__ (315.24)
+Avg life time (damage/life): __39s__ (313.54)
 <:TripleKill:1322814228477906944> 13x<:Perfect:1322879561515532308> 9x<:ShotCaller:1322884687693086771> 11x<:DoubleKill:1322814147980689430> <:OfftheRack:1322884747881353279> 2x<:KillingSpree:1322803050347499541> <:NoScope:1322882248516702220> 4x<:Stick:1322871787695898676> 7x<:Reversal:1322872797701083166> 8x<:Rifleman:1322860656399220828> 2x<:BackSmack:1322872596135546891> 3x<:Boxer:1322864064082477077> 4x<:FromtheGrave:1322884008773816351> 3x<:Bodyguard:1322867380136841279> 2x<:Spotter:1322814780796309505> 4x<:Wingman:1322854221095108609> 4x<:Killjoy:1322802841039147129> 4x<:Snipe:1322872969571340370> 2x<:GuardianAngel:1322873057928286248> <:LastShot:1322884170606972959>",
             },
             {
@@ -2413,7 +2413,7 @@ KDA: __34.33__
 Headshot kills: __119__
 Shots H:F (acc): __1,345__:__2,474__ (54.48%)
 Damage D:T (D/T): __59,176__:__59,178__ __(1)__
-Avg life time (damage/life): 29s __(334.33)__
+Avg life time (damage/life): 29s __(332.45)__
 <:360:1322885279266373703> 16x<:Perfect:1322879561515532308> 8x<:ShotCaller:1322884687693086771> 10x<:DoubleKill:1322814147980689430> 5x<:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> 4x<:Reversal:1322872797701083166> 5x<:Stick:1322871787695898676> 6x<:FromtheGrave:1322884008773816351> 8x<:Rifleman:1322860656399220828> 3x<:BackSmack:1322872596135546891> 4x<:Wingman:1322854221095108609> 2x<:GuardianAngel:1322873057928286248> 2x<:Boxer:1322864064082477077> 2x<:Bodyguard:1322867380136841279> <:Spotter:1322814780796309505> 2x<:Killjoy:1322802841039147129> <:StoppedShort:1322806739778670652>",
             },
             {
@@ -2446,7 +2446,7 @@ KDA: **20.66**
 Headshot kills: __**48**__
 Shots H:F (acc): __**376**__:**640** (58.92%)
 Damage D:T (D/T): __**17,510**__:16,025 (1.09)
-Avg life time (damage/life): 27s (364.79)
+Avg life time (damage/life): 27s (357.35)
 6x<:Perfect:1322879561515532308> 4x<:DoubleKill:1322814147980689430> <:ShotCaller:1322884687693086771> <:Stick:1322871787695898676> 2x<:Rifleman:1322860656399220828> 2x<:Bodyguard:1322867380136841279> 4x<:Reversal:1322872797701083166> 2x<:Wingman:1322854221095108609> 2x<:Killjoy:1322802841039147129> 3x<:Snipe:1322872969571340370> 2x<:GuardianAngel:1322873057928286248> <:LastShot:1322884170606972959>",
             },
             {
@@ -2459,7 +2459,7 @@ KDA: 4.66
 Headshot kills: 28
 Shots H:F (acc): 373:632 __**(60.6%)**__
 Damage D:T (D/T): 16,020:16,069 (1)
-Avg life time (damage/life): 25s (326.94)
+Avg life time (damage/life): 25s (320.4)
 3x<:Perfect:1322879561515532308> 5x<:ShotCaller:1322884687693086771> 2x<:DoubleKill:1322814147980689430> <:NoScope:1322882248516702220> 2x<:Rifleman:1322860656399220828> 2x<:Reversal:1322872797701083166> <:Spotter:1322814780796309505> 3x<:Stick:1322871787695898676> <:BackSmack:1322872596135546891> <:Boxer:1322864064082477077> 2x<:Wingman:1322854221095108609> <:FromtheGrave:1322884008773816351>",
             },
             {
@@ -2479,7 +2479,7 @@ KDA: -20.66
 Headshot kills: 19
 Shots H:F (acc): 280:553 (50.91%)
 Damage D:T (D/T): 12,570:16,718 (0.75)
-Avg life time (damage/life): 20s (220.53)
+Avg life time (damage/life): 20s (216.72)
 2x<:Perfect:1322879561515532308> 2x<:DoubleKill:1322814147980689430> <:ShotCaller:1322884687693086771> 2x<:Reversal:1322872797701083166> <:BackSmack:1322872596135546891> <:Boxer:1322864064082477077> 2x<:Rifleman:1322860656399220828> 2x<:FromtheGrave:1322884008773816351> <:Killjoy:1322802841039147129>",
             },
             {
@@ -2492,7 +2492,7 @@ KDA: -4
 Headshot kills: 4
 Shots H:F (acc): 161:326 (24.69%)
 Damage D:T (D/T): 7,718:9,491 (0.81)
-Avg life time (damage/life): 27s (266.14)
+Avg life time (damage/life): 27s (257.27)
 2x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:FromtheGrave:1322884008773816351> <:Rifleman:1322860656399220828> <:Spotter:1322814780796309505> <:Bodyguard:1322867380136841279> <:Boxer:1322864064082477077>",
             },
             {
@@ -2512,7 +2512,7 @@ KDA: 10
 Headshot kills: 10
 Shots H:F (acc): 84:162 (25.93%)
 Damage D:T (D/T): 3,859:__**3,049**__ **(1.27)**
-Avg life time (damage/life): __**53s**__ **(428.78)**
+Avg life time (damage/life): __**53s**__ **(385.9)**
 <:DoubleKill:1322814147980689430> <:Perfect:1322879561515532308> 2x<:KillingSpree:1322803050347499541> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828> <:Snipe:1322872969571340370>",
             },
             {
@@ -2545,7 +2545,7 @@ KDA: 9.33
 Headshot kills: **34**
 Shots H:F (acc): **371**:__**647**__ **(60.01%)**
 Damage D:T (D/T): **17,017**:15,450 (1.1)
-Avg life time (damage/life): 26s (362.06)
+Avg life time (damage/life): 26s (354.52)
 4x<:Perfect:1322879561515532308> <:ShotCaller:1322884687693086771> 6x<:DoubleKill:1322814147980689430> 2x<:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609> <:GuardianAngel:1322873057928286248> <:FromtheGrave:1322884008773816351> <:Killjoy:1322802841039147129>",
             },
             {
@@ -2558,7 +2558,7 @@ KDA: __**30**__
 Headshot kills: 30
 Shots H:F (acc): 335:582 (28.78%)
 Damage D:T (D/T): 13,919:10,011 __**(1.39)**__
-Avg life time (damage/life): 33s __**(579.96)**__
+Avg life time (damage/life): 33s __**(556.76)**__
 8x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> <:ShotCaller:1322884687693086771> 2x<:KillingSpree:1322803050347499541> <:Rifleman:1322860656399220828> 2x<:BackSmack:1322872596135546891> <:Reversal:1322872797701083166> <:Wingman:1322854221095108609> 2x<:Stick:1322871787695898676> 2x<:FromtheGrave:1322884008773816351> <:Boxer:1322864064082477077> <:Bodyguard:1322867380136841279> <:GuardianAngel:1322873057928286248>",
             },
             {
@@ -2578,7 +2578,7 @@ KDA: -6
 Headshot kills: 18
 Shots H:F (acc): 241:500 (47.84%)
 Damage D:T (D/T): 11,936:14,660 (0.81)
-Avg life time (damage/life): 27s (253.96)
+Avg life time (damage/life): 27s (248.67)
 <:TripleKill:1322814228477906944> <:Perfect:1322879561515532308> <:OfftheRack:1322884747881353279> 2x<:DoubleKill:1322814147980689430> 2x<:Reversal:1322872797701083166> <:Stick:1322871787695898676> 2x<:Rifleman:1322860656399220828> <:FromtheGrave:1322884008773816351> <:Bodyguard:1322867380136841279> <:Wingman:1322854221095108609>",
             },
             {
@@ -2591,7 +2591,7 @@ KDA: 14.33
 Headshot kills: 20
 Shots H:F (acc): 224:409 (27.38%)
 Damage D:T (D/T): 9,430:8,596 (1.1)
-Avg life time (damage/life): **41s** (449.05)
+Avg life time (damage/life): **41s** (428.64)
 <:360:1322885279266373703> 2x<:Perfect:1322879561515532308> 4x<:ShotCaller:1322884687693086771> <:KillingSpree:1322803050347499541> <:Stick:1322871787695898676> 2x<:FromtheGrave:1322884008773816351> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609> <:Spotter:1322814780796309505> <:BackSmack:1322872596135546891> <:Boxer:1322864064082477077>",
             },
             {
@@ -2611,7 +2611,7 @@ KDA: 1.66
 Headshot kills: 9
 Shots H:F (acc): 81:160 (25.31%)
 Damage D:T (D/T): 3,657:**4,401** (0.83)
-Avg life time (damage/life): 27s (228.56)
+Avg life time (damage/life): 27s (215.12)
 <:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> <:Stick:1322871787695898676> <:Killjoy:1322802841039147129>",
             },
             {
@@ -2624,7 +2624,7 @@ KDA: -5.33
 Headshot kills: 5
 Shots H:F (acc): 77:163 (23.61%)
 Damage D:T (D/T): 3,859:5,057 (0.76)
-Avg life time (damage/life): 29s (257.27)
+Avg life time (damage/life): 29s (241.19)
 2x<:ShotCaller:1322884687693086771> <:Rifleman:1322860656399220828> <:StoppedShort:1322806739778670652>",
             },
             {
@@ -2731,7 +2731,7 @@ KDA: __74__
 Headshot kills: __111__
 Shots H:F (acc): __984__:1,743 __(56.35%)__
 Damage D:T (D/T): __47,329__:__41,675__ __(1.14)__
-Avg life time (damage/life): __40s__ __(401.09)__
+Avg life time (damage/life): __40s__ __(397.72)__
 2x<:TripleKill:1322814228477906944> 14x<:DoubleKill:1322814147980689430> 11x<:Perfect:1322879561515532308> <:OfftheRack:1322884747881353279> 6x<:ShotCaller:1322884687693086771> 7x<:KillingSpree:1322803050347499541> <:NoScope:1322882248516702220> 4x<:Snipe:1322872969571340370> <:Killjoy:1322802841039147129> 2x<:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 8x<:Rifleman:1322860656399220828> 5x<:Reversal:1322872797701083166> 5x<:GuardianAngel:1322873057928286248> 4x<:Wingman:1322854221095108609> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:BackSmack:1322872596135546891>",
             },
             {
@@ -2744,7 +2744,7 @@ KDA: -29.33
 Headshot kills: 78
 Shots H:F (acc): 922:__1,754__ (52.91%)
 Damage D:T (D/T): 41,060:48,135 (0.85)
-Avg life time (damage/life): 23s (247.35)
+Avg life time (damage/life): 23s (245.87)
 <:SneakKing:1322883516039696415> 11x<:DoubleKill:1322814147980689430> 5x<:ShotCaller:1322884687693086771> 7x<:Perfect:1322879561515532308> <:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:NadeShot:1322877140605206528> <:Whiplash:1322882310122504202> 8x<:Rifleman:1322860656399220828> 7x<:Killjoy:1322802841039147129> <:Stick:1322871787695898676> <:StoppedShort:1322806739778670652> <:Reversal:1322872797701083166> <:GuardianAngel:1322873057928286248> <:Spotter:1322814780796309505> <:LastShot:1322884170606972959> 3x<:Wingman:1322854221095108609>",
             },
             {
@@ -2777,7 +2777,7 @@ KDA: 21
 Headshot kills: __**36**__
 Shots H:F (acc): **298**:**477** __**(62.83%)**__
 Damage D:T (D/T): __**13,418**__:12,219 (1.1)
-Avg life time (damage/life): 26s (372.72)
+Avg life time (damage/life): 26s (362.65)
 <:TripleKill:1322814228477906944> 4x<:ShotCaller:1322884687693086771> <:NoScope:1322882248516702220> 8x<:DoubleKill:1322814147980689430> 3x<:KillingSpree:1322803050347499541> 4x<:Perfect:1322879561515532308> <:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 2x<:Reversal:1322872797701083166> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
             },
             {
@@ -2790,7 +2790,7 @@ KDA: 17.33
 Headshot kills: 31
 Shots H:F (acc): 244:419 (58.36%)
 Damage D:T (D/T): 12,647:11,513 (1.1)
-Avg life time (damage/life): 28s (371.97)
+Avg life time (damage/life): 28s (361.34)
 2x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> 2x<:ShotCaller:1322884687693086771> 3x<:Snipe:1322872969571340370> 2x<:Rifleman:1322860656399220828> 3x<:Reversal:1322872797701083166> 3x<:GuardianAngel:1322873057928286248> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:Wingman:1322854221095108609> <:Stick:1322871787695898676> 2x<:BackSmack:1322872596135546891>",
             },
             {
@@ -2810,7 +2810,7 @@ KDA: __**30.33**__
 Headshot kills: 28
 Shots H:F (acc): 225:404 (55.05%)
 Damage D:T (D/T): 9,869:__**7,596**__ __**(1.3)**__
-Avg life time (damage/life): __**1m 6s**__ __**(616.81)**__
+Avg life time (damage/life): __**1m 6s**__ __**(580.53)**__
 <:DoubleKill:1322814147980689430> 3x<:Perfect:1322879561515532308> 4x<:KillingSpree:1322803050347499541> <:Killjoy:1322802841039147129> 2x<:Rifleman:1322860656399220828> <:Snipe:1322872969571340370> 2x<:GuardianAngel:1322873057928286248>",
             },
             {
@@ -2823,7 +2823,7 @@ KDA: 7.66
 Headshot kills: 16
 Shots H:F (acc): 217:443 (48.59%)
 Damage D:T (D/T): 11,395:10,347 (1.1)
-Avg life time (damage/life): 30s (356.09)
+Avg life time (damage/life): 30s (345.3)
 <:TripleKill:1322814228477906944> <:OfftheRack:1322884747881353279> 2x<:DoubleKill:1322814147980689430> 2x<:Perfect:1322879561515532308> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
             },
             {
@@ -2856,7 +2856,7 @@ KDA: **14.33**
 Headshot kills: **35**
 Shots H:F (acc): __**304**__:__**497**__ **(62.11%)**
 Damage D:T (D/T): **13,389**:12,281 **(1.09)**
-Avg life time (damage/life): 24s **(343.31)**
+Avg life time (damage/life): 24s **(334.73)**
 <:SneakKing:1322883516039696415> 8x<:DoubleKill:1322814147980689430> 5x<:Perfect:1322879561515532308> <:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:Whiplash:1322882310122504202> 2x<:Rifleman:1322860656399220828> 3x<:Killjoy:1322802841039147129>",
             },
             {
@@ -2869,7 +2869,7 @@ KDA: -6
 Headshot kills: 19
 Shots H:F (acc): 201:399 (50.41%)
 Damage D:T (D/T): 8,792:**11,203** (0.78)
-Avg life time (damage/life): 22s (214.44)
+Avg life time (damage/life): 22s (209.33)
 <:Perfect:1322879561515532308> 2x<:Rifleman:1322860656399220828> <:Stick:1322871787695898676> <:Killjoy:1322802841039147129> <:GuardianAngel:1322873057928286248> <:Wingman:1322854221095108609>",
             },
             {
@@ -2889,7 +2889,7 @@ KDA: -19.32
 Headshot kills: 14
 Shots H:F (acc): 226:458 (49.7%)
 Damage D:T (D/T): 9,495:13,037 (0.73)
-Avg life time (damage/life): 18s (202.02)
+Avg life time (damage/life): 18s (197.81)
 2x<:DoubleKill:1322814147980689430> 2x<:Rifleman:1322860656399220828> <:Reversal:1322872797701083166> <:LastShot:1322884170606972959> <:Wingman:1322854221095108609> <:Killjoy:1322802841039147129>",
             },
             {
@@ -2902,7 +2902,7 @@ KDA: -16.99
 Headshot kills: 10
 Shots H:F (acc): 191:400 (47.66%)
 Damage D:T (D/T): 9,384:11,614 (0.81)
-Avg life time (damage/life): **24s** (240.62)
+Avg life time (damage/life): **24s** (234.6)
 5x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:NadeShot:1322877140605206528> 2x<:Rifleman:1322860656399220828> <:StoppedShort:1322806739778670652> 2x<:Killjoy:1322802841039147129> <:Spotter:1322814780796309505> <:Wingman:1322854221095108609>",
             },
             {
@@ -2940,7 +2940,7 @@ KDA: 0.66
 Headshot kills: 6
 Shots H:F (acc): 83:178 (46.62%)
 Damage D:T (D/T): 4,736:4,879 (0.97)
-Avg life time (damage/life): 32s (338.29)
+Avg life time (damage/life): 32s (315.73)
 Captures: __**2**__
 Captures assists: 0
 Carrier time: 9s
@@ -2959,7 +2959,7 @@ KDA: __**10.33**__
 Headshot kills: __**17**__
 Shots H:F (acc): 108:182 (59.34%)
 Damage D:T (D/T): **5,890**:4,614 __**(1.28)**__
-Avg life time (damage/life): 29s (392.67)
+Avg life time (damage/life): 29s (368.13)
 Captures: 1
 Captures assists: 2
 Carrier time: 20s
@@ -2985,7 +2985,7 @@ KDA: 3
 Headshot kills: 11
 Shots H:F (acc): **122**:**189** **(64.55%)**
 Damage D:T (D/T): 5,717:5,479 (1.04)
-Avg life time (damage/life): 27s (336.29)
+Avg life time (damage/life): 27s (317.61)
 Captures: 0
 Captures assists: 1
 Carrier time: 11s
@@ -3004,7 +3004,7 @@ KDA: 10
 Headshot kills: 10
 Shots H:F (acc): 84:162 (51.85%)
 Damage D:T (D/T): 3,859:__**3,049**__ (1.27)
-Avg life time (damage/life): __**53s**__ __**(428.78)**__
+Avg life time (damage/life): __**53s**__ __**(385.9)**__
 Captures: 0
 Captures assists: __**3**__
 Carrier time: **22s**
@@ -3035,7 +3035,7 @@ KDA: **5**
 Headshot kills: **16**
 Shots H:F (acc): __**134**__:__**200**__ __**(67%)**__
 Damage D:T (D/T): __**6,202**__:5,431 **(1.14)**
-Avg life time (damage/life): 27s **(387.63)**
+Avg life time (damage/life): 27s **(364.82)**
 Captures: **0**
 Captures assists: **0**
 Carrier time: 26s
@@ -3054,7 +3054,7 @@ KDA: 1.66
 Headshot kills: 9
 Shots H:F (acc): 81:160 (50.62%)
 Damage D:T (D/T): 3,657:**4,401** (0.83)
-Avg life time (damage/life): 27s (228.56)
+Avg life time (damage/life): 27s (215.12)
 Captures: **0**
 Captures assists: **0**
 Carrier time: __**1m 3s**__
@@ -3080,7 +3080,7 @@ KDA: -7.66
 Headshot kills: 9
 Shots H:F (acc): 99:191 (51.83%)
 Damage D:T (D/T): 4,094:5,882 (0.7)
-Avg life time (damage/life): 19s (194.95)
+Avg life time (damage/life): 19s (186.09)
 Captures: **0**
 Captures assists: **0**
 Carrier time: 0s
@@ -3099,7 +3099,7 @@ KDA: -5.33
 Headshot kills: 5
 Shots H:F (acc): 77:163 (47.23%)
 Damage D:T (D/T): 3,859:5,057 (0.76)
-Avg life time (damage/life): **29s** (257.27)
+Avg life time (damage/life): **29s** (241.19)
 Captures: **0**
 Captures assists: **0**
 Carrier time: 17s
@@ -3144,7 +3144,7 @@ KDA: 18
 Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
-Avg life time (damage/life): 25s (405.32)
+Avg life time (damage/life): 25s (385.05)
 Captures: __**0**__
 Occupation time: **1m 11s**
 Secures: __**0**__
@@ -3162,7 +3162,7 @@ KDA: 7
 Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
-Avg life time (damage/life): 27s (355.63)
+Avg life time (damage/life): 27s (337.85)
 Captures: __**0**__
 Occupation time: 44s
 Secures: __**0**__
@@ -3187,7 +3187,7 @@ KDA: 7
 Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
-Avg life time (damage/life): 27s (369.94)
+Avg life time (damage/life): 27s (350.47)
 Captures: __**0**__
 Occupation time: 49s
 Secures: __**0**__
@@ -3205,7 +3205,7 @@ KDA: __**20.33**__
 Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
-Avg life time (damage/life): __**1m 19s**__ __**(858.57)**__
+Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
 Captures: __**0**__
 Occupation time: 53s
 Secures: __**0**__
@@ -3235,7 +3235,7 @@ KDA: -7.66
 Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
-Avg life time (damage/life): 17s (205.4)
+Avg life time (damage/life): 17s (197.5)
 Captures: __**0**__
 Occupation time: __**1m 29s**__
 Secures: __**0**__
@@ -3253,7 +3253,7 @@ KDA: -11.66
 Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
-Avg life time (damage/life): 17s (207.73)
+Avg life time (damage/life): 17s (200.04)
 Captures: __**0**__
 Occupation time: 35s
 Secures: __**0**__
@@ -3278,7 +3278,7 @@ KDA: -11.66
 Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
-Avg life time (damage/life): 19s (230.21)
+Avg life time (damage/life): 19s (221)
 Captures: __**0**__
 Occupation time: 48s
 Secures: __**0**__
@@ -3296,7 +3296,7 @@ KDA: **9.33**
 Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
-Avg life time (damage/life): **20s** **(312.48)**
+Avg life time (damage/life): **20s** **(299.46)**
 Captures: __**0**__
 Occupation time: 47s
 Secures: __**0**__
@@ -3388,7 +3388,7 @@ KDA: __74__
 Headshot kills: __111__
 Shots H:F (acc): __984__:1,743 __(56.35%)__
 Damage D:T (D/T): __47,329__:__41,675__ __(1.14)__
-Avg life time (damage/life): __40s__ __(401.09)__
+Avg life time (damage/life): __40s__ __(397.72)__
 2x<:TripleKill:1322814228477906944> 14x<:DoubleKill:1322814147980689430> 11x<:Perfect:1322879561515532308> <:OfftheRack:1322884747881353279> 6x<:ShotCaller:1322884687693086771> 7x<:KillingSpree:1322803050347499541> <:NoScope:1322882248516702220> 4x<:Snipe:1322872969571340370> <:Killjoy:1322802841039147129> 2x<:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 8x<:Rifleman:1322860656399220828> 5x<:Reversal:1322872797701083166> 5x<:GuardianAngel:1322873057928286248> 4x<:Wingman:1322854221095108609> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:BackSmack:1322872596135546891>",
             },
             {
@@ -3401,7 +3401,7 @@ KDA: -29.33
 Headshot kills: 78
 Shots H:F (acc): 922:__1,754__ (52.91%)
 Damage D:T (D/T): 41,060:48,135 (0.85)
-Avg life time (damage/life): 23s (247.35)
+Avg life time (damage/life): 23s (245.87)
 <:SneakKing:1322883516039696415> 11x<:DoubleKill:1322814147980689430> 5x<:ShotCaller:1322884687693086771> 7x<:Perfect:1322879561515532308> <:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:NadeShot:1322877140605206528> <:Whiplash:1322882310122504202> 8x<:Rifleman:1322860656399220828> 7x<:Killjoy:1322802841039147129> <:Stick:1322871787695898676> <:StoppedShort:1322806739778670652> <:Reversal:1322872797701083166> <:GuardianAngel:1322873057928286248> <:Spotter:1322814780796309505> <:LastShot:1322884170606972959> 3x<:Wingman:1322854221095108609>",
             },
             {
@@ -3434,7 +3434,7 @@ KDA: 21
 Headshot kills: __**36**__
 Shots H:F (acc): **298**:**477** __**(62.83%)**__
 Damage D:T (D/T): __**13,418**__:12,219 (1.1)
-Avg life time (damage/life): 26s (372.72)
+Avg life time (damage/life): 26s (362.65)
 <:TripleKill:1322814228477906944> 4x<:ShotCaller:1322884687693086771> <:NoScope:1322882248516702220> 8x<:DoubleKill:1322814147980689430> 3x<:KillingSpree:1322803050347499541> 4x<:Perfect:1322879561515532308> <:Stick:1322871787695898676> <:FromtheGrave:1322884008773816351> 2x<:Reversal:1322872797701083166> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
             },
             {
@@ -3447,7 +3447,7 @@ KDA: 17.33
 Headshot kills: 31
 Shots H:F (acc): 244:419 (58.36%)
 Damage D:T (D/T): 12,647:11,513 (1.1)
-Avg life time (damage/life): 28s (371.97)
+Avg life time (damage/life): 28s (361.34)
 2x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> 2x<:ShotCaller:1322884687693086771> 3x<:Snipe:1322872969571340370> 2x<:Rifleman:1322860656399220828> 3x<:Reversal:1322872797701083166> 3x<:GuardianAngel:1322873057928286248> 2x<:LastShot:1322884170606972959> <:Bodyguard:1322867380136841279> 2x<:Wingman:1322854221095108609> <:Stick:1322871787695898676> 2x<:BackSmack:1322872596135546891>",
             },
             {
@@ -3467,7 +3467,7 @@ KDA: __**30.33**__
 Headshot kills: 28
 Shots H:F (acc): 225:404 (55.05%)
 Damage D:T (D/T): 9,869:__**7,596**__ __**(1.3)**__
-Avg life time (damage/life): __**1m 6s**__ __**(616.81)**__
+Avg life time (damage/life): __**1m 6s**__ __**(580.53)**__
 <:DoubleKill:1322814147980689430> 3x<:Perfect:1322879561515532308> 4x<:KillingSpree:1322803050347499541> <:Killjoy:1322802841039147129> 2x<:Rifleman:1322860656399220828> <:Snipe:1322872969571340370> 2x<:GuardianAngel:1322873057928286248>",
             },
             {
@@ -3480,7 +3480,7 @@ KDA: 7.66
 Headshot kills: 16
 Shots H:F (acc): 217:443 (48.59%)
 Damage D:T (D/T): 11,395:10,347 (1.1)
-Avg life time (damage/life): 30s (356.09)
+Avg life time (damage/life): 30s (345.3)
 <:TripleKill:1322814228477906944> <:OfftheRack:1322884747881353279> 2x<:DoubleKill:1322814147980689430> 2x<:Perfect:1322879561515532308> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
             },
             {
@@ -3513,7 +3513,7 @@ KDA: **14.33**
 Headshot kills: **35**
 Shots H:F (acc): __**304**__:__**497**__ **(62.11%)**
 Damage D:T (D/T): **13,389**:12,281 **(1.09)**
-Avg life time (damage/life): 24s **(343.31)**
+Avg life time (damage/life): 24s **(334.73)**
 <:SneakKing:1322883516039696415> 8x<:DoubleKill:1322814147980689430> 5x<:Perfect:1322879561515532308> <:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> <:Whiplash:1322882310122504202> 2x<:Rifleman:1322860656399220828> 3x<:Killjoy:1322802841039147129>",
             },
             {
@@ -3526,7 +3526,7 @@ KDA: -6
 Headshot kills: 19
 Shots H:F (acc): 201:399 (50.41%)
 Damage D:T (D/T): 8,792:**11,203** (0.78)
-Avg life time (damage/life): 22s (214.44)
+Avg life time (damage/life): 22s (209.33)
 <:Perfect:1322879561515532308> 2x<:Rifleman:1322860656399220828> <:Stick:1322871787695898676> <:Killjoy:1322802841039147129> <:GuardianAngel:1322873057928286248> <:Wingman:1322854221095108609>",
             },
             {
@@ -3546,7 +3546,7 @@ KDA: -19.32
 Headshot kills: 14
 Shots H:F (acc): 226:458 (49.7%)
 Damage D:T (D/T): 9,495:13,037 (0.73)
-Avg life time (damage/life): 18s (202.02)
+Avg life time (damage/life): 18s (197.81)
 2x<:DoubleKill:1322814147980689430> 2x<:Rifleman:1322860656399220828> <:Reversal:1322872797701083166> <:LastShot:1322884170606972959> <:Wingman:1322854221095108609> <:Killjoy:1322802841039147129>",
             },
             {
@@ -3559,7 +3559,7 @@ KDA: -16.99
 Headshot kills: 10
 Shots H:F (acc): 191:400 (47.66%)
 Damage D:T (D/T): 9,384:11,614 (0.81)
-Avg life time (damage/life): **24s** (240.62)
+Avg life time (damage/life): **24s** (234.6)
 5x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:NadeShot:1322877140605206528> 2x<:Rifleman:1322860656399220828> <:StoppedShort:1322806739778670652> 2x<:Killjoy:1322802841039147129> <:Spotter:1322814780796309505> <:Wingman:1322854221095108609>",
             },
             {
@@ -3760,7 +3760,7 @@ KDA: 17.34
 Headshot kills: 106
 Shots H:F (acc): 1,258:2,300 __(55%)__
 Damage D:T (D/T): 58,319:60,349 (0.97)
-Avg life time (damage/life): __39s__ (315.24)
+Avg life time (damage/life): __39s__ (313.54)
 <:TripleKill:1322814228477906944> 13x<:Perfect:1322879561515532308> 9x<:ShotCaller:1322884687693086771> 11x<:DoubleKill:1322814147980689430> <:OfftheRack:1322884747881353279> 2x<:KillingSpree:1322803050347499541> <:NoScope:1322882248516702220> 4x<:Stick:1322871787695898676> 7x<:Reversal:1322872797701083166> 8x<:Rifleman:1322860656399220828> 2x<:BackSmack:1322872596135546891> 3x<:Boxer:1322864064082477077> 4x<:FromtheGrave:1322884008773816351> 3x<:Bodyguard:1322867380136841279> 2x<:Spotter:1322814780796309505> 4x<:Wingman:1322854221095108609> 4x<:Killjoy:1322802841039147129> 4x<:Snipe:1322872969571340370> 2x<:GuardianAngel:1322873057928286248> <:LastShot:1322884170606972959>",
             },
             {
@@ -3773,7 +3773,7 @@ KDA: __34.33__
 Headshot kills: __119__
 Shots H:F (acc): __1,345__:__2,474__ (54.48%)
 Damage D:T (D/T): __59,176__:__59,178__ __(1)__
-Avg life time (damage/life): 29s __(334.33)__
+Avg life time (damage/life): 29s __(332.45)__
 <:360:1322885279266373703> 16x<:Perfect:1322879561515532308> 8x<:ShotCaller:1322884687693086771> 10x<:DoubleKill:1322814147980689430> 5x<:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> 4x<:Reversal:1322872797701083166> 5x<:Stick:1322871787695898676> 6x<:FromtheGrave:1322884008773816351> 8x<:Rifleman:1322860656399220828> 3x<:BackSmack:1322872596135546891> 4x<:Wingman:1322854221095108609> 2x<:GuardianAngel:1322873057928286248> 2x<:Boxer:1322864064082477077> 2x<:Bodyguard:1322867380136841279> <:Spotter:1322814780796309505> 2x<:Killjoy:1322802841039147129> <:StoppedShort:1322806739778670652>",
             },
             {
@@ -3806,7 +3806,7 @@ KDA: **20.66**
 Headshot kills: __**48**__
 Shots H:F (acc): __**376**__:**640** (58.92%)
 Damage D:T (D/T): __**17,510**__:16,025 (1.09)
-Avg life time (damage/life): 27s (364.79)
+Avg life time (damage/life): 27s (357.35)
 6x<:Perfect:1322879561515532308> 4x<:DoubleKill:1322814147980689430> <:ShotCaller:1322884687693086771> <:Stick:1322871787695898676> 2x<:Rifleman:1322860656399220828> 2x<:Bodyguard:1322867380136841279> 4x<:Reversal:1322872797701083166> 2x<:Wingman:1322854221095108609> 2x<:Killjoy:1322802841039147129> 3x<:Snipe:1322872969571340370> 2x<:GuardianAngel:1322873057928286248> <:LastShot:1322884170606972959>",
             },
             {
@@ -3819,7 +3819,7 @@ KDA: 4.66
 Headshot kills: 28
 Shots H:F (acc): 373:632 __**(60.6%)**__
 Damage D:T (D/T): 16,020:16,069 (1)
-Avg life time (damage/life): 25s (326.94)
+Avg life time (damage/life): 25s (320.4)
 3x<:Perfect:1322879561515532308> 5x<:ShotCaller:1322884687693086771> 2x<:DoubleKill:1322814147980689430> <:NoScope:1322882248516702220> 2x<:Rifleman:1322860656399220828> 2x<:Reversal:1322872797701083166> <:Spotter:1322814780796309505> 3x<:Stick:1322871787695898676> <:BackSmack:1322872596135546891> <:Boxer:1322864064082477077> 2x<:Wingman:1322854221095108609> <:FromtheGrave:1322884008773816351>",
             },
             {
@@ -3839,7 +3839,7 @@ KDA: -20.66
 Headshot kills: 19
 Shots H:F (acc): 280:553 (50.91%)
 Damage D:T (D/T): 12,570:16,718 (0.75)
-Avg life time (damage/life): 20s (220.53)
+Avg life time (damage/life): 20s (216.72)
 2x<:Perfect:1322879561515532308> 2x<:DoubleKill:1322814147980689430> <:ShotCaller:1322884687693086771> 2x<:Reversal:1322872797701083166> <:BackSmack:1322872596135546891> <:Boxer:1322864064082477077> 2x<:Rifleman:1322860656399220828> 2x<:FromtheGrave:1322884008773816351> <:Killjoy:1322802841039147129>",
             },
             {
@@ -3852,7 +3852,7 @@ KDA: -4
 Headshot kills: 4
 Shots H:F (acc): 161:326 (24.69%)
 Damage D:T (D/T): 7,718:9,491 (0.81)
-Avg life time (damage/life): 27s (266.14)
+Avg life time (damage/life): 27s (257.27)
 2x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:FromtheGrave:1322884008773816351> <:Rifleman:1322860656399220828> <:Spotter:1322814780796309505> <:Bodyguard:1322867380136841279> <:Boxer:1322864064082477077>",
             },
             {
@@ -3872,7 +3872,7 @@ KDA: 10
 Headshot kills: 10
 Shots H:F (acc): 84:162 (25.93%)
 Damage D:T (D/T): 3,859:__**3,049**__ **(1.27)**
-Avg life time (damage/life): __**53s**__ **(428.78)**
+Avg life time (damage/life): __**53s**__ **(385.9)**
 <:DoubleKill:1322814147980689430> <:Perfect:1322879561515532308> 2x<:KillingSpree:1322803050347499541> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828> <:Snipe:1322872969571340370>",
             },
             {
@@ -3905,7 +3905,7 @@ KDA: 9.33
 Headshot kills: **34**
 Shots H:F (acc): **371**:__**647**__ **(60.01%)**
 Damage D:T (D/T): **17,017**:15,450 (1.1)
-Avg life time (damage/life): 26s (362.06)
+Avg life time (damage/life): 26s (354.52)
 4x<:Perfect:1322879561515532308> <:ShotCaller:1322884687693086771> 6x<:DoubleKill:1322814147980689430> 2x<:KillingSpree:1322803050347499541> <:OfftheRack:1322884747881353279> 2x<:Rifleman:1322860656399220828> <:Wingman:1322854221095108609> <:GuardianAngel:1322873057928286248> <:FromtheGrave:1322884008773816351> <:Killjoy:1322802841039147129>",
             },
             {
@@ -3918,7 +3918,7 @@ KDA: __**30**__
 Headshot kills: 30
 Shots H:F (acc): 335:582 (28.78%)
 Damage D:T (D/T): 13,919:10,011 __**(1.39)**__
-Avg life time (damage/life): 33s __**(579.96)**__
+Avg life time (damage/life): 33s __**(556.76)**__
 8x<:Perfect:1322879561515532308> 3x<:DoubleKill:1322814147980689430> <:ShotCaller:1322884687693086771> 2x<:KillingSpree:1322803050347499541> <:Rifleman:1322860656399220828> 2x<:BackSmack:1322872596135546891> <:Reversal:1322872797701083166> <:Wingman:1322854221095108609> 2x<:Stick:1322871787695898676> 2x<:FromtheGrave:1322884008773816351> <:Boxer:1322864064082477077> <:Bodyguard:1322867380136841279> <:GuardianAngel:1322873057928286248>",
             },
             {
@@ -3938,7 +3938,7 @@ KDA: -6
 Headshot kills: 18
 Shots H:F (acc): 241:500 (47.84%)
 Damage D:T (D/T): 11,936:14,660 (0.81)
-Avg life time (damage/life): 27s (253.96)
+Avg life time (damage/life): 27s (248.67)
 <:TripleKill:1322814228477906944> <:Perfect:1322879561515532308> <:OfftheRack:1322884747881353279> 2x<:DoubleKill:1322814147980689430> 2x<:Reversal:1322872797701083166> <:Stick:1322871787695898676> 2x<:Rifleman:1322860656399220828> <:FromtheGrave:1322884008773816351> <:Bodyguard:1322867380136841279> <:Wingman:1322854221095108609>",
             },
             {
@@ -3951,7 +3951,7 @@ KDA: 14.33
 Headshot kills: 20
 Shots H:F (acc): 224:409 (27.38%)
 Damage D:T (D/T): 9,430:8,596 (1.1)
-Avg life time (damage/life): **41s** (449.05)
+Avg life time (damage/life): **41s** (428.64)
 <:360:1322885279266373703> 2x<:Perfect:1322879561515532308> 4x<:ShotCaller:1322884687693086771> <:KillingSpree:1322803050347499541> <:Stick:1322871787695898676> 2x<:FromtheGrave:1322884008773816351> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609> <:Spotter:1322814780796309505> <:BackSmack:1322872596135546891> <:Boxer:1322864064082477077>",
             },
             {
@@ -3971,7 +3971,7 @@ KDA: 1.66
 Headshot kills: 9
 Shots H:F (acc): 81:160 (25.31%)
 Damage D:T (D/T): 3,657:**4,401** (0.83)
-Avg life time (damage/life): 27s (228.56)
+Avg life time (damage/life): 27s (215.12)
 <:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> <:Stick:1322871787695898676> <:Killjoy:1322802841039147129>",
             },
             {
@@ -3984,7 +3984,7 @@ KDA: -5.33
 Headshot kills: 5
 Shots H:F (acc): 77:163 (23.61%)
 Damage D:T (D/T): 3,859:5,057 (0.76)
-Avg life time (damage/life): 29s (257.27)
+Avg life time (damage/life): 29s (241.19)
 2x<:ShotCaller:1322884687693086771> <:Rifleman:1322860656399220828> <:StoppedShort:1322806739778670652>",
             },
             {

--- a/shared/src/halo/slayer-stats.ts
+++ b/shared/src/halo/slayer-stats.ts
@@ -55,9 +55,9 @@ export function getPlayerSlayerStats(
     display: getReadableDuration(coreStats.AverageLifeDuration, locale),
   });
   slayerStats.set("Avg damage per life", {
-    value: getSafeRatioValue(coreStats.DamageDealt, coreStats.Deaths),
+    value: getSafeRatioValue(coreStats.DamageDealt, coreStats.Deaths + 1),
     sortBy: StatsValueSortBy.DESC,
-    display: formatDamageRatio(coreStats.DamageDealt, coreStats.Deaths, locale),
+    display: formatDamageRatio(coreStats.DamageDealt, coreStats.Deaths + 1, locale),
   });
 
   return slayerStats;

--- a/shared/src/halo/tests/slayer-stats.test.ts
+++ b/shared/src/halo/tests/slayer-stats.test.ts
@@ -98,12 +98,20 @@ describe("getPlayerSlayerStats", () => {
       expect(result.get("Damage ratio")?.value).toBe(2);
     });
 
-    it("computes avg damage per life from dealt and deaths", () => {
+    it("computes avg damage per life from dealt and total lives", () => {
       const coreStats = aFakeCoreStatsWith({ DamageDealt: 15000, Deaths: 10 });
 
       const result = getPlayerSlayerStats(coreStats);
 
-      expect(result.get("Avg damage per life")?.value).toBe(1500);
+      expect(result.get("Avg damage per life")?.value).toBe(15000 / 11);
+    });
+
+    it("uses one life when a player has no deaths", () => {
+      const coreStats = aFakeCoreStatsWith({ DamageDealt: 15000, Deaths: 0 });
+
+      const result = getPlayerSlayerStats(coreStats);
+
+      expect(result.get("Avg damage per life")?.value).toBe(15000);
     });
 
     it("computes avg life time in seconds from ISO duration", () => {


### PR DESCRIPTION
## Context
The Slayer `Avg damage per life` stat represents damage dealt across the lives a player had during a match. A player begins with one life, so total lives are deaths plus one. The previous calculation divided by deaths, overstating the value and producing infinity for players with no deaths.

## This PR
- Corrects the shared Slayer stat to calculate `DamageDealt / (Deaths + 1)`.
- Corrects leaderboard ingestion so persisted `AvgDamagePerLife` uses the same formula.
- Adds normal and zero-death regression coverage, including an ingestion-level persistence test.
- Updates affected Discord embed, stats-command, and NeatQueue snapshots.
- Audited the other Slayer metrics: direct source mappings, accuracy percentage, damage-dealt/taken ratio, average life duration, and sort directions remain correct.

Validation: 247 test files passed (3455 tests, 1 skipped), lint passed, API and Pages typechecks passed with 0 errors. Pages typecheck retains 3 pre-existing hints in `pages/src/components/header/header.astro`.

## Subsequent Work
None required for this correction; PR6b can build on the corrected persisted metric.