### PR TITLE
Refresh leaderboard posts after reset

### DIFF
--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -481,6 +481,7 @@ export class LeaderboardCommand extends BaseCommand {
         CreatedAt: now,
         UpdatedAt: now,
       });
+      await this.services.leaderboardService.refreshPostsForReset(guildId, queueChannelId);
 
       const scope = this.getResetScopeLabel(queueChannelId);
       await this.services.discordService.updateDeferredReply(interaction.token, {

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -481,7 +481,6 @@ export class LeaderboardCommand extends BaseCommand {
         CreatedAt: now,
         UpdatedAt: now,
       });
-      await this.services.leaderboardService.refreshPostsForReset(guildId, queueChannelId);
 
       const scope = this.getResetScopeLabel(queueChannelId);
       await this.services.discordService.updateDeferredReply(interaction.token, {
@@ -492,6 +491,7 @@ export class LeaderboardCommand extends BaseCommand {
         ],
         components: [],
       });
+      await this.services.leaderboardService.refreshPostsForReset(guildId, queueChannelId);
     } catch (error) {
       await this.services.discordService.updateDeferredReplyWithError(interaction.token, error);
     }

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -164,6 +164,7 @@ describe("LeaderboardCommand", () => {
       },
     };
     const upsertSpy = vi.spyOn(services.databaseService, "upsertLeaderboardResetMarker").mockResolvedValue(undefined);
+    const refreshPostsSpy = vi.spyOn(services.leaderboardService, "refreshPostsForReset").mockResolvedValue(undefined);
     const updateSpy = vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
       ...fakeButtonClickInteraction.message,
       type: MessageType.Default,
