### PR TITLE
Consolidate javascript-time-ago locale registration

### DIFF
--- a/pages/src/apps/individual-tracker-overlay/create.tsx
+++ b/pages/src/apps/individual-tracker-overlay/create.tsx
@@ -4,6 +4,7 @@ import { ComponentLoader, ComponentLoaderStatus } from "../../components/compone
 import { ErrorState } from "../../components/error-state/error-state";
 import { LoadingState } from "../../components/loading-state/loading-state";
 import { createIndividualTrackerOverlayPage } from "../../components/individual-tracker/overlay/create";
+import "../../services/time-ago";
 import type { Services } from "../individual-tracker-viewer/services";
 import { installServices } from "../individual-tracker-viewer/services";
 

--- a/pages/src/apps/individual-tracker-overlay/tests/time-ago-registration.test.ts
+++ b/pages/src/apps/individual-tracker-overlay/tests/time-ago-registration.test.ts
@@ -1,9 +1,16 @@
-import { describe, it } from "vitest";
-import { expectTimeAgoLocaleRegistered } from "../../../services/tests/time-ago-test-helpers";
+import { beforeEach, describe, it, vi } from "vitest";
+import { expectTimeAgoLocaleRegistered, spyOnTimeAgoAddLocale } from "../../../services/tests/time-ago-test-helpers";
 
 describe("individual-tracker-overlay app entry", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
   it("registers the time-ago en locale so react-time-ago can render without throwing", async () => {
+    const addLocaleSpy = spyOnTimeAgoAddLocale();
+
     await import("../create");
-    await expectTimeAgoLocaleRegistered();
+
+    expectTimeAgoLocaleRegistered(addLocaleSpy);
   });
 });

--- a/pages/src/apps/individual-tracker-overlay/tests/time-ago-registration.test.ts
+++ b/pages/src/apps/individual-tracker-overlay/tests/time-ago-registration.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+describe("individual-tracker-overlay app entry", () => {
+  it("registers the time-ago en locale so react-time-ago can render without throwing", async () => {
+    await import("../create");
+    const { default: TimeAgo } = await import("javascript-time-ago");
+
+    expect(() => new TimeAgo("en").format(new Date())).not.toThrow();
+  });
+});

--- a/pages/src/apps/individual-tracker-overlay/tests/time-ago-registration.test.ts
+++ b/pages/src/apps/individual-tracker-overlay/tests/time-ago-registration.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
+import { expectTimeAgoLocaleRegistered } from "../../../services/tests/time-ago-test-helpers";
 
 describe("individual-tracker-overlay app entry", () => {
   it("registers the time-ago en locale so react-time-ago can render without throwing", async () => {
     await import("../create");
-    const { default: TimeAgo } = await import("javascript-time-ago");
-
-    expect(() => new TimeAgo("en").format(new Date())).not.toThrow();
+    await expectTimeAgoLocaleRegistered();
   });
 });

--- a/pages/src/apps/individual-tracker-viewer/create.tsx
+++ b/pages/src/apps/individual-tracker-viewer/create.tsx
@@ -4,6 +4,7 @@ import { ComponentLoader, ComponentLoaderStatus } from "../../components/compone
 import { ErrorState } from "../../components/error-state/error-state";
 import { LoadingState } from "../../components/loading-state/loading-state";
 import { createIndividualTrackerViewerPage } from "../../components/individual-tracker/viewer/create";
+import "../../services/time-ago";
 import type { Services } from "./services";
 import { installServices } from "./services";
 

--- a/pages/src/apps/individual-tracker-viewer/create.tsx
+++ b/pages/src/apps/individual-tracker-viewer/create.tsx
@@ -1,15 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ReactElement } from "react";
-import TimeAgo from "javascript-time-ago";
-import en from "javascript-time-ago/locale/en";
 import { ComponentLoader, ComponentLoaderStatus } from "../../components/component-loader/component-loader";
 import { ErrorState } from "../../components/error-state/error-state";
 import { LoadingState } from "../../components/loading-state/loading-state";
 import { createIndividualTrackerViewerPage } from "../../components/individual-tracker/viewer/create";
 import type { Services } from "./services";
 import { installServices } from "./services";
