### PR TITLE
Pause UserTracker follow alarm without active trackers

### DIFF
--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1633,8 +1633,9 @@ describe("UserTrackerDO", () => {
     expect(nudgeResponse.status).toBe(200);
 
     await vi.waitFor(() => {
-      expect(closeSubscriptions).not.toHaveBeenCalled();
+      expect(setAlarmMock).toHaveBeenCalledTimes(1);
     });
+    expect(closeSubscriptions).not.toHaveBeenCalled();
   });
 
   it("refreshes clientless view-state requests on demand", async () => {

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -2108,6 +2108,64 @@ describe("UserTrackerDO", () => {
     expect(deleteAlarmMock).toHaveBeenCalledOnce();
   });
 
+  it("resets tracker subscriptions when alarm refresh confirms an empty directory", async () => {
+    const trackerDo = aFakeIndividualTrackerDOWith({
+      viewStateResponse: {
+        state: aFakeIndividualTrackerViewStateWith({
+          trackerId: "t1",
+          gamertag: "KnownTag",
+          matches: [],
+        }),
+      },
+    });
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const services = installFakeServicesWith({ env: localEnv });
+    const persistedStorage = new Map<string, unknown>();
+    const closeSubscriptions = vi.fn();
+    mockState.storage.get = (async (key: string | string[]) => {
+      if (typeof key !== "string") {
+        return await Promise.resolve(new Map());
+      }
+
+      return await Promise.resolve(persistedStorage.get(key));
+    }) as DurableObjectStorage["get"];
+    mockState.storage.put = (async (key: string, value: unknown) => {
+      persistedStorage.set(key, value);
+      await Promise.resolve();
+    }) as DurableObjectStorage["put"];
+    vi.spyOn(mockState, "getWebSockets").mockReturnValue([{} as WebSocket]);
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId")
+      .mockResolvedValueOnce([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "active",
+          IsLive: 1,
+        }),
+      ])
+      .mockResolvedValueOnce([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "stopped",
+          IsLive: 0,
+        }),
+      ]);
+    const localUserTrackerDO = new UserTrackerDO(mockState, localEnv, () => services, webSocketAdapter);
+    Object.assign(localUserTrackerDO, {
+      trackerSubscriptionsInstalled: true,
+      closeTrackerSubscriptions: closeSubscriptions,
+    });
+
+    await localUserTrackerDO.fetch(new Request("http://do/view-state?userId=user-1", { method: "GET" }));
+    await localUserTrackerDO.alarm();
+
+    expect(closeSubscriptions).toHaveBeenCalledOnce();
+    expect(deleteAlarmMock).toHaveBeenCalledOnce();
+  });
+
   it("retries tracker subscription setup after a transient installation failure", async () => {
     const localEnv = aFakeEnvWith();
     const services = installFakeServicesWith({ env: localEnv });

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1522,6 +1522,121 @@ describe("UserTrackerDO", () => {
     });
   });
 
