### PR TITLE
Reconcile amended stats into leaderboards

### DIFF
--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -1390,7 +1390,7 @@ export class StatsCommand extends BaseCommand {
   }
 
   private async handleFixConfirmationJob(interaction: APIMessageComponentButtonInteraction): Promise<void> {
-    const { databaseService, discordService, haloService } = this.services;
+    const { databaseService, discordService, haloService, leaderboardService } = this.services;
 
     try {
       const metadata = await this.getFixMetadataWithRetry(interaction.message.id);
@@ -1485,6 +1485,17 @@ export class StatsCommand extends BaseCommand {
       await this.postSeriesEmbedsToThread(destinationThreadId, series, guildConfig, locale);
       await this.postGameStatsOrButton(destinationThreadId, series, guildConfig, locale);
       await this.cacheDiscordSeriesStats(metadata.guildId, metadata.queueData.queue, series, locale);
+      const neatQueueConfig = await databaseService.getNeatQueueConfig(metadata.guildId, metadata.channelId);
+      await leaderboardService.persistReconciledSeriesData({
+        guildId: metadata.guildId,
+        channelId: metadata.channelId,
+        queueNumber: metadata.queueData.queue,
+        neatQueueConfig,
+        series,
+        winnerTeamIndex:
+          metadata.selectedSeriesOutcome === "TEAM_0" ? 0 : metadata.selectedSeriesOutcome === "TEAM_1" ? 1 : -1,
+        locale,
+      });
 
       await discordService.updateDeferredReply(interaction.token, {
         embeds: [this.createStatusEmbed("Series stats were amended successfully.")],

--- a/api/commands/stats/stats.ts
+++ b/api/commands/stats/stats.ts
@@ -1390,7 +1390,7 @@ export class StatsCommand extends BaseCommand {
   }
 
   private async handleFixConfirmationJob(interaction: APIMessageComponentButtonInteraction): Promise<void> {
-    const { databaseService, discordService, haloService, leaderboardService } = this.services;
+    const { databaseService, discordService, haloService, leaderboardService, logService } = this.services;
 
     try {
       const metadata = await this.getFixMetadataWithRetry(interaction.message.id);
@@ -1485,17 +1485,29 @@ export class StatsCommand extends BaseCommand {
       await this.postSeriesEmbedsToThread(destinationThreadId, series, guildConfig, locale);
       await this.postGameStatsOrButton(destinationThreadId, series, guildConfig, locale);
       await this.cacheDiscordSeriesStats(metadata.guildId, metadata.queueData.queue, series, locale);
-      const neatQueueConfig = await databaseService.getNeatQueueConfig(metadata.guildId, metadata.channelId);
-      await leaderboardService.persistReconciledSeriesData({
-        guildId: metadata.guildId,
-        channelId: metadata.channelId,
-        queueNumber: metadata.queueData.queue,
-        neatQueueConfig,
-        series,
-        winnerTeamIndex:
-          metadata.selectedSeriesOutcome === "TEAM_0" ? 0 : metadata.selectedSeriesOutcome === "TEAM_1" ? 1 : -1,
-        locale,
-      });
+      try {
+        const neatQueueConfig = await databaseService.getNeatQueueConfig(metadata.guildId, metadata.channelId);
+        await leaderboardService.persistReconciledSeriesData({
+          guildId: metadata.guildId,
+          channelId: metadata.channelId,
+          queueNumber: metadata.queueData.queue,
+          neatQueueConfig,
+          series,
+          winnerTeamIndex:
+            metadata.selectedSeriesOutcome === "TEAM_0" ? 0 : metadata.selectedSeriesOutcome === "TEAM_1" ? 1 : -1,
+          locale,
+        });
+      } catch (error) {
+        logService.warn(
+          error,
+          new Map([
+            ["context", "Stats fix leaderboard reconciliation failed"],
+            ["guildId", metadata.guildId],
+            ["channelId", metadata.channelId],
+            ["queue", metadata.queueData.queue.toString()],
+          ]),
+        );
+      }
 
       await discordService.updateDeferredReply(interaction.token, {
         embeds: [this.createStatusEmbed("Series stats were amended successfully.")],

--- a/api/commands/stats/tests/stats.test.ts
+++ b/api/commands/stats/tests/stats.test.ts
@@ -1926,6 +1926,127 @@ describe("StatsCommand", () => {
       });
     });
 
+    it("persists reconciled winner as -1 when final selected outcome is tie", async () => {
+      const interaction: APIMessageComponentButtonInteraction = {
+        ...fakeButtonClickInteraction,
+        data: {
+          component_type: ComponentType.Button,
+          custom_id: "btn_stats_fix_confirm",
+        },
+        message: {
+          ...fakeButtonClickInteraction.message,
+          id: "fix-flow-message-id",
+        },
+      };
+
+      vi.spyOn(services.discordService, "getInteractionMetadata").mockResolvedValue({
+        guildId: "fake-guild-id",
+        channelId: "fake-channel-id",
+        queueData: {
+          ...discordNeatQueueData,
+          message: {
+            ...discordNeatQueueData.message,
+            id: "queue-neatqueue-message-id",
+          },
+        },
+        selectedMatchIds: ["d81554d7-ddfe-44da-a6cb-000000000ctf", "9535b946-f30c-4a43-b852-000000slayer"],
+        selectedSeriesOutcome: "TIE",
+      });
+      vi.spyOn(services.haloService, "getMatchDetails").mockResolvedValue([
+        Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf")),
+        Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer")),
+      ]);
+      vi.spyOn(services.databaseService, "getGuildConfig").mockResolvedValue(
+        aFakeGuildConfigRow({ StatsReturn: StatsReturnType.SERIES_ONLY }),
+      );
+      vi.spyOn(services.databaseService, "getNeatQueueConfig").mockResolvedValue(aFakeNeatQueueConfigRow());
+      const persistReconciledSeriesDataSpy = vi
+        .spyOn(services.leaderboardService, "persistReconciledSeriesData")
+        .mockResolvedValue();
+      vi.spyOn(services.discordService, "findExistingSeriesStatsThreadLocation").mockResolvedValue(undefined);
+      vi.spyOn(services.discordService, "createMessage").mockResolvedValue(apiMessage);
+      vi.spyOn(services.discordService, "startThreadFromMessage").mockResolvedValue({
+        id: "new-thread-id",
+      } as RESTPostAPIChannelThreadsResult);
+      vi.spyOn(services.haloService, "getPlayerXuidsToGametags").mockResolvedValue(getPlayerXuidsToGametags());
+
+      const { jobToComplete } = statsCommand.execute(interaction);
+      await jobToComplete?.();
+
+      expect(persistReconciledSeriesDataSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ winnerTeamIndex: -1, queueNumber: 777 }),
+      );
+      expect(updateDeferredReplySpy).toHaveBeenCalledWith("fake-token", {
+        embeds: [expect.objectContaining({ description: "Series stats were amended successfully." })],
+        components: [],
+      });
+    });
+
+    it("continues successfully when leaderboard reconciliation fails after discord updates", async () => {
+      const interaction: APIMessageComponentButtonInteraction = {
+        ...fakeButtonClickInteraction,
+        data: {
+          component_type: ComponentType.Button,
+          custom_id: "btn_stats_fix_confirm",
+        },
+        message: {
+          ...fakeButtonClickInteraction.message,
+          id: "fix-flow-message-id",
+        },
+      };
+
+      vi.spyOn(services.discordService, "getInteractionMetadata").mockResolvedValue({
+        guildId: "fake-guild-id",
+        channelId: "fake-channel-id",
+        queueData: {
+          ...discordNeatQueueData,
+          message: {
+            ...discordNeatQueueData.message,
+            id: "queue-neatqueue-message-id",
+          },
+        },
+        selectedMatchIds: ["d81554d7-ddfe-44da-a6cb-000000000ctf", "9535b946-f30c-4a43-b852-000000slayer"],
+        selectedSeriesOutcome: "TEAM_1",
+      });
+      vi.spyOn(services.haloService, "getMatchDetails").mockResolvedValue([
+        Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf")),
+        Preconditions.checkExists(getMatchStats("9535b946-f30c-4a43-b852-000000slayer")),
+      ]);
+      vi.spyOn(services.databaseService, "getGuildConfig").mockResolvedValue(
+        aFakeGuildConfigRow({ StatsReturn: StatsReturnType.SERIES_ONLY }),
+      );
+      vi.spyOn(services.databaseService, "getNeatQueueConfig").mockRejectedValue(
+        new Error("neat queue config unavailable"),
+      );
+      const logWarnSpy = vi.spyOn(services.logService, "warn");
+      vi.spyOn(services.discordService, "findExistingSeriesStatsThreadLocation").mockResolvedValue(undefined);
+      vi.spyOn(services.discordService, "createMessage").mockResolvedValue(apiMessage);
+      vi.spyOn(services.discordService, "startThreadFromMessage").mockResolvedValue({
+        id: "new-thread-id",
+      } as RESTPostAPIChannelThreadsResult);
+      vi.spyOn(services.haloService, "getPlayerXuidsToGametags").mockResolvedValue(getPlayerXuidsToGametags());
+
+      const { jobToComplete } = statsCommand.execute(interaction);
+      await jobToComplete?.();
+
+      expect(logWarnSpy).toHaveBeenCalled();
+      const [warnError, warnContext] = Preconditions.checkExists(
+        logWarnSpy.mock.calls.find(
+          ([, extra]) => extra?.get("context") === "Stats fix leaderboard reconciliation failed",
+        ),
+      );
+      expect(warnError).toBeInstanceOf(Error);
+      expect(warnContext?.get("context")).toBe("Stats fix leaderboard reconciliation failed");
+      expect(warnContext?.get("guildId")).toBe("fake-guild-id");
+      expect(warnContext?.get("channelId")).toBe("fake-channel-id");
+      expect(warnContext?.get("queue")).toBe("777");
+      expect(updateDeferredReplyWithErrorSpy).not.toHaveBeenCalled();
+      expect(updateDeferredReplySpy).toHaveBeenCalledWith("fake-token", {
+        embeds: [expect.objectContaining({ description: "Series stats were amended successfully." })],
+        components: [],
+      });
+    });
+
     it("creates a new thread when no existing series stats message is found", async () => {
       const interaction: APIMessageComponentButtonInteraction = {
         ...fakeButtonClickInteraction,

--- a/api/commands/stats/tests/stats.test.ts
+++ b/api/commands/stats/tests/stats.test.ts
@@ -39,7 +39,11 @@ import {
 import { aFakeMatchHistoryEntryWith, getMatchStats, getPlayerXuidsToGametags } from "../../../services/halo/fakes/data";
 import { StatsReturnType } from "../../../services/database/types/guild_config";
 import { aFakeEnvWith } from "../../../base/fakes/env.fake";
-import { aFakeDiscordAssociationsRow, aFakeGuildConfigRow } from "../../../services/database/fakes/database.fake";
+import {
+  aFakeDiscordAssociationsRow,
+  aFakeGuildConfigRow,
+  aFakeNeatQueueConfigRow,
+} from "../../../services/database/fakes/database.fake";
 import { EndUserError } from "../../../base/end-user-error";
 import type { MatchPlayer } from "../../../services/halo/types";
 import {
@@ -1843,6 +1847,10 @@ describe("StatsCommand", () => {
       vi.spyOn(services.databaseService, "getGuildConfig").mockResolvedValue(
         aFakeGuildConfigRow({ StatsReturn: StatsReturnType.SERIES_ONLY }),
       );
+      vi.spyOn(services.databaseService, "getNeatQueueConfig").mockResolvedValue(aFakeNeatQueueConfigRow());
+      const persistReconciledSeriesDataSpy = vi
+        .spyOn(services.leaderboardService, "persistReconciledSeriesData")
+        .mockResolvedValue();
       const findExistingSeriesStatsThreadLocationSpy = vi
         .spyOn(services.discordService, "findExistingSeriesStatsThreadLocation")
         .mockResolvedValue({ threadId: "existing-thread-id", parentOverviewMessageId: "original-overview-message-id" });
@@ -1909,6 +1917,9 @@ describe("StatsCommand", () => {
       const amendedByField = firstEmbed.fields?.find((field) => field.name === "Amended by");
       expect(amendedByField).toBeDefined();
       expect(Preconditions.checkExists(amendedByField).value.length).toBeGreaterThan(0);
+      expect(persistReconciledSeriesDataSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ winnerTeamIndex: 1, queueNumber: 777 }),
+      );
       expect(updateDeferredReplySpy).toHaveBeenCalledWith("fake-token", {
         embeds: [expect.objectContaining({ description: "Series stats were amended successfully." })],
         components: [],
@@ -1948,6 +1959,7 @@ describe("StatsCommand", () => {
       vi.spyOn(services.databaseService, "getGuildConfig").mockResolvedValue(
         aFakeGuildConfigRow({ StatsReturn: StatsReturnType.SERIES_ONLY }),
       );
+      vi.spyOn(services.databaseService, "getNeatQueueConfig").mockResolvedValue(aFakeNeatQueueConfigRow());
       vi.spyOn(services.discordService, "findExistingSeriesStatsThreadLocation").mockResolvedValue(undefined);
       const createMessageSpy = vi
         .spyOn(services.discordService, "createMessage")
@@ -2007,6 +2019,7 @@ describe("StatsCommand", () => {
       vi.spyOn(services.databaseService, "getGuildConfig").mockResolvedValue(
         aFakeGuildConfigRow({ StatsReturn: StatsReturnType.SERIES_ONLY }),
       );
+      vi.spyOn(services.databaseService, "getNeatQueueConfig").mockResolvedValue(aFakeNeatQueueConfigRow());
       vi.spyOn(services.discordService, "findExistingSeriesStatsThreadLocation").mockResolvedValue({
         threadId: "existing-thread-id",
       });

--- a/api/services/leaderboard/leaderboard.ts
+++ b/api/services/leaderboard/leaderboard.ts
@@ -56,16 +56,52 @@ export class LeaderboardService {
     this.logService = logService;
   }
 
+  async persistReconciledSeriesData({
+    guildId,
+    channelId,
+    queueNumber,
+    neatQueueConfig,
+    series,
+    winnerTeamIndex,
+    locale,
+  }: {
+    guildId: string;
+    channelId: string;
+    queueNumber: number;
+    neatQueueConfig: NeatQueueConfigRow;
+    series: MatchStats[];
+    winnerTeamIndex: number;
+    locale: string;
+  }): Promise<void> {
+    await this.persistSeriesData({
+      request: {
+        action: "MATCH_COMPLETED",
+        guild: guildId,
+        channel: channelId,
+        queue: queueNumber.toString(),
+        match_number: queueNumber,
+        winning_team_index: winnerTeamIndex,
+        teams: [],
+      },
+      neatQueueConfig,
+      series,
+      locale,
+      allowTie: true,
+    });
+  }
+
   async persistSeriesData({
     request,
     neatQueueConfig,
     series,
     locale,
+    allowTie = false,
   }: {
     request: NeatQueueMatchCompletedRequest;
     neatQueueConfig: NeatQueueConfigRow;
     series: MatchStats[];
     locale: string;
+    allowTie?: boolean;
   }): Promise<void> {
     if (series.length === 0) {
       this.logService.info(
@@ -79,7 +115,7 @@ export class LeaderboardService {
       return;
     }
 
-    if (request.winning_team_index === -1) {
+    if (request.winning_team_index === -1 && !allowTie) {
       this.logService.info(
         "Leaderboard persistence skipped because winning team index is unresolved",
         new Map([

--- a/api/services/leaderboard/tests/leaderboard.test.ts
+++ b/api/services/leaderboard/tests/leaderboard.test.ts
@@ -837,6 +837,28 @@ describe("LeaderboardService", () => {
     );
   });
 
+  it("persists reconciled ties with no winning team", async () => {
+    const databaseService = aFakeDatabaseServiceWith();
+    const haloService = aFakeHaloServiceWith({ databaseService });
+    const logService = aFakeLogServiceWith();
+    const service = new LeaderboardService({ databaseService, haloService, logService });
+    const upsertSpy = vi.spyOn(databaseService, "upsertLeaderboardSeriesDataBatch");
+
+    await service.persistReconciledSeriesData({
+      guildId: "guild-1",
+      channelId: "channel-1",
+      queueNumber: 42,
+      neatQueueConfig: aFakeNeatQueueConfigRow(),
+      series: [Preconditions.checkExists(getMatchStats("d81554d7-ddfe-44da-a6cb-000000000ctf"))],
+      winnerTeamIndex: -1,
+      locale: "en-US",
+    });
+
+    const [payload] = Preconditions.checkExists(upsertSpy.mock.calls[0]);
+    expect(payload.series.WinnerTeamIndex).toBe(-1);
+    expect(payload.seriesPlayers.every((player) => player.SeriesWon === 0)).toBe(true);
+  });
+
   it("persists average damage per life using total lives", async () => {
     const databaseService = aFakeDatabaseServiceWith();
     const haloService = aFakeHaloServiceWith({ databaseService });


### PR DESCRIPTION
## Context
PR14a added derived and explicit series-outcome selection to `/stats fix`. The confirmed outcome now needs to flow into leaderboard truth so corrected stats do not leave stale series/game/player facts behind.

## This PR
- Adds a reconciliation entry point on `LeaderboardService` that reuses the existing idempotent series/game/player upsert and replacement path.
- Reconciles confirmed `/stats fix` data after the amended Discord stats are rebuilt and cached.
- Persists team winners and explicit ties; ties use no winning team and produce zero `SeriesWon` values for both teams.
- Preserves the normal live-completion behavior where an unresolved winner skips persistence.
- Adds regression coverage for selected-winner propagation, explicit tie persistence, stale outcome metadata, and existing confirmation paths.

## Subsequent Work
- Continue hardening reconciliation behavior, including affected leaderboard post refresh coverage and corrected fact replacement across representative amended series.