-
-TimeAgo.addDefaultLocale(en);
 
 interface IndividualTrackerViewerAppProps {
   readonly apiHost: string;

--- a/pages/src/apps/individual-tracker-viewer/tests/time-ago-registration.test.ts
+++ b/pages/src/apps/individual-tracker-viewer/tests/time-ago-registration.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
+import { expectTimeAgoLocaleRegistered } from "../../../services/tests/time-ago-test-helpers";
 
 describe("individual-tracker-viewer app entry", () => {
   it("registers the time-ago en locale so react-time-ago can render without throwing", async () => {
     await import("../create");
-    const { default: TimeAgo } = await import("javascript-time-ago");
-
-    expect(() => new TimeAgo("en").format(new Date())).not.toThrow();
+    await expectTimeAgoLocaleRegistered();
   });
 });

--- a/pages/src/apps/individual-tracker-viewer/tests/time-ago-registration.test.ts
+++ b/pages/src/apps/individual-tracker-viewer/tests/time-ago-registration.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+describe("individual-tracker-viewer app entry", () => {
+  it("registers the time-ago en locale so react-time-ago can render without throwing", async () => {
+    await import("../create");
+    const { default: TimeAgo } = await import("javascript-time-ago");
+
+    expect(() => new TimeAgo("en").format(new Date())).not.toThrow();
+  });
+});

--- a/pages/src/apps/individual-tracker-viewer/tests/time-ago-registration.test.ts
+++ b/pages/src/apps/individual-tracker-viewer/tests/time-ago-registration.test.ts
@@ -1,9 +1,16 @@
-import { describe, it } from "vitest";
-import { expectTimeAgoLocaleRegistered } from "../../../services/tests/time-ago-test-helpers";
+import { beforeEach, describe, it, vi } from "vitest";
+import { expectTimeAgoLocaleRegistered, spyOnTimeAgoAddLocale } from "../../../services/tests/time-ago-test-helpers";
 
 describe("individual-tracker-viewer app entry", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
   it("registers the time-ago en locale so react-time-ago can render without throwing", async () => {
+    const addLocaleSpy = spyOnTimeAgoAddLocale();
+
     await import("../create");
-    await expectTimeAgoLocaleRegistered();
+
+    expectTimeAgoLocaleRegistered(addLocaleSpy);
   });
 });

--- a/pages/src/apps/live-tracker/create.tsx
+++ b/pages/src/apps/live-tracker/create.tsx
@@ -4,6 +4,7 @@ import { ComponentLoader, ComponentLoaderStatus } from "../../components/compone
 import { ErrorState } from "../../components/error-state/error-state";
 import { LoadingState } from "../../components/loading-state/loading-state";
 import { createLiveTracker } from "../../components/live-tracker/create";
+import "../../services/time-ago";
 import type { Services } from "./services";
 import { installServices } from "./services";
 

--- a/pages/src/apps/live-tracker/create.tsx
+++ b/pages/src/apps/live-tracker/create.tsx
@@ -1,15 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ReactElement } from "react";
-import TimeAgo from "javascript-time-ago";
-import en from "javascript-time-ago/locale/en";
 import { ComponentLoader, ComponentLoaderStatus } from "../../components/component-loader/component-loader";
 import { ErrorState } from "../../components/error-state/error-state";
 import { LoadingState } from "../../components/loading-state/loading-state";
 import { createLiveTracker } from "../../components/live-tracker/create";
 import type { Services } from "./services";
 import { installServices } from "./services";
-
-TimeAgo.addDefaultLocale(en);
 
 interface LiveTrackerAppProps {
   readonly apiHost: string;

--- a/pages/src/apps/live-tracker/tests/time-ago-registration.test.ts
+++ b/pages/src/apps/live-tracker/tests/time-ago-registration.test.ts
@@ -1,9 +1,16 @@
-import { describe, it } from "vitest";
-import { expectTimeAgoLocaleRegistered } from "../../../services/tests/time-ago-test-helpers";
+import { beforeEach, describe, it, vi } from "vitest";
+import { expectTimeAgoLocaleRegistered, spyOnTimeAgoAddLocale } from "../../../services/tests/time-ago-test-helpers";
 
 describe("live-tracker app entry", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
   it("registers the time-ago en locale so react-time-ago can render without throwing", async () => {
+    const addLocaleSpy = spyOnTimeAgoAddLocale();
+
     await import("../create");
-    await expectTimeAgoLocaleRegistered();
+
+    expectTimeAgoLocaleRegistered(addLocaleSpy);
   });
 });

