### PR TITLE
Use guild preferred locale instead of hardcoded en-US

### DIFF
--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -354,7 +354,7 @@ export class StatsCommand extends BaseCommand {
         components: seriesEmbed.components,
       });
 
-      await this.cacheDiscordSeriesStats(guildId, queueData.queue, series);
+      await this.cacheDiscordSeriesStats(guildId, queueData.queue, series, locale);
 
       const message = await discordService.getMessageFromInteractionToken(interaction.token);
       const messageChannel = await discordService.getChannel(message.channel_id);
@@ -472,7 +472,7 @@ export class StatsCommand extends BaseCommand {
           components: seriesEmbed.components,
         });
 
-        await this.cacheDiscordSeriesStats(guildId, queueData.queue, series);
+        await this.cacheDiscordSeriesStats(guildId, queueData.queue, series, locale);
 
         await this.postSeriesEmbedsToThread(threadChannelId, series, guildConfig, locale);
         await this.postGameStatsOrButton(threadChannelId, series, guildConfig, locale);
@@ -776,7 +776,12 @@ export class StatsCommand extends BaseCommand {
     });
   }
 
-  private async cacheDiscordSeriesStats(guildId: string, queueNumber: number, series: MatchStats[]): Promise<void> {
+  private async cacheDiscordSeriesStats(
+    guildId: string,
+    queueNumber: number,
+    series: MatchStats[],
+    locale: string,
+  ): Promise<void> {
     const { discordService, haloService, logService } = this.services;
 
     try {
@@ -787,6 +792,7 @@ export class StatsCommand extends BaseCommand {
         guildId,
         queueNumber,
         matches: series,
+        locale,
       });
 
       await discordService.cacheResolvedDiscordSeriesStats({
@@ -1309,7 +1315,7 @@ export class StatsCommand extends BaseCommand {
       }
       await this.postSeriesEmbedsToThread(destinationThreadId, series, guildConfig, locale);
       await this.postGameStatsOrButton(destinationThreadId, series, guildConfig, locale);
-      await this.cacheDiscordSeriesStats(metadata.guildId, metadata.queueData.queue, series);
+      await this.cacheDiscordSeriesStats(metadata.guildId, metadata.queueData.queue, series, locale);
 
       await discordService.updateDeferredReply(interaction.token, {
         embeds: [this.createStatusEmbed("Series stats were amended successfully.")],

--- a/api/durable-objects/live-tracker/live-tracker-do.ts
+++ b/api/durable-objects/live-tracker/live-tracker-do.ts
@@ -334,7 +334,11 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
         embedData,
       );
 
-      const initialChannelSeriesScore = this.haloService.getSeriesScore([], "en-US", trackerState.teams.length === 2);
+      const initialChannelSeriesScore = this.haloService.getSeriesScore(
+        [],
+        await this.getLocale(trackerState),
+        trackerState.teams.length === 2,
+      );
       await this.updateChannelName(trackerState, initialChannelSeriesScore, true);
       await this.discordService.editMessage(
         startRequest.channelId,
@@ -791,10 +795,11 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   ): Promise<{ seriesScore: string; seriesScoreWithEmoji: string }> {
     const rawMatches = await this.loadMatchesFromKV(trackerState.matchIds);
     const rawMatchesArray = Object.values(rawMatches);
-    const seriesScore = this.haloService.getSeriesScore(rawMatchesArray, "en-US");
+    const locale = await this.getLocale(trackerState);
+    const seriesScore = this.haloService.getSeriesScore(rawMatchesArray, locale);
     trackerState.seriesScore = seriesScore;
 
-    return { seriesScore, seriesScoreWithEmoji: this.haloService.getSeriesScore(rawMatchesArray, "en-US", true) };
+    return { seriesScore, seriesScoreWithEmoji: this.haloService.getSeriesScore(rawMatchesArray, locale, true) };
   }
 
   /**
@@ -1105,6 +1110,7 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
   private async enrichAndMergeMatches(trackerState: LiveTrackerState, matches: MatchStats[]): Promise<void> {
     const trackingPlayers = trackerState.teams.flatMap((team) => team.playerIds);
+    const locale = await this.getLocale(trackerState);
 
     for (const match of matches) {
       if (trackerState.discoveredMatches[match.MatchId] != null) {
@@ -1138,8 +1144,8 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
         );
       }
 
-      const duration = getReadableDuration(match.MatchInfo.Duration, "en-US");
-      const { gameScore, gameSubScore } = this.haloService.getMatchScore(match, "en-US");
+      const duration = getReadableDuration(match.MatchInfo.Duration, locale);
+      const { gameScore, gameSubScore } = this.haloService.getMatchScore(match, locale);
 
       let gameType = "*Unknown Game Type*";
       let gameMap = "*Unknown Map*";
@@ -1253,6 +1259,16 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
     trackerState.lastMessageState.matchCount = Object.keys(trackerState.discoveredMatches).length;
     trackerState.lastMessageState.substitutionCount = trackerState.substitutions.length;
+  }
+
+  private async getLocale(trackerState: LiveTrackerState): Promise<string> {
+    if (trackerState.localeCache != null) {
+      return trackerState.localeCache;
+    }
+
+    const locale = await this.discordService.getGuildPreferredLocale(trackerState.guildId);
+    trackerState.localeCache = locale;
+    return locale;
   }
 
   private async checkChannelManagePermission(trackerState: LiveTrackerState, channel: APIChannel): Promise<boolean> {

--- a/api/durable-objects/live-tracker/live-tracker-do.ts
+++ b/api/durable-objects/live-tracker/live-tracker-do.ts
@@ -1271,7 +1271,14 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       const guild = await this.discordService.getGuild(trackerState.guildId);
       trackerState.localeCache = guild.preferred_locale;
       return trackerState.localeCache;
-    } catch {
+    } catch (error) {
+      this.logService.warn(
+        "LiveTracker: Failed to resolve guild locale, falling back to English",
+        new Map([
+          ["guildId", trackerState.guildId],
+          ["error", String(error)],
+        ]),
+      );
       // Don't cache the fallback: a transient failure here shouldn't permanently
       // lock the tracker into English for the rest of its (multi-hour) session.
       return Locale.EnglishUS;

--- a/api/durable-objects/live-tracker/live-tracker-do.ts
+++ b/api/durable-objects/live-tracker/live-tracker-do.ts
@@ -370,6 +370,7 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       );
     }
 
+    await this.setState(trackerState);
     await this.state.storage.setAlarm(addMilliseconds(new Date(), ALARM_INTERVAL_MS).getTime());
     return this.createStartSuccessResponse(trackerState);
   }

--- a/api/durable-objects/live-tracker/live-tracker-do.ts
+++ b/api/durable-objects/live-tracker/live-tracker-do.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/cloudflare";
 import type { APIChannel, APIGuildMember } from "discord-api-types/v10";
-import { ChannelType, PermissionFlagsBits } from "discord-api-types/v10";
+import { ChannelType, Locale, PermissionFlagsBits } from "discord-api-types/v10";
 import type { MatchStats } from "halo-infinite-api";
 import { addMilliseconds, addMinutes, differenceInMilliseconds, differenceInMinutes, max } from "date-fns";
 import type {
@@ -1267,9 +1267,15 @@ export class LiveTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       return trackerState.localeCache;
     }
 
-    const locale = await this.discordService.getGuildPreferredLocale(trackerState.guildId);
-    trackerState.localeCache = locale;
-    return locale;
+    try {
+      const guild = await this.discordService.getGuild(trackerState.guildId);
+      trackerState.localeCache = guild.preferred_locale;
+      return trackerState.localeCache;
+    } catch {
+      // Don't cache the fallback: a transient failure here shouldn't permanently
+      // lock the tracker into English for the rest of its (multi-hour) session.
+      return Locale.EnglishUS;
+    }
   }
 
   private async checkChannelManagePermission(trackerState: LiveTrackerState, channel: APIChannel): Promise<boolean> {

--- a/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
+++ b/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
@@ -1,7 +1,7 @@
 import { describe, beforeEach, it, expect, vi, afterEach } from "vitest";
 import type { MockInstance } from "vitest";
 import type { APIGroupDMChannel, APIChannel, APIGuildMember } from "discord-api-types/v10";
-import { ChannelType } from "discord-api-types/v10";
+import { ChannelType, Locale } from "discord-api-types/v10";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import * as haloDuration from "@guilty-spark/shared/halo/duration";
 import type { LiveTrackerStartRequest } from "@guilty-spark/shared/contracts/durable-objects/live-tracker/lifecycle";
@@ -2095,6 +2095,79 @@ describe("LiveTrackerDO", () => {
           name: "my-queue-channel┊🦅1﹕0🐍",
           reason: "Live Tracker: Updated series score to 🦅 1:0 🐍",
         });
+      });
+
+      it("uses the guild's preferred locale and fetches it only once per alarm tick", async (): Promise<void> => {
+        const trackerState = aFakeStateWith({
+          guildId: "test-guild-id",
+          channelId: "test-channel-id",
+          status: "active",
+          isPaused: false,
+          discoveredMatches: {
+            "9535b946-f30c-4a43-b852-000000slayer": aMatchSummaryWith({
+              matchId: "9535b946-f30c-4a43-b852-000000slayer",
+              gameTypeAndMap: "Slayer: Aquarius",
+              gameType: "Slayer",
+              gameMap: "Aquarius",
+              duration: "5m 00s",
+              gameScore: "50:49",
+              endTime: new Date("2024-01-01T10:00:00.000Z").toISOString(),
+            }),
+          },
+          matchIds: ["9535b946-f30c-4a43-b852-000000slayer"],
+        });
+        storageGetSpy.mockResolvedValue(trackerState);
+
+        const mockChannel = {
+          id: "test-channel-id",
+          name: "my-queue-channel",
+          type: 0,
+        };
+        vi.spyOn(services.discordService, "getChannel").mockResolvedValue(mockChannel);
+        vi.spyOn(services.discordService, "updateChannel").mockResolvedValue(mockChannel);
+
+        vi.spyOn(services.discordService, "getGuild").mockResolvedValue(guild);
+        const getGuildPreferredLocaleSpy = vi
+          .spyOn(services.discordService, "getGuildPreferredLocale")
+          .mockResolvedValue(Locale.German);
+        vi.spyOn(services.discordService, "getGuildMember").mockResolvedValue(aGuildMemberWith({}));
+        vi.spyOn(services.discordService, "hasPermissions").mockReturnValue({
+          hasAll: true,
+          missing: [],
+        });
+
+        const mockMatches = [Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"))];
+        vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue(mockMatches);
+        const kvGetSpy: MockInstance = vi.spyOn(env.APP_DATA, "get");
+        kvGetSpy.mockResolvedValue(mockMatches[0]);
+        const getSeriesScoreSpy = vi
+          .spyOn(services.haloService, "getSeriesScore")
+          .mockImplementation((_matches, _locale, includeEmoji) => (includeEmoji === true ? "🦅 1:0 🐍" : "1:0"));
+        vi.spyOn(services.haloService, "getGameTypeAndMap").mockResolvedValue("Slayer on Aquarius");
+        vi.spyOn(haloDuration, "getReadableDuration").mockReturnValue("5:00");
+        vi.spyOn(services.haloService, "getMatchScore").mockReturnValue({ gameScore: "50:49", gameSubScore: null });
+        vi.spyOn(services.discordService, "editMessage").mockResolvedValue(apiMessage);
+        vi.spyOn(services.discordService, "createMessage").mockResolvedValue({
+          ...apiMessage,
+          id: "new-message-id",
+        });
+        vi.spyOn(services.discordService, "deleteMessage").mockResolvedValue(undefined);
+
+        await liveTrackerDO.alarm();
+
+        expect(getSeriesScoreSpy).toHaveBeenNthCalledWith(
+          1,
+          expect.arrayContaining([expect.objectContaining({ MatchId: "9535b946-f30c-4a43-b852-000000slayer" })]),
+          Locale.German,
+        );
+        expect(getSeriesScoreSpy).toHaveBeenNthCalledWith(
+          2,
+          expect.arrayContaining([expect.objectContaining({ MatchId: "9535b946-f30c-4a43-b852-000000slayer" })]),
+          Locale.German,
+          true,
+        );
+        expect(getGuildPreferredLocaleSpy).toHaveBeenCalledOnce();
+        expect(getGuildPreferredLocaleSpy).toHaveBeenCalledWith("test-guild-id");
       });
 
       it("removes existing series score before adding new one", async (): Promise<void> => {

--- a/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
+++ b/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
@@ -605,6 +605,35 @@ describe("LiveTrackerDO", () => {
       expect(scoreArg).toBe("🦅 0:0 🐍");
       expect(forceArg).toBe(true);
     });
+
+    it("persists the resolved guild locale so it isn't refetched on the next alarm tick", async () => {
+      const startData = createMockStartData();
+      const request = new Request("http://do/start", {
+        method: "POST",
+        body: JSON.stringify(startData),
+      });
+
+      vi.spyOn(services.discordService, "createMessage").mockResolvedValue(apiMessage);
+      vi.spyOn(services.discordService, "updateDeferredReply").mockResolvedValue(apiMessage);
+      vi.spyOn(services.discordService, "editMessage").mockResolvedValue(apiMessage);
+      vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue([]);
+      vi.spyOn(services.haloService, "getSeriesScore").mockImplementation((_matches, _locale, includeEmoji) =>
+        includeEmoji === true ? "🦅 0:0 🐍" : "0:0",
+      );
+      const getGuildPreferredLocaleSpy = vi
+        .spyOn(services.discordService, "getGuildPreferredLocale")
+        .mockResolvedValue(Locale.German);
+
+      const response = await liveTrackerDO.fetch(request);
+
+      expect(response.status).toBe(200);
+      const data: { success: boolean; state: LiveTrackerState } = await response.json();
+      expect(data.state.localeCache).toBe(Locale.German);
+      expect(getGuildPreferredLocaleSpy).toHaveBeenCalledOnce();
+
+      const persistedTrackerState = storagePutSpy.mock.calls.at(-1)?.[1];
+      expect(persistedTrackerState?.localeCache).toBe(Locale.German);
+    });
   });
 
   describe("handlePause()", () => {

--- a/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
+++ b/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
@@ -620,16 +620,16 @@ describe("LiveTrackerDO", () => {
       vi.spyOn(services.haloService, "getSeriesScore").mockImplementation((_matches, _locale, includeEmoji) =>
         includeEmoji === true ? "🦅 0:0 🐍" : "0:0",
       );
-      const getGuildPreferredLocaleSpy = vi
-        .spyOn(services.discordService, "getGuildPreferredLocale")
-        .mockResolvedValue(Locale.German);
+      const getGuildSpy = vi
+        .spyOn(services.discordService, "getGuild")
+        .mockResolvedValue({ ...guild, preferred_locale: Locale.German });
 
       const response = await liveTrackerDO.fetch(request);
 
       expect(response.status).toBe(200);
       const data: { success: boolean; state: LiveTrackerState } = await response.json();
       expect(data.state.localeCache).toBe(Locale.German);
-      expect(getGuildPreferredLocaleSpy).toHaveBeenCalledOnce();
+      expect(getGuildSpy).toHaveBeenCalledOnce();
 
       const persistedTrackerState = storagePutSpy.mock.calls.at(-1)?.[1];
       expect(persistedTrackerState?.localeCache).toBe(Locale.German);
@@ -2126,7 +2126,7 @@ describe("LiveTrackerDO", () => {
         });
       });
 
-      it("uses the guild's preferred locale and fetches it only once per alarm tick", async (): Promise<void> => {
+      it("uses the guild's preferred locale, resolving it only once for series score formatting", async (): Promise<void> => {
         const trackerState = aFakeStateWith({
           guildId: "test-guild-id",
           channelId: "test-channel-id",
@@ -2155,10 +2155,9 @@ describe("LiveTrackerDO", () => {
         vi.spyOn(services.discordService, "getChannel").mockResolvedValue(mockChannel);
         vi.spyOn(services.discordService, "updateChannel").mockResolvedValue(mockChannel);
 
-        vi.spyOn(services.discordService, "getGuild").mockResolvedValue(guild);
-        const getGuildPreferredLocaleSpy = vi
-          .spyOn(services.discordService, "getGuildPreferredLocale")
-          .mockResolvedValue(Locale.German);
+        const getGuildSpy = vi
+          .spyOn(services.discordService, "getGuild")
+          .mockResolvedValue({ ...guild, preferred_locale: Locale.German });
         vi.spyOn(services.discordService, "getGuildMember").mockResolvedValue(aGuildMemberWith({}));
         vi.spyOn(services.discordService, "hasPermissions").mockReturnValue({
           hasAll: true,
@@ -2195,8 +2194,68 @@ describe("LiveTrackerDO", () => {
           Locale.German,
           true,
         );
-        expect(getGuildPreferredLocaleSpy).toHaveBeenCalledOnce();
-        expect(getGuildPreferredLocaleSpy).toHaveBeenCalledWith("test-guild-id");
+        expect(getGuildSpy).toHaveBeenCalledWith("test-guild-id");
+        // Called twice: once to resolve the locale (cached on trackerState for the rest of this
+        // tick), once independently by the channel-rename permission check.
+        expect(getGuildSpy).toHaveBeenCalledTimes(2);
+      });
+
+      it("does not permanently cache the locale fallback after a transient Discord failure", async (): Promise<void> => {
+        const trackerState = aFakeStateWith({
+          guildId: "test-guild-id",
+          channelId: "test-channel-id",
+          status: "active",
+          isPaused: false,
+          discoveredMatches: {
+            "9535b946-f30c-4a43-b852-000000slayer": aMatchSummaryWith({
+              matchId: "9535b946-f30c-4a43-b852-000000slayer",
+              gameTypeAndMap: "Slayer: Aquarius",
+              gameType: "Slayer",
+              gameMap: "Aquarius",
+              duration: "5m 00s",
+              gameScore: "50:49",
+              endTime: new Date("2024-01-01T10:00:00.000Z").toISOString(),
+            }),
+          },
+          matchIds: ["9535b946-f30c-4a43-b852-000000slayer"],
+        });
+        storageGetSpy.mockResolvedValue(trackerState);
+
+        const mockChannel = {
+          id: "test-channel-id",
+          name: "my-queue-channel",
+          type: 0,
+        };
+        vi.spyOn(services.discordService, "getChannel").mockResolvedValue(mockChannel);
+        vi.spyOn(services.discordService, "updateChannel").mockResolvedValue(mockChannel);
+        vi.spyOn(services.discordService, "getGuild").mockRejectedValue(new Error("Discord unavailable"));
+        vi.spyOn(services.discordService, "getGuildMember").mockResolvedValue(aGuildMemberWith({}));
+        vi.spyOn(services.discordService, "hasPermissions").mockReturnValue({
+          hasAll: true,
+          missing: [],
+        });
+
+        const mockMatches = [Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"))];
+        vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue(mockMatches);
+        const kvGetSpy: MockInstance = vi.spyOn(env.APP_DATA, "get");
+        kvGetSpy.mockResolvedValue(mockMatches[0]);
+        vi.spyOn(services.haloService, "getSeriesScore").mockImplementation((_matches, _locale, includeEmoji) =>
+          includeEmoji === true ? "🦅 1:0 🐍" : "1:0",
+        );
+        vi.spyOn(services.haloService, "getGameTypeAndMap").mockResolvedValue("Slayer on Aquarius");
+        vi.spyOn(haloDuration, "getReadableDuration").mockReturnValue("5:00");
+        vi.spyOn(services.haloService, "getMatchScore").mockReturnValue({ gameScore: "50:49", gameSubScore: null });
+        vi.spyOn(services.discordService, "editMessage").mockResolvedValue(apiMessage);
+        vi.spyOn(services.discordService, "createMessage").mockResolvedValue({
+          ...apiMessage,
+          id: "new-message-id",
+        });
+        vi.spyOn(services.discordService, "deleteMessage").mockResolvedValue(undefined);
+
+        await liveTrackerDO.alarm();
+
+        const persistedTrackerState = storagePutSpy.mock.calls.at(-1)?.[1];
+        expect(persistedTrackerState?.localeCache).toBeUndefined();
       });
 
       it("removes existing series score before adding new one", async (): Promise<void> => {

--- a/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
+++ b/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
@@ -2228,12 +2228,14 @@ describe("LiveTrackerDO", () => {
         };
         vi.spyOn(services.discordService, "getChannel").mockResolvedValue(mockChannel);
         vi.spyOn(services.discordService, "updateChannel").mockResolvedValue(mockChannel);
-        vi.spyOn(services.discordService, "getGuild").mockRejectedValue(new Error("Discord unavailable"));
+        const discordUnavailableError = new Error("Discord unavailable");
+        vi.spyOn(services.discordService, "getGuild").mockRejectedValue(discordUnavailableError);
         vi.spyOn(services.discordService, "getGuildMember").mockResolvedValue(aGuildMemberWith({}));
         vi.spyOn(services.discordService, "hasPermissions").mockReturnValue({
           hasAll: true,
           missing: [],
         });
+        const warnSpy = vi.spyOn(services.logService, "warn").mockImplementation(() => undefined);
 
         const mockMatches = [Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer"))];
         vi.spyOn(services.haloService, "getSeriesFromDiscordQueue").mockResolvedValue(mockMatches);
@@ -2256,6 +2258,13 @@ describe("LiveTrackerDO", () => {
 
         const persistedTrackerState = storagePutSpy.mock.calls.at(-1)?.[1];
         expect(persistedTrackerState?.localeCache).toBeUndefined();
+        expect(warnSpy).toHaveBeenCalledWith(
+          "LiveTracker: Failed to resolve guild locale, falling back to English",
+          new Map([
+            ["guildId", "test-guild-id"],
+            ["error", String(discordUnavailableError)],
+          ]),
+        );
       });
 
       it("removes existing series score before adding new one", async (): Promise<void> => {

--- a/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
+++ b/api/durable-objects/live-tracker/tests/live-tracker-do.test.ts
@@ -606,7 +606,7 @@ describe("LiveTrackerDO", () => {
       expect(forceArg).toBe(true);
     });
 
-    it("persists the resolved guild locale so it isn't refetched on the next alarm tick", async () => {
+    it("persists the resolved guild locale in trackerState during handleStart", async () => {
       const startData = createMockStartData();
       const request = new Request("http://do/start", {
         method: "POST",
@@ -629,7 +629,7 @@ describe("LiveTrackerDO", () => {
       expect(response.status).toBe(200);
       const data: { success: boolean; state: LiveTrackerState } = await response.json();
       expect(data.state.localeCache).toBe(Locale.German);
-      expect(getGuildSpy).toHaveBeenCalledOnce();
+      expect(getGuildSpy).toHaveBeenCalled();
 
       const persistedTrackerState = storagePutSpy.mock.calls.at(-1)?.[1];
       expect(persistedTrackerState?.localeCache).toBe(Locale.German);

--- a/api/durable-objects/live-tracker/types.ts
+++ b/api/durable-objects/live-tracker/types.ts
@@ -49,6 +49,7 @@ export interface LiveTrackerState {
     substitutionCount: number;
   };
   channelManagePermissionCache?: boolean;
+  localeCache?: string;
   lastRefreshAttempt?: string;
   refreshInProgress?: boolean;
   refreshStartedAt?: string | undefined;

--- a/api/services/discord/discord-series-stats.ts
+++ b/api/services/discord/discord-series-stats.ts
@@ -134,6 +134,7 @@ export async function buildDiscordSeriesRenderDataFromMatches({
   guildId,
   queueNumber,
   matches,
+  locale,
 }: {
   discordService: DiscordService;
   logService: LogService;
@@ -141,6 +142,7 @@ export async function buildDiscordSeriesRenderDataFromMatches({
   guildId: string;
   queueNumber: number;
   matches: MatchStats[];
+  locale?: string;
 }): Promise<DiscordSeriesStatsResolved["renderData"]> {
   if (matches.length === 0) {
     throw new Error("No Halo match details were found for discovered match IDs");
@@ -150,9 +152,9 @@ export async function buildDiscordSeriesRenderDataFromMatches({
     left.MatchInfo.StartTime.localeCompare(right.MatchInfo.StartTime),
   );
 
-  const [playerXuidToGametagMap, locale] = await Promise.all([
+  const [playerXuidToGametagMap, resolvedLocale] = await Promise.all([
     haloService.getPlayerXuidsToGametags(sortedMatches, { presentAtBeginningOnly: true }),
-    discordService.getGuildPreferredLocale(guildId),
+    locale ?? discordService.getGuildPreferredLocale(guildId),
   ]);
 
   const renderMatches = await Promise.all(
@@ -162,7 +164,7 @@ export async function buildDiscordSeriesRenderDataFromMatches({
         haloService.getMapThumbnailUrl(match.MatchInfo.MapVariant.AssetId, match.MatchInfo.MapVariant.VersionId),
       ]);
       const { gameType, gameMap } = splitGameTypeAndMap(gameTypeAndMap);
-      const { gameScore, gameSubScore } = haloService.getMatchScore(match, locale);
+      const { gameScore, gameSubScore } = haloService.getMatchScore(match, resolvedLocale);
 
       const playerXuidToGametag: Record<string, string> = {};
       for (const player of match.Players) {
@@ -181,7 +183,7 @@ export async function buildDiscordSeriesRenderDataFromMatches({
         gameType,
         gameMap,
         gameMapThumbnailUrl: mapThumbnailUrl ?? "data:,",
-        duration: getReadableDuration(match.MatchInfo.Duration, locale),
+        duration: getReadableDuration(match.MatchInfo.Duration, resolvedLocale),
         gameScore,
         gameSubScore,
         startTime: new Date(match.MatchInfo.StartTime).toISOString(),
@@ -210,7 +212,7 @@ export async function buildDiscordSeriesRenderDataFromMatches({
   return {
     title: `Queue #${queueNumber.toString()} Series Stats`,
     subtitle,
-    seriesScore: haloService.getSeriesScore(sortedMatches, locale),
+    seriesScore: haloService.getSeriesScore(sortedMatches, resolvedLocale),
     teams,
     matches: renderMatches,
   };

--- a/api/services/discord/discord-series-stats.ts
+++ b/api/services/discord/discord-series-stats.ts
@@ -150,9 +150,10 @@ export async function buildDiscordSeriesRenderDataFromMatches({
     left.MatchInfo.StartTime.localeCompare(right.MatchInfo.StartTime),
   );
 
-  const playerXuidToGametagMap = await haloService.getPlayerXuidsToGametags(sortedMatches, {
-    presentAtBeginningOnly: true,
-  });
+  const [playerXuidToGametagMap, locale] = await Promise.all([
+    haloService.getPlayerXuidsToGametags(sortedMatches, { presentAtBeginningOnly: true }),
+    discordService.getGuildPreferredLocale(guildId),
+  ]);
 
   const renderMatches = await Promise.all(
     sortedMatches.map(async (match) => {
@@ -161,7 +162,7 @@ export async function buildDiscordSeriesRenderDataFromMatches({
         haloService.getMapThumbnailUrl(match.MatchInfo.MapVariant.AssetId, match.MatchInfo.MapVariant.VersionId),
       ]);
       const { gameType, gameMap } = splitGameTypeAndMap(gameTypeAndMap);
-      const { gameScore, gameSubScore } = haloService.getMatchScore(match, "en-US");
+      const { gameScore, gameSubScore } = haloService.getMatchScore(match, locale);
 
       const playerXuidToGametag: Record<string, string> = {};
       for (const player of match.Players) {
@@ -180,7 +181,7 @@ export async function buildDiscordSeriesRenderDataFromMatches({
         gameType,
         gameMap,
         gameMapThumbnailUrl: mapThumbnailUrl ?? "data:,",
-        duration: getReadableDuration(match.MatchInfo.Duration, "en-US"),
+        duration: getReadableDuration(match.MatchInfo.Duration, locale),
         gameScore,
         gameSubScore,
         startTime: new Date(match.MatchInfo.StartTime).toISOString(),
@@ -209,7 +210,7 @@ export async function buildDiscordSeriesRenderDataFromMatches({
   return {
     title: `Queue #${queueNumber.toString()} Series Stats`,
     subtitle,
-    seriesScore: haloService.getSeriesScore(sortedMatches, "en-US"),
+    seriesScore: haloService.getSeriesScore(sortedMatches, locale),
     teams,
     matches: renderMatches,
   };

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -203,7 +203,6 @@ export class DiscordService {
   private readonly verifyKey: typeof discordInteractionsVerifyKey;
   private commands: Map<string, BaseCommand> | undefined = undefined;
   private readonly guildMemberCache = new Map<string, APIGuildMember>();
-  private readonly guildCache = new Map<string, APIGuild>();
   private readonly rateLimitDebounceMap = new Map<string, { timeout: NodeJS.Timeout; data: string }>();
 
   constructor({ env, logService, fetch, verifyKey }: DiscordServiceOpts) {
@@ -983,17 +982,10 @@ export class DiscordService {
   }
 
   async getGuild(guildId: string): Promise<APIGuild> {
-    if (!this.guildCache.has(guildId)) {
-      const guild = await this.fetch<APIGuild>(Routes.guild(guildId), {
-        method: "GET",
-        cf: {
-          cacheTtlByStatus: { "200-299": TimeInSeconds["1_MINUTE"], 404: TimeInSeconds["1_MINUTE"], "500-599": 0 },
-        },
-      });
-      this.guildCache.set(guildId, guild);
-    }
-
-    return Preconditions.checkExists(this.guildCache.get(guildId));
+    return this.fetch<APIGuild>(Routes.guild(guildId), {
+      method: "GET",
+      cf: { cacheTtlByStatus: { "200-299": TimeInSeconds["1_MINUTE"], 404: TimeInSeconds["1_MINUTE"], "500-599": 0 } },
+    });
   }
 
   async getGuildPreferredLocale(guildId: string): Promise<Locale> {

--- a/api/services/discord/discord.ts
+++ b/api/services/discord/discord.ts
@@ -203,6 +203,7 @@ export class DiscordService {
   private readonly verifyKey: typeof discordInteractionsVerifyKey;
   private commands: Map<string, BaseCommand> | undefined = undefined;
   private readonly guildMemberCache = new Map<string, APIGuildMember>();
+  private readonly guildCache = new Map<string, APIGuild>();
   private readonly rateLimitDebounceMap = new Map<string, { timeout: NodeJS.Timeout; data: string }>();
 
   constructor({ env, logService, fetch, verifyKey }: DiscordServiceOpts) {
@@ -982,10 +983,17 @@ export class DiscordService {
   }
 
   async getGuild(guildId: string): Promise<APIGuild> {
-    return this.fetch<APIGuild>(Routes.guild(guildId), {
-      method: "GET",
-      cf: { cacheTtlByStatus: { "200-299": TimeInSeconds["1_MINUTE"], 404: TimeInSeconds["1_MINUTE"], "500-599": 0 } },
-    });
+    if (!this.guildCache.has(guildId)) {
+      const guild = await this.fetch<APIGuild>(Routes.guild(guildId), {
+        method: "GET",
+        cf: {
+          cacheTtlByStatus: { "200-299": TimeInSeconds["1_MINUTE"], 404: TimeInSeconds["1_MINUTE"], "500-599": 0 },
+        },
+      });
+      this.guildCache.set(guildId, guild);
+    }
+
+    return Preconditions.checkExists(this.guildCache.get(guildId));
   }
 
   async getGuildPreferredLocale(guildId: string): Promise<Locale> {

--- a/api/services/discord/tests/discord-series-stats.test.ts
+++ b/api/services/discord/tests/discord-series-stats.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { Locale } from "discord-api-types/v10";
+import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import { buildDiscordSeriesRenderDataFromMatches } from "../discord-series-stats";
+import { aFakeDiscordServiceWith } from "../fakes/discord.fake";
+import { aFakeHaloServiceWith } from "../../halo/fakes/halo.fake";
+import { aFakeLogServiceWith } from "../../log/fakes/log.fake";
+import { getMatchStats } from "../../halo/fakes/data";
+import { guild } from "../fakes/data";
+
+describe("buildDiscordSeriesRenderDataFromMatches()", () => {
+  it("uses the guild's preferred locale instead of a hardcoded locale", async () => {
+    const discordService = aFakeDiscordServiceWith();
+    vi.spyOn(discordService, "getGuild").mockResolvedValue({ ...guild, preferred_locale: Locale.German });
+
+    const haloService = aFakeHaloServiceWith();
+    const getMatchScoreSpy = vi.spyOn(haloService, "getMatchScore");
+    const getSeriesScoreSpy = vi.spyOn(haloService, "getSeriesScore");
+
+    const match = Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf"));
+
+    await buildDiscordSeriesRenderDataFromMatches({
+      discordService,
+      logService: aFakeLogServiceWith(),
+      haloService,
+      guildId: "fake-guild-id",
+      queueNumber: 1,
+      matches: [match],
+    });
+
+    expect(getMatchScoreSpy).toHaveBeenCalledWith(match, Locale.German);
+    expect(getSeriesScoreSpy).toHaveBeenCalledWith([match], Locale.German);
+  });
+});

--- a/api/services/discord/tests/discord.test.ts
+++ b/api/services/discord/tests/discord.test.ts
@@ -1259,16 +1259,6 @@ describe("DiscordService", () => {
 
       expect(result).toEqual(guild);
     });
-
-    it("caches the guild for repeated calls with the same guildId", async () => {
-      await discordService.getGuild("fake-guild-id");
-      await discordService.getGuild("fake-guild-id");
-
-      const guildFetchCalls = mockFetch.mock.calls.filter(
-        ([path]) => path === "https://discord.com/api/v10/guilds/fake-guild-id",
-      );
-      expect(guildFetchCalls).toHaveLength(1);
-    });
   });
 
   describe("getGuildPreferredLocale()", () => {

--- a/api/services/discord/tests/discord.test.ts
+++ b/api/services/discord/tests/discord.test.ts
@@ -117,6 +117,9 @@ describe("DiscordService", () => {
       if (path === `${prefix}/channels/fake-channel/messages/fake-message-delete`) {
         return Promise.resolve(new Response(null, { status: 204 }));
       }
+      if (path === `${prefix}/guilds/fake-guild-id`) {
+        return Promise.resolve(new Response(JSON.stringify(guild)));
+      }
 
       return Promise.reject(new Error(`Invalid path: ${path}`));
     });
@@ -1247,6 +1250,24 @@ describe("DiscordService", () => {
       const url = discordService.getGuildIconUrl("fake-guild-id", null);
 
       expect(url).toBeNull();
+    });
+  });
+
+  describe("getGuild()", () => {
+    it("fetches the guild from the Discord API", async () => {
+      const result = await discordService.getGuild("fake-guild-id");
+
+      expect(result).toEqual(guild);
+    });
+
+    it("caches the guild for repeated calls with the same guildId", async () => {
+      await discordService.getGuild("fake-guild-id");
+      await discordService.getGuild("fake-guild-id");
+
+      const guildFetchCalls = mockFetch.mock.calls.filter(
+        ([path]) => path === "https://discord.com/api/v10/guilds/fake-guild-id",
+      );
+      expect(guildFetchCalls).toHaveLength(1);
     });
   });
 

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -365,7 +365,7 @@ export class NeatQueueService {
         await discordService.updateDeferredReply(interaction.token, data);
       }
 
-      await this.cacheDiscordSeriesStats(guildId, queue, series);
+      await this.cacheDiscordSeriesStats(guildId, queue, series, locale);
 
       if (channel.type !== ChannelType.PublicThread && channel.type !== ChannelType.AnnouncementThread) {
         const thread = await discordService.startThreadFromMessage(
@@ -1488,13 +1488,15 @@ export class NeatQueueService {
       timeline: NeatQueueTimelineEvent[];
     },
   ): Promise<void> {
+    const locale = await this.discordService.getGuildPreferredLocale(opts.neatQueueConfig.GuildId);
+
     switch (mode) {
       case NeatQueuePostSeriesDisplayMode.THREAD:
-        await this.postSeriesDataByThread(opts);
+        await this.postSeriesDataByThread({ ...opts, locale });
         break;
       case NeatQueuePostSeriesDisplayMode.MESSAGE:
       case NeatQueuePostSeriesDisplayMode.CHANNEL:
-        await this.postSeriesDataByChannel(opts);
+        await this.postSeriesDataByChannel({ ...opts, locale });
         break;
       default:
         throw new UnreachableError(mode);
@@ -2094,11 +2096,13 @@ export class NeatQueueService {
     neatQueueConfig,
     series,
     timeline,
+    locale,
   }: {
     request: NeatQueueMatchCompletedRequest;
     neatQueueConfig: NeatQueueConfigRow;
     series: MatchStats[];
     timeline: NeatQueueTimelineEvent[];
+    locale: string;
   }): Promise<void> {
     const { discordService } = this;
     let foundResultsMessage = false;
@@ -2106,7 +2110,6 @@ export class NeatQueueService {
     let thread: RESTPostAPIChannelThreadsResult | undefined;
 
     try {
-      const locale = await discordService.getGuildPreferredLocale(neatQueueConfig.GuildId);
       const resultsMessage = await discordService.getTeamsFromQueueResult(
         neatQueueConfig.GuildId,
         neatQueueConfig.ResultsChannelId,
@@ -2140,7 +2143,7 @@ export class NeatQueueService {
       });
 
       await Promise.all([
-        this.cacheDiscordSeriesStats(request.guild, request.match_number, series),
+        this.cacheDiscordSeriesStats(request.guild, request.match_number, series, locale),
         this.leaderboardService.persistSeriesData({ request, neatQueueConfig, series, locale }),
         this.postSeriesDetailsToChannel(thread.id, request.guild, series, locale),
       ]);
@@ -2154,7 +2157,7 @@ export class NeatQueueService {
       if (useFallback) {
         this.logService.info("Attempting to post direct to channel");
 
-        await this.postSeriesDataByChannel({ request, neatQueueConfig, series, timeline });
+        await this.postSeriesDataByChannel({ request, neatQueueConfig, series, timeline, locale });
       } else if (thread != null) {
         this.logService.info("Attempting to post error to thread");
 
@@ -2218,17 +2221,18 @@ export class NeatQueueService {
     neatQueueConfig,
     series,
     timeline,
+    locale,
   }: {
     request: NeatQueueMatchCompletedRequest;
     neatQueueConfig: NeatQueueConfigRow;
     series: MatchStats[];
     timeline: NeatQueueTimelineEvent[];
+    locale: string;
   }): Promise<void> {
     const { discordService } = this;
     let channelId = neatQueueConfig.PostSeriesChannelId ?? neatQueueConfig.ResultsChannelId;
 
     try {
-      const locale = await discordService.getGuildPreferredLocale(neatQueueConfig.GuildId);
       const resultsMessage = await discordService.getTeamsFromQueueResult(
         neatQueueConfig.GuildId,
         neatQueueConfig.ResultsChannelId,
@@ -2261,7 +2265,7 @@ export class NeatQueueService {
 
       channelId = thread.id;
       await Promise.all([
-        this.cacheDiscordSeriesStats(request.guild, request.match_number, series),
+        this.cacheDiscordSeriesStats(request.guild, request.match_number, series, locale),
         this.leaderboardService.persistSeriesData({ request, neatQueueConfig, series, locale }),
         this.postSeriesDetailsToChannel(channelId, request.guild, series, locale),
       ]);
@@ -2433,7 +2437,12 @@ export class NeatQueueService {
     });
   }
 
-  private async cacheDiscordSeriesStats(guildId: string, queueNumber: number, series: MatchStats[]): Promise<void> {
+  private async cacheDiscordSeriesStats(
+    guildId: string,
+    queueNumber: number,
+    series: MatchStats[],
+    locale: string,
+  ): Promise<void> {
     const { discordService, haloService, logService } = this;
 
     try {
@@ -2444,6 +2453,7 @@ export class NeatQueueService {
         guildId,
         queueNumber,
         matches: series,
+        locale,
       });
 
       await discordService.cacheResolvedDiscordSeriesStats({

--- a/api/services/neatqueue/neatqueue.ts
+++ b/api/services/neatqueue/neatqueue.ts
@@ -86,7 +86,6 @@ export class NeatQueueService {
   private readonly leaderboardService: LeaderboardService;
   private readonly liveTrackerService: LiveTrackerService;
   private readonly individualTrackerService: IndividualTrackerService;
-  private readonly locale = "en-US";
   private readonly queueStateCache = new Map<string, NeatQueueState>();
 
   constructor({
@@ -338,6 +337,8 @@ export class NeatQueueService {
         }
       }
 
+      const locale = await discordService.getGuildPreferredLocale(guildId);
+
       const seriesOverviewEmbed = await this.getSeriesOverviewEmbed({
         guildId,
         channelId: queueMessage.message.channel_id,
@@ -349,6 +350,7 @@ export class NeatQueueService {
           playerIds: team.players.map((player) => player.user.id),
         })),
         substitutions: substitutionsEmbed,
+        locale,
       });
 
       let threadId = channelId;
@@ -369,12 +371,12 @@ export class NeatQueueService {
         const thread = await discordService.startThreadFromMessage(
           channelId,
           messageId,
-          `Queue #${queue.toString()} series stats (${haloService.getSeriesScore(series, "en-US", true)})`,
+          `Queue #${queue.toString()} series stats (${haloService.getSeriesScore(series, locale, true)})`,
         );
         threadId = thread.id;
       }
 
-      await this.postSeriesDetailsToChannel(threadId, guildId, series);
+      await this.postSeriesDetailsToChannel(threadId, guildId, series, locale);
     } catch (error) {
       if (error instanceof EndUserError) {
         if (error.handled) {
@@ -2104,6 +2106,7 @@ export class NeatQueueService {
     let thread: RESTPostAPIChannelThreadsResult | undefined;
 
     try {
+      const locale = await discordService.getGuildPreferredLocale(neatQueueConfig.GuildId);
       const resultsMessage = await discordService.getTeamsFromQueueResult(
         neatQueueConfig.GuildId,
         neatQueueConfig.ResultsChannelId,
@@ -2115,7 +2118,7 @@ export class NeatQueueService {
       thread = await discordService.startThreadFromMessage(
         channelId,
         messageId,
-        `Queue #${request.match_number.toString()} series stats (${this.haloService.getSeriesScore(series, "en-US", true)})`,
+        `Queue #${request.match_number.toString()} series stats (${this.haloService.getSeriesScore(series, locale, true)})`,
       );
       useFallback = false;
 
@@ -2129,6 +2132,7 @@ export class NeatQueueService {
         series,
         finalTeams,
         substitutions,
+        locale,
       });
       await discordService.createMessage(thread.id, {
         embeds: seriesOverviewEmbed.embeds,
@@ -2137,8 +2141,8 @@ export class NeatQueueService {
 
       await Promise.all([
         this.cacheDiscordSeriesStats(request.guild, request.match_number, series),
-        this.leaderboardService.persistSeriesData({ request, neatQueueConfig, series, locale: this.locale }),
-        this.postSeriesDetailsToChannel(thread.id, request.guild, series),
+        this.leaderboardService.persistSeriesData({ request, neatQueueConfig, series, locale }),
+        this.postSeriesDetailsToChannel(thread.id, request.guild, series, locale),
       ]);
     } catch (error) {
       this.logService.warn(error, new Map([["reason", "Failed to post series data to thread"]]));
@@ -2224,6 +2228,7 @@ export class NeatQueueService {
     let channelId = neatQueueConfig.PostSeriesChannelId ?? neatQueueConfig.ResultsChannelId;
 
     try {
+      const locale = await discordService.getGuildPreferredLocale(neatQueueConfig.GuildId);
       const resultsMessage = await discordService.getTeamsFromQueueResult(
         neatQueueConfig.GuildId,
         neatQueueConfig.ResultsChannelId,
@@ -2240,6 +2245,7 @@ export class NeatQueueService {
         series: series,
         finalTeams,
         substitutions,
+        locale,
       });
 
       const createdMessage = await discordService.createMessage(channelId, {
@@ -2250,14 +2256,14 @@ export class NeatQueueService {
       const thread = await discordService.startThreadFromMessage(
         channelId,
         createdMessage.id,
-        `Queue #${request.match_number.toString()} series stats (${this.haloService.getSeriesScore(series, "en-US", true)})`,
+        `Queue #${request.match_number.toString()} series stats (${this.haloService.getSeriesScore(series, locale, true)})`,
       );
 
       channelId = thread.id;
       await Promise.all([
         this.cacheDiscordSeriesStats(request.guild, request.match_number, series),
-        this.leaderboardService.persistSeriesData({ request, neatQueueConfig, series, locale: this.locale }),
-        this.postSeriesDetailsToChannel(channelId, request.guild, series),
+        this.leaderboardService.persistSeriesData({ request, neatQueueConfig, series, locale }),
+        this.postSeriesDetailsToChannel(channelId, request.guild, series, locale),
       ]);
     } catch (error) {
       this.logService.error(error, new Map([["reason", "Failed to post series data direct to channel"]]));
@@ -2328,12 +2334,17 @@ export class NeatQueueService {
     }
   }
 
-  private async postSeriesDetailsToChannel(channelId: string, guildId: string, series: MatchStats[]): Promise<void> {
+  private async postSeriesDetailsToChannel(
+    channelId: string,
+    guildId: string,
+    series: MatchStats[],
+    locale: string,
+  ): Promise<void> {
     const { databaseService, discordService, haloService } = this;
 
     const guildConfig = await databaseService.getGuildConfig(guildId);
 
-    const seriesTeamsEmbed = new SeriesTeamsEmbed({ discordService, haloService, guildConfig, locale: this.locale });
+    const seriesTeamsEmbed = new SeriesTeamsEmbed({ discordService, haloService, guildConfig, locale });
     const seriesTeamsEmbedOutput = await seriesTeamsEmbed.getSeriesEmbed(series);
     await discordService.createMessage(channelId, {
       embeds: [seriesTeamsEmbedOutput],
@@ -2346,9 +2357,9 @@ export class NeatQueueService {
       discordService,
       haloService,
       guildConfig,
-      locale: this.locale,
+      locale,
     });
-    const seriesPlayersEmbedsOutput = await seriesPlayersEmbed.getSeriesEmbed(series, seriesPlayers, this.locale);
+    const seriesPlayersEmbedsOutput = await seriesPlayersEmbed.getSeriesEmbed(series, seriesPlayers, locale);
     for (const seriesPlayersEmbedOutput of seriesPlayersEmbedsOutput) {
       await discordService.createMessage(channelId, {
         embeds: [seriesPlayersEmbedOutput],
@@ -2379,7 +2390,7 @@ export class NeatQueueService {
         const players = await haloService.getPlayerXuidsToGametags(match, {
           presentAtBeginningOnly: true,
         });
-        const matchEmbed = this.getMatchEmbed(guildConfig, match, this.locale);
+        const matchEmbed = this.getMatchEmbed(guildConfig, match, locale);
         const embed = await matchEmbed.getEmbed(match, players);
 
         await discordService.createMessage(channelId, { embeds: [embed] });
@@ -2395,6 +2406,7 @@ export class NeatQueueService {
     series,
     finalTeams,
     substitutions,
+    locale,
   }: {
     guildId: string;
     channelId: string;
@@ -2403,6 +2415,7 @@ export class NeatQueueService {
     series: MatchStats[];
     finalTeams: TeamMapping[];
     substitutions: SeriesOverviewEmbedSubstitution[];
+    locale: string;
   }): Promise<SeriesOverviewEmbedOutput> {
     const { discordService, haloService } = this;
     const seriesOverviewEmbed = new SeriesOverviewEmbed({ discordService, haloService });
@@ -2411,7 +2424,7 @@ export class NeatQueueService {
       channelId,
       messageId,
       pagesUrl: this.env.PAGES_URL,
-      locale: this.locale,
+      locale,
       queue,
       series,
       finalTeams,

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -1299,6 +1299,7 @@ describe("NeatQueueService", () => {
           it("falls back to creating a message in post series channel if it fails to create thread", async () => {
             const error = new Error("Failed to create thread");
             const logServiceWarnSpy = vi.spyOn(logService, "warn");
+            const getGuildPreferredLocaleSpy = vi.spyOn(discordService, "getGuildPreferredLocale");
 
             discordServiceStartThreadFromMessageSpy
               .mockReset()
@@ -1325,6 +1326,10 @@ describe("NeatQueueService", () => {
             expect(discordServiceCreateMessageSpy.mock.calls[0]).toMatchSnapshot();
             expect(discordServiceCreateMessageSpy).toHaveBeenNthCalledWith(2, "thread-id-2", expect.any(Object));
             expect(discordServiceCreateMessageSpy).toHaveBeenNthCalledWith(3, "thread-id-2", expect.any(Object));
+
+            // The locale resolved for the initial thread attempt is reused for the channel fallback,
+            // instead of being fetched again from Discord.
+            expect(getGuildPreferredLocaleSpy).toHaveBeenCalledOnce();
           });
         }
       });

--- a/api/services/neatqueue/tests/neatqueue.test.ts
+++ b/api/services/neatqueue/tests/neatqueue.test.ts
@@ -7,7 +7,7 @@ import type {
   APIEmbed,
   APIGuildMember,
 } from "discord-api-types/v10";
-import { ChannelType } from "discord-api-types/v10";
+import { ChannelType, Locale } from "discord-api-types/v10";
 import { sub } from "date-fns";
 import type { LiveTrackerMatchSummary } from "@guilty-spark/shared/live-tracker/types";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
@@ -937,6 +937,21 @@ describe("NeatQueueService", () => {
           expect(resolvedPersistArg.neatQueueConfig.ResultsChannelId).toBe("results-channel-1");
           expect(resolvedPersistArg.locale).toBe("en-US");
           expect(Array.isArray(resolvedPersistArg.series)).toBe(true);
+        });
+
+        it("uses the guild's preferred locale instead of a hardcoded locale", async () => {
+          vi.spyOn(discordService, "getGuild").mockResolvedValue({ ...guild, preferred_locale: Locale.German });
+
+          const { jobToComplete } = neatQueueService.handleRequest(
+            getFakeNeatQueueData("matchCompleted"),
+            neatQueueConfig,
+          );
+
+          await jobToComplete?.();
+
+          expect(persistSeriesDataSpy).toHaveBeenCalledOnce();
+          const [persistArg] = persistSeriesDataSpy.mock.calls[0] ?? [];
+          expect(Preconditions.checkExists(persistArg).locale).toBe(Locale.German);
         });
 
         it("creates the thread/message and posts overviews and game stats, clears timeline", async () => {

--- a/shared/src/contracts/durable-objects/live-tracker/lifecycle.ts
+++ b/shared/src/contracts/durable-objects/live-tracker/lifecycle.ts
@@ -48,6 +48,7 @@ export const liveTrackerStateSchema = z.object({
     substitutionCount: z.number(),
   }),
   channelManagePermissionCache: z.boolean().optional(),
+  localeCache: z.string().optional(),
   lastRefreshAttempt: z.string().optional(),
   refreshInProgress: z.boolean().optional(),
   refreshStartedAt: z.string().optional(),


### PR DESCRIPTION
## Context

`DiscordService.getGuildPreferredLocale()` was added recently but never used — meanwhile a bunch of code across the API paths guild-scoped Discord content (series stats embeds, thread titles, leaderboard persistence, live tracker) hardcoded `"en-US"` instead of using the guild's actual preferred locale.

## This change

- Threads `getGuildPreferredLocale()` through every call site that had a guild in scope: `NeatQueueService`, `discord-series-stats.ts`, `StatsCommand`, and `LiveTrackerDO`. Sites without a guild in scope (the individual-tracker viewer widgets, the public series-matches route, the Halo API's own Accept-Language header) were left alone since there's no guild locale to apply there.
- Fetches the locale once per logical operation and threads it as a parameter, rather than re-fetching at each step — including through the NeatQueue thread→channel posting fallback path, which previously would have refetched.
- Caches the resolved locale on `LiveTrackerState` so a 3-minute-interval live tracker doesn't refetch it every alarm tick, while making sure a transient Discord API failure doesn't permanently lock the tracker into English for the rest of its (potentially multi-hour) session — only successful lookups get cached.
- Adds the missing `localeCache` field to the shared live-tracker lifecycle Zod schema, which was silently stripping it from DO lifecycle API responses.
- Persists `LiveTrackerDO`'s state at the end of `handleStart` so the resolved locale (and other state set up during start) survives into the first alarm tick instead of being discarded.

An earlier version of this change also added an in-memory cache to `DiscordService.getGuild()`. A code review caught that this was the wrong fix — since `LiveTrackerDO` holds one `DiscordService` instance for its entire multi-hour session, that cache made guild name/icon/permissions permanently stale for connected viewers. It's been removed in favor of fixing the actual duplicate-fetch case directly (parameter threading) and relying on the existing 1-minute Cloudflare edge cache for cross-request caching.

## Subsequent work

- The pages workspace has a handful of `javascript-time-ago` locale usages (individual tracker viewer, live tracker OBS overlay) that are also hardcoded to `"en"`, with some duplicate/inconsistent locale-registration code. That's unrelated to Discord guild locale (no guild context on those pages, and the browser is the only locale signal available client-side), so it'll be handled as a separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)