### PR TITLE
Fix King of the Hill objective stats display

### DIFF
--- a/api/commands/stats/tests/__snapshots__/stats.test.ts.snap
+++ b/api/commands/stats/tests/__snapshots__/stats.test.ts.snap
@@ -697,9 +697,8 @@ Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
 Avg life time (damage/life): 25s (385.05)
-Captures: __**0**__
+Points: **61**
 Occupation time: **1m 11s**
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: __**4**__
 <:TripleKill:1322814228477906944> 8x<:DoubleKill:1322814147980689430> 3x<:KillingSpree:1322803050347499541> 2x<:ShotCaller:1322884687693086771> 4x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> <:Reversal:1322872797701083166>",
@@ -715,9 +714,8 @@ Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
 Avg life time (damage/life): 27s (337.85)
-Captures: __**0**__
+Points: 29
 Occupation time: 44s
-Secures: __**0**__
 Offensive kills: 2
 Defensive kills: 3
 <:ShotCaller:1322884687693086771> 2x<:DoubleKill:1322814147980689430> <:Reversal:1322872797701083166> <:Stick:1322871787695898676> <:GuardianAngel:1322873057928286248> <:Rifleman:1322860656399220828> 2x<:BackSmack:1322872596135546891> <:Wingman:1322854221095108609> <:LastShot:1322884170606972959>",
@@ -740,9 +738,8 @@ Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
 Avg life time (damage/life): 27s (350.47)
-Captures: __**0**__
+Points: 39
 Occupation time: 49s
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: 1
 2x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
@@ -758,9 +755,8 @@ Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
 Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
-Captures: __**0**__
+Points: 50
 Occupation time: 53s
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: 1
 2x<:KillingSpree:1322803050347499541> 2x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> 2x<:GuardianAngel:1322873057928286248>",
@@ -788,9 +784,8 @@ Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
 Avg life time (damage/life): 17s (197.5)
-Captures: __**0**__
+Points: __**74**__
 Occupation time: __**1m 29s**__
-Secures: __**0**__
 Offensive kills: 3
 Defensive kills: 3
 <:Rifleman:1322860656399220828> <:GuardianAngel:1322873057928286248> <:Wingman:1322854221095108609>",
@@ -806,9 +801,8 @@ Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
 Avg life time (damage/life): 17s (200.04)
-Captures: __**0**__
+Points: 27
 Occupation time: 35s
-Secures: __**0**__
 Offensive kills: 2
 Defensive kills: 2
 <:DoubleKill:1322814147980689430> <:LastShot:1322884170606972959> <:Wingman:1322854221095108609> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828>",
@@ -831,9 +825,8 @@ Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
 Avg life time (damage/life): 19s (221)
-Captures: __**0**__
+Points: 42
 Occupation time: 48s
-Secures: __**0**__
 Offensive kills: 4
 Defensive kills: 0
 3x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:NadeShot:1322877140605206528> 2x<:Killjoy:1322802841039147129> <:Spotter:1322814780796309505> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
@@ -849,9 +842,8 @@ Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
 Avg life time (damage/life): **20s** **(299.46)**
-Captures: __**0**__
+Points: 34
 Occupation time: 47s
-Secures: __**0**__
 Offensive kills: **5**
 Defensive kills: __**4**__
 <:SneakKing:1322883516039696415> 2x<:Perfect:1322879561515532308> 5x<:DoubleKill:1322814147980689430> <:Whiplash:1322882310122504202> <:Rifleman:1322860656399220828> 2x<:Killjoy:1322802841039147129>",

--- a/api/commands/stats/tests/__snapshots__/stats.test.ts.snap
+++ b/api/commands/stats/tests/__snapshots__/stats.test.ts.snap
@@ -697,7 +697,7 @@ Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
 Avg life time (damage/life): 25s (385.05)
-Points: **61**
+Scoring ticks: **61**
 Occupation time: **1m 11s**
 Offensive kills: __**7**__
 Defensive kills: __**4**__
@@ -714,7 +714,7 @@ Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
 Avg life time (damage/life): 27s (337.85)
-Points: 29
+Scoring ticks: 29
 Occupation time: 44s
 Offensive kills: 2
 Defensive kills: 3
@@ -738,7 +738,7 @@ Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
 Avg life time (damage/life): 27s (350.47)
-Points: 39
+Scoring ticks: 39
 Occupation time: 49s
 Offensive kills: __**7**__
 Defensive kills: 1
@@ -755,7 +755,7 @@ Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
 Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
-Points: 50
+Scoring ticks: 50
 Occupation time: 53s
 Offensive kills: __**7**__
 Defensive kills: 1
@@ -784,7 +784,7 @@ Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
 Avg life time (damage/life): 17s (197.5)
