### PR TITLE
Restore v6 migration tag as no-op placeholder

### DIFF
--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -68,6 +68,10 @@
       "tag": "v5",
       "new_classes": ["UserTrackerDO"],
     },
+    // No-op placeholder: keeps Cloudflare's last-applied-tag pointer resolvable without redeclaring classes.
+    {
+      "tag": "v6",
+    },
   ],
 
   // Development environment variables


### PR DESCRIPTION
## Context
PR #819 removed the `v6` Durable Object migration tag entirely, believing Cloudflare tracks applied migrations as an independent set (so a removed tag would simply be skipped). This was wrong. The next deploy failed:

```
The published script guilty-spark has a migration tag "v6", which was not found in your wrangler.jsonc file... Applying all available migrations to the script...
Cannot apply new-class migration to class 'LiveTrackerDO' that is already depended on by existing Durable Objects [code: 10074]
```

Cloudflare tracks a pointer to the **last applied tag**, not a set of applied tags. With `v6` missing entirely, Wrangler couldn't locate that pointer in the array and fell back to reapplying every migration from `v1`, which then failed because `LiveTrackerDO` already has live instances.

## This PR
- Restores `v6` as a no-op placeholder (`{ "tag": "v6" }`, no directives). This keeps the last-applied-tag pointer resolvable for Cloudflare's reconciliation without redeclaring any classes, so it does not reintroduce the duplicate `new_classes` validation error that broke local `wrangler dev`/`wrangler types` (the original problem PR #819 was trying to solve).
- Confirmed via Wrangler's config schema that `tag` is the only required field on a migration entry, so this is valid syntax.

Validated locally: `wrangler types` succeeds, and dry-run deploys for both the default and `production` environments resolve cleanly with no migration warnings. Note `--dry-run` does not contact the Cloudflare API to compare against the live deployed migration state, so full confirmation will come from the next merge-triggered deploy.

## Subsequent Work
- Monitor the next Deploy API GitHub Action run after merge to confirm the fix resolves cleanly against the live account state.