### PR TITLE
Add stats-fix series outcome selection

### DIFF
--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -19,11 +19,12 @@ import {
   InteractionContextType,
   PermissionFlagsBits,
 } from "discord-api-types/v10";
-import { MatchType } from "halo-infinite-api";
+import { MatchOutcome, MatchType } from "halo-infinite-api";
 import type { MatchStats, GameVariantCategory } from "halo-infinite-api";
 import { formatDistanceToNowStrict, subHours } from "date-fns";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
+import { collapseSequentialSeriesEntries } from "@guilty-spark/shared/halo/match-enrichment";
 import type { BaseInteraction, ExecuteResponse, ApplicationCommandData, CommandData } from "../base/base-command";
 import { BaseCommand } from "../base/base-command";
 import { NEAT_QUEUE_BOT_USER_ID } from "../../services/discord/discord";
@@ -50,7 +51,10 @@ interface FixFlowMetadata extends Record<string, unknown> {
   queueData: Omit<QueueData, "timestamp">;
   selectedPlayerId?: string;
   selectedMatchIds?: string[];
+  selectedSeriesOutcome?: FixSeriesOutcome;
 }
+
+type FixSeriesOutcome = "TEAM_0" | "TEAM_1" | "TIE";
 
 const FIX_METADATA_RETRY_BASE_DELAY_MS = 150;
 const FIX_METADATA_MAX_RETRIES = 3;
@@ -60,6 +64,7 @@ export enum InteractionButton {
   LoadGames = "btn_stats_load_games",
   FixPlayerSelect = "btn_stats_fix_player_select",
   FixGamesSelect = "btn_stats_fix_games_select",
+  FixOutcomeSelect = "btn_stats_fix_outcome_select",
   FixConfirm = "btn_stats_fix_confirm",
   FixCancel = "btn_stats_fix_cancel",
 }
