### PR TITLE
Improve leaderboard error state UX

### DIFF
--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -1,6 +1,7 @@
 import type {
   APIApplicationCommandInteraction,
   APIApplicationCommandInteractionDataBasicOption,
+  APIMessage,
   APIMessageComponentButtonInteraction,
   APIMessageComponentSelectMenuInteraction,
   APIMessageTopLevelComponent,
@@ -42,6 +43,7 @@ import {
   LEADERBOARD_NEXT_PAGE_CONTROL_ID,
   LEADERBOARD_PREV_PAGE_CONTROL_ID,
   LEADERBOARD_REFRESH_CONTROL_ID,
+  LEADERBOARD_TEMPORARY_ERROR_FOOTER,
   LEADERBOARD_WINDOW_SELECT_CONTROL_ID,
 } from "../../services/leaderboard/leaderboard-response";
 import type { ApplicationCommandData, BaseInteraction, CommandData, ExecuteResponse } from "../base/base-command";
@@ -747,9 +749,13 @@ export class LeaderboardCommand extends BaseCommand {
       await this.refreshLeaderboard(interaction.token, locale, {
         ...state,
         page: lastPage,
-      });
+      }, interaction.message);
     } catch (error) {
-      await this.services.discordService.updateDeferredReplyWithError(interaction.token, error);
+      await this.services.discordService.updateDeferredReplyWithError(
+        interaction.token,
+        error,
+        { preserveMessage: interaction.message, errorEmbedFooter: LEADERBOARD_TEMPORARY_ERROR_FOOTER },
+      );
     }
   }
 
@@ -856,9 +862,13 @@ export class LeaderboardCommand extends BaseCommand {
       this.assertCanUseLeaderboardControls(interaction);
       const state = this.getStateFromInteractionMessage(interaction);
       const locale = this.getInteractionLocale(interaction);
-      await this.refreshLeaderboard(interaction.token, locale, stateUpdater(state));
+      await this.refreshLeaderboard(interaction.token, locale, stateUpdater(state), interaction.message);
     } catch (error) {
-      await this.services.discordService.updateDeferredReplyWithError(interaction.token, error);
+      await this.services.discordService.updateDeferredReplyWithError(
+        interaction.token,
+        error,
+        { preserveMessage: interaction.message, errorEmbedFooter: LEADERBOARD_TEMPORARY_ERROR_FOOTER },
+      );
     }
   }
 
@@ -876,7 +886,12 @@ export class LeaderboardCommand extends BaseCommand {
     this.services.discordService.getDiscordUserId(interaction);
   }
 
-  private async refreshLeaderboard(token: string, locale: string, state: LeaderboardViewState): Promise<void> {
+  private async refreshLeaderboard(
+    token: string,
+    locale: string,
+    state: LeaderboardViewState,
+    preservedMessage?: APIMessage,
+  ): Promise<void> {
     try {
       const leaderboard = await this.services.leaderboardService.getLeaderboardWithResolvedPage({
         guildId: state.guildId,
@@ -907,7 +922,15 @@ export class LeaderboardCommand extends BaseCommand {
         });
       }
     } catch (error) {
-      await this.services.discordService.updateDeferredReplyWithError(token, error);
+      if (preservedMessage == null) {
+        await this.services.discordService.updateDeferredReplyWithError(token, error);
+        return;
+      }
+
+      await this.services.discordService.updateDeferredReplyWithError(token, error, {
+        preserveMessage: preservedMessage,
+        errorEmbedFooter: LEADERBOARD_TEMPORARY_ERROR_FOOTER,
+      });
     }
   }
 

--- a/api/commands/leaderboard/leaderboard.ts
+++ b/api/commands/leaderboard/leaderboard.ts
@@ -746,16 +746,20 @@ export class LeaderboardCommand extends BaseCommand {
       });
       const lastPage = Math.max(1, Math.ceil(firstPage.total / firstPage.pageSize));
 
