### PR TITLE
Remove import-x/no-cycle to fix WSL out-of-memory crash

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,7 +78,6 @@ export default defineConfig(
       "import-x/no-duplicates": "error",
       "import-x/no-mutable-exports": "error",
       "import-x/no-self-import": "error",
-      "import-x/no-cycle": "error",
       "import-x/no-empty-named-blocks": "error",
       "import-x/no-useless-path-segments": "error",
       "import-x/consistent-type-specifier-style": ["error", "prefer-top-level"],


### PR DESCRIPTION
## Context

After #797 merged, running `eslint` on Windows WSL started throwing a "JavaScript heap out of memory" error that wasn't happening before.

## This change

`import-x/no-cycle` (added in #797) recursively traverses the entire module dependency graph for every linted file, with no depth bound by default. It's the one rule among everything added in #797 that does whole-project graph traversal rather than single-file/line-level checks, and this class of rule has a documented history of causing OOM crashes in the import plugin ecosystem (e.g. [`no-unused-modules` in the original `eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import/issues/1364)).

It ran fine on this machine, but had caught zero real cycles in this repo since it was added — so the coverage lost by removing it is speculative, while the WSL crash is real and reproducible. Removing the rule entirely rather than bounding it with `maxDepth` or bumping Node's heap size, since neither guarantees it'd be enough for a WSL VM's memory ceiling, whereas removing it guarantees the issue is gone everywhere.

## Test plan

- [x] `npx eslint .` — 0 errors, 0 warnings (config-only change, no other diff)
- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — full suite unaffected (only `eslint.config.mjs` changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)