-Points: __**74**__
+Scoring ticks: __**74**__
 Occupation time: __**1m 29s**__
 Offensive kills: 3
 Defensive kills: 3
@@ -801,7 +801,7 @@ Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
 Avg life time (damage/life): 17s (200.04)
-Points: 27
+Scoring ticks: 27
 Occupation time: 35s
 Offensive kills: 2
 Defensive kills: 2
@@ -825,7 +825,7 @@ Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
 Avg life time (damage/life): 19s (221)
-Points: 42
+Scoring ticks: 42
 Occupation time: 48s
 Offensive kills: 4
 Defensive kills: 0
@@ -842,7 +842,7 @@ Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
 Avg life time (damage/life): **20s** **(299.46)**
-Points: 34
+Scoring ticks: 34
 Occupation time: 47s
 Offensive kills: **5**
 Defensive kills: __**4**__

--- a/api/embeds/stats/koth-match-embed.ts
+++ b/api/embeds/stats/koth-match-embed.ts
@@ -1,10 +1,10 @@
 import type { GameVariantCategory, Stats } from "halo-infinite-api";
-import { getStrongholdsObjectiveStats } from "@guilty-spark/shared/halo/objective-stats";
+import { getKothObjectiveStats } from "@guilty-spark/shared/halo/objective-stats";
 import type { EmbedPlayerStats } from "./base-match-embed";
 import { BaseMatchEmbed } from "./base-match-embed";
 
 export class KOTHMatchEmbed extends BaseMatchEmbed<GameVariantCategory.MultiplayerKingOfTheHill> {
   override getPlayerObjectiveStats(stats: Stats<GameVariantCategory.MultiplayerKingOfTheHill>): EmbedPlayerStats {
-    return new Map(getStrongholdsObjectiveStats(stats, this.locale));
+    return new Map(getKothObjectiveStats(stats, this.locale));
   }
 }

--- a/api/embeds/stats/tests/__snapshots__/koth-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/koth-match-embed.test.ts.snap
@@ -20,9 +20,8 @@ Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
 Avg life time (damage/life): 25s (385.05)
-Captures: __**0**__
+Points: **61**
 Occupation time: **1m 11s**
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: __**4**__
 <:TripleKill:1322814228477906944> 8x<:DoubleKill:1322814147980689430> 3x<:KillingSpree:1322803050347499541> 2x<:ShotCaller:1322884687693086771> 4x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> <:Reversal:1322872797701083166>",
@@ -38,9 +37,8 @@ Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
 Avg life time (damage/life): 27s (337.85)
-Captures: __**0**__
+Points: 29
 Occupation time: 44s
-Secures: __**0**__
 Offensive kills: 2
 Defensive kills: 3
 <:ShotCaller:1322884687693086771> 2x<:DoubleKill:1322814147980689430> <:Reversal:1322872797701083166> <:Stick:1322871787695898676> <:GuardianAngel:1322873057928286248> <:Rifleman:1322860656399220828> 2x<:BackSmack:1322872596135546891> <:Wingman:1322854221095108609> <:LastShot:1322884170606972959>",
@@ -63,9 +61,8 @@ Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
 Avg life time (damage/life): 27s (350.47)
-Captures: __**0**__
+Points: 39
 Occupation time: 49s
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: 1
 2x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
@@ -81,9 +78,8 @@ Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
 Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
-Captures: __**0**__
+Points: 50
 Occupation time: 53s
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: 1
 2x<:KillingSpree:1322803050347499541> 2x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> 2x<:GuardianAngel:1322873057928286248>",
@@ -111,9 +107,8 @@ Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
 Avg life time (damage/life): 17s (197.5)
-Captures: __**0**__
+Points: __**74**__
 Occupation time: __**1m 29s**__
-Secures: __**0**__
 Offensive kills: 3
 Defensive kills: 3
 <:Rifleman:1322860656399220828> <:GuardianAngel:1322873057928286248> <:Wingman:1322854221095108609>",
@@ -129,9 +124,8 @@ Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
 Avg life time (damage/life): 17s (200.04)
-Captures: __**0**__
+Points: 27
 Occupation time: 35s
-Secures: __**0**__
 Offensive kills: 2
 Defensive kills: 2
 <:DoubleKill:1322814147980689430> <:LastShot:1322884170606972959> <:Wingman:1322854221095108609> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828>",
@@ -154,9 +148,8 @@ Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
 Avg life time (damage/life): 19s (221)
-Captures: __**0**__
+Points: 42
 Occupation time: 48s
-Secures: __**0**__
 Offensive kills: 4
 Defensive kills: 0
 3x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:NadeShot:1322877140605206528> 2x<:Killjoy:1322802841039147129> <:Spotter:1322814780796309505> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
