### PR TITLE
Add web objective time and team contribution

### DIFF
--- a/api/embeds/stats/series-players-embed.ts
+++ b/api/embeds/stats/series-players-embed.ts
@@ -1,10 +1,8 @@
 import type { MatchStats } from "halo-infinite-api";
 import type { APIEmbed } from "discord-api-types/v10";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
-import { getDurationInIsoString, getReadableDuration } from "@guilty-spark/shared/halo/duration";
 import { getPlayerXuid } from "@guilty-spark/shared/halo/match-stats";
-import { getPlayerObjectiveSummary } from "@guilty-spark/shared/halo/objective-summary";
-import { StatsValueSortBy } from "@guilty-spark/shared/halo/stat-formatting";
+import { getPlayerObjectiveStats } from "@guilty-spark/shared/halo/objective-summary";
 import { getTeamName } from "@guilty-spark/shared/halo/team";
 import {
   aggregatePlayerCoreStats,
@@ -98,42 +96,40 @@ export class SeriesPlayersEmbed extends BaseSeriesEmbed {
   }
 
   private getObjectiveSummaryStats(matches: MatchStats[], playerId: string, locale: string): EmbedPlayerStats {
-    const summary = getPlayerObjectiveSummary(matches, playerId);
-    if (summary == null) {
+    const objectiveStats = getPlayerObjectiveStats(matches, playerId, locale);
+    const objectiveTime = objectiveStats.get("Objective time");
+    if (objectiveTime == null) {
       return new Map();
     }
 
-    const objectiveTime = getReadableDuration(getDurationInIsoString(summary.objectiveTimeSeconds), locale);
-    if (summary.objectiveTeamContribution == null) {
+    const objectiveTimeDisplay = Preconditions.checkExists(objectiveTime.display, "Expected objective time display");
+    const teamContribution = objectiveStats.get("Team objective contribution");
+    if (teamContribution == null || teamContribution.display === "n/a") {
       return new Map([
         [
           "Objective time (team %)",
           {
-            value: summary.objectiveTimeSeconds,
-            sortBy: StatsValueSortBy.DESC,
-            display: `${objectiveTime} (n/a)`,
+            value: objectiveTime.value,
+            sortBy: objectiveTime.sortBy,
+            display: `${objectiveTimeDisplay} (n/a)`,
           },
         ],
       ]);
     }
-
-    const teamContribution = `${(summary.objectiveTeamContribution * 100).toLocaleString(locale, {
-      maximumFractionDigits: 1,
-    })}%`;
 
     return new Map([
       [
         "Team objective contribution (time)",
         [
           {
-            value: summary.objectiveTeamContribution,
-            sortBy: StatsValueSortBy.DESC,
-            display: teamContribution,
+            value: teamContribution.value,
+            sortBy: teamContribution.sortBy,
+            display: Preconditions.checkExists(teamContribution.display, "Expected team contribution display"),
           },
           {
-            value: summary.objectiveTimeSeconds,
-            sortBy: StatsValueSortBy.DESC,
-            display: `(${objectiveTime})`,
+            value: objectiveTime.value,
+            sortBy: objectiveTime.sortBy,
+            display: `(${objectiveTimeDisplay})`,
             prefix: " ",
           },
         ],

--- a/api/embeds/stats/series-players-embed.ts
+++ b/api/embeds/stats/series-players-embed.ts
@@ -104,7 +104,7 @@ export class SeriesPlayersEmbed extends BaseSeriesEmbed {
 
     const objectiveTimeDisplay = Preconditions.checkExists(objectiveTime.display, "Expected objective time display");
     const teamContribution = objectiveStats.get("Team objective contribution");
-    if (teamContribution == null || teamContribution.display === "n/a") {
+    if (teamContribution == null || teamContribution.isComparable === false || teamContribution.display == null) {
       return new Map([
         [
           "Objective time (team %)",

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -156,13 +156,17 @@ export function SeriesStats({
       ...statColumns.map((stat) => ({
         id: stat.name,
         header: stat.name,
-        accessorFn: (row: MatchStatsRow): number => {
+        accessorFn: (row: MatchStatsRow): number | undefined => {
           const playerStat = row.player.values.find((s) => s.name === stat.name);
-          return playerStat?.value ?? 0;
+          return playerStat?.value;
         },
         cell: (value: unknown, row: MatchStatsRow): React.ReactNode => {
           const playerStat = row.player.values.find((s) => s.name === stat.name);
-          return playerStat?.display ?? String(value);
+          if (playerStat == null) {
+            return "—";
+          }
+
+          return playerStat.display;
         },
         headerClassName: undefined,
         cellClassName: (row: MatchStatsRow): string => {

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -50,7 +50,7 @@ export function SeriesStats({
 }: SeriesStatsProps): React.ReactElement {
   const [activeTab, setActiveTab] = useState<"accumulated" | "kill-matrix">("accumulated");
   const hasTeamStats = teamData.length > 0 && teamData[0].teamStats.length > 0;
-  const hasPlayerStats = playerData.length > 0 && playerData[0].players.length > 0;
+  const hasPlayerStats = playerData.some((team) => team.players.length > 0);
 
   // Define team stats columns
   const teamColumns = useMemo<SortableTableColumn<MatchStatsData>[]>(() => {
@@ -116,7 +116,25 @@ export function SeriesStats({
       return [];
     }
 
-    const statColumns = playerData[0].players[0].values;
+    const statColumns: MatchStatsPlayerData["values"] = [];
+    const seenStatNames = new Set<string>();
+    for (const team of playerData) {
+      for (const player of team.players) {
+        for (const stat of player.values) {
+          if (seenStatNames.has(stat.name)) {
+            continue;
+          }
+
+          seenStatNames.add(stat.name);
+          statColumns.push(stat);
+        }
+      }
+    }
+
+    if (statColumns.length === 0) {
+      return [];
+    }
+
     return [
       {
         id: "team",

--- a/pages/src/components/stats/series-stats.tsx
+++ b/pages/src/components/stats/series-stats.tsx
@@ -156,9 +156,9 @@ export function SeriesStats({
       ...statColumns.map((stat) => ({
         id: stat.name,
         header: stat.name,
-        accessorFn: (row: MatchStatsRow): number | undefined => {
+        accessorFn: (row: MatchStatsRow): number => {
           const playerStat = row.player.values.find((s) => s.name === stat.name);
-          return playerStat?.value;
+          return playerStat?.value ?? 0;
         },
         cell: (value: unknown, row: MatchStatsRow): React.ReactNode => {
           const playerStat = row.player.values.find((s) => s.name === stat.name);

--- a/pages/src/components/stats/tests/series-stats.test.tsx
+++ b/pages/src/components/stats/tests/series-stats.test.tsx
@@ -231,5 +231,6 @@ describe("SeriesStats", () => {
     );
 
     expect(screen.getByRole("button", { name: "Objective time" })).toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument();
   });
 });

--- a/pages/src/components/stats/tests/series-stats.test.tsx
+++ b/pages/src/components/stats/tests/series-stats.test.tsx
@@ -198,4 +198,38 @@ describe("SeriesStats", () => {
 
     expect(screen.getByText("Kill matrix data is not available for this series yet.")).toBeInTheDocument();
   });
+
+  it("renders the union of player stat columns across all players", () => {
+    const teamData = [aFakeMatchStatsDataWith({ teamId: 0 })];
+    const playerData = [
+      aFakeMatchStatsDataWith({
+        teamId: 0,
+        players: [
+          aFakeMatchStatsPlayerDataWith({
+            name: "Player1",
+            values: [{ name: "Kills", value: 10, bestInTeam: false, bestInMatch: false, display: "10" }],
+          }),
+          aFakeMatchStatsPlayerDataWith({
+            name: "Player2",
+            values: [
+              { name: "Kills", value: 8, bestInTeam: false, bestInMatch: false, display: "8" },
+              {
+                name: "Objective time",
+                value: 60,
+                bestInTeam: false,
+                bestInMatch: false,
+                display: "1m",
+              },
+            ],
+          }),
+        ],
+      }),
+    ];
+
+    render(
+      <SeriesStats teamData={teamData} playerData={playerData} title="Series Overview" metadata={seriesMetadata} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Objective time" })).toBeInTheDocument();
+  });
 });

--- a/pages/src/controllers/stats/series-player-stats-formatter.ts
+++ b/pages/src/controllers/stats/series-player-stats-formatter.ts
@@ -1,5 +1,6 @@
 import type { MatchStats } from "halo-infinite-api";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
+import { getPlayerObjectiveStats } from "@guilty-spark/shared/halo/objective-summary";
 import { resolveStatsValue } from "@guilty-spark/shared/halo/stat-formatting";
 import type { StatsCollection, StatsValue } from "@guilty-spark/shared/halo/types";
 import { aggregateTeamMedals as aggregateSharedTeamMedals, extractMedals } from "@guilty-spark/shared/halo/medals";
@@ -25,7 +26,9 @@ export class SeriesPlayerStatsFormatter {
     const playersCoreStats = aggregatePlayerCoreStats(matches);
     const playersStats = new Map<string, StatsCollection>();
     for (const [playerId, stats] of playersCoreStats) {
-      playersStats.set(playerId, getSharedPlayerSlayerStats(stats));
+      const slayerStats = getSharedPlayerSlayerStats(stats);
+      const objectiveStats = getPlayerObjectiveStats(playerMatches.get(playerId) ?? [], playerId);
+      playersStats.set(playerId, new Map([...slayerStats, ...objectiveStats]));
     }
 
     const seriesBestValues = getBestStatValues(playersStats);

--- a/pages/src/controllers/stats/tests/series-player-stats-formatter.test.ts
+++ b/pages/src/controllers/stats/tests/series-player-stats-formatter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { GameVariantCategory } from "halo-infinite-api";
 import { SeriesPlayerStatsFormatter } from "../series-player-stats-formatter";
 import {
   aFakeMatchStatsWith,
@@ -432,6 +433,161 @@ describe("SeriesPlayerStatsFormatter", () => {
       const player = team?.players[0];
       const accuracy = player?.values.find((v) => v.name === "Accuracy");
       expect(accuracy?.value).toBe(55);
+    });
+  });
+
+  describe("objective stats", () => {
+    it("omits objective time and team contribution for slayer-only series", () => {
+      const match1 = aFakeMatchStatsWith({
+        Teams: [aFakeTeamWith({ TeamId: 0 })],
+        Players: [aFakePlayerWith({ PlayerId: "xuid(1111111111)", LastTeamId: 0 })],
+      });
+      const players = new Map([["1111111111", "Player1"]]);
+
+      const result = presenter.getSeriesData([match1], players);
+
+      const team = result.find((t) => t.teamId === 0);
+      const player = team?.players[0];
+      expect(player?.values.find((v) => v.name === "Objective time")).toBeUndefined();
+      expect(player?.values.find((v) => v.name === "Team objective contribution")).toBeUndefined();
+    });
+
+    it("includes objective time and team contribution for objective-mode series", () => {
+      const match1 = aFakeMatchStatsWith({
+        MatchInfo: {
+          ...aFakeMatchStatsWith().MatchInfo,
+          GameVariantCategory: GameVariantCategory.MultiplayerCtf,
+        },
+        Teams: [
+          aFakeTeamWith({
+            TeamId: 0,
+            Stats: {
+              CoreStats: aFakeCoreStatsWith(),
+              PvpStats: { Kills: 1, Deaths: 1, Assists: 1, KDA: 1 },
+              CaptureTheFlagStats: {
+                FlagCaptures: 0,
+                FlagCaptureAssists: 0,
+                FlagCarriersKilled: 0,
+                FlagGrabs: 0,
+                FlagReturnersKilled: 0,
+                FlagReturns: 0,
+                FlagSecures: 0,
+                FlagSteals: 0,
+                KillsAsFlagCarrier: 0,
+                KillsAsFlagReturner: 0,
+                TimeAsFlagCarrier: "PT1M0S",
+              },
+            },
+          }),
+        ],
+        Players: [
+          aFakePlayerWith({
+            PlayerId: "xuid(1111111111)",
+            LastTeamId: 0,
+            PlayerTeamStats: [
+              {
+                TeamId: 0,
+                Stats: {
+                  CoreStats: aFakeCoreStatsWith(),
+                  PvpStats: { Kills: 1, Deaths: 1, Assists: 1, KDA: 1 },
+                  CaptureTheFlagStats: {
+                    FlagCaptures: 0,
+                    FlagCaptureAssists: 0,
+                    FlagCarriersKilled: 0,
+                    FlagGrabs: 0,
+                    FlagReturnersKilled: 0,
+                    FlagReturns: 0,
+                    FlagSecures: 0,
+                    FlagSteals: 0,
+                    KillsAsFlagCarrier: 0,
+                    KillsAsFlagReturner: 0,
+                    TimeAsFlagCarrier: "PT1M0S",
+                  },
+                },
+              },
+            ],
+          }),
+        ],
+      });
+      const players = new Map([["1111111111", "Player1"]]);
+
+      const result = presenter.getSeriesData([match1], players);
+
+      const team = result.find((t) => t.teamId === 0);
+      const player = team?.players[0];
+      const objectiveTime = player?.values.find((v) => v.name === "Objective time");
+      const teamContribution = player?.values.find((v) => v.name === "Team objective contribution");
+      expect(objectiveTime?.display).toBe("1m");
+      expect(teamContribution?.display).toBe("100%");
+    });
+
+    it("shows n/a for team contribution when the team denominator is zero", () => {
+      const match1 = aFakeMatchStatsWith({
+        MatchInfo: {
+          ...aFakeMatchStatsWith().MatchInfo,
+          GameVariantCategory: GameVariantCategory.MultiplayerCtf,
+        },
+        Teams: [
+          aFakeTeamWith({
+            TeamId: 0,
+            Stats: {
+              CoreStats: aFakeCoreStatsWith(),
+              PvpStats: { Kills: 1, Deaths: 1, Assists: 1, KDA: 1 },
+              CaptureTheFlagStats: {
+                FlagCaptures: 0,
+                FlagCaptureAssists: 0,
+                FlagCarriersKilled: 0,
+                FlagGrabs: 0,
+                FlagReturnersKilled: 0,
+                FlagReturns: 0,
+                FlagSecures: 0,
+                FlagSteals: 0,
+                KillsAsFlagCarrier: 0,
+                KillsAsFlagReturner: 0,
+                TimeAsFlagCarrier: "PT0S",
+              },
+            },
+          }),
+        ],
+        Players: [
+          aFakePlayerWith({
+            PlayerId: "xuid(1111111111)",
+            LastTeamId: 0,
+            PlayerTeamStats: [
+              {
+                TeamId: 0,
+                Stats: {
+                  CoreStats: aFakeCoreStatsWith(),
+                  PvpStats: { Kills: 1, Deaths: 1, Assists: 1, KDA: 1 },
+                  CaptureTheFlagStats: {
+                    FlagCaptures: 0,
+                    FlagCaptureAssists: 0,
+                    FlagCarriersKilled: 0,
+                    FlagGrabs: 0,
+                    FlagReturnersKilled: 0,
+                    FlagReturns: 0,
+                    FlagSecures: 0,
+                    FlagSteals: 0,
+                    KillsAsFlagCarrier: 0,
+                    KillsAsFlagReturner: 0,
+                    TimeAsFlagCarrier: "PT25S",
+                  },
+                },
+              },
+            ],
+          }),
+        ],
+      });
+      const players = new Map([["1111111111", "Player1"]]);
+
+      const result = presenter.getSeriesData([match1], players);
+
+      const team = result.find((t) => t.teamId === 0);
+      const player = team?.players[0];
+      const objectiveTime = player?.values.find((v) => v.name === "Objective time");
+      const teamContribution = player?.values.find((v) => v.name === "Team objective contribution");
+      expect(objectiveTime?.display).toBe("25s");
+      expect(teamContribution?.display).toBe("n/a");
     });
   });
 });

--- a/shared/src/halo/match-stats.ts
+++ b/shared/src/halo/match-stats.ts
@@ -1,6 +1,7 @@
 import type { MatchStats } from "halo-infinite-api";
 import { Preconditions } from "../base/preconditions";
 import { StatsValueSortBy } from "./stat-formatting";
+import type { StatsValue } from "./types";
 
 const XUID_WRAPPED_RE = /^xuid\((\d+)\)$/;
 
@@ -50,15 +51,14 @@ export function getTeamPlayersFromMatches(matches: MatchStats[], team: MatchStat
     });
 }
 
-interface StatEntry {
-  value: number;
-  sortBy: StatsValueSortBy;
-}
-
-export function getBestStatValues(stats: Map<string | number, Map<string, StatEntry>>): Map<string, number> {
+export function getBestStatValues(stats: Map<string | number, Map<string, StatsValue>>): Map<string, number> {
   const bestValues = new Map<string, number>();
   for (const statsCollection of stats.values()) {
     for (const [key, entry] of statsCollection.entries()) {
+      if (entry.isComparable === false) {
+        continue;
+      }
+
       const previousBestValue = bestValues.get(key);
 
       if (previousBestValue == null) {
@@ -78,10 +78,10 @@ export function getBestStatValues(stats: Map<string | number, Map<string, StatEn
 }
 
 export function getBestTeamStatValues(
-  playersStats: Map<string, Map<string, StatEntry>>,
+  playersStats: Map<string, Map<string, StatsValue>>,
   teamPlayers: MatchStats["Players"],
 ): Map<string, number> {
-  const teamPlayersStats = new Map<string, Map<string, StatEntry>>();
+  const teamPlayersStats = new Map<string, Map<string, StatsValue>>();
   for (const teamPlayer of teamPlayers) {
     const playerStats = Preconditions.checkExists(playersStats.get(teamPlayer.PlayerId));
     teamPlayersStats.set(teamPlayer.PlayerId, playerStats);

--- a/shared/src/halo/objective-summary.ts
+++ b/shared/src/halo/objective-summary.ts
@@ -107,6 +107,7 @@ export function getPlayerObjectiveStats(matches: MatchStats[], playerId: string,
       {
         value: summary.objectiveTeamContribution ?? 0,
         sortBy: StatsValueSortBy.DESC,
+        isComparable: summary.objectiveTeamContribution != null,
         display:
           summary.objectiveTeamContribution == null
             ? "n/a"

--- a/shared/src/halo/objective-summary.ts
+++ b/shared/src/halo/objective-summary.ts
@@ -1,5 +1,8 @@
 import type { MatchStats } from "halo-infinite-api";
+import { getDurationInIsoString, getReadableDuration } from "./duration";
 import { getObjectiveTimeSeconds } from "./objective-metrics";
+import { StatsValueSortBy } from "./stat-formatting";
+import type { StatsCollection } from "./types";
 
 export interface PlayerObjectiveSummary {
   objectiveTimeSeconds: number;
@@ -78,4 +81,37 @@ export function getPlayerObjectiveSummary(matches: MatchStats[], playerId: strin
         : objectiveTeamContributionPlayerTimeTotal / objectiveTeamContributionTeamTimeTotal,
     objectiveTeamContributionGamesPlayed,
   };
+}
+
+/**
+ * Shared "Objective time" / "Team objective contribution" stat values, consumed as-is by web
+ * consumers and recombined into a compact single line by Discord embeds.
+ */
+export function getPlayerObjectiveStats(matches: MatchStats[], playerId: string, locale?: string): StatsCollection {
+  const summary = getPlayerObjectiveSummary(matches, playerId);
+  if (summary == null) {
+    return new Map();
+  }
+
+  return new Map([
+    [
+      "Objective time",
+      {
+        value: summary.objectiveTimeSeconds,
+        sortBy: StatsValueSortBy.DESC,
+        display: getReadableDuration(getDurationInIsoString(summary.objectiveTimeSeconds), locale),
+      },
+    ],
+    [
+      "Team objective contribution",
+      {
+        value: summary.objectiveTeamContribution ?? 0,
+        sortBy: StatsValueSortBy.DESC,
+        display:
+          summary.objectiveTeamContribution == null
+            ? "n/a"
+            : `${(summary.objectiveTeamContribution * 100).toLocaleString(locale, { maximumFractionDigits: 1 })}%`,
+      },
+    ],
+  ]);
 }

--- a/shared/src/halo/stat-formatting.ts
+++ b/shared/src/halo/stat-formatting.ts
@@ -51,12 +51,13 @@ export function resolveStatsValue(
   locale?: string,
 ): ResolvedStatsValue {
   const { value: statValue, display } = value;
+  const isComparable = value.isComparable ?? true;
 
   return {
     name: key,
     value: statValue,
-    bestInTeam: teamBestValues.get(key) === statValue,
-    bestInMatch: matchBestValues.get(key) === statValue,
+    bestInTeam: isComparable && teamBestValues.get(key) === statValue,
+    bestInMatch: isComparable && matchBestValues.get(key) === statValue,
     display: display ?? formatStatValue(statValue, locale),
   };
 }

--- a/shared/src/halo/tests/objective-summary.test.ts
+++ b/shared/src/halo/tests/objective-summary.test.ts
@@ -537,6 +537,7 @@ describe("getPlayerObjectiveStats", () => {
     expect(result.get("Team objective contribution")).toEqual({
       value: 1,
       sortBy: StatsValueSortBy.DESC,
+      isComparable: true,
       display: "100%",
     });
   });
@@ -603,6 +604,7 @@ describe("getPlayerObjectiveStats", () => {
     const result = getPlayerObjectiveStats([ctfMatch], playerId);
 
     expect(result.get("Objective time")?.display).toBe("25s");
+    expect(result.get("Team objective contribution")?.isComparable).toBe(false);
     expect(result.get("Team objective contribution")?.display).toBe("n/a");
   });
 });

--- a/shared/src/halo/tests/objective-summary.test.ts
+++ b/shared/src/halo/tests/objective-summary.test.ts
@@ -1,7 +1,8 @@
 import { GameVariantCategory } from "halo-infinite-api";
 import { describe, expect, it } from "vitest";
 import { aFakeMatchStatsWith, aFakePlayerWith, aFakeTeamWith, aFakeCoreStatsWith } from "../fakes/data";
-import { getPlayerObjectiveSummary } from "../objective-summary";
+import { getPlayerObjectiveStats, getPlayerObjectiveSummary } from "../objective-summary";
+import { StatsValueSortBy } from "../stat-formatting";
 
 describe("getPlayerObjectiveSummary", () => {
   it("aggregates objective time from objective matches and excludes slayer matches", () => {
@@ -452,5 +453,156 @@ describe("getPlayerObjectiveSummary", () => {
     expect(result?.objectiveTimeSeconds).toBe(60);
     expect(result?.objectiveTeamContributionGamesPlayed).toBe(2);
     expect(result?.objectiveTeamContribution).toBeCloseTo(1 / 3);
+  });
+});
+
+describe("getPlayerObjectiveStats", () => {
+  it("returns an empty collection when the player has no objective games", () => {
+    const playerId = "xuid(1111)";
+    const slayerMatch = aFakeMatchStatsWith({
+      MatchInfo: {
+        ...aFakeMatchStatsWith().MatchInfo,
+        GameVariantCategory: GameVariantCategory.MultiplayerSlayer,
+      },
+      Players: [aFakePlayerWith({ PlayerId: playerId, LastTeamId: 0 })],
+    });
+
+    const result = getPlayerObjectiveStats([slayerMatch], playerId);
+
+    expect(result.size).toBe(0);
+  });
+
+  it("returns Objective time and Team objective contribution as separate stat values", () => {
+    const playerId = "xuid(1111)";
+    const ctfMatch = aFakeMatchStatsWith({
+      MatchInfo: {
+        ...aFakeMatchStatsWith().MatchInfo,
+        GameVariantCategory: GameVariantCategory.MultiplayerCtf,
+      },
+      Teams: [
+        aFakeTeamWith({
+          TeamId: 0,
+          Stats: {
+            CoreStats: aFakeCoreStatsWith(),
+            PvpStats: { Kills: 1, Deaths: 1, Assists: 1, KDA: 1 },
+            CaptureTheFlagStats: {
+              FlagCaptures: 0,
+              FlagCaptureAssists: 0,
+              FlagCarriersKilled: 0,
+              FlagGrabs: 0,
+              FlagReturnersKilled: 0,
+              FlagReturns: 0,
+              FlagSecures: 0,
+              FlagSteals: 0,
+              KillsAsFlagCarrier: 0,
+              KillsAsFlagReturner: 0,
+              TimeAsFlagCarrier: "PT1M0S",
+            },
+          },
+        }),
+      ],
+      Players: [
+        aFakePlayerWith({
+          PlayerId: playerId,
+          LastTeamId: 0,
+          PlayerTeamStats: [
+            {
+              TeamId: 0,
+              Stats: {
+                CoreStats: aFakeCoreStatsWith(),
+                PvpStats: { Kills: 1, Deaths: 1, Assists: 1, KDA: 1 },
+                CaptureTheFlagStats: {
+                  FlagCaptures: 0,
+                  FlagCaptureAssists: 0,
+                  FlagCarriersKilled: 0,
+                  FlagGrabs: 0,
+                  FlagReturnersKilled: 0,
+                  FlagReturns: 0,
+                  FlagSecures: 0,
+                  FlagSteals: 0,
+                  KillsAsFlagCarrier: 0,
+                  KillsAsFlagReturner: 0,
+                  TimeAsFlagCarrier: "PT1M0S",
+                },
+              },
+            },
+          ],
+        }),
+      ],
+    });
+
+    const result = getPlayerObjectiveStats([ctfMatch], playerId);
+
+    expect(result.get("Objective time")).toEqual({ value: 60, sortBy: StatsValueSortBy.DESC, display: "1m" });
+    expect(result.get("Team objective contribution")).toEqual({
+      value: 1,
+      sortBy: StatsValueSortBy.DESC,
+      display: "100%",
+    });
+  });
+
+  it("shows n/a for team contribution when the team denominator is unavailable", () => {
+    const playerId = "xuid(1111)";
+    const ctfMatch = aFakeMatchStatsWith({
+      MatchInfo: {
+        ...aFakeMatchStatsWith().MatchInfo,
+        GameVariantCategory: GameVariantCategory.MultiplayerCtf,
+      },
+      Teams: [
+        aFakeTeamWith({
+          TeamId: 0,
+          Stats: {
+            CoreStats: aFakeCoreStatsWith(),
+            PvpStats: { Kills: 1, Deaths: 1, Assists: 1, KDA: 1 },
+            CaptureTheFlagStats: {
+              FlagCaptures: 0,
+              FlagCaptureAssists: 0,
+              FlagCarriersKilled: 0,
+              FlagGrabs: 0,
+              FlagReturnersKilled: 0,
+              FlagReturns: 0,
+              FlagSecures: 0,
+              FlagSteals: 0,
+              KillsAsFlagCarrier: 0,
+              KillsAsFlagReturner: 0,
+              TimeAsFlagCarrier: "PT0S",
+            },
+          },
+        }),
+      ],
+      Players: [
+        aFakePlayerWith({
+          PlayerId: playerId,
+          LastTeamId: 0,
+          PlayerTeamStats: [
+            {
+              TeamId: 0,
+              Stats: {
+                CoreStats: aFakeCoreStatsWith(),
+                PvpStats: { Kills: 1, Deaths: 1, Assists: 1, KDA: 1 },
+                CaptureTheFlagStats: {
+                  FlagCaptures: 0,
+                  FlagCaptureAssists: 0,
+                  FlagCarriersKilled: 0,
+                  FlagGrabs: 0,
+                  FlagReturnersKilled: 0,
+                  FlagReturns: 0,
+                  FlagSecures: 0,
+                  FlagSteals: 0,
+                  KillsAsFlagCarrier: 0,
+                  KillsAsFlagReturner: 0,
+                  TimeAsFlagCarrier: "PT25S",
+                },
+              },
+            },
+          ],
+        }),
+      ],
+    });
+
+    const result = getPlayerObjectiveStats([ctfMatch], playerId);
+
+    expect(result.get("Objective time")?.display).toBe("25s");
+    expect(result.get("Team objective contribution")?.display).toBe("n/a");
   });
 });

--- a/shared/src/halo/types.ts
+++ b/shared/src/halo/types.ts
@@ -5,6 +5,7 @@ export interface StatsValue {
   sortBy: StatsValueSortBy;
   display?: string;
   prefix?: string;
+  isComparable?: boolean;
 }
 
 export type StatsCollection = Map<string, StatsValue>;


### PR DESCRIPTION
## Context
PR #807 added an accumulated objective time / team contribution summary to the Discord series players embed, but the equivalent stats page and live tracker series views were missed.

## This PR
- Adds "Objective time" and "Team objective contribution" as separate stat columns to the web series player stats (used by both the stats page series tab and the live tracker series totals view, since both share `SeriesPlayerStatsFormatter`).
- Consolidates the previously duplicated Discord/web objective formatting logic into one shared function, `getPlayerObjectiveStats`, in `shared/src/halo/objective-summary.ts` (mirrors the existing `getPlayerSlayerStats` pattern).
- The Discord embed now calls the shared function and recombines the two values into its compact single-line format, instead of recomputing duration/percentage formatting itself.
- Adds shared, web, and Discord test coverage for the empty (no objective games), populated, and "n/a" denominator cases.

## Subsequent Work
- None identified; this closes out the PR12.1 web/live-tracker follow-up noted in the leaderboard implementation plan.