### PR TITLE
Fix invalid Sunday cron trigger

### DIFF
--- a/api/worker.ts
+++ b/api/worker.ts
@@ -53,7 +53,7 @@ export default Sentry.withSentry(
           await cleanup.execute();
           break;
         }
-        case "0 0 * * 0": {
+        case "0 0 * * SUN": {
           const reaper = new LeaderboardPostReaper({ databaseService, discordService, logService });
           await reaper.execute();
           break;

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -8,7 +8,7 @@
 
   // Scheduled jobs: daily stale NeatQueue cleanup and weekly leaderboard post reaping
   "triggers": {
-    "crons": ["0 15 * * *", "0 0 * * 0"],
+    "crons": ["0 15 * * *", "0 0 * * SUN"],
   },
 
   // KV namespaces for development


### PR DESCRIPTION
## Context
The weekly leaderboard post reaper could not be deployed because Cloudflare rejects numeric weekday `0` in cron expressions. Cloudflare cron weekdays use `1-7` or three-letter names such as `SUN`.

## This PR
- Replaces `0 0 * * 0` with the valid explicit Sunday expression `0 0 * * SUN` in `api/wrangler.jsonc`.
- Updates the scheduled handler in `api/worker.ts` to dispatch the corrected expression.
- Keeps the weekly reaper schedule at 00:00 UTC on Sunday.

## Subsequent Work
- None; the Wrangler dry-run validated the corrected trigger configuration.