### PR TITLE
Remove clientless UserTracker alarms

### DIFF
--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1288,7 +1288,8 @@ describe("UserTrackerDO", () => {
       }
 
       if (typeof key === "string") {
-        await Promise.resolve(undefined); return;
+        await Promise.resolve(undefined);
+        return;
       }
 
       return await Promise.resolve(new Map());

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1313,7 +1313,8 @@ describe("UserTrackerDO", () => {
     await localUserTrackerDO.alarm();
 
     expect(setAlarmMock).toHaveBeenCalledTimes(1);
-    const [message, context] = debugSpy.mock.calls.find(([currentMessage]) => currentMessage === "UserTracker follow tick") ?? [];
+    const [message, context] =
+      debugSpy.mock.calls.find(([currentMessage]) => currentMessage === "UserTracker follow tick") ?? [];
     expect(message).toBe("UserTracker follow tick");
     expect(context?.get("userId")).toBe("user-1");
     expect(context?.get("tickType")).toBe("follow");
@@ -1768,6 +1769,17 @@ describe("UserTrackerDO", () => {
 
     await userTrackerDO.alarm();
 
+    expect(deleteAlarmMock).toHaveBeenCalledOnce();
+  });
+
+  it("does not re-arm follow alarm when the last websocket disconnects during a tick", async () => {
+    vi.spyOn(mockState, "getWebSockets")
+      .mockReturnValueOnce([{} as WebSocket])
+      .mockReturnValue([]);
+
+    await userTrackerDO.alarm();
+
+    expect(setAlarmMock).not.toHaveBeenCalled();
     expect(deleteAlarmMock).toHaveBeenCalledOnce();
   });
 

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -24,8 +24,6 @@ import { installFakeServicesWith } from "../../../services/fakes/services";
 import { aFakeWebSocketHibernationAdapter } from "../../../base/fakes/websocket-hibernation-adapter.fake";
 import type { FakeWebSocketHibernationAdapter } from "../../../base/fakes/websocket-hibernation-adapter.fake";
 
-const RECONCILE_WINDOW_MS = 300000;
-
 interface PersistentStateHarness {
   state: DurableObjectState & { storage: DurableObjectStorage };
   persistedStorage: Map<string, unknown>;
@@ -1276,7 +1274,19 @@ describe("UserTrackerDO", () => {
       },
     });
     const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
-    const services = installFakeServicesWith({ env: localEnv });
+    const logService = aFakeLogServiceWith();
+    const debugSpy = vi.spyOn(logService, "debug");
+    const services = installFakeServicesWith({ env: localEnv, logService });
+    mockState.storage.get = (async (key: string | string[]) => {
+      if (typeof key === "string") {
+        return await Promise.resolve({
+          state: { userId: "user-1", lastUpdateTime: new Date().toISOString() },
+          viewState: null,
+        });
+      }
+
+      return await Promise.resolve(new Map());
+    }) as DurableObjectStorage["get"];
     vi.spyOn(mockState, "getWebSockets").mockReturnValue([{} as WebSocket]);
     vi.spyOn(services.databaseService, "findIndividualTrackersByUserId")
       .mockResolvedValueOnce([
@@ -1303,9 +1313,14 @@ describe("UserTrackerDO", () => {
     await localUserTrackerDO.alarm();
 
     expect(setAlarmMock).toHaveBeenCalledTimes(1);
+    const [message, context] = debugSpy.mock.calls.find(([currentMessage]) => currentMessage === "UserTracker follow tick") ?? [];
+    expect(message).toBe("UserTracker follow tick");
+    expect(context?.get("userId")).toBe("user-1");
+    expect(context?.get("tickType")).toBe("follow");
+    expect(context?.get("connectedClientCount")).toBe("1");
   });
 
-  it("reconciles through alarm when no websocket clients are connected but state exists", async () => {
+  it("refreshes clientless view-state requests on demand", async () => {
     const persistedStorage = new Map<string, unknown>();
     let alarmTime: number | null = null;
     const localSetAlarmMock = vi.fn<DurableObjectStorage["setAlarm"]>(async (scheduledTime) => {
@@ -1374,53 +1389,17 @@ describe("UserTrackerDO", () => {
     );
     const initialPayload = await userTrackerViewStateContract.fromResponse(initialResponse);
     expect(initialPayload.state?.directory.trackers).toHaveLength(1);
-    expect(localSetAlarmMock).toHaveBeenCalledOnce();
-
-    alarmTime = null;
-    await localUserTrackerDO.alarm();
 
     const reconciledResponse = await localUserTrackerDO.fetch(
       new Request("http://do/view-state?userId=user-1", { method: "GET" }),
     );
     const reconciledPayload = await userTrackerViewStateContract.fromResponse(reconciledResponse);
     expect(reconciledPayload.state?.directory.trackers).toHaveLength(0);
-    expect(localSetAlarmMock).toHaveBeenCalledTimes(2);
+    expect(localSetAlarmMock).not.toHaveBeenCalled();
     expect(localDeleteAlarmMock).not.toHaveBeenCalled();
   });
 
-  it("stops reconciling and clears the alarm once the clientless reconcile window elapses", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
-    const harness = aPersistentStateHarness();
-    const localEnv = aFakeEnvWith({
-      INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(
-        aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } }),
-      ),
-    });
-    const services = installFakeServicesWith({ env: localEnv });
-    vi.spyOn(harness.state, "getWebSockets").mockReturnValue([]);
-    const findTrackersSpy = vi
-      .spyOn(services.databaseService, "findIndividualTrackersByUserId")
-      .mockResolvedValue([aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1", Status: "active" })]);
-    const localUserTrackerDO = new UserTrackerDO(harness.state, localEnv, () => services, webSocketAdapter);
-
-    await localUserTrackerDO.fetch(new Request("http://do/view-state?userId=user-1", { method: "GET" }));
-    expect(harness.setAlarmMock).toHaveBeenCalledOnce();
-
-    vi.advanceTimersByTime(RECONCILE_WINDOW_MS + 1);
-    findTrackersSpy.mockClear();
-    await localUserTrackerDO.alarm();
-
-    expect(harness.deleteAlarmMock).toHaveBeenCalledOnce();
-    expect(harness.setAlarmMock).toHaveBeenCalledOnce();
-    expect(findTrackersSpy).not.toHaveBeenCalled();
-
-    await localUserTrackerDO.fetch(new Request("http://do/view-state?userId=user-1", { method: "GET" }));
-    expect(findTrackersSpy).toHaveBeenCalledOnce();
-    vi.useRealTimers();
-  });
-
-  it("stops reconciling when no reconcile deadline has been recorded", async () => {
+  it("clears an alarm when it fires without websocket clients", async () => {
     const harness = aPersistentStateHarness();
     harness.persistedStorage.set("userTrackerState", {
       state: { userId: "user-1", lastUpdateTime: new Date().toISOString() },
@@ -1443,35 +1422,7 @@ describe("UserTrackerDO", () => {
     expect(findTrackersSpy).not.toHaveBeenCalled();
   });
 
-  it("extends the reconcile window when view-state is requested again", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
-    const harness = aPersistentStateHarness();
-    const localEnv = aFakeEnvWith({
-      INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(
-        aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } }),
-      ),
-    });
-    const services = installFakeServicesWith({ env: localEnv });
-    vi.spyOn(harness.state, "getWebSockets").mockReturnValue([]);
-    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([
-      aFakeIndividualTrackersRow({ TrackerId: "t1", UserId: "user-1", Status: "active" }),
-    ]);
-    const localUserTrackerDO = new UserTrackerDO(harness.state, localEnv, () => services, webSocketAdapter);
-
-    await localUserTrackerDO.fetch(new Request("http://do/view-state?userId=user-1", { method: "GET" }));
-    vi.advanceTimersByTime(RECONCILE_WINDOW_MS - 1000);
-    await localUserTrackerDO.fetch(new Request("http://do/view-state?userId=user-1", { method: "GET" }));
-
-    vi.advanceTimersByTime(2000);
-    await localUserTrackerDO.alarm();
-
-    expect(harness.deleteAlarmMock).not.toHaveBeenCalled();
-    expect(harness.setAlarmMock).toHaveBeenCalledTimes(2);
-    vi.useRealTimers();
-  });
-
-  it("re-arms reconcile alarm and logs directory refresh failures when rebuild fails transiently", async () => {
+  it("logs directory refresh failures from a connected-client alarm", async () => {
     const persistedStorage = new Map<string, unknown>();
     let alarmTime: number | null = null;
     const localSetAlarmMock = vi.fn<DurableObjectStorage["setAlarm"]>(async (scheduledTime) => {
@@ -1515,8 +1466,8 @@ describe("UserTrackerDO", () => {
     const logService = aFakeLogServiceWith();
     const errorSpy = vi.spyOn(logService, "error");
     const services = installFakeServicesWith({ env: localEnv, logService });
-    vi.spyOn(localState, "getWebSockets").mockReturnValue([]);
     const transientFailure = new Error("transient reconcile failure");
+    vi.spyOn(localState, "getWebSockets").mockReturnValue([{} as WebSocket]);
     vi.spyOn(services.databaseService, "findIndividualTrackersByUserId")
       .mockResolvedValueOnce([
         aFakeIndividualTrackersRow({
@@ -1534,12 +1485,9 @@ describe("UserTrackerDO", () => {
       new Request("http://do/view-state?userId=user-1", { method: "GET" }),
     );
     expect(initialResponse.status).toBe(200);
-    expect(localSetAlarmMock).toHaveBeenCalledOnce();
-
-    alarmTime = null;
     await localUserTrackerDO.alarm();
 
-    expect(localSetAlarmMock).toHaveBeenCalledTimes(2);
+    expect(localSetAlarmMock).toHaveBeenCalledOnce();
     expect(localDeleteAlarmMock).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalled();
     const [loggedError, loggedContext] = errorSpy.mock.calls.at(-1) ?? [];
@@ -1591,7 +1539,7 @@ describe("UserTrackerDO", () => {
     const logService = aFakeLogServiceWith();
     const errorSpy = vi.spyOn(logService, "error");
     const services = installFakeServicesWith({ env: localEnv, logService });
-    vi.spyOn(localState, "getWebSockets").mockReturnValue([]);
+    vi.spyOn(localState, "getWebSockets").mockReturnValue([{} as WebSocket]);
     vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([
       aFakeIndividualTrackersRow({
         TrackerId: "t1",
@@ -1620,7 +1568,7 @@ describe("UserTrackerDO", () => {
     expect(loggedError).toBe(alarmFailure);
     expect(loggedContext?.get("context")).toBe("UserTracker alarm error");
     expect(loggedContext?.get("userId")).toBe("user-1");
-    expect(loggedContext?.get("tickType")).toBe("reconcile");
+    expect(loggedContext?.get("tickType")).toBe("follow");
   });
 
   it("logs alarm errors with fallback context when state enrichment fails", async () => {
@@ -1721,7 +1669,7 @@ describe("UserTrackerDO", () => {
     const logService = aFakeLogServiceWith();
     const errorSpy = vi.spyOn(logService, "error");
     const services = installFakeServicesWith({ env: localEnv, logService });
-    vi.spyOn(localState, "getWebSockets").mockReturnValue([]);
+    vi.spyOn(localState, "getWebSockets").mockReturnValue([{} as WebSocket]);
     vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([
       aFakeIndividualTrackersRow({
         TrackerId: "t1",
@@ -1742,7 +1690,7 @@ describe("UserTrackerDO", () => {
     shouldFailNextPut = true;
     await localUserTrackerDO.alarm();
 
-    expect(localSetAlarmMock).toHaveBeenCalledTimes(2);
+    expect(localSetAlarmMock).toHaveBeenCalledOnce();
     expect(localDeleteAlarmMock).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalled();
     const [loggedError, loggedContext] = errorSpy.mock.calls.at(-1) ?? [];

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -24,6 +24,8 @@ import { installFakeServicesWith } from "../../../services/fakes/services";
 import { aFakeWebSocketHibernationAdapter } from "../../../base/fakes/websocket-hibernation-adapter.fake";
 import type { FakeWebSocketHibernationAdapter } from "../../../base/fakes/websocket-hibernation-adapter.fake";
 
+const USER_TRACKER_STATE_KEY = "userTrackerState";
+
 interface PersistentStateHarness {
   state: DurableObjectState & { storage: DurableObjectStorage };
   persistedStorage: Map<string, unknown>;
@@ -1278,11 +1280,15 @@ describe("UserTrackerDO", () => {
     const debugSpy = vi.spyOn(logService, "debug");
     const services = installFakeServicesWith({ env: localEnv, logService });
     mockState.storage.get = (async (key: string | string[]) => {
-      if (typeof key === "string") {
+      if (key === USER_TRACKER_STATE_KEY) {
         return await Promise.resolve({
           state: { userId: "user-1", lastUpdateTime: new Date().toISOString() },
           viewState: null,
         });
+      }
+
+      if (typeof key === "string") {
+        await Promise.resolve(undefined); return;
       }
 
       return await Promise.resolve(new Map());

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1320,6 +1320,12 @@ describe("UserTrackerDO", () => {
     await localUserTrackerDO.alarm();
 
     expect(setAlarmMock).toHaveBeenCalledTimes(1);
+    const [startMessage, startContext] =
+      debugSpy.mock.calls.find(([currentMessage]) => currentMessage === "UserTracker alarm start") ?? [];
+    expect(startMessage).toBe("UserTracker alarm start");
+    expect(startContext?.get("userId")).toBe("user-1");
+    expect(startContext?.get("hasConnectedClients")).toBe("true");
+    expect(startContext?.get("connectedClientCount")).toBe("1");
     const [message, context] =
       debugSpy.mock.calls.find(([currentMessage]) => currentMessage === "UserTracker follow tick") ?? [];
     expect(message).toBe("UserTracker follow tick");
@@ -1418,7 +1424,9 @@ describe("UserTrackerDO", () => {
         aFakeIndividualTrackerDOWith({ viewStateResponse: { state: null } }),
       ),
     });
-    const services = installFakeServicesWith({ env: localEnv });
+    const logService = aFakeLogServiceWith();
+    const debugSpy = vi.spyOn(logService, "debug");
+    const services = installFakeServicesWith({ env: localEnv, logService });
     vi.spyOn(harness.state, "getWebSockets").mockReturnValue([]);
     const findTrackersSpy = vi.spyOn(services.databaseService, "findIndividualTrackersByUserId");
     const localUserTrackerDO = new UserTrackerDO(harness.state, localEnv, () => services, webSocketAdapter);
@@ -1428,6 +1436,12 @@ describe("UserTrackerDO", () => {
     expect(harness.deleteAlarmMock).toHaveBeenCalledOnce();
     expect(harness.setAlarmMock).not.toHaveBeenCalled();
     expect(findTrackersSpy).not.toHaveBeenCalled();
+    const [message, context] =
+      debugSpy.mock.calls.find(([currentMessage]) => currentMessage === "UserTracker alarm start") ?? [];
+    expect(message).toBe("UserTracker alarm start");
+    expect(context?.get("userId")).toBe("user-1");
+    expect(context?.get("hasConnectedClients")).toBe("false");
+    expect(context?.get("connectedClientCount")).toBe("0");
   });
 
   it("logs directory refresh failures from a connected-client alarm", async () => {
@@ -1728,10 +1742,10 @@ describe("UserTrackerDO", () => {
     const sharedStorage = aFakeDurableObjectStorageWith({
       get: (async (key: string | string[]) => {
         getCalls += 1;
-        if (getCalls === 1) {
+        if (getCalls === 2) {
           throw refreshFailure;
         }
-        if (getCalls === 2) {
+        if (getCalls === 3) {
           throw enrichFailure;
         }
         if (typeof key === "string") {

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -223,16 +223,27 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
       const connectedClientCount = this.state.getWebSockets().length;
       const hasConnectedClients = connectedClientCount > 0;
+      let stored = await this.loadStateForTickLog();
+      this.logService.debug(
+        "UserTracker alarm start",
+        new Map([
+          ["userId", stored.state?.userId ?? "unknown"],
+          ["hasConnectedClients", hasConnectedClients.toString()],
+          ["connectedClientCount", connectedClientCount.toString()],
+        ]),
+      );
+
       if (!hasConnectedClients) {
         await this.stopUpdateLoop();
         return;
       }
 
-      let stored: UserTrackerInternalState | null = null;
       const tickType = "follow";
+      let didRefresh = false;
 
       try {
         await this.queueDirectoryPush();
+        didRefresh = true;
       } catch (error) {
         stored = await this.loadStateForErrorContext("UserTracker alarm error context load failed");
         this.logService.error(
@@ -248,18 +259,20 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
         Sentry.captureException(error);
       }
 
-      if (stored == null) {
-        stored = await this.loadStateForTickLog();
-        this.logService.debug(
-          `UserTracker ${tickType} tick`,
-          new Map([
-            ["userId", stored.state?.userId ?? "unknown"],
-            ["tickType", tickType],
-            ["hasConnectedClients", hasConnectedClients.toString()],
-            ["connectedClientCount", connectedClientCount.toString()],
-          ]),
-        );
+      if (!didRefresh) {
+        await this.scheduleNextAlarm(FOLLOW_WS_POLL_INTERVAL_MS);
+        return;
       }
+
+      this.logService.debug(
+        `UserTracker ${tickType} tick`,
+        new Map([
+          ["userId", stored.state?.userId ?? "unknown"],
+          ["tickType", tickType],
+          ["hasConnectedClients", hasConnectedClients.toString()],
+          ["connectedClientCount", connectedClientCount.toString()],
+        ]),
+      );
 
       const hasConnectedClientsAfterTick = this.state.getWebSockets().length > 0;
       if (!hasConnectedClientsAfterTick) {

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -224,8 +224,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       const connectedClientCount = this.state.getWebSockets().length;
       const hasConnectedClients = connectedClientCount > 0;
       if (!hasConnectedClients) {
-        await this.state.storage.delete(USER_TRACKER_RECONCILE_DEADLINE_KEY);
-        await this.state.storage.deleteAlarm();
+        await this.stopUpdateLoop();
         return;
       }
 
@@ -264,8 +263,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
       const hasConnectedClientsAfterTick = this.state.getWebSockets().length > 0;
       if (!hasConnectedClientsAfterTick) {
-        await this.state.storage.delete(USER_TRACKER_RECONCILE_DEADLINE_KEY);
-        await this.state.storage.deleteAlarm();
+        await this.stopUpdateLoop();
         return;
       }
 

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -262,9 +262,14 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
         );
       }
 
-      await this.scheduleNextAlarm(
-        FOLLOW_WS_POLL_INTERVAL_MS,
-      );
+      const hasConnectedClientsAfterTick = this.state.getWebSockets().length > 0;
+      if (!hasConnectedClientsAfterTick) {
+        await this.state.storage.delete(USER_TRACKER_RECONCILE_DEADLINE_KEY);
+        await this.state.storage.deleteAlarm();
+        return;
+      }
+
+      await this.scheduleNextAlarm(FOLLOW_WS_POLL_INTERVAL_MS);
     });
   }
 

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -35,8 +35,6 @@ const USER_TRACKER_STATE_KEY = "userTrackerState";
 const USER_TRACKER_MARKERS_KEY = "userTrackerMarkers";
 const USER_TRACKER_RECONCILE_DEADLINE_KEY = "userTrackerReconcileDeadline";
 const FOLLOW_WS_POLL_INTERVAL_MS = 3000;
-const USER_TRACKER_RECONCILE_INTERVAL_MS = 30000;
-const USER_TRACKER_RECONCILE_WINDOW_MS = 300000;
 const TRACKER_MARKER_LIMIT = 500;
 
 function isNonStopped(row: IndividualTrackersRow): boolean {
@@ -223,31 +221,21 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       Sentry.setTag("durableObject", "UserTrackerDO");
       Sentry.setTag("method", "alarm");
 
-      const hasConnectedClients = this.state.getWebSockets().length > 0;
+      const connectedClientCount = this.state.getWebSockets().length;
+      const hasConnectedClients = connectedClientCount > 0;
       if (!hasConnectedClients) {
-        const stored = await this.loadState();
-        await this.stopUpdateLoop({ scheduleReconcile: false, stored });
-
-        if (stored.state?.userId == null) {
-          return;
-        }
-
-        if (await this.hasReconcileWindowElapsed()) {
-          await this.stopReconciling(stored.state.userId);
-          return;
-        }
+        await this.state.storage.delete(USER_TRACKER_RECONCILE_DEADLINE_KEY);
+        await this.state.storage.deleteAlarm();
+        return;
       }
 
-      const tickType = hasConnectedClients ? "follow" : "reconcile";
-      this.logService.debug(
-        `UserTracker ${tickType} tick`,
-        new Map([["hasConnectedClients", hasConnectedClients.toString()]]),
-      );
+      let stored: UserTrackerInternalState | null = null;
+      const tickType = "follow";
 
       try {
         await this.queueDirectoryPush();
       } catch (error) {
-        const stored = await this.loadStateForErrorContext("UserTracker alarm error context load failed");
+        stored = await this.loadStateForErrorContext("UserTracker alarm error context load failed");
         this.logService.error(
           error,
           new Map([
@@ -255,13 +243,27 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
             ["userId", stored.state?.userId ?? "unknown"],
             ["tickType", tickType],
             ["hasConnectedClients", hasConnectedClients.toString()],
+            ["connectedClientCount", connectedClientCount.toString()],
           ]),
         );
         Sentry.captureException(error);
       }
 
+      if (stored == null) {
+        stored = await this.loadStateForTickLog();
+        this.logService.debug(
+          `UserTracker ${tickType} tick`,
+          new Map([
+            ["userId", stored.state?.userId ?? "unknown"],
+            ["tickType", tickType],
+            ["hasConnectedClients", hasConnectedClients.toString()],
+            ["connectedClientCount", connectedClientCount.toString()],
+          ]),
+        );
+      }
+
       await this.scheduleNextAlarm(
-        hasConnectedClients ? FOLLOW_WS_POLL_INTERVAL_MS : USER_TRACKER_RECONCILE_INTERVAL_MS,
+        FOLLOW_WS_POLL_INTERVAL_MS,
       );
     });
   }
@@ -288,6 +290,18 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     };
   }
 
+  private async loadStateForTickLog(): Promise<UserTrackerInternalState> {
+    try {
+      return await this.loadState();
+    } catch (error) {
+      this.logService.warn(error, new Map([["context", "UserTracker tick context load failed"]]));
+      return {
+        state: null,
+        viewState: null,
+      };
+    }
+  }
+
   private async handleStatus(): Promise<Response> {
     const stored = await this.loadState();
     const response: UserTrackerStatusResponse = {
@@ -298,9 +312,6 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
   private async handleViewState(request: Request): Promise<Response> {
     const stored = await this.getOrBuildState(request);
-    if (stored?.state?.userId != null && this.state.getWebSockets().length === 0) {
-      await this.scheduleReconcileAlarmIfNeeded();
-    }
 
     const response: UserTrackerViewStateResponse = {
       state: stored?.viewState ?? null,
@@ -359,7 +370,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       return stored.viewState == null ? null : stored;
     }
 
-    if (stored.viewState != null && stored.state?.userId === userId) {
+    if (stored.viewState != null && stored.state?.userId === userId && this.state.getWebSockets().length > 0) {
       return stored;
     }
 
@@ -440,61 +451,12 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     void this.installTrackerSubscriptionsAsync();
   }
 
-  private async stopUpdateLoop(
-    options: { scheduleReconcile: boolean; stored?: UserTrackerInternalState } = { scheduleReconcile: true },
-  ): Promise<void> {
+  private async stopUpdateLoop(): Promise<void> {
     this.closeTrackerSubscriptions();
     this.closeTrackerSubscriptions = (): void => {
       // reset after closing
     };
     this.trackerSubscriptionsInstalled = false;
-
-    const stored = options.stored ?? (await this.loadState());
-    if (stored.state?.userId == null) {
-      await this.state.storage.delete(USER_TRACKER_RECONCILE_DEADLINE_KEY);
-      await this.state.storage.deleteAlarm();
-      return;
-    }
-
-    if (!options.scheduleReconcile) {
-      return;
-    }
-
-    await this.scheduleReconcileAlarmIfNeeded();
-  }
-
-  private async scheduleReconcileAlarmIfNeeded(): Promise<void> {
-    await this.state.storage.put(USER_TRACKER_RECONCILE_DEADLINE_KEY, Date.now() + USER_TRACKER_RECONCILE_WINDOW_MS);
-
-    const nextAlarmTime = await this.state.storage.getAlarm();
-    if (nextAlarmTime != null) {
-      return;
-    }
-
-    await this.scheduleNextAlarm(USER_TRACKER_RECONCILE_INTERVAL_MS);
-  }
-
-  private async hasReconcileWindowElapsed(): Promise<boolean> {
-    const deadline = await this.state.storage.get<number>(USER_TRACKER_RECONCILE_DEADLINE_KEY);
-    if (typeof deadline !== "number") {
-      // No deadline recorded — the alarm predates this key, so stop rather than reconcile forever.
-      return true;
-    }
-
-    return Date.now() >= deadline;
-  }
-
-  private async stopReconciling(userId: string): Promise<void> {
-    this.logService.debug("UserTracker reconcile window elapsed", new Map([["userId", userId]]));
-
-    const stored = await this.loadState();
-    if (stored.state?.userId === userId && stored.viewState != null) {
-      await this.state.storage.put(USER_TRACKER_STATE_KEY, {
-        ...stored,
-        viewState: null,
-      });
-    }
-
     await this.state.storage.delete(USER_TRACKER_RECONCILE_DEADLINE_KEY);
     await this.state.storage.deleteAlarm();
   }

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -294,15 +294,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   }
 
   private async loadStateForTickLog(): Promise<UserTrackerInternalState> {
-    try {
-      return await this.loadState();
-    } catch (error) {
-      this.logService.warn(error, new Map([["context", "UserTracker tick context load failed"]]));
-      return {
-        state: null,
-        viewState: null,
-      };
-    }
+    return await this.loadStateForErrorContext("UserTracker tick context load failed");
   }
 
   private async handleStatus(): Promise<Response> {

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -294,7 +294,23 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   }
 
   private async loadStateForTickLog(): Promise<UserTrackerInternalState> {
-    return await this.loadStateForErrorContext("UserTracker tick context load failed");
+    try {
+      const stored = await this.state.storage.get<UserTrackerInternalState>(USER_TRACKER_STATE_KEY);
+      if (stored == null) {
+        return {
+          state: null,
+          viewState: null,
+        };
+      }
+
+      return stored;
+    } catch (error) {
+      this.logService.warn(error, new Map([["context", "UserTracker tick context load failed"]]));
+      return {
+        state: null,
+        viewState: null,
+      };
+    }
   }
 
   private async handleStatus(): Promise<Response> {


### PR DESCRIPTION
## Context
UserTracker Durable Objects were continuing to run reconcile alarms for several minutes after their last WebSocket client disconnected. This created a steady stream of background work and made it difficult to distinguish active follow tracking from stale alarm behavior.

## This PR
- Removes the clientless reconcile interval and reconcile window.
- Deletes alarms immediately when an alarm fires with no connected WebSocket clients.
- Keeps the 3-second follow alarm only while clients are connected.
- Rebuilds clientless public view state on demand instead of maintaining it with a background alarm.
- Updates UserTrackerDO coverage for on-demand refresh, alarm cleanup, connected-client refresh failures, and diagnostic logging.

Validation completed: 35 focused UserTrackerDO tests, API typecheck, and focused ESLint.

## Subsequent Work
- Monitor production `UserTracker follow tick` logs after deployment. Each remaining tick now includes the owner `userId` and `connectedClientCount`.