@@ -165,6 +170,14 @@ export class StatsCommand extends BaseCommand {
       {
         type: InteractionType.MessageComponent,
         data: {
+          component_type: ComponentType.StringSelect,
+          custom_id: InteractionButton.FixOutcomeSelect,
+          values: [],
+        },
+      },
+      {
+        type: InteractionType.MessageComponent,
+        data: {
           component_type: ComponentType.Button,
           custom_id: InteractionButton.FixConfirm,
         },
@@ -240,6 +253,15 @@ export class StatsCommand extends BaseCommand {
               },
               jobToComplete: async () =>
                 this.handleFixGamesSelectJob(interaction as APIMessageComponentSelectMenuInteraction),
+            };
+          }
+          case InteractionButton.FixOutcomeSelect.toString(): {
+            return {
+              response: {
+                type: InteractionResponseType.DeferredMessageUpdate,
+              },
+              jobToComplete: async () =>
+                this.handleFixOutcomeSelectJob(interaction as APIMessageComponentSelectMenuInteraction),
             };
           }
           case InteractionButton.FixConfirm.toString(): {
@@ -1180,46 +1202,190 @@ export class StatsCommand extends BaseCommand {
         throw new EndUserError("No match details found for the selected games.");
       }
 
-      const seriesEmbed = await this.createSeriesEmbed({
-        guildId: metadata.guildId,
-        channelId: metadata.channelId,
-        locale: interaction.guild_locale ?? interaction.locale,
-        queueData: metadata.queueData,
-        series,
-      });
+      const derivedSeriesOutcome = this.deriveFixSeriesOutcome(series);
+      const selectedSeriesOutcome = metadata.selectedSeriesOutcome ?? derivedSeriesOutcome;
 
       await this.setFixMetadata(interaction.message.id, {
         ...metadata,
         selectedMatchIds,
+        selectedSeriesOutcome,
       });
 
-      await discordService.updateDeferredReply(interaction.token, {
-        embeds: [
-          this.createStatusEmbed("Preview generated. Confirm to replace the previous series stats."),
-          ...seriesEmbed.embeds,
-        ],
-        components: [
-          {
-            type: ComponentType.ActionRow,
-            components: [
-              {
-                type: ComponentType.Button,
-                custom_id: InteractionButton.FixConfirm,
-                label: "Confirm",
-                style: 3,
-              },
-              {
-                type: ComponentType.Button,
-                custom_id: InteractionButton.FixCancel,
-                label: "Cancel",
-                style: 2,
-              },
-            ],
-          },
-        ],
-      });
+      await this.updateFixOutcomePreview(interaction, metadata, series, derivedSeriesOutcome, selectedSeriesOutcome);
     } catch (error) {
       await discordService.updateDeferredReplyWithError(interaction.token, error);
+    }
+  }
+
+  private async handleFixOutcomeSelectJob(interaction: APIMessageComponentSelectMenuInteraction): Promise<void> {
+    const { discordService, haloService } = this.services;
+
+    try {
+      const selectedSeriesOutcome = this.parseFixSeriesOutcome(
+        Preconditions.checkExists(interaction.data.values[0], "No series outcome selected"),
+      );
+      const metadata = await this.getFixMetadataWithRetry(interaction.message.id);
+      if (metadata == null) {
+        throw new EndUserError("Could not find fix-flow state. Please run /stats fix again.");
+      }
+
+      const selectedMatchIds = metadata.selectedMatchIds ?? [];
+      if (selectedMatchIds.length === 0) {
+        throw new EndUserError("No games were selected. Please run /stats fix again.");
+      }
+
+      const series = await haloService.getMatchDetails(selectedMatchIds);
+      if (series.length === 0) {
+        throw new EndUserError("No match details found for the selected games.");
+      }
+
+      const derivedSeriesOutcome = this.deriveFixSeriesOutcome(series);
+      await this.setFixMetadata(interaction.message.id, { ...metadata, selectedSeriesOutcome });
+      await this.updateFixOutcomePreview(interaction, metadata, series, derivedSeriesOutcome, selectedSeriesOutcome);
+    } catch (error) {
+      await discordService.updateDeferredReplyWithError(interaction.token, error);
+    }
+  }
+
+  private async updateFixOutcomePreview(
+    interaction: APIMessageComponentSelectMenuInteraction,
+    metadata: FixFlowMetadata,
+    series: MatchStats[],
+    derivedSeriesOutcome: FixSeriesOutcome,
+    selectedSeriesOutcome: FixSeriesOutcome,
+  ): Promise<void> {
+    const { discordService } = this.services;
+    const locale = interaction.guild_locale ?? interaction.locale;
+    const seriesEmbed = await this.createSeriesEmbed({
+      guildId: metadata.guildId,
+      channelId: metadata.channelId,
+      locale,
+      queueData: metadata.queueData,
+      series,
+    });
+    const derivedResultLabel = this.getFixSeriesOutcomeLabel(derivedSeriesOutcome, metadata.queueData);
+    const selectedResultLabel = this.getFixSeriesOutcomeLabel(selectedSeriesOutcome, metadata.queueData);
+
+    await discordService.updateDeferredReply(interaction.token, {
+      embeds: [
+        this.createStatusEmbed(
+          `Preview generated. Confirm to replace the previous series stats.\nDerived result: ${derivedResultLabel}\nFinal result: ${selectedResultLabel}`,
+        ),
+        ...seriesEmbed.embeds,
+      ],
+      components: [
+        {
+          type: ComponentType.ActionRow,
+          components: [
+            {
+              type: ComponentType.StringSelect,
+              custom_id: InteractionButton.FixOutcomeSelect,
+              min_values: 1,
+              max_values: 1,
+              options: this.getFixSeriesOutcomeOptions(metadata.queueData, selectedSeriesOutcome),
+            },
+          ],
+        },
+        {
+          type: ComponentType.ActionRow,
+          components: [
+            {
+              type: ComponentType.Button,
+              custom_id: InteractionButton.FixConfirm,
+              label: "Confirm",
+              style: 3,
+            },
+            {
+              type: ComponentType.Button,
+              custom_id: InteractionButton.FixCancel,
+              label: "Cancel",
+              style: 2,
+            },
+          ],
+        },
+      ],
+    });
+  }
+
+  private deriveFixSeriesOutcome(series: MatchStats[]): FixSeriesOutcome {
+    const winsByTeamId = new Map<number, number>();
+    const entries = series.map((match) => ({
+      match,
+      startTime: match.MatchInfo.StartTime,
+      mapAssetId: match.MatchInfo.MapVariant.AssetId,
+      mapVersionId: match.MatchInfo.MapVariant.VersionId,
+      gameVariantCategory: match.MatchInfo.GameVariantCategory,
+    }));
+
+    for (const { match } of collapseSequentialSeriesEntries(entries)) {
+      for (const team of match.Teams) {
+        if (team.Outcome !== MatchOutcome.Win.valueOf()) {
+          continue;
+        }
+
+        winsByTeamId.set(team.TeamId, (winsByTeamId.get(team.TeamId) ?? 0) + 1);
+      }
+    }
+
+    const team0Wins = winsByTeamId.get(0) ?? 0;
+    const team1Wins = winsByTeamId.get(1) ?? 0;
+    if (team0Wins === team1Wins) {
+      return "TIE";
+    }
+
+    return team0Wins > team1Wins ? "TEAM_0" : "TEAM_1";
+  }
+
+  private parseFixSeriesOutcome(value: string): FixSeriesOutcome {
+    switch (value) {
+      case "TEAM_0":
+      case "TEAM_1":
+      case "TIE": {
+        return value;
+      }
+      default: {
+        throw new EndUserError("Invalid series outcome selection. Please run /stats fix again.");
+      }
+    }
+  }
+
+  private getFixSeriesOutcomeOptions(
+    queueData: Omit<QueueData, "timestamp">,
+    selectedSeriesOutcome: FixSeriesOutcome,
+  ): APISelectMenuOption[] {
+    return [
+      {
+        label: `${Preconditions.checkExists(queueData.teams[0], "Expected first queue team").name} wins`,
+        value: "TEAM_0",
+        default: selectedSeriesOutcome === "TEAM_0",
+      },
+      {
+        label: `${Preconditions.checkExists(queueData.teams[1], "Expected second queue team").name} wins`,
+        value: "TEAM_1",
+        default: selectedSeriesOutcome === "TEAM_1",
+      },
+      {
+        label: "Tie",
+        value: "TIE",
+        default: selectedSeriesOutcome === "TIE",
+      },
+    ];
+  }
+
+  private getFixSeriesOutcomeLabel(seriesOutcome: FixSeriesOutcome, queueData: Omit<QueueData, "timestamp">): string {
+    switch (seriesOutcome) {
+      case "TEAM_0": {
+        return `${Preconditions.checkExists(queueData.teams[0], "Expected first queue team").name} wins`;
+      }
+      case "TEAM_1": {
+        return `${Preconditions.checkExists(queueData.teams[1], "Expected second queue team").name} wins`;
+      }
+      case "TIE": {
+        return "Tie";
+      }
+      default: {
+        throw new UnreachableError(seriesOutcome);
+      }
     }
   }
 