-      await this.refreshLeaderboard(interaction.token, locale, {
-        ...state,
-        page: lastPage,
-      }, interaction.message);
-    } catch (error) {
-      await this.services.discordService.updateDeferredReplyWithError(
+      await this.refreshLeaderboard(
         interaction.token,
-        error,
-        { preserveMessage: interaction.message, errorEmbedFooter: LEADERBOARD_TEMPORARY_ERROR_FOOTER },
+        locale,
+        {
+          ...state,
+          page: lastPage,
+        },
+        interaction.message,
       );
+    } catch (error) {
+      await this.services.discordService.updateDeferredReplyWithError(interaction.token, error, {
+        preserveMessage: interaction.message,
+        errorEmbedFooter: LEADERBOARD_TEMPORARY_ERROR_FOOTER,
+      });
     }
   }
 
@@ -864,11 +868,10 @@ export class LeaderboardCommand extends BaseCommand {
       const locale = this.getInteractionLocale(interaction);
       await this.refreshLeaderboard(interaction.token, locale, stateUpdater(state), interaction.message);
     } catch (error) {
-      await this.services.discordService.updateDeferredReplyWithError(
-        interaction.token,
-        error,
-        { preserveMessage: interaction.message, errorEmbedFooter: LEADERBOARD_TEMPORARY_ERROR_FOOTER },
-      );
+      await this.services.discordService.updateDeferredReplyWithError(interaction.token, error, {
+        preserveMessage: interaction.message,
+        errorEmbedFooter: LEADERBOARD_TEMPORARY_ERROR_FOOTER,
+      });
     }
   }
 

--- a/api/commands/leaderboard/tests/leaderboard.test.ts
+++ b/api/commands/leaderboard/tests/leaderboard.test.ts
@@ -1211,6 +1211,7 @@ describe("LeaderboardCommand", () => {
       expect.objectContaining({
         endUserMessage: "This leaderboard control interaction is invalid. Run /leaderboard show again.",
       }),
+      { preserveMessage: interaction.message, errorEmbedFooter: "Temporary leaderboard error" },
     );
   });
 
@@ -1251,6 +1252,7 @@ describe("LeaderboardCommand", () => {
       expect.objectContaining({
         endUserMessage: "This leaderboard control interaction is invalid. Run /leaderboard show again.",
       }),
+      { preserveMessage: interaction.message, errorEmbedFooter: "Temporary leaderboard error" },
     );
   });
 
@@ -1287,6 +1289,7 @@ describe("LeaderboardCommand", () => {
       expect.objectContaining({
         endUserMessage: "This leaderboard control interaction is invalid. Run /leaderboard show again.",
       }),
+      { preserveMessage: interaction.message, errorEmbedFooter: "Temporary leaderboard error" },
     );
   });
 
@@ -1788,6 +1791,7 @@ describe("LeaderboardCommand", () => {
       expect.objectContaining({
         endUserMessage: "This leaderboard message is missing filter settings. Run /leaderboard show again.",
       }),
+      { preserveMessage: interaction.message, errorEmbedFooter: "Temporary leaderboard error" },
     );
   });
 
@@ -1823,6 +1827,7 @@ describe("LeaderboardCommand", () => {
       expect.objectContaining({
         endUserMessage: "This leaderboard message has invalid filter settings. Run /leaderboard show again.",
       }),
+      { preserveMessage: interaction.message, errorEmbedFooter: "Temporary leaderboard error" },
     );
   });
 
@@ -1856,6 +1861,7 @@ describe("LeaderboardCommand", () => {
     expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
       interaction.token,
       expect.objectContaining({ endUserMessage: "This leaderboard interaction does not belong to this server." }),
+      { preserveMessage: interaction.message, errorEmbedFooter: "Temporary leaderboard error" },
     );
   });
 
@@ -1889,6 +1895,7 @@ describe("LeaderboardCommand", () => {
       expect.objectContaining({
         endUserMessage: "This leaderboard message is missing its interaction context. Run /leaderboard show again.",
       }),
+      { preserveMessage: interaction.message, errorEmbedFooter: "Temporary leaderboard error" },
     );
   });
 
@@ -1924,6 +1931,7 @@ describe("LeaderboardCommand", () => {
       expect.objectContaining({
         endUserMessage: "This leaderboard message has an invalid window filter. Run /leaderboard show again.",
       }),
+      { preserveMessage: interaction.message, errorEmbedFooter: "Temporary leaderboard error" },
     );
   });
 