@@ -172,9 +165,8 @@ Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
 Avg life time (damage/life): **20s** **(299.46)**
-Captures: __**0**__
+Points: 34
 Occupation time: 47s
-Secures: __**0**__
 Offensive kills: **5**
 Defensive kills: __**4**__
 <:SneakKing:1322883516039696415> 2x<:Perfect:1322879561515532308> 5x<:DoubleKill:1322814147980689430> <:Whiplash:1322882310122504202> <:Rifleman:1322860656399220828> 2x<:Killjoy:1322802841039147129>",

--- a/api/embeds/stats/tests/__snapshots__/koth-match-embed.test.ts.snap
+++ b/api/embeds/stats/tests/__snapshots__/koth-match-embed.test.ts.snap
@@ -20,7 +20,7 @@ Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
 Avg life time (damage/life): 25s (385.05)
-Points: **61**
+Scoring ticks: **61**
 Occupation time: **1m 11s**
 Offensive kills: __**7**__
 Defensive kills: __**4**__
@@ -37,7 +37,7 @@ Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
 Avg life time (damage/life): 27s (337.85)
-Points: 29
+Scoring ticks: 29
 Occupation time: 44s
 Offensive kills: 2
 Defensive kills: 3
@@ -61,7 +61,7 @@ Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
 Avg life time (damage/life): 27s (350.47)
-Points: 39
+Scoring ticks: 39
 Occupation time: 49s
 Offensive kills: __**7**__
 Defensive kills: 1
@@ -78,7 +78,7 @@ Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
 Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
-Points: 50
+Scoring ticks: 50
 Occupation time: 53s
 Offensive kills: __**7**__
 Defensive kills: 1
@@ -107,7 +107,7 @@ Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
 Avg life time (damage/life): 17s (197.5)
-Points: __**74**__
+Scoring ticks: __**74**__
 Occupation time: __**1m 29s**__
 Offensive kills: 3
 Defensive kills: 3
@@ -124,7 +124,7 @@ Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
 Avg life time (damage/life): 17s (200.04)
-Points: 27
+Scoring ticks: 27
 Occupation time: 35s
 Offensive kills: 2
 Defensive kills: 2
@@ -148,7 +148,7 @@ Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
 Avg life time (damage/life): 19s (221)
-Points: 42
+Scoring ticks: 42
 Occupation time: 48s
 Offensive kills: 4
 Defensive kills: 0
@@ -165,7 +165,7 @@ Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
 Avg life time (damage/life): **20s** **(299.46)**
-Points: 34
+Scoring ticks: 34
 Occupation time: 47s
 Offensive kills: **5**
 Defensive kills: __**4**__

--- a/api/services/neatqueue/tests/__snapshots__/neatqueue.test.ts.snap
+++ b/api/services/neatqueue/tests/__snapshots__/neatqueue.test.ts.snap
@@ -481,9 +481,8 @@ Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
 Avg life time (damage/life): 25s (385.05)
-Captures: __**0**__
+Points: **61**
 Occupation time: **1m 11s**
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: __**4**__
 <:TripleKill:1322814228477906944> 8x<:DoubleKill:1322814147980689430> 3x<:KillingSpree:1322803050347499541> 2x<:ShotCaller:1322884687693086771> 4x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> <:Reversal:1322872797701083166>",
@@ -499,9 +498,8 @@ Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
 Avg life time (damage/life): 27s (337.85)
-Captures: __**0**__
+Points: 29
 Occupation time: 44s
-Secures: __**0**__
 Offensive kills: 2
 Defensive kills: 3
 <:ShotCaller:1322884687693086771> 2x<:DoubleKill:1322814147980689430> <:Reversal:1322872797701083166> <:Stick:1322871787695898676> <:GuardianAngel:1322873057928286248> <:Rifleman:1322860656399220828> 2x<:BackSmack:1322872596135546891> <:Wingman:1322854221095108609> <:LastShot:1322884170606972959>",
@@ -524,9 +522,8 @@ Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
 Avg life time (damage/life): 27s (350.47)
-Captures: __**0**__
+Points: 39
 Occupation time: 49s
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: 1
 2x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
@@ -542,9 +539,8 @@ Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
 Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
-Captures: __**0**__
+Points: 50
 Occupation time: 53s
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: 1
 2x<:KillingSpree:1322803050347499541> 2x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> 2x<:GuardianAngel:1322873057928286248>",
@@ -572,9 +568,8 @@ Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
 Avg life time (damage/life): 17s (197.5)
-Captures: __**0**__
+Points: __**74**__
 Occupation time: __**1m 29s**__
-Secures: __**0**__
 Offensive kills: 3
 Defensive kills: 3
 <:Rifleman:1322860656399220828> <:GuardianAngel:1322873057928286248> <:Wingman:1322854221095108609>",