+  it("reinstalls subscriptions after follow websocket start with an initially empty directory", async () => {
+    const trackerDo = aFakeIndividualTrackerDOWith({
+      viewStateResponse: {
+        state: aFakeIndividualTrackerViewStateWith({
+          trackerId: "t1",
+          gamertag: "KnownTag",
+          matches: [],
+        }),
+      },
+    });
+    const trackerFetchSpy = vi.spyOn(trackerDo, "fetch");
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const services = installFakeServicesWith({ env: localEnv });
+    const persistedStorage = new Map<string, unknown>();
+    mockState.storage.get = (async (key: string | string[]) => {
+      if (typeof key !== "string") {
+        return await Promise.resolve(new Map());
+      }
+
+      return await Promise.resolve(persistedStorage.get(key));
+    }) as DurableObjectStorage["get"];
+    mockState.storage.put = (async (key: string, value: unknown) => {
+      persistedStorage.set(key, value);
+      await Promise.resolve();
+    }) as DurableObjectStorage["put"];
+    vi.spyOn(mockState, "getWebSockets").mockReturnValue([{} as WebSocket]);
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId")
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "active",
+          IsLive: 1,
+        }),
+      ])
+      .mockResolvedValue([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "active",
+          IsLive: 1,
+        }),
+      ]);
+    const localUserTrackerDO = new UserTrackerDO(mockState, localEnv, () => services, webSocketAdapter);
+
+    const socketResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/websocket?userId=user-1", {
+        headers: { Upgrade: "websocket" },
+      }),
+    );
+    expect(socketResponse.status).toBe(200);
+    expect(trackerFetchSpy).toHaveBeenCalledTimes(0);
+
+    const nudgeResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "user-1",
+          trackerId: "t1",
+          lastUpdateTime: "2026-07-05T00:01:00.000Z",
+        }),
+      }),
+    );
+    expect(nudgeResponse.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(trackerFetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("keeps subscription state when nudge cannot load directory state", async () => {
+    const localEnv = aFakeEnvWith();
+    const services = installFakeServicesWith({ env: localEnv });
+    const persistedStorage = new Map<string, unknown>();
+    const closeSubscriptions = vi.fn();
+    mockState.storage.get = (async (key: string | string[]) => {
+      if (typeof key !== "string") {
+        return await Promise.resolve(new Map());
+      }
+
+      return await Promise.resolve(persistedStorage.get(key));
+    }) as DurableObjectStorage["get"];
+    mockState.storage.put = (async (key: string, value: unknown) => {
+      persistedStorage.set(key, value);
+      await Promise.resolve();
+    }) as DurableObjectStorage["put"];
+    vi.spyOn(mockState, "getWebSockets").mockReturnValue([{} as WebSocket]);
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId").mockResolvedValue([]);
+    const localUserTrackerDO = new UserTrackerDO(mockState, localEnv, () => services, webSocketAdapter);
+    Object.assign(localUserTrackerDO, {
+      trackerSubscriptionsInstalled: true,
+      closeTrackerSubscriptions: closeSubscriptions,
+      loadStateForTickLog: vi.fn(async () => Promise.resolve({ state: { userId: "user-1" }, viewState: null })),
+    });
+
+    const nudgeResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "user-1",
+          trackerId: "t1",
+          lastUpdateTime: "2026-07-05T00:01:00.000Z",
+        }),
+      }),
+    );
+    expect(nudgeResponse.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(closeSubscriptions).not.toHaveBeenCalled();
+    });
+  });
+
   it("refreshes clientless view-state requests on demand", async () => {
     const persistedStorage = new Map<string, unknown>();
     let alarmTime: number | null = null;

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1454,6 +1454,74 @@ describe("UserTrackerDO", () => {
     });
   });
 