--- a/pages/src/apps/live-tracker/tests/time-ago-registration.test.ts
+++ b/pages/src/apps/live-tracker/tests/time-ago-registration.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+describe("live-tracker app entry", () => {
+  it("registers the time-ago en locale so react-time-ago can render without throwing", async () => {
+    await import("../create");
+    const { default: TimeAgo } = await import("javascript-time-ago");
+
+    expect(() => new TimeAgo("en").format(new Date())).not.toThrow();
+  });
+});

--- a/pages/src/apps/live-tracker/tests/time-ago-registration.test.ts
+++ b/pages/src/apps/live-tracker/tests/time-ago-registration.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
+import { expectTimeAgoLocaleRegistered } from "../../../services/tests/time-ago-test-helpers";
 
 describe("live-tracker app entry", () => {
   it("registers the time-ago en locale so react-time-ago can render without throwing", async () => {
     await import("../create");
-    const { default: TimeAgo } = await import("javascript-time-ago");
-
-    expect(() => new TimeAgo("en").format(new Date())).not.toThrow();
+    await expectTimeAgoLocaleRegistered();
   });
 });

--- a/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
+++ b/pages/src/components/individual-tracker/overlay/individual-tracker-overlay-presenter.ts
@@ -2,7 +2,6 @@ import { getTeamName } from "@guilty-spark/shared/halo/team";
 import { getRankTierFromCsr } from "@guilty-spark/shared/halo/rank";
 import type { MatchStats } from "halo-infinite-api";
 import { differenceInHours } from "date-fns";
-import TimeAgo from "javascript-time-ago";
 import { createElement } from "react";
 import type { CSSProperties } from "react";
 import type { MedalEntry, MedalMetadata } from "@guilty-spark/shared/halo/medals";
@@ -33,6 +32,7 @@ import {
   MIN_PREVIOUS_GAMES_TO_SHOW,
 } from "../../live-tracker/settings/types";
 import haloTrophyIconPng from "../../../assets/halo-trophy-icon.png";