@@ -590,9 +585,8 @@ Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
 Avg life time (damage/life): 17s (200.04)
-Captures: __**0**__
+Points: 27
 Occupation time: 35s
-Secures: __**0**__
 Offensive kills: 2
 Defensive kills: 2
 <:DoubleKill:1322814147980689430> <:LastShot:1322884170606972959> <:Wingman:1322854221095108609> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828>",
@@ -615,9 +609,8 @@ Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
 Avg life time (damage/life): 19s (221)
-Captures: __**0**__
+Points: 42
 Occupation time: 48s
-Secures: __**0**__
 Offensive kills: 4
 Defensive kills: 0
 3x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:NadeShot:1322877140605206528> 2x<:Killjoy:1322802841039147129> <:Spotter:1322814780796309505> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
@@ -633,9 +626,8 @@ Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
 Avg life time (damage/life): **20s** **(299.46)**
-Captures: __**0**__
+Points: 34
 Occupation time: 47s
-Secures: __**0**__
 Offensive kills: **5**
 Defensive kills: __**4**__
 <:SneakKing:1322883516039696415> 2x<:Perfect:1322879561515532308> 5x<:DoubleKill:1322814147980689430> <:Whiplash:1322882310122504202> <:Rifleman:1322860656399220828> 2x<:Killjoy:1322802841039147129>",
@@ -1813,9 +1805,8 @@ Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
 Avg life time (damage/life): 25s (385.05)
-Captures: __**0**__
+Points: **61**
 Occupation time: **1m 11s**
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: __**4**__
 <:TripleKill:1322814228477906944> 8x<:DoubleKill:1322814147980689430> 3x<:KillingSpree:1322803050347499541> 2x<:ShotCaller:1322884687693086771> 4x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> <:Reversal:1322872797701083166>",
@@ -1831,9 +1822,8 @@ Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
 Avg life time (damage/life): 27s (337.85)
-Captures: __**0**__
+Points: 29
 Occupation time: 44s
-Secures: __**0**__
 Offensive kills: 2
 Defensive kills: 3
 <:ShotCaller:1322884687693086771> 2x<:DoubleKill:1322814147980689430> <:Reversal:1322872797701083166> <:Stick:1322871787695898676> <:GuardianAngel:1322873057928286248> <:Rifleman:1322860656399220828> 2x<:BackSmack:1322872596135546891> <:Wingman:1322854221095108609> <:LastShot:1322884170606972959>",
@@ -1856,9 +1846,8 @@ Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
 Avg life time (damage/life): 27s (350.47)
-Captures: __**0**__
+Points: 39
 Occupation time: 49s
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: 1
 2x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
@@ -1874,9 +1863,8 @@ Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
 Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
-Captures: __**0**__
+Points: 50
 Occupation time: 53s
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: 1
 2x<:KillingSpree:1322803050347499541> 2x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> 2x<:GuardianAngel:1322873057928286248>",
@@ -1904,9 +1892,8 @@ Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
 Avg life time (damage/life): 17s (197.5)
-Captures: __**0**__
+Points: __**74**__
 Occupation time: __**1m 29s**__
-Secures: __**0**__
 Offensive kills: 3
 Defensive kills: 3
 <:Rifleman:1322860656399220828> <:GuardianAngel:1322873057928286248> <:Wingman:1322854221095108609>",
@@ -1922,9 +1909,8 @@ Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
 Avg life time (damage/life): 17s (200.04)
-Captures: __**0**__
+Points: 27
 Occupation time: 35s
-Secures: __**0**__
 Offensive kills: 2
 Defensive kills: 2
 <:DoubleKill:1322814147980689430> <:LastShot:1322884170606972959> <:Wingman:1322854221095108609> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828>",
@@ -1947,9 +1933,8 @@ Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
 Avg life time (damage/life): 19s (221)
-Captures: __**0**__
+Points: 42
 Occupation time: 48s
-Secures: __**0**__
 Offensive kills: 4
 Defensive kills: 0
 3x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:NadeShot:1322877140605206528> 2x<:Killjoy:1322802841039147129> <:Spotter:1322814780796309505> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
@@ -1965,9 +1950,8 @@ Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
 Avg life time (damage/life): **20s** **(299.46)**
-Captures: __**0**__
+Points: 34
 Occupation time: 47s
-Secures: __**0**__
 Offensive kills: **5**
 Defensive kills: __**4**__
 <:SneakKing:1322883516039696415> 2x<:Perfect:1322879561515532308> 5x<:DoubleKill:1322814147980689430> <:Whiplash:1322882310122504202> <:Rifleman:1322860656399220828> 2x<:Killjoy:1322802841039147129>",