+  it("reinstalls tracker subscriptions on nudge when followable trackers return", async () => {
+    const trackerDo = aFakeIndividualTrackerDOWith({
+      viewStateResponse: {
+        state: aFakeIndividualTrackerViewStateWith({
+          trackerId: "t1",
+          gamertag: "KnownTag",
+          matches: [],
+        }),
+      },
+    });
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const services = installFakeServicesWith({ env: localEnv });
+    const persistedStorage = new Map<string, unknown>();
+    mockState.storage.get = (async (key: string | string[]) => {
+      if (typeof key !== "string") {
+        return await Promise.resolve(new Map());
+      }
+
+      return await Promise.resolve(persistedStorage.get(key));
+    }) as DurableObjectStorage["get"];
+    mockState.storage.put = (async (key: string, value: unknown) => {
+      persistedStorage.set(key, value);
+      await Promise.resolve();
+    }) as DurableObjectStorage["put"];
+    vi.spyOn(mockState, "getWebSockets").mockReturnValue([{} as WebSocket]);
+    const findByUserIdSpy = vi
+      .spyOn(services.databaseService, "findIndividualTrackersByUserId")
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "active",
+          IsLive: 1,
+        }),
+      ])
+      .mockResolvedValue([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "active",
+          IsLive: 1,
+        }),
+      ]);
+    const localUserTrackerDO = new UserTrackerDO(mockState, localEnv, () => services, webSocketAdapter);
+
+    await localUserTrackerDO.fetch(new Request("http://do/view-state?userId=user-1", { method: "GET" }));
+    expect(findByUserIdSpy).toHaveBeenCalledTimes(1);
+
+    const nudgeResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "user-1",
+          trackerId: "t1",
+          lastUpdateTime: "2026-07-05T00:01:00.000Z",
+        }),
+      }),
+    );
+    expect(nudgeResponse.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(findByUserIdSpy).toHaveBeenCalledTimes(3);
+    });
+  });
+
   it("refreshes clientless view-state requests on demand", async () => {
     const persistedStorage = new Map<string, unknown>();
     let alarmTime: number | null = null;

--- a/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
+++ b/api/durable-objects/user-tracker/tests/user-tracker-do.test.ts
@@ -1279,21 +1279,22 @@ describe("UserTrackerDO", () => {
     const logService = aFakeLogServiceWith();
     const debugSpy = vi.spyOn(logService, "debug");
     const services = installFakeServicesWith({ env: localEnv, logService });
+    const persistedStorage = new Map<string, unknown>();
+    persistedStorage.set(USER_TRACKER_STATE_KEY, {
+      state: { userId: "user-1", lastUpdateTime: new Date().toISOString() },
+      viewState: null,
+    });
     mockState.storage.get = (async (key: string | string[]) => {
-      if (key === USER_TRACKER_STATE_KEY) {
-        return await Promise.resolve({
-          state: { userId: "user-1", lastUpdateTime: new Date().toISOString() },
-          viewState: null,
-        });
+      if (typeof key !== "string") {
+        return await Promise.resolve(new Map());
       }
 
-      if (typeof key === "string") {
-        await Promise.resolve(undefined);
-        return;
-      }
-
-      return await Promise.resolve(new Map());
+      return await Promise.resolve(persistedStorage.get(key));
     }) as DurableObjectStorage["get"];
+    mockState.storage.put = (async (key: string, value: unknown) => {
+      persistedStorage.set(key, value);
+      await Promise.resolve();
+    }) as DurableObjectStorage["put"];
     vi.spyOn(mockState, "getWebSockets").mockReturnValue([{} as WebSocket]);
     vi.spyOn(services.databaseService, "findIndividualTrackersByUserId")
       .mockResolvedValueOnce([
@@ -1332,6 +1333,125 @@ describe("UserTrackerDO", () => {
     expect(context?.get("userId")).toBe("user-1");
     expect(context?.get("tickType")).toBe("follow");
     expect(context?.get("connectedClientCount")).toBe("1");
+  });
+
+  it("pauses the follow alarm once a connected client has no active or paused trackers", async () => {
+    const trackerDo = aFakeIndividualTrackerDOWith({
+      viewStateResponse: {
+        state: aFakeIndividualTrackerViewStateWith({
+          trackerId: "t1",
+          gamertag: "KnownTag",
+          matches: [],
+        }),
+      },
+    });
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const logService = aFakeLogServiceWith();
+    const debugSpy = vi.spyOn(logService, "debug");
+    const services = installFakeServicesWith({ env: localEnv, logService });
+    const persistedStorage = new Map<string, unknown>();
+    mockState.storage.get = (async (key: string | string[]) => {
+      if (typeof key !== "string") {
+        return await Promise.resolve(new Map());
+      }
+
+      return await Promise.resolve(persistedStorage.get(key));
+    }) as DurableObjectStorage["get"];
+    mockState.storage.put = (async (key: string, value: unknown) => {
+      persistedStorage.set(key, value);
+      await Promise.resolve();
+    }) as DurableObjectStorage["put"];
+    vi.spyOn(mockState, "getWebSockets").mockReturnValue([{} as WebSocket]);
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId")
+      .mockResolvedValueOnce([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "active",
+          IsLive: 1,
+        }),
+      ])
+      .mockResolvedValueOnce([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "stopped",
+          IsLive: 0,
+        }),
+      ]);
+    const localUserTrackerDO = new UserTrackerDO(mockState, localEnv, () => services, webSocketAdapter);
+
+    await localUserTrackerDO.fetch(new Request("http://do/view-state?userId=user-1", { method: "GET" }));
+    await localUserTrackerDO.alarm();
+
+    expect(setAlarmMock).not.toHaveBeenCalled();
+    expect(deleteAlarmMock).toHaveBeenCalledOnce();
+    const [message, context] =
+      debugSpy.mock.calls.find(
+        ([currentMessage]) => currentMessage === "UserTracker alarm loop paused - no active or paused trackers",
+      ) ?? [];
+    expect(message).toBe("UserTracker alarm loop paused - no active or paused trackers");
+    expect(context?.get("userId")).toBe("user-1");
+  });
+
+  it("resumes the follow alarm when a nudge makes a tracker followable again", async () => {
+    const trackerDo = aFakeIndividualTrackerDOWith({
+      viewStateResponse: {
+        state: aFakeIndividualTrackerViewStateWith({
+          trackerId: "t1",
+          gamertag: "KnownTag",
+          matches: [],
+        }),
+      },
+    });
+    const localEnv = aFakeEnvWith({ INDIVIDUAL_TRACKER_DO: aFakeDurableObjectNamespaceWith(trackerDo) });
+    const services = installFakeServicesWith({ env: localEnv });
+    const persistedStorage = new Map<string, unknown>();
+    mockState.storage.get = (async (key: string | string[]) => {
+      if (typeof key !== "string") {
+        return await Promise.resolve(new Map());
+      }
+
+      return await Promise.resolve(persistedStorage.get(key));
+    }) as DurableObjectStorage["get"];
+    mockState.storage.put = (async (key: string, value: unknown) => {
+      persistedStorage.set(key, value);
+      await Promise.resolve();
+    }) as DurableObjectStorage["put"];
+    vi.spyOn(mockState, "getWebSockets").mockReturnValue([{} as WebSocket]);
+    vi.spyOn(services.databaseService, "findIndividualTrackersByUserId")
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        aFakeIndividualTrackersRow({
+          TrackerId: "t1",
+          UserId: "user-1",
+          Gamertag: "KnownTag",
+          Status: "active",
+          IsLive: 1,
+        }),
+      ]);
+    const localUserTrackerDO = new UserTrackerDO(mockState, localEnv, () => services, webSocketAdapter);
+
+    await localUserTrackerDO.fetch(new Request("http://do/view-state?userId=user-1", { method: "GET" }));
+    expect(setAlarmMock).not.toHaveBeenCalled();
+
+    const nudgeResponse = await localUserTrackerDO.fetch(
+      new Request("http://do/nudge", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "user-1",
+          trackerId: "t1",
+          lastUpdateTime: "2026-07-05T00:01:00.000Z",
+        }),
+      }),
+    );
+    expect(nudgeResponse.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(setAlarmMock).toHaveBeenCalledOnce();
+    });
   });
 
   it("refreshes clientless view-state requests on demand", async () => {

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -283,6 +283,14 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       }
 
       const refreshedStored = await this.loadStateForTickLog();
+      const refreshedDirectory = refreshedStored.viewState?.directory;
+      if (refreshedDirectory != null && !this.hasFollowableTrackers(refreshedDirectory)) {
+        this.closeTrackerSubscriptions();
+        this.closeTrackerSubscriptions = (): void => {
+          // reset after closing
+        };
+        this.trackerSubscriptionsInstalled = false;
+      }
       await this.scheduleFollowAlarmIfNeeded(refreshedStored);
     });
   }

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -509,6 +509,16 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     }
 
     const stored = await this.loadStateForTickLog();
