### PR TITLE
Recreate deleted Durable Object classes

### DIFF
--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -135,32 +135,6 @@
     "production": {
       "name": "guilty-spark",
       "routes": ["api.guilty-spark.app/*"],
-      "migrations": [
-        {
-          "tag": "v1",
-          "new_classes": ["LiveTrackerDO"],
-        },
-        {
-          "tag": "v2",
-          "new_classes": ["LiveTrackerIndividualDO"],
-        },
-        {
-          "tag": "v3",
-          "deleted_classes": ["LiveTrackerIndividualDO"],
-        },
-        {
-          "tag": "v4",
-          "new_classes": ["IndividualTrackerDO"],
-        },
-        {
-          "tag": "v5",
-          "new_classes": ["UserTrackerDO"],
-        },
-        {
-          "tag": "v6",
-          "new_classes": ["IndividualTrackerDO", "UserTrackerDO"],
-        },
-      ],
       "kv_namespaces": [
         {
           "binding": "APP_DATA",

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -135,6 +135,32 @@
     "production": {
       "name": "guilty-spark",
       "routes": ["api.guilty-spark.app/*"],
+      "migrations": [
+        {
+          "tag": "v1",
+          "new_classes": ["LiveTrackerDO"],
+        },
+        {
+          "tag": "v2",
+          "new_classes": ["LiveTrackerIndividualDO"],
+        },
+        {
+          "tag": "v3",
+          "deleted_classes": ["LiveTrackerIndividualDO"],
+        },
+        {
+          "tag": "v4",
+          "new_classes": ["IndividualTrackerDO"],
+        },
+        {
+          "tag": "v5",
+          "new_classes": ["UserTrackerDO"],
+        },
+        {
+          "tag": "v6",
+          "new_classes": ["IndividualTrackerDO", "UserTrackerDO"],
+        },
+      ],
       "kv_namespaces": [
         {
           "binding": "APP_DATA",

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -68,6 +68,10 @@
       "tag": "v5",
       "new_classes": ["UserTrackerDO"],
     },
+    {
+      "tag": "v6",
+      "new_classes": ["IndividualTrackerDO", "UserTrackerDO"],
+    },
   ],
 
   // Development environment variables


### PR DESCRIPTION
## Context
The production Durable Object namespaces for `IndividualTrackerDO` and `UserTrackerDO` were deleted server-side. The existing migration history records when those classes were first created, but Cloudflare does not replay historical migrations when a binding is recreated.

## This PR
- Adds migration `v6` declaring `IndividualTrackerDO` and `UserTrackerDO` as new Durable Object classes.
- Allows the production deployment to recreate the deleted namespaces before applying the existing bindings.
- Preserves the existing legacy storage backend used by migrations `v4` and `v5`.
- Keeps deployment in GitHub Actions so the configured production variables and secrets remain available.

The production dry run passes from the `api` directory and recognizes all three Durable Object bindings.

## Subsequent Work
- Merge this PR to trigger the existing production deployment workflow after the `Typecheck` workflow succeeds.