@@ -3145,9 +3129,8 @@ Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
 Avg life time (damage/life): 25s (385.05)
-Captures: __**0**__
+Points: **61**
 Occupation time: **1m 11s**
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: __**4**__
 <:TripleKill:1322814228477906944> 8x<:DoubleKill:1322814147980689430> 3x<:KillingSpree:1322803050347499541> 2x<:ShotCaller:1322884687693086771> 4x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> <:Reversal:1322872797701083166>",
@@ -3163,9 +3146,8 @@ Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
 Avg life time (damage/life): 27s (337.85)
-Captures: __**0**__
+Points: 29
 Occupation time: 44s
-Secures: __**0**__
 Offensive kills: 2
 Defensive kills: 3
 <:ShotCaller:1322884687693086771> 2x<:DoubleKill:1322814147980689430> <:Reversal:1322872797701083166> <:Stick:1322871787695898676> <:GuardianAngel:1322873057928286248> <:Rifleman:1322860656399220828> 2x<:BackSmack:1322872596135546891> <:Wingman:1322854221095108609> <:LastShot:1322884170606972959>",
@@ -3188,9 +3170,8 @@ Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
 Avg life time (damage/life): 27s (350.47)
-Captures: __**0**__
+Points: 39
 Occupation time: 49s
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: 1
 2x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
@@ -3206,9 +3187,8 @@ Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
 Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
-Captures: __**0**__
+Points: 50
 Occupation time: 53s
-Secures: __**0**__
 Offensive kills: __**7**__
 Defensive kills: 1
 2x<:KillingSpree:1322803050347499541> 2x<:Perfect:1322879561515532308> <:Rifleman:1322860656399220828> 2x<:GuardianAngel:1322873057928286248>",
@@ -3236,9 +3216,8 @@ Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
 Avg life time (damage/life): 17s (197.5)
-Captures: __**0**__
+Points: __**74**__
 Occupation time: __**1m 29s**__
-Secures: __**0**__
 Offensive kills: 3
 Defensive kills: 3
 <:Rifleman:1322860656399220828> <:GuardianAngel:1322873057928286248> <:Wingman:1322854221095108609>",
@@ -3254,9 +3233,8 @@ Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
 Avg life time (damage/life): 17s (200.04)
-Captures: __**0**__
+Points: 27
 Occupation time: 35s
-Secures: __**0**__
 Offensive kills: 2
 Defensive kills: 2
 <:DoubleKill:1322814147980689430> <:LastShot:1322884170606972959> <:Wingman:1322854221095108609> <:Killjoy:1322802841039147129> <:Rifleman:1322860656399220828>",
@@ -3279,9 +3257,8 @@ Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
 Avg life time (damage/life): 19s (221)
-Captures: __**0**__
+Points: 42
 Occupation time: 48s
-Secures: __**0**__
 Offensive kills: 4
 Defensive kills: 0
 3x<:ShotCaller:1322884687693086771> <:Perfect:1322879561515532308> <:DoubleKill:1322814147980689430> <:NadeShot:1322877140605206528> 2x<:Killjoy:1322802841039147129> <:Spotter:1322814780796309505> <:Rifleman:1322860656399220828> <:Wingman:1322854221095108609>",
@@ -3297,9 +3274,8 @@ Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
 Avg life time (damage/life): **20s** **(299.46)**
-Captures: __**0**__
+Points: 34
 Occupation time: 47s
-Secures: __**0**__
 Offensive kills: **5**
 Defensive kills: __**4**__
 <:SneakKing:1322883516039696415> 2x<:Perfect:1322879561515532308> 5x<:DoubleKill:1322814147980689430> <:Whiplash:1322882310122504202> <:Rifleman:1322860656399220828> 2x<:Killjoy:1322802841039147129>",

--- a/api/services/neatqueue/tests/__snapshots__/neatqueue.test.ts.snap
+++ b/api/services/neatqueue/tests/__snapshots__/neatqueue.test.ts.snap
@@ -481,7 +481,7 @@ Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
 Avg life time (damage/life): 25s (385.05)
-Points: **61**
+Scoring ticks: **61**
 Occupation time: **1m 11s**
 Offensive kills: __**7**__
 Defensive kills: __**4**__
@@ -498,7 +498,7 @@ Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
 Avg life time (damage/life): 27s (337.85)
-Points: 29
+Scoring ticks: 29
 Occupation time: 44s
 Offensive kills: 2
 Defensive kills: 3
@@ -522,7 +522,7 @@ Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
 Avg life time (damage/life): 27s (350.47)
-Points: 39
+Scoring ticks: 39
 Occupation time: 49s
 Offensive kills: __**7**__
 Defensive kills: 1