@@ -1959,6 +1967,7 @@ describe("LeaderboardCommand", () => {
       expect.objectContaining({
         endUserMessage: "This leaderboard message has an invalid metric filter. Run /leaderboard show again.",
       }),
+      { preserveMessage: interaction.message, errorEmbedFooter: "Temporary leaderboard error" },
     );
   });
 

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -926,13 +926,7 @@ export class DiscordService {
       };
 
       return await this.updateDeferredReply(interactionToken, {
-        embeds:
-          preservedMessage == null
-            ? [errorEmbed]
-            : [
-                ...preservedMessage.embeds.filter((embed) => embed.footer?.text !== errorEmbedFooter),
-                errorEmbed,
-              ],
+        embeds: this.getEmbedsForErrorUpdate(preservedMessage, errorEmbed, errorEmbedFooter),
         components: preservedMessage?.components ?? endUserError.discordActions,
       });
     } catch {
@@ -957,18 +951,28 @@ export class DiscordService {
       return await this.fetch<APIMessage>(Routes.channelMessage(channelId, messageId), {
         method: "PATCH",
         body: JSON.stringify({
-          embeds:
-            preservedMessage == null
-              ? [errorEmbed]
-              : [
-                  ...preservedMessage.embeds.filter((embed) => embed.footer?.text !== errorEmbedFooter),
-                  errorEmbed,
-                ],
+          embeds: this.getEmbedsForErrorUpdate(preservedMessage, errorEmbed, errorEmbedFooter),
         }),
       });
     } catch {
       return undefined;
     }
+  }
+
+  private getEmbedsForErrorUpdate(
+    preservedMessage: APIMessage | undefined,
+    errorEmbed: APIMessage["embeds"][number],
+    errorEmbedFooter: string | undefined,
+  ): APIMessage["embeds"] {
+    if (preservedMessage == null) {
+      return [errorEmbed];
+    }
+
+    const preservedEmbeds =
+      errorEmbedFooter == null
+        ? preservedMessage.embeds
+        : preservedMessage.embeds.filter((embed) => embed.footer?.text !== errorEmbedFooter);
+    return [...preservedEmbeds, errorEmbed];
   }
 
   async getGuild(guildId: string): Promise<APIGuild> {

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -894,9 +894,9 @@ export class DiscordService {
     return response;
   }
 
-  private handleError(error: unknown, logService: LogService): EndUserError {
+  private handleError(error: unknown, logService: LogService, options?: { suppressLogging?: boolean }): EndUserError {
     const isHandled = error instanceof EndUserError && error.handled;
-    if (!isHandled) {
+    if (!isHandled && options?.suppressLogging !== true) {
       logService[error instanceof EndUserError && error.errorType === EndUserErrorType.WARNING ? "warn" : "error"](
         error,
       );
@@ -914,10 +914,13 @@ export class DiscordService {
   async updateDeferredReplyWithError(
     interactionToken: string,
     error: unknown,
-    options?: { preserveMessage?: APIMessage; errorEmbedFooter?: string },
+    options?: { preserveMessage?: APIMessage; errorEmbedFooter?: string; suppressErrorLogging?: boolean },
   ): Promise<APIMessage | undefined> {
     try {
-      const endUserError = this.handleError(error, this.logService);
+      const endUserError =
+        options?.suppressErrorLogging === true
+          ? this.handleError(error, this.logService, { suppressLogging: true })
+          : this.handleError(error, this.logService);
       const preservedMessage = options?.preserveMessage;
       const errorEmbedFooter = options?.errorEmbedFooter;
       const errorEmbed = {
@@ -938,10 +941,13 @@ export class DiscordService {
     channelId: string,
     messageId: string,
     error: unknown,
-    options?: { preserveMessage?: APIMessage; errorEmbedFooter?: string },
+    options?: { preserveMessage?: APIMessage; errorEmbedFooter?: string; suppressErrorLogging?: boolean },
   ): Promise<APIMessage | undefined> {
     try {
-      const endUserError = this.handleError(error, this.logService);
+      const endUserError =
+        options?.suppressErrorLogging === true
+          ? this.handleError(error, this.logService, { suppressLogging: true })
+          : this.handleError(error, this.logService);
       const preservedMessage = options?.preserveMessage;
       const errorEmbedFooter = options?.errorEmbedFooter;
       const errorEmbed = {
@@ -972,7 +978,7 @@ export class DiscordService {
       errorEmbedFooter == null
         ? preservedMessage.embeds
         : preservedMessage.embeds.filter((embed) => embed.footer?.text !== errorEmbedFooter);
-    return [...preservedEmbeds, errorEmbed];
+    return [...preservedEmbeds.slice(-9), errorEmbed];
   }
 
   async getGuild(guildId: string): Promise<APIGuild> {

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -894,7 +894,7 @@ export class DiscordService {
     return response;
   }
 
-  private handleError(error: EndUserError | Error, logService: LogService): EndUserError {
+  private handleError(error: unknown, logService: LogService): EndUserError {
     const isHandled = error instanceof EndUserError && error.handled;
     if (!isHandled) {
       logService[error instanceof EndUserError && error.errorType === EndUserErrorType.WARNING ? "warn" : "error"](
@@ -911,13 +911,29 @@ export class DiscordService {
       : new EndUserError("An unexpected error has occurred. It has been logged. Sorry for the inconvenience.");
   }
 
-  async updateDeferredReplyWithError(interactionToken: string, error: unknown): Promise<APIMessage | undefined> {
+  async updateDeferredReplyWithError(
+    interactionToken: string,
+    error: unknown,
+    options?: { preserveMessage?: APIMessage; errorEmbedFooter?: string },
+  ): Promise<APIMessage | undefined> {
     try {
-      const endUserError = this.handleError(error as Error, this.logService);
+      const endUserError = this.handleError(error, this.logService);
+      const preservedMessage = options?.preserveMessage;
+      const errorEmbedFooter = options?.errorEmbedFooter;
+      const errorEmbed = {
+        ...endUserError.discordEmbed,
+        ...(errorEmbedFooter != null ? { footer: { text: errorEmbedFooter } } : {}),
+      };
 
       return await this.updateDeferredReply(interactionToken, {
-        embeds: [endUserError.discordEmbed],
-        components: endUserError.discordActions,
+        embeds:
+          preservedMessage == null
+            ? [errorEmbed]
+            : [
+                ...preservedMessage.embeds.filter((embed) => embed.footer?.text !== errorEmbedFooter),
+                errorEmbed,
+              ],
+        components: preservedMessage?.components ?? endUserError.discordActions,
       });
     } catch {
       return undefined;
@@ -927,14 +943,27 @@ export class DiscordService {
   async updateMessageWithError(
     channelId: string,
     messageId: string,
-    error: EndUserError | Error,
+    error: unknown,
+    options?: { preserveMessage?: APIMessage; errorEmbedFooter?: string },
   ): Promise<APIMessage | undefined> {
     try {
       const endUserError = this.handleError(error, this.logService);
+      const preservedMessage = options?.preserveMessage;
+      const errorEmbedFooter = options?.errorEmbedFooter;
+      const errorEmbed = {
+        ...endUserError.discordEmbed,
+        ...(errorEmbedFooter != null ? { footer: { text: errorEmbedFooter } } : {}),
+      };
       return await this.fetch<APIMessage>(Routes.channelMessage(channelId, messageId), {
         method: "PATCH",
         body: JSON.stringify({
-          embeds: [endUserError.discordEmbed],
+          embeds:
+            preservedMessage == null
+              ? [errorEmbed]
+              : [
+                  ...preservedMessage.embeds.filter((embed) => embed.footer?.text !== errorEmbedFooter),
+                  errorEmbed,
+                ],
         }),
       });
     } catch {

--- a/api/services/discord/tests/discord.test.ts
+++ b/api/services/discord/tests/discord.test.ts
@@ -1028,6 +1028,47 @@ describe("DiscordService", () => {
 
       expect(response).toEqual(apiMessage);
     });
+
+    it("preserves the leaderboard message and replaces a previous temporary error", async () => {
+      const message: APIMessage = {
+        ...apiMessage,
+        embeds: [
+          { title: "Leaderboard" },
+          { title: "Old error", footer: { text: "Temporary leaderboard error" } },
+        ],
+        components: [
+          {
+            type: ComponentType.ActionRow,
+            components: [],
+          },
+        ],
+      };
+      const error = new Error("Leaderboard unavailable");
+
+      await discordService.updateDeferredReplyWithError("fake-interaction-token", error, {
+        preserveMessage: message,
+        errorEmbedFooter: "Temporary leaderboard error",
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://discord.com/api/v10/webhooks/DISCORD_APP_ID/fake-interaction-token/messages/@original",
+        expect.objectContaining({
+          body: JSON.stringify({
+            embeds: [
+              { title: "Leaderboard" },
+              {
+                title: "Something went wrong",
+                description: "An unexpected error has occurred. It has been logged. Sorry for the inconvenience.",
+                color: 16_711_680,
+                fields: [],
+                footer: { text: "Temporary leaderboard error" },
+              },
+            ],
+            components: message.components,
+          }),
+        }),
+      );
+    });
   });
 
   describe("getGuildIconUrl()", () => {

--- a/api/services/discord/tests/discord.test.ts
+++ b/api/services/discord/tests/discord.test.ts
@@ -1144,6 +1144,44 @@ describe("DiscordService", () => {
   });
 
   describe("updateMessageWithError()", () => {
+    it("replaces a previous temporary error embed when an error footer is provided", async () => {
+      mockFetch.mockImplementation(async (path) => {
+        if (path === "https://discord.com/api/v10/channels/fake-channel/messages/fake-message") {
+          return Promise.resolve(new Response(JSON.stringify(apiMessage)));
+        }
+        return Promise.reject(new Error(`Invalid path: ${typeof path === "string" ? path : "non-string path"}`));
+      });
+      const message: APIMessage = {
+        ...apiMessage,
+        embeds: [{ title: "Leaderboard" }, { title: "Old error", footer: { text: "Temporary leaderboard error" } }],
+      };
+      const error = new Error("Leaderboard unavailable");
+
+      await discordService.updateMessageWithError("fake-channel", "fake-message", error, {
+        preserveMessage: message,
+        errorEmbedFooter: "Temporary leaderboard error",
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://discord.com/api/v10/channels/fake-channel/messages/fake-message",
+        expect.objectContaining({
+          body: JSON.stringify({
+            embeds: [
+              { title: "Leaderboard" },
+              {
+                title: "Something went wrong",
+                description: "An unexpected error has occurred. It has been logged. Sorry for the inconvenience.",
+                color: 16_711_680,
+                fields: [],
+                footer: { text: "Temporary leaderboard error" },
+              },
+            ],
+          }),
+          method: "PATCH",
+        }),
+      );
+    });
+
     it("preserves embeds without footers when no error footer is provided", async () => {
       mockFetch.mockImplementation(async (path) => {
         if (path === "https://discord.com/api/v10/channels/fake-channel/messages/fake-message") {

--- a/api/services/discord/tests/discord.test.ts
+++ b/api/services/discord/tests/discord.test.ts
@@ -1032,10 +1032,7 @@ describe("DiscordService", () => {
     it("preserves the leaderboard message and replaces a previous temporary error", async () => {
       const message: APIMessage = {
         ...apiMessage,
-        embeds: [
-          { title: "Leaderboard" },
-          { title: "Old error", footer: { text: "Temporary leaderboard error" } },
-        ],
+        embeds: [{ title: "Leaderboard" }, { title: "Old error", footer: { text: "Temporary leaderboard error" } }],
         components: [
           {
             type: ComponentType.ActionRow,
@@ -1066,6 +1063,82 @@ describe("DiscordService", () => {
             ],
             components: message.components,
           }),
+        }),
+      );
+    });
+
+    it("preserves embeds without footers when no error footer is provided", async () => {
+      const message: APIMessage = {
+        ...apiMessage,
+        embeds: [{ title: "Leaderboard" }, { title: "No footer embed", description: "Keep me" }],
+        components: [
+          {
+            type: ComponentType.ActionRow,
+            components: [],
+          },
+        ],
+      };
+      const error = new Error("Leaderboard unavailable");
+
+      await discordService.updateDeferredReplyWithError("fake-interaction-token", error, {
+        preserveMessage: message,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://discord.com/api/v10/webhooks/DISCORD_APP_ID/fake-interaction-token/messages/@original",
+        expect.objectContaining({
+          body: JSON.stringify({
+            embeds: [
+              { title: "Leaderboard" },
+              { title: "No footer embed", description: "Keep me" },
+              {
+                title: "Something went wrong",
+                description: "An unexpected error has occurred. It has been logged. Sorry for the inconvenience.",
+                color: 16_711_680,
+                fields: [],
+              },
+            ],
+            components: message.components,
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("updateMessageWithError()", () => {
+    it("preserves embeds without footers when no error footer is provided", async () => {
+      mockFetch.mockImplementation(async (path) => {
+        if (path === "https://discord.com/api/v10/channels/fake-channel/messages/fake-message") {
+          return Promise.resolve(new Response(JSON.stringify(apiMessage)));
+        }
+        return Promise.reject(new Error(`Invalid path: ${typeof path === "string" ? path : "non-string path"}`));
+      });
+      const message: APIMessage = {
+        ...apiMessage,
+        embeds: [{ title: "Leaderboard" }, { title: "No footer embed", description: "Keep me too" }],
+      };
+      const error = new Error("Leaderboard unavailable");
+
+      await discordService.updateMessageWithError("fake-channel", "fake-message", error, {
+        preserveMessage: message,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://discord.com/api/v10/channels/fake-channel/messages/fake-message",
+        expect.objectContaining({
+          body: JSON.stringify({
+            embeds: [
+              { title: "Leaderboard" },
+              { title: "No footer embed", description: "Keep me too" },
+              {
+                title: "Something went wrong",
+                description: "An unexpected error has occurred. It has been logged. Sorry for the inconvenience.",
+                color: 16_711_680,
+                fields: [],
+              },
+            ],
+          }),
+          method: "PATCH",
         }),
       );
     });

--- a/api/services/discord/tests/discord.test.ts
+++ b/api/services/discord/tests/discord.test.ts
@@ -1103,6 +1103,44 @@ describe("DiscordService", () => {
         }),
       );
     });
+
+    it("keeps only the most recent preserved embeds when appending an error embed", async () => {
+      const message: APIMessage = {
+        ...apiMessage,
+        embeds: Array.from({ length: 10 }, (_, index) => ({ title: `Embed ${index.toString()}` })),
+      };
+      const error = new Error("Leaderboard unavailable");
+
+      await discordService.updateDeferredReplyWithError("fake-interaction-token", error, {
+        preserveMessage: message,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://discord.com/api/v10/webhooks/DISCORD_APP_ID/fake-interaction-token/messages/@original",
+        expect.objectContaining({
+          body: JSON.stringify({
+            embeds: [
+              { title: "Embed 1" },
+              { title: "Embed 2" },
+              { title: "Embed 3" },
+              { title: "Embed 4" },
+              { title: "Embed 5" },
+              { title: "Embed 6" },
+              { title: "Embed 7" },
+              { title: "Embed 8" },
+              { title: "Embed 9" },
+              {
+                title: "Something went wrong",
+                description: "An unexpected error has occurred. It has been logged. Sorry for the inconvenience.",
+                color: 16_711_680,
+                fields: [],
+              },
+            ],
+            components: [],
+          }),
+        }),
+      );
+    });
   });
 
   describe("updateMessageWithError()", () => {
@@ -1141,6 +1179,22 @@ describe("DiscordService", () => {
           method: "PATCH",
         }),
       );
+    });
+
+    it("skips service-level error logging when explicitly suppressed", async () => {
+      mockFetch.mockImplementation(async (path) => {
+        if (path === "https://discord.com/api/v10/channels/fake-channel/messages/fake-message") {
+          return Promise.resolve(new Response(JSON.stringify(apiMessage)));
+        }
+        return Promise.reject(new Error(`Invalid path: ${typeof path === "string" ? path : "non-string path"}`));
+      });
+      const errorSpy = vi.spyOn(logService, "error");
+
+      await discordService.updateMessageWithError("fake-channel", "fake-message", new Error("already logged"), {
+        suppressErrorLogging: true,
+      });
+
+      expect(errorSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/api/services/leaderboard/leaderboard-response.ts
+++ b/api/services/leaderboard/leaderboard-response.ts
@@ -21,6 +21,7 @@ import type { LeaderboardMetricFamily } from "@guilty-spark/shared/halo/leaderbo
 import { EmbedColors } from "../../embeds/colors";
 
 const MAX_ROWS_IN_DISCORD_EMBED = 10;
+export const LEADERBOARD_TEMPORARY_ERROR_FOOTER = "Temporary leaderboard error";
 
 export const LEADERBOARD_FIRST_PAGE_CONTROL_ID = "btn_leaderboard_first";
 export const LEADERBOARD_PREV_PAGE_CONTROL_ID = "btn_leaderboard_prev";

--- a/api/services/leaderboard/leaderboard.ts
+++ b/api/services/leaderboard/leaderboard.ts
@@ -1,5 +1,6 @@
 import { MatchOutcome } from "halo-infinite-api";
 import type { MatchStats } from "halo-infinite-api";
+import type { APIMessage } from "discord-api-types/v10";
 import { sub } from "date-fns";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
@@ -21,7 +22,7 @@ import type { HaloService } from "../halo/halo";
 import type { LogService } from "../log/types";
 import type { NeatQueueMatchCompletedRequest } from "../neatqueue/types";
 import { getLeaderboardMessageState } from "./leaderboard-message";
-import { createLeaderboardResponse } from "./leaderboard-response";
+import { createLeaderboardResponse, LEADERBOARD_TEMPORARY_ERROR_FOOTER } from "./leaderboard-response";
 
 export interface LeaderboardServiceOpts {
   databaseService: DatabaseService;
@@ -265,12 +266,13 @@ export class LeaderboardService {
   }
 
   private async refreshLeaderboardPost(post: LeaderboardPostRow, locale: string): Promise<void> {
+    let message: APIMessage | undefined;
     try {
       const discordService = Preconditions.checkExists(
         this.discordService,
         "Discord service is required for leaderboard refresh",
       );
-      const message = await discordService.getMessage(post.ChannelId, post.MessageId);
+      message = await discordService.getMessage(post.ChannelId, post.MessageId);
       const state = getLeaderboardMessageState(message, post);
       if (state == null) {
         this.logService.warn(
@@ -325,6 +327,13 @@ export class LeaderboardService {
           ["reason", "Failed to refresh leaderboard post"],
         ]),
       );
+
+      if (message != null) {
+        await this.discordService?.updateMessageWithError(post.ChannelId, post.MessageId, error, {
+          preserveMessage: message,
+          errorEmbedFooter: LEADERBOARD_TEMPORARY_ERROR_FOOTER,
+        });
+      }
     }
   }
 

--- a/api/services/leaderboard/leaderboard.ts
+++ b/api/services/leaderboard/leaderboard.ts
@@ -332,6 +332,7 @@ export class LeaderboardService {
         await this.discordService?.updateMessageWithError(post.ChannelId, post.MessageId, error, {
           preserveMessage: message,
           errorEmbedFooter: LEADERBOARD_TEMPORARY_ERROR_FOOTER,
+          suppressErrorLogging: true,
         });
       }
     }

--- a/api/services/leaderboard/tests/leaderboard.test.ts
+++ b/api/services/leaderboard/tests/leaderboard.test.ts
@@ -631,6 +631,42 @@ describe("LeaderboardService", () => {
     expect(context.get("reason")).toBe("Failed to refresh leaderboard post");
   });
 
+  it("preserves a posted leaderboard when its refresh query fails", async () => {
+    const databaseService = aFakeDatabaseServiceWith();
+    const haloService = aFakeHaloServiceWith({ databaseService });
+    const discordService = aFakeDiscordServiceWith();
+    const logService = aFakeLogServiceWith();
+    const service = new LeaderboardService({ databaseService, discordService, haloService, logService });
+    const firstPost = aFakeLeaderboardPostRow();
+    const secondPost = aFakeLeaderboardPostRow({ ChannelId: "channel-2", MessageId: "message-2" });
+    const firstMessage = aLeaderboardMessageWith();
+    const refreshError = new Error("Leaderboard query failed");
+    vi.spyOn(databaseService, "findLeaderboardPostsForRefresh").mockResolvedValue([firstPost, secondPost]);
+    vi.spyOn(discordService, "getMessage").mockResolvedValue(firstMessage);
+    vi.spyOn(discordService, "getGuildPreferredLocale").mockResolvedValue(Locale.EnglishUS);
+    vi.spyOn(databaseService, "getLeaderboardConfig")
+      .mockRejectedValueOnce(refreshError)
+      .mockResolvedValue(aFakeLeaderboardConfigRow({ GuildId: "guild-1", MinGamesPlayed: 3 }));
+    vi.spyOn(databaseService, "getLeaderboardStatMetricRankings").mockResolvedValue({
+      total: 23,
+      rows: killsRankingRows,
+    });
+    const preserveErrorSpy = vi
+      .spyOn(discordService, "updateMessageWithError")
+      .mockResolvedValue(apiMessage);
+    const editMessageSpy = vi.spyOn(discordService, "editMessage").mockResolvedValue(apiMessage);
+
+    await service.refreshPostsForCompletedQueue("guild-1", "queue-1");
+
+    expect(preserveErrorSpy).toHaveBeenCalledWith(
+      firstPost.ChannelId,
+      firstPost.MessageId,
+      refreshError,
+      { preserveMessage: firstMessage, errorEmbedFooter: "Temporary leaderboard error" },
+    );
+    expect(editMessageSpy).toHaveBeenCalledWith("channel-2", "message-2", expect.any(Object));
+  });
+
   it("continues refreshing posts when deleting a missing post registration fails", async () => {
     const databaseService = aFakeDatabaseServiceWith();
     const haloService = aFakeHaloServiceWith({ databaseService });

--- a/api/services/leaderboard/tests/leaderboard.test.ts
+++ b/api/services/leaderboard/tests/leaderboard.test.ts
@@ -651,19 +651,16 @@ describe("LeaderboardService", () => {
       total: 23,
       rows: killsRankingRows,
     });
-    const preserveErrorSpy = vi
-      .spyOn(discordService, "updateMessageWithError")
-      .mockResolvedValue(apiMessage);
+    const preserveErrorSpy = vi.spyOn(discordService, "updateMessageWithError").mockResolvedValue(apiMessage);
     const editMessageSpy = vi.spyOn(discordService, "editMessage").mockResolvedValue(apiMessage);
 
     await service.refreshPostsForCompletedQueue("guild-1", "queue-1");
 
-    expect(preserveErrorSpy).toHaveBeenCalledWith(
-      firstPost.ChannelId,
-      firstPost.MessageId,
-      refreshError,
-      { preserveMessage: firstMessage, errorEmbedFooter: "Temporary leaderboard error" },
-    );
+    expect(preserveErrorSpy).toHaveBeenCalledWith(firstPost.ChannelId, firstPost.MessageId, refreshError, {
+      preserveMessage: firstMessage,
+      errorEmbedFooter: "Temporary leaderboard error",
+      suppressErrorLogging: true,
+    });
     expect(editMessageSpy).toHaveBeenCalledWith("channel-2", "message-2", expect.any(Object));
   });
 


### PR DESCRIPTION
## Context
Leaderboard interactions and automatic post refreshes could replace a working leaderboard with an error-only response. That left the controls unavailable and made recovery difficult.

## This PR
- Preserve the last successful leaderboard embed when interactive updates fail.
- Keep leaderboard controls available while showing a temporary error embed.
- Replace temporary errors instead of accumulating them.
- Clear temporary errors on successful retries and preserve posted boards during background refresh failures.
- Keep confirmed missing-resource cleanup unchanged.
- Add focused regression coverage for interactive and background failure paths.

Validation: API typecheck, changed-file ESLint, and 185 focused tests pass.

## Subsequent Work
PR10 is ready for review. After merge, continue with PR11 objective-stat and medal metrics discovery.