@@ -175,6 +176,7 @@ describe("LeaderboardCommand", () => {
     expect(upsertSpy).toHaveBeenCalledWith(
       expect.objectContaining({ GuildId: "guild-123", QueueChannelId: "queue-123", ResetAt: resetAt }),
     );
+    expect(refreshPostsSpy).toHaveBeenCalledWith("guild-123", "queue-123");
     expect(updateSpy).toHaveBeenCalledWith(
       interaction.token,
       expect.objectContaining({ embeds: [expect.objectContaining({ title: "Leaderboard reset" })], components: [] }),

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -183,6 +183,50 @@ describe("LeaderboardCommand", () => {
     );
   });
 
+  it("updates the reset confirmation before refreshing leaderboard posts", async () => {
+    const resetAt = 1_723_600_000;
+    const interaction: APIMessageComponentButtonInteraction = {
+      ...fakeButtonClickInteraction,
+      guild_id: "guild-123",
+      guild: {
+        ...Preconditions.checkExists(fakeButtonClickInteraction.guild),
+        id: "guild-123",
+      },
+      data: {
+        component_type: ComponentType.Button,
+        custom_id: `btn_leaderboard_reset_confirm:guild-123:queue-123:${resetAt.toString(36)}`,
+      },
+    };
+    const deferredRefresh = {
+      resolve: (): void => {
+        throw new Error("Expected refresh resolver to be initialized");
+      },
+    };
+    const refreshPromise = new Promise<void>((resolve) => {
+      deferredRefresh.resolve = resolve;
+    });
+    vi.spyOn(services.databaseService, "upsertLeaderboardResetMarker").mockResolvedValue(undefined);
+    const refreshSpy = vi.spyOn(services.leaderboardService, "refreshPostsForReset").mockReturnValue(refreshPromise);
+    const updateSpy = vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue({
+      ...fakeButtonClickInteraction.message,
+      type: MessageType.Default,
+    });
+
+    const result = command.execute(interaction);
+    const completion = result.jobToComplete?.();
+
+    await vi.waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      Preconditions.checkExists(refreshSpy.mock.invocationCallOrder[0]),
+    );
+
+    deferredRefresh.resolve();
+    await completion;
+  });
+
   it("allows admins to reset leaderboards without Manage Server", async () => {
     vi.spyOn(services.discordService, "computeMemberPermissions").mockResolvedValue(PermissionFlagsBits.Administrator);
     vi.spyOn(services.discordService, "extractSubcommand").mockReturnValue({

--- a/api/services/database/database.ts
+++ b/api/services/database/database.ts
@@ -415,6 +415,12 @@ export class DatabaseService {
     return response.results;
   }
 
+  async findLeaderboardPostsForGuildRefresh(guildId: string): Promise<LeaderboardPostRow[]> {
+    const stmt = this.DB.prepare("SELECT * FROM LeaderboardPosts WHERE GuildId = ?").bind(guildId);
+    const response = await stmt.all<LeaderboardPostRow>();
+    return response.results;
+  }
+
   async getAllLeaderboardPosts(): Promise<LeaderboardPostRow[]> {
     const stmt = this.DB.prepare("SELECT * FROM LeaderboardPosts");
     const response = await stmt.all<LeaderboardPostRow>();

--- a/api/services/database/tests/database.test.ts
+++ b/api/services/database/tests/database.test.ts
@@ -990,6 +990,20 @@ describe("Database Service", () => {
       expect(posts).toEqual([guildWidePost, queuePost]);
     });
 
+    it("finds every leaderboard post for a guild reset", async () => {
+      const post = aFakeLeaderboardPostRow();
+      const fakePreparedStatement = new FakePreparedStatement<typeof post>();
+      const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue(fakePreparedStatement);
+      const bindSpy = vi.spyOn(fakePreparedStatement, "bind");
+      vi.spyOn(fakePreparedStatement, "all").mockResolvedValue({ ...fakeD1Response, results: [post] });
+
+      const posts = await databaseService.findLeaderboardPostsForGuildRefresh("guild-1");
+
+      expect(prepareSpy).toHaveBeenCalledWith("SELECT * FROM LeaderboardPosts WHERE GuildId = ?");
+      expect(bindSpy).toHaveBeenCalledWith("guild-1");
+      expect(posts).toEqual([post]);
+    });
+
     it("gets every leaderboard post for reaping", async () => {
       const post = aFakeLeaderboardPostRow();
       const fakePreparedStatement = new FakePreparedStatement<typeof post>();

--- a/api/services/leaderboard/leaderboard.ts
+++ b/api/services/leaderboard/leaderboard.ts
@@ -196,9 +196,9 @@ export class LeaderboardService {
       return;
     }
 
-    let posts: LeaderboardPostRow[];
     try {
-      posts = await this.databaseService.findLeaderboardPostsForRefresh(guildId, queueChannelId);
+      const posts = await this.databaseService.findLeaderboardPostsForRefresh(guildId, queueChannelId);
+      await this.refreshLeaderboardPosts(posts, guildId);
     } catch (error) {
       this.logService.warn(
         error,
@@ -210,8 +210,30 @@ export class LeaderboardService {
       );
       return;
     }
+  }
 
-    if (posts.length === 0) {
+  async refreshPostsForReset(guildId: string, queueChannelId: string | null): Promise<void> {
+    try {
+      const posts =
+        queueChannelId == null
+          ? await this.databaseService.findLeaderboardPostsForGuildRefresh(guildId)
+          : await this.databaseService.findLeaderboardPostsForRefresh(guildId, queueChannelId);
+      await this.refreshLeaderboardPosts(posts, guildId);
+    } catch (error) {
+      this.logService.warn(
+        error,
+        new Map([
+          ["guildId", guildId],
+          ["queueChannelId", queueChannelId],
+          ["reason", "Failed to refresh leaderboard posts after reset"],
+        ]),
+      );
+    }
+  }
+
+  private async refreshLeaderboardPosts(posts: LeaderboardPostRow[], guildId: string): Promise<void> {
+    const { discordService } = this;
+    if (discordService == null || posts.length === 0) {
       return;
     }
 

--- a/api/services/leaderboard/leaderboard.ts
+++ b/api/services/leaderboard/leaderboard.ts
@@ -213,6 +213,11 @@ export class LeaderboardService {
   }
 
   async refreshPostsForReset(guildId: string, queueChannelId: string | null): Promise<void> {
+    const { discordService } = this;
+    if (discordService == null) {
+      return;
+    }
+
     try {
       const posts =
         queueChannelId == null

--- a/api/services/leaderboard/tests/leaderboard.test.ts
+++ b/api/services/leaderboard/tests/leaderboard.test.ts
@@ -485,6 +485,73 @@ describe("LeaderboardService", () => {
     expect(findQueuePostsSpy).not.toHaveBeenCalled();
   });
 
+  it("refreshes guild-wide posts for reset when queue channel is omitted", async () => {
+    const databaseService = aFakeDatabaseServiceWith();
+    const haloService = aFakeHaloServiceWith({ databaseService });
+    const discordService = aFakeDiscordServiceWith();
+    const logService = aFakeLogServiceWith();
+    const service = new LeaderboardService({ databaseService, discordService, haloService, logService });
+    const firstPost = aFakeLeaderboardPostRow();
+    const secondPost = aFakeLeaderboardPostRow({ ChannelId: "channel-2", MessageId: "message-2" });
+    const findGuildPostsSpy = vi
+      .spyOn(databaseService, "findLeaderboardPostsForGuildRefresh")
+      .mockResolvedValue([firstPost, secondPost]);
+    const findQueuePostsSpy = vi.spyOn(databaseService, "findLeaderboardPostsForRefresh");
+    vi.spyOn(discordService, "getGuildPreferredLocale").mockResolvedValue(Locale.EnglishUS);
+    vi.spyOn(discordService, "getMessage").mockResolvedValue(aLeaderboardMessageWith());
+    vi.spyOn(databaseService, "getLeaderboardConfig").mockResolvedValue(
+      aFakeLeaderboardConfigRow({ GuildId: "guild-1", MinGamesPlayed: 3 }),
+    );
+    vi.spyOn(databaseService, "getLeaderboardStatMetricRankings").mockResolvedValue({
+      total: 23,
+      rows: killsRankingRows,
+    });
+    const editMessageSpy = vi.spyOn(discordService, "editMessage").mockResolvedValue(apiMessage);
+
+    await service.refreshPostsForReset("guild-1", null);
+
+    expect(findGuildPostsSpy).toHaveBeenCalledWith("guild-1");
+    expect(findQueuePostsSpy).not.toHaveBeenCalled();
+    expect(editMessageSpy).toHaveBeenCalledTimes(2);
+    expect(editMessageSpy).toHaveBeenNthCalledWith(
+      1,
+      "leaderboard-channel-1",
+      "leaderboard-message-1",
+      expect.any(Object),
+    );
+    expect(editMessageSpy).toHaveBeenNthCalledWith(2, "channel-2", "message-2", expect.any(Object));
+  });
+
+  it("refreshes queue-scoped posts for reset when queue channel is provided", async () => {
+    const databaseService = aFakeDatabaseServiceWith();
+    const haloService = aFakeHaloServiceWith({ databaseService });
+    const discordService = aFakeDiscordServiceWith();
+    const logService = aFakeLogServiceWith();
+    const service = new LeaderboardService({ databaseService, discordService, haloService, logService });
+    const queuePost = aFakeLeaderboardPostRow({ ChannelId: "channel-2", MessageId: "message-2" });
+    const findGuildPostsSpy = vi.spyOn(databaseService, "findLeaderboardPostsForGuildRefresh");
+    const findQueuePostsSpy = vi
+      .spyOn(databaseService, "findLeaderboardPostsForRefresh")
+      .mockResolvedValue([queuePost]);
+    vi.spyOn(discordService, "getGuildPreferredLocale").mockResolvedValue(Locale.EnglishUS);
+    vi.spyOn(discordService, "getMessage").mockResolvedValue(aLeaderboardMessageWith());
+    vi.spyOn(databaseService, "getLeaderboardConfig").mockResolvedValue(
+      aFakeLeaderboardConfigRow({ GuildId: "guild-1", MinGamesPlayed: 3 }),
+    );
+    vi.spyOn(databaseService, "getLeaderboardStatMetricRankings").mockResolvedValue({
+      total: 23,
+      rows: killsRankingRows,
+    });
+    const editMessageSpy = vi.spyOn(discordService, "editMessage").mockResolvedValue(apiMessage);
+
+    await service.refreshPostsForReset("guild-1", "queue-1");
+
+    expect(findQueuePostsSpy).toHaveBeenCalledWith("guild-1", "queue-1");
+    expect(findGuildPostsSpy).not.toHaveBeenCalled();
+    expect(editMessageSpy).toHaveBeenCalledTimes(1);
+    expect(editMessageSpy).toHaveBeenCalledWith("channel-2", "message-2", expect.any(Object));
+  });
+
   it("continues refreshing posts with the preferred locale helper result", async () => {
     const databaseService = aFakeDatabaseServiceWith();
     const haloService = aFakeHaloServiceWith({ databaseService });

--- a/api/services/leaderboard/tests/leaderboard.test.ts
+++ b/api/services/leaderboard/tests/leaderboard.test.ts
@@ -470,6 +470,21 @@ describe("LeaderboardService", () => {
     expect(getGuildPreferredLocaleSpy).not.toHaveBeenCalled();
   });
 
+  it("skips loading reset refresh registrations when Discord service is unavailable", async () => {
+    const databaseService = aFakeDatabaseServiceWith();
+    const haloService = aFakeHaloServiceWith({ databaseService });
+    const logService = aFakeLogServiceWith();
+    const service = new LeaderboardService({ databaseService, haloService, logService });
+    const findGuildPostsSpy = vi.spyOn(databaseService, "findLeaderboardPostsForGuildRefresh");
+    const findQueuePostsSpy = vi.spyOn(databaseService, "findLeaderboardPostsForRefresh");
+
+    await service.refreshPostsForReset("guild-1", null);
+    await service.refreshPostsForReset("guild-1", "queue-1");
+
+    expect(findGuildPostsSpy).not.toHaveBeenCalled();
+    expect(findQueuePostsSpy).not.toHaveBeenCalled();
+  });
+
   it("continues refreshing posts with the preferred locale helper result", async () => {
     const databaseService = aFakeDatabaseServiceWith();
     const haloService = aFakeHaloServiceWith({ databaseService });


### PR DESCRIPTION
## Context
A confirmed reset changes the effective timeframe of existing leaderboard posts. Those posts should update immediately rather than waiting for another interaction or completed series.

## This PR
- Refreshes registered leaderboard posts after a reset marker is confirmed.
- Queue-scoped resets refresh matching queue posts and server-wide posts in the guild.
- Server-wide resets refresh every registered leaderboard post in the guild.
- Reuses the existing message-state parsing and leaderboard renderer.
- Preserves per-post failure isolation and missing-resource cleanup.
- Adds a guild-wide post lookup and regression coverage for reset refresh triggering.

Validation: full test suite passed (248 files, 3586 tests, 1 skipped); lint and API typecheck pass.

## Subsequent Work
Proceed to PR10 objective-stat discovery and metrics after review.