@@ -539,7 +539,7 @@ Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
 Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
-Points: 50
+Scoring ticks: 50
 Occupation time: 53s
 Offensive kills: __**7**__
 Defensive kills: 1
@@ -568,7 +568,7 @@ Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
 Avg life time (damage/life): 17s (197.5)
-Points: __**74**__
+Scoring ticks: __**74**__
 Occupation time: __**1m 29s**__
 Offensive kills: 3
 Defensive kills: 3
@@ -585,7 +585,7 @@ Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
 Avg life time (damage/life): 17s (200.04)
-Points: 27
+Scoring ticks: 27
 Occupation time: 35s
 Offensive kills: 2
 Defensive kills: 2
@@ -609,7 +609,7 @@ Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
 Avg life time (damage/life): 19s (221)
-Points: 42
+Scoring ticks: 42
 Occupation time: 48s
 Offensive kills: 4
 Defensive kills: 0
@@ -626,7 +626,7 @@ Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
 Avg life time (damage/life): **20s** **(299.46)**
-Points: 34
+Scoring ticks: 34
 Occupation time: 47s
 Offensive kills: **5**
 Defensive kills: __**4**__
@@ -1805,7 +1805,7 @@ Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
 Avg life time (damage/life): 25s (385.05)
-Points: **61**
+Scoring ticks: **61**
 Occupation time: **1m 11s**
 Offensive kills: __**7**__
 Defensive kills: __**4**__
@@ -1822,7 +1822,7 @@ Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
 Avg life time (damage/life): 27s (337.85)
-Points: 29
+Scoring ticks: 29
 Occupation time: 44s
 Offensive kills: 2
 Defensive kills: 3
@@ -1846,7 +1846,7 @@ Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
 Avg life time (damage/life): 27s (350.47)
-Points: 39
+Scoring ticks: 39
 Occupation time: 49s
 Offensive kills: __**7**__
 Defensive kills: 1
@@ -1863,7 +1863,7 @@ Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
 Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
-Points: 50
+Scoring ticks: 50
 Occupation time: 53s
 Offensive kills: __**7**__
 Defensive kills: 1
@@ -1892,7 +1892,7 @@ Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
 Avg life time (damage/life): 17s (197.5)
-Points: __**74**__
+Scoring ticks: __**74**__
 Occupation time: __**1m 29s**__
 Offensive kills: 3
 Defensive kills: 3
@@ -1909,7 +1909,7 @@ Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
 Avg life time (damage/life): 17s (200.04)
-Points: 27
+Scoring ticks: 27
 Occupation time: 35s
 Offensive kills: 2
 Defensive kills: 2
@@ -1933,7 +1933,7 @@ Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
 Avg life time (damage/life): 19s (221)
-Points: 42
+Scoring ticks: 42
 Occupation time: 48s
 Offensive kills: 4
 Defensive kills: 0
@@ -1950,7 +1950,7 @@ Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
 Avg life time (damage/life): **20s** **(299.46)**
-Points: 34
+Scoring ticks: 34
 Occupation time: 47s
 Offensive kills: **5**
 Defensive kills: __**4**__
@@ -3129,7 +3129,7 @@ Headshot kills: __**25**__
 Shots H:F (acc): __**176**__:**288** __**(61.11%)**__
 Damage D:T (D/T): __**7,701**__:6,740 (1.14)
 Avg life time (damage/life): 25s (385.05)
-Points: **61**
+Scoring ticks: **61**
 Occupation time: **1m 11s**
 Offensive kills: __**7**__
 Defensive kills: __**4**__
@@ -3146,7 +3146,7 @@ Headshot kills: 14
 Shots H:F (acc): 136:237 (57.38%)
 Damage D:T (D/T): 6,757:6,899 (0.98)
 Avg life time (damage/life): 27s (337.85)
-Points: 29
+Scoring ticks: 29
 Occupation time: 44s
 Offensive kills: 2
 Defensive kills: 3
@@ -3170,7 +3170,7 @@ Headshot kills: 10
 Shots H:F (acc): 134:265 (50.56%)
 Damage D:T (D/T): 6,659:5,468 (1.22)
 Avg life time (damage/life): 27s (350.47)
-Points: 39
+Scoring ticks: 39
 Occupation time: 49s
 Offensive kills: __**7**__
 Defensive kills: 1
@@ -3187,7 +3187,7 @@ Headshot kills: 18
 Shots H:F (acc): 141:242 (58.26%)
 Damage D:T (D/T): 6,010:__**4,547**__ __**(1.32)**__
 Avg life time (damage/life): __**1m 19s**__ __**(751.25)**__
-Points: 50
+Scoring ticks: 50
 Occupation time: 53s
 Offensive kills: __**7**__
 Defensive kills: 1
