### PR TITLE
fix(user-tracker): bound the clientless reconcile loop

### DIFF
--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
 import {
   userTrackerDirectoryMessageContract,
   userTrackerStatusContract,
@@ -22,6 +23,47 @@ import { aFakeIndividualTrackersRow } from "../../../services/database/fakes/dat
 import { installFakeServicesWith } from "../../../services/fakes/services";
 import { aFakeWebSocketHibernationAdapter } from "../../../base/fakes/websocket-hibernation-adapter.fake";
 import type { FakeWebSocketHibernationAdapter } from "../../../base/fakes/websocket-hibernation-adapter.fake";
+
+const RECONCILE_WINDOW_MS = 300000;
+
+interface PersistentStateHarness {
+  state: DurableObjectState & { storage: DurableObjectStorage };
+  persistedStorage: Map<string, unknown>;
+  setAlarmMock: Mock<DurableObjectStorage["setAlarm"]>;
+  deleteAlarmMock: Mock<DurableObjectStorage["deleteAlarm"]>;
+}
+
+function aPersistentStateHarness(): PersistentStateHarness {
+  const persistedStorage = new Map<string, unknown>();
+  let alarmTime: number | null = null;
+  const setAlarmMock = vi.fn<DurableObjectStorage["setAlarm"]>(async (scheduledTime) => {
+    alarmTime = typeof scheduledTime === "number" ? scheduledTime : scheduledTime.getTime();
+    return Promise.resolve();
+  });
+  const getAlarmMock = vi.fn<DurableObjectStorage["getAlarm"]>(async () => Promise.resolve(alarmTime));
+  const deleteAlarmMock = vi.fn<DurableObjectStorage["deleteAlarm"]>(async () => {
+    alarmTime = null;
+    return Promise.resolve();
+  });
+  const storage = aFakeDurableObjectStorageWith({
+    get: (async (key: string) => Promise.resolve(persistedStorage.get(key))) as DurableObjectStorage["get"],
+    put: (async (key: string, value: unknown) => {
+      persistedStorage.set(key, value);
+      await Promise.resolve();
+    }) as DurableObjectStorage["put"],
+    delete: (async (key: string) => Promise.resolve(persistedStorage.delete(key))) as DurableObjectStorage["delete"],
+    setAlarm: setAlarmMock,
+    getAlarm: getAlarmMock,
+    deleteAlarm: deleteAlarmMock,
+  });
+
+  return {
+    state: aFakeDurableObjectStateWith({ storage }),
+    persistedStorage,
+    setAlarmMock,
+    deleteAlarmMock,
+  };
+}
 
 describe("UserTrackerDO", () => {
   let userTrackerDO: UserTrackerDO;
@@ -1344,6 +1386,86 @@ describe("UserTrackerDO", () => {
     expect(reconciledPayload.state?.directory.trackers).toHaveLength(0);
     expect(localSetAlarmMock).toHaveBeenCalledTimes(2);
     expect(localDeleteAlarmMock).not.toHaveBeenCalled();
+  });
+
+  it("stops reconciling and clears the alarm once the clientless reconcile window elapses", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+    const harness = aPersistentStateHarness();
+    const localEnv = aFakeEnvWith({
+      INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(
+        aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } }),
+      ),
+    });
+    const services = installFakeServicesWith({ env: localEnv });
+    vi.spyOn(harness.state, "getWebSockets").mockReturnValue([]);
+    const findTrackersSpy = vi
+      .spyOn(services.databaseService, "findIndividualTrackersByUserId")
+      .mockResolvedValue([aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1", Status: "active" })]);
+    const localUserTrackerDO = new UserTrackerDO(harness.state, localEnv, () => services, webSocketAdapter);
+
+    await localUserTrackerDO.fetch(new Request("http://do/view-state?userId=user-1", { method: "GET" }));
+    expect(harness.setAlarmMock).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(RECONCILE_WINDOW_MS + 1);
+    findTrackersSpy.mockClear();
+    await localUserTrackerDO.alarm();
+
+    expect(harness.deleteAlarmMock).toHaveBeenCalledOnce();
+    expect(harness.setAlarmMock).toHaveBeenCalledOnce();
+    expect(findTrackersSpy).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("stops reconciling when no reconcile deadline has been recorded", async () => {
+    const harness = aPersistentStateHarness();
+    harness.persistedStorage.set("userTrackerState", {
+      state: { userId: "user-1", lastUpdateTime: new Date().toISOString() },
+      viewState: null,
+    });
+    const localEnv = aFakeEnvWith({
+      INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(
+        aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } }),
+      ),
+    });
+    const services = installFakeServicesWith({ env: localEnv });
+    vi.spyOn(harness.state, "getWebSockets").mockReturnValue([]);
+    const findTrackersSpy = vi.spyOn(services.databaseService, "findIndividualTrackersByUserId");
+    const localUserTrackerDO = new UserTrackerDO(harness.state, localEnv, () => services, webSocketAdapter);
+
+    await localUserTrackerDO.alarm();
+
+    expect(harness.deleteAlarmMock).toHaveBeenCalledOnce();
+    expect(harness.setAlarmMock).not.toHaveBeenCalled();
+    expect(findTrackersSpy).not.toHaveBeenCalled();
+  });
+
+  it("extends the reconcile window when view-state is requested again", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+    const harness = aPersistentStateHarness();
+    const localEnv = aFakeEnvWith({
+      INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(
+        aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } }),
+      ),
+    });
+    const services = installFakeServicesWith({ env: localEnv });
+    vi.spyOn(harness.state, "getWebSockets").mockReturnValue([]);
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([
+      aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1", Status: "active" }),
+    ]);
+    const localUserTrackerDO = new UserTrackerDO(harness.state, localEnv, () => services, webSocketAdapter);
+
+    await localUserTrackerDO.fetch(new Request("http://do/view-state?userId=user-1", { method: "GET" }));
+    vi.advanceTimersByTime(RECONCILE_WINDOW_MS - 1000);
+    await localUserTrackerDO.fetch(new Request("http://do/view-state?userId=user-1", { method: "GET" }));
+
+    vi.advanceTimersByTime(2000);
+    await localUserTrackerDO.alarm();
+
+    expect(harness.deleteAlarmMock).not.toHaveBeenCalled();
+    expect(harness.setAlarmMock).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
   });
 
   it("re-arms reconcile alarm and logs directory refresh failures when rebuild fails transiently", async () => {

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1414,6 +1414,9 @@ describe("UserTrackerDO", () => {
     expect(harness.deleteAlarmMock).toHaveBeenCalledOnce();
     expect(harness.setAlarmMock).toHaveBeenCalledOnce();
     expect(findTrackersSpy).not.toHaveBeenCalled();
+
+    await localUserTrackerDO.fetch(new Request("http://do/view-state?userId=user-1", { method: "GET" }));
+    expect(findTrackersSpy).toHaveBeenCalledOnce();
     vi.useRealTimers();
   });
 

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -33,8 +33,10 @@ import type { UserTrackerInternalState } from "./types";
 
 const USER_TRACKER_STATE_KEY = "userTrackerState";
 const USER_TRACKER_MARKERS_KEY = "userTrackerMarkers";
+const USER_TRACKER_RECONCILE_DEADLINE_KEY = "userTrackerReconcileDeadline";
 const FOLLOW_WS_POLL_INTERVAL_MS = 3000;
 const USER_TRACKER_RECONCILE_INTERVAL_MS = 30000;
+const USER_TRACKER_RECONCILE_WINDOW_MS = 300000;
 const TRACKER_MARKER_LIMIT = 500;
 
 function isNonStopped(row: IndividualTrackersRow): boolean {
@@ -224,12 +226,16 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       const hasConnectedClients = this.state.getWebSockets().length > 0;
       if (!hasConnectedClients) {
         const stored = await this.loadState();
+        await this.stopUpdateLoop({ scheduleReconcile: false, stored });
+
         if (stored.state?.userId == null) {
-          await this.stopUpdateLoop({ scheduleReconcile: false, stored });
           return;
         }
 
-        await this.stopUpdateLoop({ scheduleReconcile: false, stored });
+        if (await this.hasReconcileWindowElapsed()) {
+          await this.stopReconciling(stored.state.userId);
+          return;
+        }
       }
 
       const tickType = hasConnectedClients ? "follow" : "reconcile";
@@ -445,6 +451,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
     const stored = options.stored ?? (await this.loadState());
     if (stored.state?.userId == null) {
+      await this.state.storage.delete(USER_TRACKER_RECONCILE_DEADLINE_KEY);
       await this.state.storage.deleteAlarm();
       return;
     }
@@ -457,12 +464,30 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   }
 
   private async scheduleReconcileAlarmIfNeeded(): Promise<void> {
+    await this.state.storage.put(USER_TRACKER_RECONCILE_DEADLINE_KEY, Date.now() + USER_TRACKER_RECONCILE_WINDOW_MS);
+
     const nextAlarmTime = await this.state.storage.getAlarm();
     if (nextAlarmTime != null) {
       return;
     }
 
     await this.scheduleNextAlarm(USER_TRACKER_RECONCILE_INTERVAL_MS);
+  }
+
+  private async hasReconcileWindowElapsed(): Promise<boolean> {
+    const deadline = await this.state.storage.get<number>(USER_TRACKER_RECONCILE_DEADLINE_KEY);
+    if (typeof deadline !== "number") {
+      // No deadline recorded — the alarm predates this key, so stop rather than reconcile forever.
+      return true;
+    }
+
+    return Date.now() >= deadline;
+  }
+
+  private async stopReconciling(userId: string): Promise<void> {
+    this.logService.debug("UserTracker reconcile window elapsed", new Map([["userId", userId]]));
+    await this.state.storage.delete(USER_TRACKER_RECONCILE_DEADLINE_KEY);
+    await this.state.storage.deleteAlarm();
   }
 
   private async installTrackerSubscriptionsAsync(): Promise<void> {

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -486,6 +486,15 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
   private async stopReconciling(userId: string): Promise<void> {
     this.logService.debug("UserTracker reconcile window elapsed", new Map([["userId", userId]]));
+
+    const stored = await this.loadState();
+    if (stored.state?.userId === userId && stored.viewState != null) {
+      await this.state.storage.put(USER_TRACKER_STATE_KEY, {
+        ...stored,
+        viewState: null,
+      });
+    }
+
     await this.state.storage.delete(USER_TRACKER_RECONCILE_DEADLINE_KEY);
     await this.state.storage.deleteAlarm();
   }


### PR DESCRIPTION
## Context

`UserTrackerDO` runs an alarm loop with two modes: a 3s "follow" tick while WebSocket clients are connected, and a 30s "reconcile" tick as a safety net for changes missed while nobody is watching. All real mutations (tracker create/start/stop, individual tracker updates, settings changes) already push directly via `/nudge` and `/settings-changed`, so reconcile is purely a backstop.

## This PR

Production logs showed a constant stream of `UserTracker reconcile tick` entries with `hasConnectedClients=false`. The alarm handler unconditionally re-armed itself, and the only path that cancelled the alarm required `state.userId == null` — which never happens once `storeDirectoryState` has written it. So the first `view-state` request or follow socket for a user started a 30s loop that ran forever, each tick doing a full directory rebuild (2 D1 reads plus a fanout that wakes every non-stopped `IndividualTrackerDO`) with nobody listening for the broadcast.

This change bounds the clientless reconcile loop with a persisted deadline:

- `scheduleReconcileAlarmIfNeeded` records a deadline 5 minutes out (refreshed on every arm, so a page load extends the window).
- The alarm stops re-arming and deletes the alarm once the window has elapsed with no clients connected, logging `UserTracker reconcile window elapsed`.
- A missing deadline is treated as elapsed, so existing zombie loops in production drain on their next tick.
- Tidied the duplicated `stopUpdateLoop` call in the clientless alarm branch and cleared the deadline key alongside the alarm when state is gone.

Regression tests cover window expiry, the missing-deadline case, and window extension on repeat `view-state` requests.

## Subsequent work

- Consider whether reconcile is needed at all given nudges cover every mutation path, or whether the window/interval should be tuned once production log volume is confirmed to drop.