### PR TITLE
Enforce no-barrel-reexports and remove dead re-export wrappers

### DIFF
--- a/api/embeds/stats/base-match-embed.ts
+++ b/api/embeds/stats/base-match-embed.ts
@@ -6,8 +6,6 @@ import { getTeamName } from "@guilty-spark/shared/halo/team";
 import type { StatsCollection, StatsValue } from "@guilty-spark/shared/halo/types";
 import { getPlayerSlayerStats as getSharedPlayerSlayerStats } from "@guilty-spark/shared/halo/slayer-stats";
 import { getPlayerXuid, getTeamPlayersFromMatches } from "@guilty-spark/shared/halo/match-stats";
-export { StatsValueSortBy } from "@guilty-spark/shared/halo/stat-formatting";
-export type { StatsValue } from "@guilty-spark/shared/halo/types";
 import type { HaloService } from "../../services/halo/halo";
 import type { DiscordService } from "../../services/discord/discord";
 import type { GuildConfigRow } from "../../services/database/types/guild_config";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -82,9 +82,29 @@ export default defineConfig(
       "import-x/no-empty-named-blocks": "error",
       "import-x/no-useless-path-segments": "error",
       "import-x/consistent-type-specifier-style": ["error", "prefer-top-level"],
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "ExportNamedDeclaration[source]",
+          message:
+            "Do not re-export a symbol from another module. Consumers must import directly from the source module.",
+        },
+        {
+          selector: "ExportAllDeclaration",
+          message:
+            "Do not re-export a symbol from another module. Consumers must import directly from the source module.",
+        },
+      ],
       curly: ["error", "all"],
       "default-case": "error",
       "no-fallthrough": "error",
+    },
+  },
+  {
+    files: ["api/worker.ts"],
+    rules: {
+      // Cloudflare Workers requires Durable Object classes to be exported from the worker entrypoint module.
+      "no-restricted-syntax": "off",
     },
   },
   {

--- a/pages/src/base/preconditions.ts
+++ b/pages/src/base/preconditions.ts
@@ -1,1 +1,0 @@
-export { Preconditions } from "@guilty-spark/shared/base/preconditions";

--- a/pages/src/base/unreachable-error.ts
+++ b/pages/src/base/unreachable-error.ts
@@ -1,1 +1,0 @@
-export { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";

--- a/pages/src/controllers/stats/types.ts
+++ b/pages/src/controllers/stats/types.ts
@@ -4,8 +4,6 @@ import type { MedalEntry } from "@guilty-spark/shared/halo/medals";
 export type PlayerTeamStats<TCategory extends GameVariantCategory> =
   MatchStats<TCategory>["Players"][0]["PlayerTeamStats"][0];
 
-export { StatsValueSortBy } from "@guilty-spark/shared/halo/stat-formatting";
-
 export interface MatchStatsData {
   teamId: number;
   teamStats: MatchStatsValues[];


### PR DESCRIPTION
## Context

Follow-up to #797, which reviewed `eslint-plugin-import-x`'s config against this repo's strict conventions. AGENTS.md already documents a "No re-exports" convention (consumers import directly from the source module, never through an intermediary wrapper), but nothing enforced it, and 4 existing files violated it.

## This change

- Added a `no-restricted-syntax` rule to `eslint.config.mjs` blocking `export { x } from 'y'` and `export * from 'y'` statements, so the convention is now mechanically enforced. `api/worker.ts` is exempted since Cloudflare Workers requires Durable Object classes to be exported from the worker entrypoint module.
- Investigated the 4 existing violations found in #797 (`pages/src/base/preconditions.ts`, `pages/src/base/unreachable-error.ts`, `pages/src/controllers/stats/types.ts`'s `StatsValueSortBy` re-export, `api/embeds/stats/base-match-embed.ts`'s `StatsValueSortBy`/`StatsValue` re-exports). All 4 turned out to be **dead code** — every real consumer already imports directly from `@guilty-spark/shared`, so no consumer repointing was needed:
  - Deleted the two one-line wrapper files (`pages/src/base/preconditions.ts`, `pages/src/base/unreachable-error.ts`).
  - Removed the two unused re-export lines from `pages/src/controllers/stats/types.ts` and `api/embeds/stats/base-match-embed.ts` (both files keep their other, legitimate exports).

## Test plan

- [x] `npx eslint .` — 0 errors, 0 warnings
- [x] Sanity-checked the new rule fires on a throwaway `export { x } from 'y'` / `export * from 'y'` file, and that `api/worker.ts`'s existing DO re-exports are unaffected
- [x] `npm run typecheck` — 0 errors (api + pages, including `astro check`: 0 errors/warnings/hints)
- [x] `npm test` — 248 test files, 3568 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)