+    if (!this.hasFollowableTrackers(stored.viewState?.directory)) {
+      this.closeTrackerSubscriptions();
+      this.closeTrackerSubscriptions = (): void => {
+        // reset after closing
+      };
+      this.trackerSubscriptionsInstalled = false;
+    } else if (!this.trackerSubscriptionsInstalled) {
+      await this.installTrackerSubscriptionsAsync();
+    }
+
     await this.scheduleFollowAlarmIfNeeded(stored);
   }
 

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -522,6 +522,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       };
       this.trackerSubscriptionsInstalled = false;
     } else if (!this.trackerSubscriptionsInstalled) {
+      this.trackerSubscriptionsInstalled = true;
       await this.installTrackerSubscriptionsAsync();
     }
 

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -470,6 +470,11 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   private async ensureUpdateLoopStarted(stored: UserTrackerInternalState): Promise<void> {
     await this.scheduleFollowAlarmIfNeeded(stored);
 
+    if (!this.hasFollowableTrackers(stored.viewState?.directory)) {
+      this.trackerSubscriptionsInstalled = false;
+      return;
+    }
+
     if (this.trackerSubscriptionsInstalled) {
       return;
     }
@@ -509,7 +514,8 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     }
 
     const stored = await this.loadStateForTickLog();
-    if (!this.hasFollowableTrackers(stored.viewState?.directory)) {
+    const directory = stored.viewState?.directory;
+    if (directory != null && !this.hasFollowableTrackers(directory)) {
       this.closeTrackerSubscriptions();
       this.closeTrackerSubscriptions = (): void => {
         // reset after closing

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -34,7 +34,8 @@ import type { UserTrackerInternalState } from "./types";
 const USER_TRACKER_STATE_KEY = "userTrackerState";
 const USER_TRACKER_MARKERS_KEY = "userTrackerMarkers";
 const USER_TRACKER_RECONCILE_DEADLINE_KEY = "userTrackerReconcileDeadline";
-const FOLLOW_WS_POLL_INTERVAL_MS = 3000;
+// Fallback poll only; primary updates arrive via tracker websocket messages and nudges.
+const FOLLOW_WS_POLL_INTERVAL_MS = 60000;
 const TRACKER_MARKER_LIMIT = 500;
 
 function isNonStopped(row: IndividualTrackersRow): boolean {
@@ -230,6 +231,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
           ["userId", stored.state?.userId ?? "unknown"],
           ["hasConnectedClients", hasConnectedClients.toString()],
           ["connectedClientCount", connectedClientCount.toString()],
+          ["trackerCount", (stored.viewState?.directory.trackers.length ?? 0).toString()],
         ]),
       );
 
@@ -280,7 +282,8 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
         return;
       }
 
