### PR TITLE
Add public leaderboard interaction policy

### DIFF
--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -375,7 +375,7 @@ export class LeaderboardCommand extends BaseCommand {
   ): Promise<void> {
     try {
       this.assertButtonInteraction(interaction);
-      await this.assertCanUseLeaderboardControls(interaction);
+      this.assertCanUseLeaderboardControls(interaction);
       const state = this.getStateFromInteractionMessage(interaction);
       const locale = this.getInteractionLocale(interaction);
       const firstPage = await this.services.leaderboardService.getLeaderboard({
@@ -498,7 +498,7 @@ export class LeaderboardCommand extends BaseCommand {
     stateUpdater: (state: LeaderboardViewState) => LeaderboardViewState,
   ): Promise<void> {
     try {
-      await this.assertCanUseLeaderboardControls(interaction);
+      this.assertCanUseLeaderboardControls(interaction);
       const state = this.getStateFromInteractionMessage(interaction);
       const locale = this.getInteractionLocale(interaction);
       await this.refreshLeaderboard(interaction.token, locale, stateUpdater(state));
@@ -507,10 +507,9 @@ export class LeaderboardCommand extends BaseCommand {
     }
   }
 
-  private async assertCanUseLeaderboardControls(
+  private assertCanUseLeaderboardControls(
     interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
-  ): Promise<void> {
-    await Promise.resolve();
+  ): void {
     const guildId = interaction.guild_id;
     if (guildId == null || guildId === "") {
       throw new EndUserError("Leaderboard controls can only be used inside a server.", {

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -79,12 +79,14 @@ interface LeaderboardViewState {
   metric?: LeaderboardMetric;
   page: number;
   minGamesPlayed?: number;
+  locked?: boolean;
 }
 
 interface ResolvedLeaderboardViewState extends LeaderboardViewState {
   window: LeaderboardWindow;
   metric: LeaderboardMetric;
   minGamesPlayed: number;
+  locked: boolean;
 }
 
 export class LeaderboardCommand extends BaseCommand {
@@ -158,6 +160,12 @@ export class LeaderboardCommand extends BaseCommand {
               type: ApplicationCommandOptionType.Integer,
               required: false,
               min_value: 0,
+            },
+            {
+              name: "locked",
+              description: "Post a static leaderboard without interactive controls",
+              type: ApplicationCommandOptionType.Boolean,
+              required: false,
             },
           ],
         },
@@ -317,6 +325,7 @@ export class LeaderboardCommand extends BaseCommand {
       );
       const page = this.getOptionalNumberOption(options, "page") ?? 1;
       const minGamesPlayed = this.getOptionalNumberOption(options, "min_games_played");
+      const locked = this.getOptionalBooleanOption(options, "locked") ?? false;
       const locale = this.getInteractionLocale(interaction);
 
       await this.refreshLeaderboard(interaction.token, locale, {
@@ -326,6 +335,7 @@ export class LeaderboardCommand extends BaseCommand {
         ...(metric != null ? { metric } : {}),
         page,
         ...(minGamesPlayed != null ? { minGamesPlayed } : {}),
+        locked,
       });
     } catch (error) {
       await this.services.discordService.updateDeferredReplyWithError(interaction.token, error);
@@ -500,6 +510,7 @@ export class LeaderboardCommand extends BaseCommand {
   private async assertCanUseLeaderboardControls(
     interaction: APIMessageComponentButtonInteraction | APIMessageComponentSelectMenuInteraction,
   ): Promise<void> {
+    await Promise.resolve();
     const guildId = interaction.guild_id;
     if (guildId == null || guildId === "") {
       throw new EndUserError("Leaderboard controls can only be used inside a server.", {
@@ -508,16 +519,7 @@ export class LeaderboardCommand extends BaseCommand {
       });
     }
 
-    const userId = this.services.discordService.getDiscordUserId(interaction);
-    const permissions = await this.services.discordService.computeMemberPermissions(guildId, userId);
-    const hasManageGuildPermission = (permissions & PermissionFlagsBits.ManageGuild) !== 0n;
-
-    if (!hasManageGuildPermission) {
-      throw new EndUserError("You need the Manage Server permission to use leaderboard controls.", {
-        handled: true,
-        errorType: EndUserErrorType.WARNING,
-      });
-    }
+    this.services.discordService.getDiscordUserId(interaction);
   }
 
   private async refreshLeaderboard(token: string, locale: string, state: LeaderboardViewState): Promise<void> {
@@ -536,14 +538,17 @@ export class LeaderboardCommand extends BaseCommand {
         locale,
         leaderboard,
         this.services.discordService.getTimestamp(new Date().toISOString(), "R"),
+        state.locked ?? false,
       );
       const message = await this.services.discordService.updateDeferredReply(token, response);
-      await this.upsertLeaderboardPost({
-        ChannelId: message.channel_id,
-        MessageId: message.id,
-        GuildId: leaderboard.guildId,
-        QueueChannelId: leaderboard.queueChannelId,
-      });
+      if (state.locked !== true) {
+        await this.upsertLeaderboardPost({
+          ChannelId: message.channel_id,
+          MessageId: message.id,
+          GuildId: leaderboard.guildId,
+          QueueChannelId: leaderboard.queueChannelId,
+        });
+      }
     } catch (error) {
       await this.services.discordService.updateDeferredReplyWithError(token, error);
     }
@@ -611,6 +616,7 @@ export class LeaderboardCommand extends BaseCommand {
       metric: parsedMetric,
       page: Number.isNaN(parsedPage) ? 1 : Math.max(1, parsedPage),
       minGamesPlayed: Number.isNaN(parsedMinGamesPlayed) ? 0 : Math.max(0, parsedMinGamesPlayed),
+      locked: false,
     });
   }
 
@@ -641,6 +647,7 @@ export class LeaderboardCommand extends BaseCommand {
       metric: state.metric,
       page: state.page,
       minGamesPlayed: state.minGamesPlayed,
+      locked: state.locked,
     };
   }
 
@@ -679,6 +686,7 @@ export class LeaderboardCommand extends BaseCommand {
       metric,
       page: Math.max(1, page),
       minGamesPlayed: Math.max(0, minGamesPlayed),
+      locked: false,
     };
   }
 
@@ -849,6 +857,22 @@ export class LeaderboardCommand extends BaseCommand {
 
     if (typeof value !== "number") {
       throw new Error(`Expected numeric option: ${optionName}`);
+    }
+
+    return value;
+  }
+
+  private getOptionalBooleanOption(
+    options: Map<string, APIApplicationCommandInteractionDataBasicOption["value"]>,
+    optionName: string,
+  ): boolean | undefined {
+    const value = options.get(optionName);
+    if (value == null) {
+      return undefined;
+    }
+
+    if (typeof value !== "boolean") {
+      throw new Error(`Expected boolean option: ${optionName}`);
     }
 
     return value;

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -750,7 +750,7 @@ describe("LeaderboardCommand", () => {
     });
   });
 
-  it("updates deferred reply with error when leaderboard controls are used without manage server permission", async () => {
+  it("allows leaderboard controls without manage server permission", async () => {
     vi.spyOn(services.discordService, "computeMemberPermissions").mockResolvedValueOnce(0n);
     const interaction: APIMessageComponentButtonInteraction = {
       ...fakeButtonClickInteraction,
@@ -771,23 +771,26 @@ describe("LeaderboardCommand", () => {
       },
     };
 
-    const updateDeferredReplyWithErrorSpy = vi
-      .spyOn(services.discordService, "updateDeferredReplyWithError")
-      .mockResolvedValue(undefined);
-    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard");
-    const logErrorSpy = vi.spyOn(services.logService, "error");
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "guild-123",
+      queueChannelId: null,
+      window: LeaderboardWindow.ThreeMonths,
+      metric: LeaderboardMetric.Kills,
+      minGamesPlayed: 0,
+      page: 3,
+      pageSize: 10,
+      total: 0,
+      rows: [],
+    });
+    vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      ...Preconditions.checkExists(interaction.message),
+      type: MessageType.Default,
+    });
 
     const result = command.execute(interaction);
     await result.jobToComplete?.();
 
-    expect(getLeaderboardSpy).not.toHaveBeenCalled();
-    expect(logErrorSpy).not.toHaveBeenCalled();
-    expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
-      interaction.token,
-      expect.objectContaining({
-        endUserMessage: "You need the Manage Server permission to use leaderboard controls.",
-      }),
-    );
+    expect(getLeaderboardSpy).toHaveBeenCalledOnce();
   });
 
   it("updates deferred reply with error when page-change interaction payload has wrong component type", async () => {

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -247,6 +247,86 @@ describe("LeaderboardCommand", () => {
     expect(getBrowserUrlFromComponents(payload.components)).toBeNull();
   });
 
+  it("omits controls and skips post registration for locked leaderboard show", async () => {
+    const mappedOptions = new Map<string, string | number | boolean>();
+    mappedOptions.set("locked", true);
+
+    vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
+      name: "show",
+      options: [],
+      mappedOptions,
+    });
+    const getLeaderboardSpy = vi.spyOn(services.leaderboardService, "getLeaderboard").mockResolvedValue({
+      guildId: "guild-123",
+      queueChannelId: null,
+      window: LeaderboardWindow.ThreeMonths,
+      metric: LeaderboardMetric.SeriesWinRate,
+      minGamesPlayed: 0,
+      page: 1,
+      pageSize: 10,
+      total: 0,
+      rows: [],
+    });
+    const upsertLeaderboardPostSpy = vi
+      .spyOn(services.databaseService, "upsertLeaderboardPost")
+      .mockResolvedValue(undefined);
+    const updateDeferredReplySpy = vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      id: "message-id",
+      channel_id: "channel-id",
+      content: "",
+      timestamp: "2026-08-12T00:00:00.000Z",
+      edited_timestamp: null,
+      tts: false,
+      mention_everyone: false,
+      mentions: [],
+      mention_roles: [],
+      attachments: [],
+      embeds: [],
+      pinned: false,
+      type: MessageType.Default,
+      author: {
+        id: "bot-id",
+        username: "Guilty Spark",
+        discriminator: "0000",
+        avatar: null,
+        global_name: null,
+      },
+      components: [],
+    });
+
+    const interaction: APIApplicationCommandInteraction = {
+      ...fakeBaseAPIApplicationCommandInteraction,
+      type: InteractionType.ApplicationCommand,
+      guild_id: "guild-123",
+      data: {
+        id: "fake-command-id",
+        name: "leaderboard",
+        type: ApplicationCommandType.ChatInput,
+        options: [
+          {
+            type: ApplicationCommandOptionType.Subcommand,
+            name: "show",
+            options: [],
+          },
+        ],
+      },
+    };
+
+    const result = command.execute(interaction);
+
+    expect(result.response.type).toBe(InteractionResponseType.DeferredChannelMessageWithSource);
+    await result.jobToComplete?.();
+
+    expect(getLeaderboardSpy).toHaveBeenCalledWith({
+      guildId: "guild-123",
+      page: 1,
+      pageSize: 10,
+    });
+    expect(upsertLeaderboardPostSpy).not.toHaveBeenCalled();
+    const [, payload] = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]);
+    expect(payload.components).toBeUndefined();
+  });
+
   it("prefers guild locale over user locale for leaderboard formatting", async () => {
     vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({
       name: "show",

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -751,7 +751,6 @@ describe("LeaderboardCommand", () => {
   });
 
   it("allows leaderboard controls without manage server permission", async () => {
-    vi.spyOn(services.discordService, "computeMemberPermissions").mockResolvedValueOnce(0n);
     const interaction: APIMessageComponentButtonInteraction = {
       ...fakeButtonClickInteraction,
       guild_id: "guild-123",

--- a/api/services/leaderboard/leaderboard-response.ts
+++ b/api/services/leaderboard/leaderboard-response.ts
@@ -435,6 +435,7 @@ export function createLeaderboardResponse(
   locale: string,
   leaderboard: LeaderboardResponse,
   updatedTimestamp: string,
+  locked = false,
 ): RESTPostAPIChannelMessageJSONBody {
   const rows = leaderboard.rows.slice(0, MAX_ROWS_IN_DISCORD_EMBED);
   const totalPages = Math.max(1, Math.ceil(leaderboard.total / leaderboard.pageSize));
@@ -455,6 +456,6 @@ export function createLeaderboardResponse(
         },
       },
     ],
-    components: createComponents(leaderboard),
+    ...(locked ? {} : { components: createComponents(leaderboard) }),
   };
 }

--- a/api/services/leaderboard/tests/leaderboard-response.test.ts
+++ b/api/services/leaderboard/tests/leaderboard-response.test.ts
@@ -282,4 +282,22 @@ describe("createLeaderboardResponse", () => {
     ]);
     expect(familySelect.options.map((option) => option.label)).not.toContain("Series win rate");
   });
+
+  it("omits components for a locked leaderboard", () => {
+    const leaderboard: LeaderboardResponse = {
+      guildId: "guild-123",
+      queueChannelId: null,
+      window: LeaderboardWindow.OneMonth,
+      metric: LeaderboardMetric.Kills,
+      minGamesPlayed: 3,
+      page: 1,
+      pageSize: 10,
+      total: 0,
+      rows: [],
+    };
+
+    const response = createLeaderboardResponse("en-US", leaderboard, "<t:1733483139:R>", true);
+
+    expect(response.components).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Context
Leaderboards should be usable by ordinary server members without requiring Manage Server, while administrators still need a way to publish a static board with no interaction. The interaction policy also needs to leave room for future guild/role restrictions and administrative reset controls.

## This PR
- Adds optional `/leaderboard show locked`, defaulting to `false`.
- Renders locked leaderboards without buttons or selectors.
- Keeps unlocked controls available to server members without a Manage Server permission check.
- Avoids registering locked static boards for automatic background refresh.
- Preserves existing guild-only validation and component state behavior.
- Adds regression coverage for public controls and locked rendering.

Validation: 248 test files passed, 3567 tests passed, 1 skipped; TypeScript lint and API/Pages typechecks pass. Pages typecheck retains 3 pre-existing Astro hints.

## Subsequent Work
- Add the configurable guild/role interaction-policy model if needed.
- Implement `/leaderboard reset` marker permissions and confirmation flow.