### PR TITLE
Remove invalid duplicate Durable Object migration

### DIFF
--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -68,10 +68,6 @@
       "tag": "v5",
       "new_classes": ["UserTrackerDO"],
     },
-    {
-      "tag": "v6",
-      "new_classes": ["IndividualTrackerDO", "UserTrackerDO"],
-    },
   ],
 
   // Development environment variables


### PR DESCRIPTION
## Context
`IndividualTrackerDO` and `UserTrackerDO` namespaces were deleted server-side outside of Wrangler's migration bookkeeping. A prior PR (#815) added migration `v6` to recreate them via `new_classes`, and remote deploys have since succeeded — the namespaces exist again in staging and production.

## This PR
- Removes the `v6` migration entry. Both classes were already declared as new in `v4`/`v5`, so redeclaring them in `v6` is an invalid duplicate `new_classes` declaration per Wrangler's legacy migrations format.
- This duplicate declaration passed remote deploy (which reconciles against actual provisioned state) but fails local `wrangler dev` / `wrangler types`, which statically validates the full migrations array and errors with `Cannot apply new_classes migration to existing class IndividualTrackerDO`.
- No functional or deployment risk: Cloudflare tracks already-applied migration tags server-side, independent of the config file's future contents. `v1`–`v5` remain, so the `migrations` key stays non-empty, and nothing is rolled back by removing an already-applied tag.

Validated: `wrangler types` now succeeds locally, dry-run deploys for both the default and staging environments resolve all three Durable Object bindings, and API typecheck passes.

## Subsequent Work
- None anticipated.