-      await this.scheduleNextAlarm(FOLLOW_WS_POLL_INTERVAL_MS);
+      const refreshedStored = await this.loadStateForTickLog();
+      await this.scheduleFollowAlarmIfNeeded(refreshedStored);
     });
   }
 
@@ -360,12 +363,12 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       return userTrackerNudgeContract.toResponse({ success: true }, { noStore: true });
     }
 
-    void this.queueDirectoryPush();
+    this.queueDirectoryPushAndSyncAlarm();
     return userTrackerNudgeContract.toResponse({ success: true }, { noStore: true });
   }
 
   private handleSettingsChanged(): Response {
-    void this.queueDirectoryPush();
+    this.queueDirectoryPushAndSyncAlarm();
     return new Response(null, { status: 204 });
   }
 
@@ -381,7 +384,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
     const directory = stored.viewState?.directory ?? emptyTrackerDirectory;
     const payload = this.serializeDirectory(directory);
-    await this.ensureUpdateLoopStarted();
+    await this.ensureUpdateLoopStarted(stored);
     const response = this.webSocketAdapter.upgrade(this.state, payload);
     return response;
   }
@@ -464,8 +467,8 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     return nextState;
   }
 
-  private async ensureUpdateLoopStarted(): Promise<void> {
-    await this.scheduleNextAlarm(FOLLOW_WS_POLL_INTERVAL_MS);
+  private async ensureUpdateLoopStarted(stored: UserTrackerInternalState): Promise<void> {
+    await this.scheduleFollowAlarmIfNeeded(stored);
 
     if (this.trackerSubscriptionsInstalled) {
       return;
@@ -473,6 +476,40 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
     this.trackerSubscriptionsInstalled = true;
     void this.installTrackerSubscriptionsAsync();
+  }
+
+  private hasFollowableTrackers(directory: TrackerDirectory | null | undefined): boolean {
+    return (directory?.trackers.length ?? 0) > 0;
+  }
+
+  // Only pauses the alarm on a confirmed empty directory; an unknown directory keeps polling.
+  private async scheduleFollowAlarmIfNeeded(stored: UserTrackerInternalState): Promise<void> {
+    const directory = stored.viewState?.directory;
+    if (directory == null || this.hasFollowableTrackers(directory)) {
+      await this.scheduleNextAlarm(FOLLOW_WS_POLL_INTERVAL_MS);
+      return;
+    }
+
+    this.logService.debug(
+      "UserTracker alarm loop paused - no active or paused trackers",
+      new Map([["userId", stored.state?.userId ?? "unknown"]]),
+    );
+    await this.state.storage.deleteAlarm();
+  }
+
+  private queueDirectoryPushAndSyncAlarm(): void {
+    void this.queueDirectoryPushAndSyncAlarmAsync();
+  }
+
+  private async queueDirectoryPushAndSyncAlarmAsync(): Promise<void> {
+    await this.queueDirectoryPush();
+
+    if (this.state.getWebSockets().length === 0) {
+      return;
+    }
+
+    const stored = await this.loadStateForTickLog();
+    await this.scheduleFollowAlarmIfNeeded(stored);
   }
 
   private async stopUpdateLoop(): Promise<void> {
@@ -533,7 +570,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
 
             socket.accept();
             socket.addEventListener("message", (): void => {
-              void this.queueDirectoryPush();
+              this.queueDirectoryPushAndSyncAlarm();
             });
             return socket;
           } catch (error) {

--- a/api/durable-objects/user-tracker/user-tracker-do.ts
+++ b/api/durable-objects/user-tracker/user-tracker-do.ts
@@ -285,11 +285,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
       const refreshedStored = await this.loadStateForTickLog();
       const refreshedDirectory = refreshedStored.viewState?.directory;
       if (refreshedDirectory != null && !this.hasFollowableTrackers(refreshedDirectory)) {
-        this.closeTrackerSubscriptions();
-        this.closeTrackerSubscriptions = (): void => {
-          // reset after closing
-        };
-        this.trackerSubscriptionsInstalled = false;
+        this.resetTrackerSubscriptionsState();
       }
       await this.scheduleFollowAlarmIfNeeded(refreshedStored);
     });
@@ -524,11 +520,7 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
     const stored = await this.loadStateForTickLog();
     const directory = stored.viewState?.directory;
     if (directory != null && !this.hasFollowableTrackers(directory)) {
-      this.closeTrackerSubscriptions();
-      this.closeTrackerSubscriptions = (): void => {
-        // reset after closing
-      };
-      this.trackerSubscriptionsInstalled = false;
+      this.resetTrackerSubscriptionsState();
     } else if (!this.trackerSubscriptionsInstalled) {
       this.trackerSubscriptionsInstalled = true;
       await this.installTrackerSubscriptionsAsync();
@@ -538,13 +530,17 @@ export class UserTrackerDO implements DurableObject, Rpc.DurableObjectBranded {
   }
 
   private async stopUpdateLoop(): Promise<void> {
+    this.resetTrackerSubscriptionsState();
+    await this.state.storage.delete(USER_TRACKER_RECONCILE_DEADLINE_KEY);
+    await this.state.storage.deleteAlarm();
+  }
+
+  private resetTrackerSubscriptionsState(): void {
     this.closeTrackerSubscriptions();
     this.closeTrackerSubscriptions = (): void => {
       // reset after closing
     };
     this.trackerSubscriptionsInstalled = false;
-    await this.state.storage.delete(USER_TRACKER_RECONCILE_DEADLINE_KEY);
-    await this.state.storage.deleteAlarm();
   }
 
   private async installTrackerSubscriptionsAsync(): Promise<void> {


### PR DESCRIPTION
## Context
The UserTracker follow alarm previously only checked for connected WebSocket clients before rescheduling itself. A viewer could stay connected to the follow page with zero active or paused trackers (all idled/stopped), and the alarm would keep firing on its poll interval indefinitely for no benefit, generating a steady stream of no-op log ticks.

## This PR
- `alarm()` now checks the confirmed tracker directory after each tick: if it is definitively empty (no active or paused trackers), the alarm is deleted instead of rescheduled. An unknown/unloaded directory still reschedules, so we never silently stop polling on a transient read failure.
- Nudges, settings-changed pushes, and per-tracker WebSocket message events now route through a shared `queueDirectoryPushAndSyncAlarm` helper, so the alarm automatically resumes once a tracker becomes followable again — no reconnect required.
- Added a `UserTracker alarm loop paused - no active or paused trackers` debug log and included `trackerCount` in the existing `UserTracker alarm start` log for direct visibility of this condition.
- Reduced `FOLLOW_WS_POLL_INTERVAL_MS` from 3s to 60s. This alarm is only a fallback safety net for transitions the message/nudge channels miss (e.g. an individual tracker's silent idle-timeout auto-stop); it does not need sub-minute cadence.
- Added regression tests covering the pause and resume behavior.

Validation: 38 focused UserTrackerDO tests, API typecheck, ESLint, and Prettier all pass.

## Subsequent Work
- None anticipated; monitor production logs post-deploy for the new pause/resume debug messages to confirm the fix resolves the observed steady-stream alarm ticks.