@@ -3216,7 +3216,7 @@ Headshot kills: 10
 Shots H:F (acc): 120:239 (50.2%)
 Damage D:T (D/T): 5,135:6,802 (0.75)
 Avg life time (damage/life): 17s (197.5)
-Points: __**74**__
+Scoring ticks: __**74**__
 Occupation time: __**1m 29s**__
 Offensive kills: 3
 Defensive kills: 3
@@ -3233,7 +3233,7 @@ Headshot kills: 5
 Shots H:F (acc): 127:267 (47.56%)
 Damage D:T (D/T): 5,401:7,155 (0.75)
 Avg life time (damage/life): 17s (200.04)
-Points: 27
+Scoring ticks: 27
 Occupation time: 35s
 Offensive kills: 2
 Defensive kills: 2
@@ -3257,7 +3257,7 @@ Headshot kills: 5
 Shots H:F (acc): 114:237 (48.1%)
 Damage D:T (D/T): 5,525:**6,557** (0.84)
 Avg life time (damage/life): 19s (221)
-Points: 42
+Scoring ticks: 42
 Occupation time: 48s
 Offensive kills: 4
 Defensive kills: 0
@@ -3274,7 +3274,7 @@ Headshot kills: **19**
 Shots H:F (acc): **170**:__**297**__ **(57.23%)**
 Damage D:T (D/T): **7,187**:6,850 **(1.05)**
 Avg life time (damage/life): **20s** **(299.46)**
-Points: 34
+Scoring ticks: 34
 Occupation time: 47s
 Offensive kills: **5**
 Defensive kills: __**4**__

--- a/pages/src/controllers/stats/koth-match-stats-formatter.ts
+++ b/pages/src/controllers/stats/koth-match-stats-formatter.ts
@@ -1,10 +1,10 @@
 import type { GameVariantCategory, Stats } from "halo-infinite-api";
-import { getStrongholdsObjectiveStats } from "@guilty-spark/shared/halo/objective-stats";
+import { getKothObjectiveStats } from "@guilty-spark/shared/halo/objective-stats";
 import type { StatsCollection } from "@guilty-spark/shared/halo/types";
 import { BaseMatchStatsFormatter } from "./base-match-stats-formatter";
 
 export class KOTHMatchStatsFormatter extends BaseMatchStatsFormatter {
   protected getPlayerObjectiveStats(stats: Stats<GameVariantCategory.MultiplayerKingOfTheHill>): StatsCollection {
-    return new Map(getStrongholdsObjectiveStats(stats));
+    return new Map(getKothObjectiveStats(stats));
   }
 }

