### PR TITLE
Fix Vite native config-loader warning on every test run

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Discord app to pull Halo stats from Halo Waypoint. Works in conjunction with NeatQueue.",
   "license": "MIT",
   "private": true,
+  "type": "module",
   "workspaces": [
     "api",
     "pages",


### PR DESCRIPTION
## Context

Every `vitest run` invocation printed this warning, once per test project (api/pages/shared):

```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - ESM syntax in a file loaded as CommonJS (vitest.config.ts:1:1). Use a `.mjs` extension or set `"type": "module"` in the closest package.json
Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.
```

`vitest.config.ts` uses ESM syntax (`import`/`export default`) but lives at the repo root, whose `package.json` had no `"type"` field — so Node/Vite's native config loader treats it as ambiguous and flags it.

## This change

Adds `"type": "module"` to the root `package.json`.

The other option Vite suggests — renaming the file to `.mts` — was tried first but rejected: it breaks ESLint's typed-linting (`Error: ... requires type information, but don't have parserOptions set to generate type information for this file`) because the project's tsconfig doesn't include `.mts` files, and `eslint.config.*`/`tsconfig*.json` are off-limits for me to modify per this repo's conventions. Declaring `"type": "module"` at the root avoids touching either.

Verified safe: no root-level CommonJS scripts exist that this could break (root-level tooling configs already use explicit `.mjs` — `eslint.config.mjs`, `prettier.config.mjs` — and every npm script at the root either delegates to a workspace via `--workspace=X` or invokes a tool directly). Each workspace (`api`, `pages`, `shared`) already declares its own `"type": "module"`, which takes precedence for files under those directories regardless.

## Test plan

- [x] `vitest run` (full suite, 3652 tests) — warning gone, all pass
- [x] `npm run typecheck` — clean (api/pages)
- [x] `npm run lint:ts:fix` — clean
- [x] `prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)