@@ -1235,6 +1401,9 @@ export class StatsCommand extends BaseCommand {
       const selectedMatchIds = metadata.selectedMatchIds ?? [];
       if (selectedMatchIds.length === 0) {
         throw new EndUserError("No games were selected. Please run /stats fix again.");
+      }
+      if (metadata.selectedSeriesOutcome == null) {
+        throw new EndUserError("No final series result was selected. Please run /stats fix again.");
       }
 
       const locale = interaction.guild_locale ?? interaction.locale;

--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -1221,9 +1221,11 @@ export class StatsCommand extends BaseCommand {
     const { discordService, haloService } = this.services;
 
     try {
-      const selectedSeriesOutcome = this.parseFixSeriesOutcome(
-        Preconditions.checkExists(interaction.data.values[0], "No series outcome selected"),
-      );
+      const [selectedSeriesOutcomeRaw] = interaction.data.values;
+      if (selectedSeriesOutcomeRaw == null) {
+        throw new EndUserError("No series outcome selected. Please run /stats fix again.");
+      }
+      const selectedSeriesOutcome = this.parseFixSeriesOutcome(selectedSeriesOutcomeRaw);
       const metadata = await this.getFixMetadataWithRetry(interaction.message.id);
       if (metadata == null) {
         throw new EndUserError("Could not find fix-flow state. Please run /stats fix again.");
@@ -1353,14 +1355,17 @@ export class StatsCommand extends BaseCommand {
     queueData: Omit<QueueData, "timestamp">,
     selectedSeriesOutcome: FixSeriesOutcome,
   ): APISelectMenuOption[] {
+    const firstTeamName = this.getFixSeriesOutcomeTeamName(queueData, 0);
+    const secondTeamName = this.getFixSeriesOutcomeTeamName(queueData, 1);
+
     return [
       {
-        label: `${Preconditions.checkExists(queueData.teams[0], "Expected first queue team").name} wins`,
+        label: `${firstTeamName} wins`,
         value: "TEAM_0",
         default: selectedSeriesOutcome === "TEAM_0",
       },
       {
-        label: `${Preconditions.checkExists(queueData.teams[1], "Expected second queue team").name} wins`,
+        label: `${secondTeamName} wins`,
         value: "TEAM_1",
         default: selectedSeriesOutcome === "TEAM_1",
       },
@@ -1375,10 +1380,10 @@ export class StatsCommand extends BaseCommand {
   private getFixSeriesOutcomeLabel(seriesOutcome: FixSeriesOutcome, queueData: Omit<QueueData, "timestamp">): string {
     switch (seriesOutcome) {
       case "TEAM_0": {
-        return `${Preconditions.checkExists(queueData.teams[0], "Expected first queue team").name} wins`;
+        return `${this.getFixSeriesOutcomeTeamName(queueData, 0)} wins`;
       }
       case "TEAM_1": {
-        return `${Preconditions.checkExists(queueData.teams[1], "Expected second queue team").name} wins`;
+        return `${this.getFixSeriesOutcomeTeamName(queueData, 1)} wins`;
       }
       case "TIE": {
         return "Tie";
@@ -1387,6 +1392,11 @@ export class StatsCommand extends BaseCommand {
         throw new UnreachableError(seriesOutcome);
       }
     }
+  }
+
+  private getFixSeriesOutcomeTeamName(queueData: Omit<QueueData, "timestamp">, teamIndex: 0 | 1): string {
+    const teamName = Preconditions.checkExists(queueData.teams[teamIndex], "Expected queue team").name;
+    return teamName.replaceAll(/[*_~`|]/g, "");
   }
 
   private async handleFixConfirmationJob(interaction: APIMessageComponentButtonInteraction): Promise<void> {

--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -1203,7 +1203,7 @@ export class StatsCommand extends BaseCommand {
       }
 
       const derivedSeriesOutcome = this.deriveFixSeriesOutcome(series);
-      const selectedSeriesOutcome = metadata.selectedSeriesOutcome ?? derivedSeriesOutcome;
+      const selectedSeriesOutcome = derivedSeriesOutcome;
 
       await this.setFixMetadata(interaction.message.id, {
         ...metadata,

--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -1360,12 +1360,12 @@ export class StatsCommand extends BaseCommand {
 
     return [
       {
-        label: `${firstTeamName} wins`,
+        label: `${firstTeamName} wins`.slice(0, 100),
         value: "TEAM_0",
         default: selectedSeriesOutcome === "TEAM_0",
       },
       {
-        label: `${secondTeamName} wins`,
+        label: `${secondTeamName} wins`.slice(0, 100),
         value: "TEAM_1",
         default: selectedSeriesOutcome === "TEAM_1",
       },

--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -19,12 +19,12 @@ import {
   InteractionContextType,
   PermissionFlagsBits,
 } from "discord-api-types/v10";
-import { MatchOutcome, MatchType } from "halo-infinite-api";
+import { MatchType } from "halo-infinite-api";
 import type { MatchStats, GameVariantCategory } from "halo-infinite-api";
 import { formatDistanceToNowStrict, subHours } from "date-fns";
 import { Preconditions } from "@guilty-spark/shared/base/preconditions";
 import { UnreachableError } from "@guilty-spark/shared/base/unreachable-error";
-import { collapseSequentialSeriesEntries } from "@guilty-spark/shared/halo/match-enrichment";
+import { computeSeriesTeamWins } from "@guilty-spark/shared/halo/series-score";
 import type { BaseInteraction, ExecuteResponse, ApplicationCommandData, CommandData } from "../base/base-command";
 import { BaseCommand } from "../base/base-command";
 import { NEAT_QUEUE_BOT_USER_ID } from "../../services/discord/discord";
@@ -1310,27 +1310,17 @@ export class StatsCommand extends BaseCommand {
   }
 
   private deriveFixSeriesOutcome(series: MatchStats[]): FixSeriesOutcome {
-    const winsByTeamId = new Map<number, number>();
     const entries = series.map((match) => ({
-      match,
       startTime: match.MatchInfo.StartTime,
       mapAssetId: match.MatchInfo.MapVariant.AssetId,
       mapVersionId: match.MatchInfo.MapVariant.VersionId,
       gameVariantCategory: match.MatchInfo.GameVariantCategory,
+      teamOutcomes: match.Teams.map((team) => team.Outcome),
     }));
+    const winsByTeam = computeSeriesTeamWins(entries);
+    const team0Wins = winsByTeam[0] ?? 0;
+    const team1Wins = winsByTeam[1] ?? 0;
 
-    for (const { match } of collapseSequentialSeriesEntries(entries)) {
-      for (const team of match.Teams) {
-        if (team.Outcome !== MatchOutcome.Win.valueOf()) {
-          continue;
-        }
-
-        winsByTeamId.set(team.TeamId, (winsByTeamId.get(team.TeamId) ?? 0) + 1);
-      }
-    }
-
-    const team0Wins = winsByTeamId.get(0) ?? 0;
-    const team1Wins = winsByTeamId.get(1) ?? 0;
     if (team0Wins === team1Wins) {
       return "TIE";
     }

--- a/api/commands/stats/tests/stats.test.ts
+++ b/api/commands/stats/tests/stats.test.ts
@@ -1537,12 +1537,19 @@ describe("StatsCommand", () => {
         "statsFix:fix-flow-message-id",
         expect.objectContaining({
           selectedMatchIds: ["d81554d7-ddfe-44da-a6cb-000000000ctf", "9535b946-f30c-4a43-b852-000000slayer"],
+          selectedSeriesOutcome: "TIE",
         }),
       );
       const updatePayload = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]?.[1]);
       const statusEmbed = Preconditions.checkExists(updatePayload.embeds?.[0]);
-      expect(statusEmbed.description).toBe("Preview generated. Confirm to replace the previous series stats.");
+      expect(statusEmbed.description).toContain("Preview generated. Confirm to replace the previous series stats.");
+      expect(statusEmbed.description).toContain("Derived result:");
+      expect(statusEmbed.description).toContain("Final result:");
       expect(updatePayload.components).toEqual([
+        {
+          type: ComponentType.ActionRow,
+          components: [expect.objectContaining({ custom_id: "btn_stats_fix_outcome_select" })],
+        },
         {
           type: ComponentType.ActionRow,
           components: [
@@ -1551,6 +1558,48 @@ describe("StatsCommand", () => {
           ],
         },
       ]);
+    });
+  });
+
+  describe("execute(): message component fix outcome select", () => {
+    it("persists an explicit tie outcome and rerenders the preview", async () => {
+      const interaction: APIMessageComponentSelectMenuInteraction = {
+        ...fakeButtonClickInteraction,
+        data: {
+          component_type: ComponentType.StringSelect,
+          custom_id: "btn_stats_fix_outcome_select",
+          values: ["TIE"],
+        },
+        message: {
+          ...fakeButtonClickInteraction.message,
+          id: "fix-flow-message-id",
+        },
+      };
+      vi.spyOn(services.discordService, "getInteractionMetadata").mockResolvedValue({
+        guildId: "fake-guild-id",
+        channelId: "fake-channel-id",
+        queueData: discordNeatQueueData,
+        selectedMatchIds: ["d81554d7-ddfe-44da-a6cb-000000000ctf", "9535b946-f30c-4a43-b852-000000slayer"],
+        selectedSeriesOutcome: "TEAM_1",
+      });
+      vi.spyOn(services.haloService, "getMatchDetails").mockResolvedValue([
+        Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf")),
+        Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer")),
+      ]);
+      const setInteractionMetadataSpy = vi.spyOn(services.discordService, "setInteractionMetadata").mockResolvedValue();
+
+      const { response, jobToComplete } = statsCommand.execute(interaction);
+      expect(response).toEqual({ type: InteractionResponseType.DeferredMessageUpdate });
+
+      await jobToComplete?.();
+
+      expect(setInteractionMetadataSpy).toHaveBeenCalledWith(
+        "statsFix:fix-flow-message-id",
+        expect.objectContaining({ selectedSeriesOutcome: "TIE" }),
+      );
+      const updatePayload = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]?.[1]);
+      const statusEmbed = Preconditions.checkExists(updatePayload.embeds?.[0]);
+      expect(statusEmbed.description).toContain("Final result: Tie");
     });
   });
 
@@ -1579,6 +1628,7 @@ describe("StatsCommand", () => {
           },
         },
         selectedMatchIds: ["d81554d7-ddfe-44da-a6cb-000000000ctf", "9535b946-f30c-4a43-b852-000000slayer"],
+        selectedSeriesOutcome: "TEAM_1",
       });
       vi.spyOn(services.haloService, "getMatchDetails").mockResolvedValue([
         Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf")),
@@ -1683,6 +1733,7 @@ describe("StatsCommand", () => {
           },
         },
         selectedMatchIds: ["d81554d7-ddfe-44da-a6cb-000000000ctf", "9535b946-f30c-4a43-b852-000000slayer"],
+        selectedSeriesOutcome: "TEAM_1",
       });
       vi.spyOn(services.haloService, "getMatchDetails").mockResolvedValue([
         Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf")),
@@ -1741,6 +1792,7 @@ describe("StatsCommand", () => {
           },
         },
         selectedMatchIds: ["d81554d7-ddfe-44da-a6cb-000000000ctf", "9535b946-f30c-4a43-b852-000000slayer"],
+        selectedSeriesOutcome: "TEAM_1",
       });
       vi.spyOn(services.haloService, "getMatchDetails").mockResolvedValue([
         Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf")),

--- a/api/commands/stats/tests/stats.test.ts
+++ b/api/commands/stats/tests/stats.test.ts
@@ -1653,6 +1653,56 @@ describe("StatsCommand", () => {
         ]),
       );
     });
+
+    it("truncates outcome selector labels to Discord's 100 character limit", async () => {
+      const interaction: APIMessageComponentSelectMenuInteraction = {
+        ...fakeButtonClickInteraction,
+        data: {
+          component_type: ComponentType.StringSelect,
+          custom_id: "btn_stats_fix_games_select",
+          values: ["d81554d7-ddfe-44da-a6cb-000000000ctf", "9535b946-f30c-4a43-b852-000000slayer"],
+        },
+        message: {
+          ...fakeButtonClickInteraction.message,
+          id: "fix-flow-message-id",
+        },
+      };
+
+      vi.spyOn(services.discordService, "getInteractionMetadata").mockResolvedValue({
+        guildId: "fake-guild-id",
+        channelId: "fake-channel-id",
+        queueData: {
+          ...discordNeatQueueData,
+          teams: [
+            { ...Preconditions.checkExists(discordNeatQueueData.teams[0]), name: "A".repeat(140) },
+            { ...Preconditions.checkExists(discordNeatQueueData.teams[1]), name: "B".repeat(160) },
+          ],
+        },
+      });
+      vi.spyOn(services.haloService, "getMatchDetails").mockResolvedValue([
+        Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf")),
+        Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer")),
+      ]);
+      vi.spyOn(services.discordService, "setInteractionMetadata").mockResolvedValue();
+
+      const { jobToComplete } = statsCommand.execute(interaction);
+      await jobToComplete?.();
+
+      const updatePayload = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]?.[1]);
+      const outcomeRow = Preconditions.checkExists(updatePayload.components?.[0]);
+      if (!("components" in outcomeRow)) {
+        throw new Error("Expected outcome action row");
+      }
+      const outcomeSelect = Preconditions.checkExists(outcomeRow.components[0]);
+      if (!("options" in outcomeSelect)) {
+        throw new Error("Expected outcome select");
+      }
+
+      const team0Option = Preconditions.checkExists(outcomeSelect.options.find((option) => option.value === "TEAM_0"));
+      const team1Option = Preconditions.checkExists(outcomeSelect.options.find((option) => option.value === "TEAM_1"));
+      expect(team0Option.label.length).toBe(100);
+      expect(team1Option.label.length).toBe(100);
+    });
   });
 
   describe("execute(): message component fix outcome select", () => {

--- a/api/commands/stats/tests/stats.test.ts
+++ b/api/commands/stats/tests/stats.test.ts
@@ -1604,6 +1604,43 @@ describe("StatsCommand", () => {
   });
 
   describe("execute(): message component fix confirm", () => {
+    it("returns an error when selected series outcome is missing from fix-flow metadata", async () => {
+      const interaction: APIMessageComponentButtonInteraction = {
+        ...fakeButtonClickInteraction,
+        data: {
+          component_type: ComponentType.Button,
+          custom_id: "btn_stats_fix_confirm",
+        },
+        message: {
+          ...fakeButtonClickInteraction.message,
+          id: "fix-flow-message-id",
+        },
+      };
+
+      vi.spyOn(services.discordService, "getInteractionMetadata").mockResolvedValue({
+        guildId: "fake-guild-id",
+        channelId: "fake-channel-id",
+        queueData: {
+          ...discordNeatQueueData,
+          message: {
+            ...discordNeatQueueData.message,
+            id: "queue-neatqueue-message-id",
+          },
+        },
+        selectedMatchIds: ["d81554d7-ddfe-44da-a6cb-000000000ctf", "9535b946-f30c-4a43-b852-000000slayer"],
+      });
+
+      const { jobToComplete } = statsCommand.execute(interaction);
+      await jobToComplete?.();
+
+      expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+        "fake-token",
+        expect.objectContaining({
+          message: "No final series result was selected. Please run /stats fix again.",
+        }),
+      );
+    });
+
     it("rebuilds stats in related thread and marks amendment", async () => {
       const interaction: APIMessageComponentButtonInteraction = {
         ...fakeButtonClickInteraction,

--- a/api/commands/stats/tests/stats.test.ts
+++ b/api/commands/stats/tests/stats.test.ts
@@ -1559,6 +1559,48 @@ describe("StatsCommand", () => {
         },
       ]);
     });
+
+    it("resets final outcome to the newly derived outcome when game selection changes", async () => {
+      const interaction: APIMessageComponentSelectMenuInteraction = {
+        ...fakeButtonClickInteraction,
+        data: {
+          component_type: ComponentType.StringSelect,
+          custom_id: "btn_stats_fix_games_select",
+          values: ["d81554d7-ddfe-44da-a6cb-000000000ctf", "9535b946-f30c-4a43-b852-000000slayer"],
+        },
+        message: {
+          ...fakeButtonClickInteraction.message,
+          id: "fix-flow-message-id",
+        },
+      };
+
+      vi.spyOn(services.discordService, "getInteractionMetadata").mockResolvedValue({
+        guildId: "fake-guild-id",
+        channelId: "fake-channel-id",
+        queueData: discordNeatQueueData,
+        selectedSeriesOutcome: "TEAM_1",
+      });
+      vi.spyOn(services.haloService, "getMatchDetails").mockResolvedValue([
+        Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf")),
+        Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer")),
+      ]);
+      const setInteractionMetadataSpy = vi.spyOn(services.discordService, "setInteractionMetadata").mockResolvedValue();
+
+      const { jobToComplete } = statsCommand.execute(interaction);
+      await jobToComplete?.();
+
+      expect(setInteractionMetadataSpy).toHaveBeenCalledWith(
+        "statsFix:fix-flow-message-id",
+        expect.objectContaining({
+          selectedMatchIds: ["d81554d7-ddfe-44da-a6cb-000000000ctf", "9535b946-f30c-4a43-b852-000000slayer"],
+          selectedSeriesOutcome: "TIE",
+        }),
+      );
+      const updatePayload = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]?.[1]);
+      const statusEmbed = Preconditions.checkExists(updatePayload.embeds?.[0]);
+      expect(statusEmbed.description).toContain("Derived result: Tie");
+      expect(statusEmbed.description).toContain("Final result: Tie");
+    });
   });
 
   describe("execute(): message component fix outcome select", () => {

--- a/api/commands/stats/tests/stats.test.ts
+++ b/api/commands/stats/tests/stats.test.ts
@@ -1601,6 +1601,58 @@ describe("StatsCommand", () => {
       expect(statusEmbed.description).toContain("Derived result: Tie");
       expect(statusEmbed.description).toContain("Final result: Tie");
     });
+
+    it("sanitizes markdown in team labels for outcome selector", async () => {
+      const interaction: APIMessageComponentSelectMenuInteraction = {
+        ...fakeButtonClickInteraction,
+        data: {
+          component_type: ComponentType.StringSelect,
+          custom_id: "btn_stats_fix_games_select",
+          values: ["d81554d7-ddfe-44da-a6cb-000000000ctf", "9535b946-f30c-4a43-b852-000000slayer"],
+        },
+        message: {
+          ...fakeButtonClickInteraction.message,
+          id: "fix-flow-message-id",
+        },
+      };
+
+      vi.spyOn(services.discordService, "getInteractionMetadata").mockResolvedValue({
+        guildId: "fake-guild-id",
+        channelId: "fake-channel-id",
+        queueData: {
+          ...discordNeatQueueData,
+          teams: [
+            { ...Preconditions.checkExists(discordNeatQueueData.teams[0]), name: "__Cobra__" },
+            { ...Preconditions.checkExists(discordNeatQueueData.teams[1]), name: "**Viper**" },
+          ],
+        },
+      });
+      vi.spyOn(services.haloService, "getMatchDetails").mockResolvedValue([
+        Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf")),
+        Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer")),
+      ]);
+      vi.spyOn(services.discordService, "setInteractionMetadata").mockResolvedValue();
+
+      const { jobToComplete } = statsCommand.execute(interaction);
+      await jobToComplete?.();
+
+      const updatePayload = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]?.[1]);
+      const outcomeRow = Preconditions.checkExists(updatePayload.components?.[0]);
+      if (!("components" in outcomeRow)) {
+        throw new Error("Expected outcome action row");
+      }
+      const outcomeSelect = Preconditions.checkExists(outcomeRow.components[0]);
+      if (!("options" in outcomeSelect)) {
+        throw new Error("Expected outcome select");
+      }
+
+      expect(outcomeSelect.options).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ value: "TEAM_0", label: "Cobra wins" }),
+          expect.objectContaining({ value: "TEAM_1", label: "Viper wins" }),
+        ]),
+      );
+    });
   });
 
   describe("execute(): message component fix outcome select", () => {
@@ -1642,6 +1694,31 @@ describe("StatsCommand", () => {
       const updatePayload = Preconditions.checkExists(updateDeferredReplySpy.mock.calls[0]?.[1]);
       const statusEmbed = Preconditions.checkExists(updatePayload.embeds?.[0]);
       expect(statusEmbed.description).toContain("Final result: Tie");
+    });
+
+    it("returns an error when no outcome value is selected", async () => {
+      const interaction: APIMessageComponentSelectMenuInteraction = {
+        ...fakeButtonClickInteraction,
+        data: {
+          component_type: ComponentType.StringSelect,
+          custom_id: "btn_stats_fix_outcome_select",
+          values: [],
+        },
+        message: {
+          ...fakeButtonClickInteraction.message,
+          id: "fix-flow-message-id",
+        },
+      };
+
+      const { jobToComplete } = statsCommand.execute(interaction);
+      await jobToComplete?.();
+
+      expect(updateDeferredReplyWithErrorSpy).toHaveBeenCalledWith(
+        "fake-token",
+        expect.objectContaining({
+          message: "No series outcome selected. Please run /stats fix again.",
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
## Context
PR14 needs corrected leaderboard facts to reflect the authoritative amended series. Before reconciliation can safely write those facts, `/stats fix` must capture an outcome that handles both normal derived results and exceptional agreed ties or restarted deciding games.

## This PR
- Derives a default amended-series result from selected match outcomes after applying the existing sequential restart-collapse rule.
- Adds an outcome selector to the `/stats fix` preview for either queue team or `Tie`; it defaults to the derived result.
- Shows the derived result and final selected result in the confirmation preview.
- Persists the final selection in fix-flow metadata and blocks confirmation when stale metadata lacks it.
- Adds regression coverage for derived defaults, preview selector rendering, persisted outcome metadata, explicit tie override, and existing confirmation paths.

## Subsequent Work
- PR14b will use the stored outcome to reconcile amended leaderboard series/game/player facts through the existing idempotent persistence path and refresh affected leaderboard posts.