+import { timeAgo } from "../../../services/time-ago";
 import type {
   IndividualTrackerOverlayViewModel,
   OverlayDisplaySettings,
@@ -41,9 +41,6 @@ import type {
   OverlayTopSectionModel,
 } from "./types";
 import { getOverlayDisplaySettings, MATCHMAKING_SUMMARY_TAB_SERIES_ID } from "./types";
-import "javascript-time-ago/locale/en";
-
-const timeAgo = new TimeAgo("en");
 
 const DIFFICULTY_RANGE = new Map<number, readonly [number, number]>([
   [0, [0, 99]],

--- a/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
+++ b/pages/src/components/live-tracker/streamer-overlay/streamer-overlay.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useCallback } from "react";
 import { getRankTierFromCsr } from "@guilty-spark/shared/halo/rank";
 import { getTeamName } from "@guilty-spark/shared/halo/team";
-import TimeAgo from "javascript-time-ago";
 import { differenceInHours } from "date-fns";
 import type { TeamColor } from "../../team-colors/team-colors";
 import type { TickerMatchGroup, TickerStatRow } from "../../information-ticker/information-ticker";
@@ -24,11 +23,9 @@ import { TopSection } from "../../streamer-overlay/top-section";
 import { TeamDetailsContent } from "../../streamer-overlay/team-details-content";
 import { createStreamerOverlaySection } from "../../streamer-overlay/create";
 import type { OverlayTab } from "../../streamer-overlay/tabs-bar";
+import { timeAgo } from "../../../services/time-ago";
 import { StatsPanelContent } from "./stats-panel";
 import styles from "./streamer-overlay.module.css";
-import "javascript-time-ago/locale/en";
-
-const timeAgo = new TimeAgo("en");
 
 const DIFFICULTY_RANGE = new Map([
   [0, [0, 99]],

--- a/pages/src/services/tests/time-ago-test-helpers.ts
+++ b/pages/src/services/tests/time-ago-test-helpers.ts
@@ -1,0 +1,7 @@
+import { expect } from "vitest";
+
+export async function expectTimeAgoLocaleRegistered(): Promise<void> {
+  const { default: TimeAgo } = await import("javascript-time-ago");
+
+  expect(() => new TimeAgo("en").format(new Date())).not.toThrow();
+}

--- a/pages/src/services/tests/time-ago-test-helpers.ts
+++ b/pages/src/services/tests/time-ago-test-helpers.ts
@@ -1,7 +1,21 @@
-import { expect } from "vitest";
+import type { MockInstance } from "vitest";
+import { expect, vi } from "vitest";
+import TimeAgo from "javascript-time-ago";
 
-export async function expectTimeAgoLocaleRegistered(): Promise<void> {
-  const { default: TimeAgo } = await import("javascript-time-ago");
+/**
+ * `javascript-time-ago` keeps locale registration in module-level state that
+ * Vitest's dependency pre-bundling does not reset between tests, so asserting
+ * on the resulting behaviour (e.g. `timeAgo.format()` not throwing) can pass
+ * even when the module under test no longer registers the locale itself, if
+ * an earlier test already registered it. Spying on `TimeAgo.addLocale` checks
+ * that *this* import actually triggered registration, independent of any
+ * prior test's side effects. Call `vi.resetModules()` before this so the
+ * source module under test re-executes and re-triggers the spy.
+ */
+export function spyOnTimeAgoAddLocale(): MockInstance<typeof TimeAgo.addLocale> {
+  return vi.spyOn(TimeAgo, "addLocale");
+}
 
-  expect(() => new TimeAgo("en").format(new Date())).not.toThrow();
+export function expectTimeAgoLocaleRegistered(addLocaleSpy: MockInstance<typeof TimeAgo.addLocale>): void {
+  expect(addLocaleSpy).toHaveBeenCalled();
 }

--- a/pages/src/services/tests/time-ago.test.ts
+++ b/pages/src/services/tests/time-ago.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+describe("time-ago", () => {
+  it("registers the en locale so timeAgo can format dates without throwing", async () => {
+    const { timeAgo } = await import("../time-ago");
+
+    expect(() => timeAgo.format(new Date())).not.toThrow();
+  });
+});

--- a/pages/src/services/tests/time-ago.test.ts
+++ b/pages/src/services/tests/time-ago.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { expectTimeAgoLocaleRegistered, spyOnTimeAgoAddLocale } from "./time-ago-test-helpers";
 
 describe("time-ago", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
   it("registers the en locale so timeAgo can format dates without throwing", async () => {
+    const addLocaleSpy = spyOnTimeAgoAddLocale();
+
     const { timeAgo } = await import("../time-ago");
 
+    expectTimeAgoLocaleRegistered(addLocaleSpy);
     expect(() => timeAgo.format(new Date())).not.toThrow();
   });
 });

--- a/pages/src/services/time-ago.ts
+++ b/pages/src/services/time-ago.ts
@@ -1,0 +1,6 @@
+import TimeAgo from "javascript-time-ago";
+import en from "javascript-time-ago/locale/en";
+
+TimeAgo.addLocale(en);
+
+export const timeAgo = new TimeAgo("en");


### PR DESCRIPTION
## Context

Follow-up to #808, which flagged this as out-of-scope work: four places across the pages workspace registered the `javascript-time-ago` "en" locale and constructed `TimeAgo`/`ReactTimeAgo` instances, with duplicated boilerplate (a raw locale-file import + registration call) copy-pasted across app entry points and presenter files.

## This change

- Consolidates locale registration into a single shared module (`pages/src/services/time-ago.ts`) that registers the locale once and exports one reusable `timeAgo` instance.
- Kept the locale fixed to English rather than switching to the viewer's browser locale — these are largely OBS browser-source overlays where the streamer controls the output language, so a fixed language is the safer default (discussed and confirmed before implementing).
- **Caught and fixed a real regression along the way**: an initial pass removed the per-file registration entirely and only imported the shared module from the two presenter files that already used it directly. That silently broke the `individual-tracker-viewer` page's own `<ReactTimeAgo>` usage (and left the `live-tracker` page's usage working only by accident, via an unrelated transitive import) — a code review caught it before merge. Fixed by having each of the three affected app entry points explicitly import the shared registration module, matching the original "each island owns its own setup" pattern instead of relying on incidental imports through unrelated components.
- Added regression tests per app entry point that exercise the real `javascript-time-ago`/`react-time-ago` packages (not mocked, unlike the existing component tests) to catch this specific class of bug — confirmed each test actually fails without its corresponding fix.

## Test plan

- [x] `npm run typecheck:pages` — clean
- [x] `pages` workspace test suite — 1097 tests pass
- [x] Manually verified each new regression test fails when its corresponding fix is reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)