--- a/shared/src/halo/objective-stats.ts
+++ b/shared/src/halo/objective-stats.ts
@@ -154,7 +154,7 @@ export function getOddballObjectiveStats(
 }
 
 export function getStrongholdsObjectiveStats(
-  stats: Stats<GameVariantCategory.MultiplayerStrongholds | GameVariantCategory.MultiplayerKingOfTheHill>,
+  stats: Stats<GameVariantCategory.MultiplayerStrongholds>,
   locale?: string,
 ): StatsCollection {
   return new Map([
@@ -168,6 +168,25 @@ export function getStrongholdsObjectiveStats(
       },
     ],
     ["Secures", { value: stats.ZonesStats.StrongholdSecures, sortBy: StatsValueSortBy.DESC }],
+    ["Offensive kills", { value: stats.ZonesStats.StrongholdOffensiveKills, sortBy: StatsValueSortBy.DESC }],
+    ["Defensive kills", { value: stats.ZonesStats.StrongholdDefensiveKills, sortBy: StatsValueSortBy.DESC }],
+  ]);
+}
+
+export function getKothObjectiveStats(
+  stats: Stats<GameVariantCategory.MultiplayerKingOfTheHill>,
+  locale?: string,
+): StatsCollection {
+  return new Map([
+    ["Points", { value: stats.ZonesStats.StrongholdScoringTicks, sortBy: StatsValueSortBy.DESC }],
+    [
+      "Occupation time",
+      {
+        value: getDurationInSeconds(stats.ZonesStats.StrongholdOccupationTime),
+        sortBy: StatsValueSortBy.DESC,
+        display: getReadableDuration(stats.ZonesStats.StrongholdOccupationTime, locale),
+      },
+    ],
     ["Offensive kills", { value: stats.ZonesStats.StrongholdOffensiveKills, sortBy: StatsValueSortBy.DESC }],
     ["Defensive kills", { value: stats.ZonesStats.StrongholdDefensiveKills, sortBy: StatsValueSortBy.DESC }],
   ]);

--- a/shared/src/halo/objective-stats.ts
+++ b/shared/src/halo/objective-stats.ts
@@ -178,7 +178,7 @@ export function getKothObjectiveStats(
   locale?: string,
 ): StatsCollection {
   return new Map([
-    ["Points", { value: stats.ZonesStats.StrongholdScoringTicks, sortBy: StatsValueSortBy.DESC }],
+    ["Scoring ticks", { value: stats.ZonesStats.StrongholdScoringTicks, sortBy: StatsValueSortBy.DESC }],
     [
       "Occupation time",
       {

--- a/shared/src/halo/tests/objective-stats.test.ts
+++ b/shared/src/halo/tests/objective-stats.test.ts
@@ -128,7 +128,7 @@ describe("zone objective stats", () => {
 
     const result = getKothObjectiveStats(stats);
 
-    expect(result.get("Points")?.value).toBe(39);
+    expect(result.get("Scoring ticks")?.value).toBe(39);
     expect(result.get("Occupation time")?.value).toBe(getDurationInSeconds("PT47.1S"));
     expect(result.has("Captures")).toBe(false);
     expect(result.has("Secures")).toBe(false);

--- a/shared/src/halo/tests/objective-stats.test.ts
+++ b/shared/src/halo/tests/objective-stats.test.ts
@@ -4,6 +4,8 @@ import {
   getEmptyObjectiveStats,
   getEliminationObjectiveStats,
   getExtractionObjectiveStats,
+  getKothObjectiveStats,
+  getStrongholdsObjectiveStats,
 } from "../objective-stats";
 import { StatsValueSortBy } from "../stat-formatting";
 import { getDurationInSeconds } from "../duration";
@@ -84,6 +86,52 @@ describe("getCtfObjectiveStats", () => {
     expect(pagesResult.get("Captures")?.value).toBe(apiResult.get("Captures")?.value);
     expect(pagesResult.get("Grabs")?.value).toBe(apiResult.get("Grabs")?.value);
     expect(pagesResult.get("Carrier time")?.value).toBe(apiResult.get("Carrier time")?.value);
+  });
+});
+
+describe("zone objective stats", () => {
+  it("maps captures and secures for Strongholds", () => {
+    const stats = {
+      CoreStats: {} as never,
+      PvpStats: {} as never,
+      ZonesStats: {
+        StrongholdCaptures: 8,
+        StrongholdDefensiveKills: 3,
+        StrongholdOffensiveKills: 4,
+        StrongholdSecures: 2,
+        StrongholdOccupationTime: "PT1M20S",
+        StrongholdScoringTicks: 0,
+      },
+    } as never;
+
+    const result = getStrongholdsObjectiveStats(stats);
+
+    expect(result.get("Captures")?.value).toBe(8);
+    expect(result.get("Secures")?.value).toBe(2);
+    expect(result.get("Occupation time")?.value).toBe(getDurationInSeconds("PT1M20S"));
+    expect(result.has("Points")).toBe(false);
+  });
+
+  it("maps points rather than zero captures for King of the Hill", () => {
+    const stats = {
+      CoreStats: {} as never,
+      PvpStats: {} as never,
+      ZonesStats: {
+        StrongholdCaptures: 0,
+        StrongholdDefensiveKills: 1,
+        StrongholdOffensiveKills: 2,
+        StrongholdSecures: 0,
+        StrongholdOccupationTime: "PT47.1S",
+        StrongholdScoringTicks: 39,
+      },
+    } as never;
+
+    const result = getKothObjectiveStats(stats);
+
+    expect(result.get("Points")?.value).toBe(39);
+    expect(result.get("Occupation time")?.value).toBe(getDurationInSeconds("PT47.1S"));
+    expect(result.has("Captures")).toBe(false);
+    expect(result.has("Secures")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Context
King of the Hill and Strongholds both use Halo `ZonesStats`, but the fields do not have the same gameplay semantics. Real match payloads show KOTH player captures and secures at zero while scoring ticks and occupation time are populated; Strongholds has populated captures while player scoring ticks are zero.

## This PR
- Split KOTH objective stats from the shared Strongholds formatter.
- Display KOTH `Points` from `StrongholdScoringTicks` and `Occupation time`, plus offensive/defensive kills.
- Retain Strongholds captures, secures, and occupation time unchanged.
- Apply the KOTH mapping to both Discord embeds and the pages stats formatter.
- Add shared semantic regression tests and update the KOTH Discord snapshot.

Validation: 34 focused tests, API typecheck, pages typecheck, and changed-file ESLint pass.

## Subsequent Work
Continue PR12 objective-metrics design using the now-correct Strongholds and KOTH semantics for normalization.